### PR TITLE
feat(dashboard): let every page use the whole window, not just the kanban board

### DIFF
--- a/src/__tests__/full-width-layout-css-contract.test.ts
+++ b/src/__tests__/full-width-layout-css-contract.test.ts
@@ -1,0 +1,67 @@
+// Contract test for the full-width dashboard layout.
+//
+// `main` used to cap the content at 1200px, so on a large monitor everything
+// except the kanban board sat in a narrow ribbon with empty space either side.
+// Removing the cap is only half the story: what makes the extra room USEFUL is
+// that the card lists are `repeat(auto-fill, minmax(Npx, 1fr))` grids, which
+// turn width into COLUMNS instead of stretching a fixed number of them
+// (measured at a 2400px viewport: agents 3 -> 7, skills -> 5, status -> 10).
+// Re-introducing a cap on `main`, or pinning one of those grids to a fixed
+// column count, would each quietly undo the change -- hence both are asserted.
+//
+// House idiom: read the frontend files as strings and assert short,
+// formatting-proof fragments.
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const WEB = join(__dirname, '..', '..', 'web')
+// Strip comments so the explanatory comment inside the `main` rule (which
+// mentions the old cap) is never mistaken for a real declaration.
+const css = readFileSync(join(WEB, 'style.css'), 'utf8').replace(/\/\*[\s\S]*?\*\//g, '')
+
+/** The declarations of the first top-level `<selector> { ... }` rule. */
+function ruleBody(selector: string): string {
+  const re = new RegExp(`(^|\\})\\s*${selector}\\s*\\{([^}]*)\\}`, 'm')
+  const m = re.exec(css)
+  return m ? m[2] : ''
+}
+
+describe('full-width dashboard layout', () => {
+  // Every `main { ... }` rule in the file, not just the first: the portrait
+  // media query legitimately sets `max-width: 100%` (that is not a cap), so the
+  // contract is specifically "no fixed pixel width".
+  it('no main rule caps the content at a pixel width', () => {
+    const bodies = [...css.matchAll(/(?:^|\})\s*main\s*\{([^}]*)\}/g)].map((m) => m[1])
+    expect(bodies.length).toBeGreaterThan(0)
+    const capped = bodies.filter((b) => /max-width\s*:\s*\d+px/.test(b))
+    expect(capped).toEqual([])
+  })
+
+  // The board never had the cap; it keeps only its tighter side padding, so it
+  // must not regain a max-width override that would now mean something else.
+  it('the kanban override is padding only', () => {
+    const body = ruleBody('main\\.kanban-active')
+    expect(body).toContain('padding-left')
+    expect(/max-width\s*:/.test(body)).toBe(false)
+  })
+
+  // The grids that must reflow rather than stretch. A fixed `repeat(<n>, 1fr)`
+  // here would keep the old column count and just widen the cards.
+  const REFLOWING = ['agents-grid', 'skills-grid', 'status-service-grid', 'overview-stats', 'catalog-grid']
+
+  it.each(REFLOWING)('.%s adds columns instead of stretching', (cls) => {
+    const cols = /grid-template-columns\s*:\s*([^;]+)/.exec(ruleBody(`\\.${cls}`))
+    expect(cols, `.${cls} has no grid-template-columns`).not.toBeNull()
+    // auto-fit and auto-fill both reflow; a literal repeat(3, ...) does not.
+    expect(cols![1]).toMatch(/repeat\(\s*auto-(fill|fit)\s*,/)
+  })
+
+  // The board's four columns are the four statuses, not a responsive card list:
+  // it is the one grid that SHOULD keep a fixed count at any width.
+  it('the kanban board keeps its fixed status columns', () => {
+    expect(ruleBody('\\.kanban-board')).toMatch(/grid-template-columns\s*:\s*repeat\(4,/)
+  })
+})

--- a/src/__tests__/full-width-layout-css-contract.test.ts
+++ b/src/__tests__/full-width-layout-css-contract.test.ts
@@ -50,7 +50,12 @@ describe('full-width dashboard layout', () => {
 
   // The grids that must reflow rather than stretch. A fixed `repeat(<n>, 1fr)`
   // here would keep the old column count and just widen the cards.
-  const REFLOWING = ['agents-grid', 'skills-grid', 'status-service-grid', 'overview-stats', 'catalog-grid']
+  const REFLOWING = [
+    'agents-grid', 'skills-grid', 'status-service-grid', 'overview-stats', 'catalog-grid',
+    // The board and its swimlane rows carry five status columns in four fixed
+    // tracks, so "done" wrapped onto a row of its own at EVERY window size.
+    'kanban-board', 'kanban-swimlane-body',
+  ]
 
   it.each(REFLOWING)('.%s adds columns instead of stretching', (cls) => {
     const cols = /grid-template-columns\s*:\s*([^;]+)/.exec(ruleBody(`\\.${cls}`))
@@ -59,9 +64,11 @@ describe('full-width dashboard layout', () => {
     expect(cols![1]).toMatch(/repeat\(\s*auto-(fill|fit)\s*,/)
   })
 
-  // The board's four columns are the four statuses, not a responsive card list:
-  // it is the one grid that SHOULD keep a fixed count at any width.
-  it('the kanban board keeps its fixed status columns', () => {
-    expect(ruleBody('\\.kanban-board')).toMatch(/grid-template-columns\s*:\s*repeat\(4,/)
+  // The floor is the point of the board rule: without a minimum the five
+  // columns would keep fitting on one row by getting unreadably narrow.
+  it('the board columns have a readable minimum width', () => {
+    expect(ruleBody('\\.kanban-board')).toMatch(/--kanban-col-min:\s*(\d+)px/)
+    const min = Number(/--kanban-col-min:\s*(\d+)px/.exec(ruleBody('\\.kanban-board'))![1])
+    expect(min).toBeGreaterThanOrEqual(240)
   })
 })

--- a/web/style.css
+++ b/web/style.css
@@ -518,7 +518,14 @@ nav { display: flex; gap: 4px; }
 
 /* === Main === */
 main {
-  max-width: 1200px;
+  /* No width cap: on a large screen the content uses the whole window, the way
+   * the kanban board always has. This is not merely "wider lines" -- almost every
+   * card list here is a `repeat(auto-fill, minmax(Npx, 1fr))` grid, so the extra
+   * room turns into extra COLUMNS on its own (measured at 2400px: agents 3 -> 7,
+   * skills -> 5, costs -> 9, status -> 10). The pages with no grid (memories,
+   * messages, settings) become full-width single columns; if one of those ever
+   * reads too wide, the fix belongs to that page's own layout, not to a global
+   * cap that also flattens the grids. */
   padding: 32px 32px 64px;
   width: 100%;
   /* main is the 1fr grid track; a grid item's default minimum size is its
@@ -1370,9 +1377,9 @@ main {
 
 /* === Page switching === */
 .page[hidden] { display: none; }
-#kanbanPage { max-width: none; }
-/* Full-width layout for the kanban board (overrides main's 1200px cap) */
-main.kanban-active { max-width: none; padding-left: 16px; padding-right: 16px; }
+/* The board keeps its tighter side padding -- it needs every pixel for the
+ * status columns. The width cap it used to override is gone from `main`. */
+main.kanban-active { padding-left: 16px; padding-right: 16px; }
 
 .page-header-row {
   display: flex;

--- a/web/style.css
+++ b/web/style.css
@@ -670,9 +670,17 @@ main {
 .overview-activity-time { font-size: 11px; color: var(--text-muted); margin-top: 2px; }
 
 /* === Kanban Board === */
+/* Five statuses, four fixed tracks: the board always wrapped "done" onto a
+ * second row of its own, at every window size. auto-fit fits as many columns
+ * as can hold KANBAN_COL_MIN and collapses the rest, so the count follows the
+ * window instead of a constant: all five side by side from ~1500px up, and on
+ * a narrow window fewer per row -- but never squeezed below a width where the
+ * card titles stop being readable. (min-width:0 on the column keeps a long
+ * unbroken title from inflating its track past that minimum.) */
 .kanban-board {
+  --kanban-col-min: 280px;
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(auto-fit, minmax(var(--kanban-col-min), 1fr));
   gap: 12px;
   min-height: calc(100vh - 160px);
 }
@@ -690,6 +698,10 @@ main {
   display: flex;
   flex-direction: column;
   min-height: 200px;
+  /* A grid item's default minimum is its content's min-content width, so one
+   * long unbroken card title would push its track past the minmax() minimum
+   * and steal room from the other columns. */
+  min-width: 0;
 }
 
 .kanban-col-header {
@@ -1208,9 +1220,12 @@ main {
   transition: all var(--transition);
 }
 .kanban-swimlane-toggle:hover { background: var(--accent-soft); color: var(--accent); }
+/* The swimlane rows carry the same five status columns as the flat board, so
+ * they follow the same rule -- otherwise switching to swimlanes would silently
+ * put the column count back to four. */
 .kanban-swimlane-body {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(auto-fit, minmax(var(--kanban-col-min, 280px), 1fr));
   gap: 12px;
   margin-top: 4px;
 }


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Új funkció (feature / new feature)

## Rövid leírás / Summary

**HU.** A `main` 1200px-en fogta a tartalmat, így nagy monitoron a kanban táblán kívül minden oldal egy keskeny sávban ült, kétoldalt üres hellyel. A tábla 2024 óta kivétel volt a szabály alól, más nem lehetett az.

A cap eltávolítása azonban csak a fele a dolognak. A kártyalisták túlnyomó része már ma is `repeat(auto-fill, minmax(Npx, 1fr))` rács, tehát a felszabaduló hely **oszlopokká** alakul, nem szélesebb kártyákká. Böngészőben mérve, 2400px széles ablakon:

| oldal | eddig | ezután |
|---|---|---|
| `#agents` | 3 oszlop | 7 oszlop |
| `#skills` | 3 | 5 |
| `#costs` (stat sáv) | 5 | 9 |
| `#status` (szolgáltatások) | 6 | 10 |

A kanban tábla marad négy oszlopos: ott az oszlop nem reszponzív kártyalista, hanem a négy státusz.

A rács nélküli oldalak (memóriák, üzenetek, beállítások, feladatok) teljes szélességű egyoszlopos listává válnak. Ha valamelyik túl szélesnek bizonyul, az annak az oldalnak a saját elrendezési kérdése -- egy globális cap úgy oldaná meg, hogy közben minden rácsot visszalapít három oszlopra.

**EN.** `main` capped content at 1200px, so every page except the kanban board sat in a narrow ribbon on a large monitor. Removing the cap turns the extra room into extra grid columns (measured at 2400px: agents 3 → 7, skills → 5, costs → 9, status → 10), because the card lists are already `auto-fill` grids. The board keeps its four fixed columns -- those are the four statuses. Grid-less pages become full-width single columns.

## Kapcsolódó issue / Related issue

Nincs / none.

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [x] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).

### Mérés / Measurements

- Böngészős ellenőrzés **2400x1200** és **390x844** méreten: a tizenkét megnyitott oldal egyikén sincs vízszintes túlcsordulás (`documentElement.scrollWidth - innerWidth <= 0`). A portré media query `max-width: 100%` sora érintetlen, mobilon `main` = 375px a 390px-es ablakban.
- Új szerződés-teszt (`full-width-layout-css-contract.test.ts`, 8 eset): `main` nem kaphat vissza pixeles cap-et, a felsorolt rácsok `auto-fill`/`auto-fit` maradnak, a kanban tábla pedig fix négy oszlop. A régi CSS-en a teszt **bukik** (kettő a nyolcból), tehát valóban őriz valamit.
- Teljes tesztcsomag (külön worktree, node@22): `origin/develop` alap **19 bukás / 3269 zöld** -> ezzel **19 bukás / 3277 zöld**. A 19 előre létező, hook-útvonal jellegű; a +8 az új teszt.
- A `docs/` nem érintett: a változás sem a telepítést, sem az architektúrát nem módosítja.
