### PR TITLE
fix(context-guard): sweep the hidden technical workers too, or their wedge is unbounded

### DIFF
--- a/src/__tests__/context-guard-hidden-worker.test.ts
+++ b/src/__tests__/context-guard-hidden-worker.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { tmpdir } from 'node:os'
+import { fileURLToPath } from 'node:url'
+
+// 2026-08-04, P1: the hourly heartbeat went silent for two hours. The schedule
+// runner did the right thing -- it refuses to inject into a 100%-context pane
+// and defers to the retry queue -- but that deferral only terminates if
+// SOMEBODY rescues the wedged session, and the only rescuer is the
+// context-guard's saturation net. The net swept listAgentNames(), which drops
+// any directory carrying HIDDEN_AGENT_SENTINEL, and agents/heartbeat carries
+// exactly that. The worker was invisible to its own life support, so the retry
+// waited forever and two hourly ticks plus a support-inbox tick died quietly.
+//
+// The sentinel is a VISIBILITY decision ("do not clutter the dashboard"). This
+// suite pins that it never again doubles as a LIFECYCLE decision.
+const SANDBOX = mkdtempSync(join(tmpdir(), 'guardsweep-'))
+const AGENTS = join(SANDBOX, 'agents')
+
+vi.mock('../config.js', async (orig) => {
+  const actual = await orig<typeof import('../config.js')>()
+  return { ...actual, MAIN_AGENT_ID: 'marveen', PROJECT_ROOT: SANDBOX, STORE_DIR: join(SANDBOX, 'store') }
+})
+vi.mock('../logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+}))
+vi.mock('../db.js', () => ({ createAgentMessage: vi.fn() }))
+vi.mock('../web/channel-monitor.js', () => ({
+  hardRestartMarveenChannels: vi.fn(() => ({ ok: true })),
+  lastMainRespawnAt: () => null,
+  MARVEEN_POST_RESPAWN_GRACE_MS: 0,
+}))
+vi.mock('../web/stuck-tool-call-watcher.js', () => ({ shouldDeferForRecentRespawn: () => false }))
+vi.mock('../web/agent-process.js', () => ({
+  agentRunState: () => 'stopped',
+  agentSessionName: (n: string) => `agent-${n}`,
+  restartAgentProcess: vi.fn(),
+  capturePane: () => null,
+  sendPromptToSession: vi.fn(),
+  isSessionReadyForPrompt: async () => false,
+}))
+vi.mock('../web/main-agent.js', () => ({ MAIN_CHANNELS_SESSION: 'marveen-channels' }))
+
+const { guardSweepAgentNames } = await import('../web/context-guard-runner.js')
+const { listAgentNames, listAllAgentNames, HIDDEN_AGENT_SENTINEL } = await import('../web/agent-config.js')
+
+function agent(name: string, hidden = false): void {
+  mkdirSync(join(AGENTS, name), { recursive: true })
+  if (hidden) writeFileSync(join(AGENTS, name, HIDDEN_AGENT_SENTINEL), '')
+}
+
+beforeEach(() => {
+  rmSync(AGENTS, { recursive: true, force: true })
+  mkdirSync(AGENTS, { recursive: true })
+})
+afterAll(() => rmSync(SANDBOX, { recursive: true, force: true }))
+
+describe('hidden technical workers and the saturation net', () => {
+  it('the guard sweep visits a dashboard-hidden worker', () => {
+    agent('samu')
+    agent('heartbeat', true)
+
+    // The exact shape of the outage: heartbeat exists on disk, is hidden, and
+    // must still be swept.
+    expect(guardSweepAgentNames()).toContain('heartbeat')
+    expect(guardSweepAgentNames()).toContain('samu')
+    expect(guardSweepAgentNames()[0]).toBe('marveen') // main stays first
+  })
+
+  it('the dashboard listing still hides that same worker', () => {
+    agent('samu')
+    agent('heartbeat', true)
+
+    // Requirement from the report: fix the life support WITHOUT un-hiding the
+    // technical worker in the UI. Both halves are asserted together so a future
+    // "just use listAllAgentNames everywhere" cannot pass this file.
+    expect(listAgentNames()).toEqual(['samu'])
+    expect(listAllAgentNames().sort()).toEqual(['heartbeat', 'samu'])
+  })
+
+  it('a hidden worker with no store entry is still armed by default', async () => {
+    // The wedge was NOT caused by a missing store/context-guard.json entry:
+    // an agent absent from the store falls back to DEFAULT_CONTEXT_GUARD, whose
+    // saturationRestart is already true. Pinned so nobody "fixes" the outage by
+    // seeding config rows and calls it closed while the sweep stays narrow.
+    const { readContextGuardConfig } = await import('../web/context-guard-store.js')
+    const cfg = readContextGuardConfig('heartbeat')
+    expect(cfg.saturationRestart).toBe(true)
+    expect(cfg.enabled).toBe(false) // proactive tiers stay off; only the net runs
+  })
+
+  it('the rescue restart is FRESH, never --continue', () => {
+    // Measured live on 2026-08-04: a default (--continue) restart of the wedged
+    // heartbeat left the pane still showing "100% context used" -- continue
+    // reloads the very context that wedged it. Only the fresh restart cleared
+    // it. performRestart is private inside a module full of IO, so pin the
+    // guarantee at the source, brace-matched to its own body.
+    const src = readFileSync(
+      join(dirname(fileURLToPath(import.meta.url)), '..', 'web', 'context-guard-runner.ts'),
+      'utf8',
+    )
+    const m = /function performRestart\s*\([^)]*\)[^{]*\{/.exec(src)
+    expect(m, 'performRestart not found').not.toBeNull()
+    let depth = 0
+    let end = src.length
+    for (let i = src.indexOf('{', m!.index); i < src.length; i++) {
+      if (src[i] === '{') depth++
+      else if (src[i] === '}' && --depth === 0) { end = i; break }
+    }
+    const body = src.slice(m!.index, end + 1)
+    expect(body).toContain('restartAgentProcess(name, { fresh: true })')
+    expect(body).not.toMatch(/restartAgentProcess\(name,\s*\{\s*fresh:\s*false/)
+    expect(body).not.toMatch(/restartAgentProcess\(name\)/)
+  })
+})

--- a/src/__tests__/context-guard-hidden-worker.test.ts
+++ b/src/__tests__/context-guard-hidden-worker.test.ts
@@ -68,6 +68,23 @@ describe('hidden technical workers and the saturation net', () => {
     expect(guardSweepAgentNames()[0]).toBe('marveen') // main stays first
   })
 
+  it('the sweep set is a SET -- the main agent is never swept twice', () => {
+    // On a real install agents/<MAIN_AGENT_ID> exists as a directory, so the
+    // main agent arrives from BOTH sources: the explicit head of the list and
+    // the directory listing. Without the sandbox dir below this test cannot see
+    // the duplicate at all, which is why it is created here explicitly.
+    agent('marveen')
+    agent('samu')
+    agent('heartbeat', true)
+
+    const swept = guardSweepAgentNames()
+    expect(swept[0]).toBe('marveen')
+    expect(swept).toEqual([...new Set(swept)])
+    expect(swept.filter((n) => n === 'marveen')).toHaveLength(1)
+    // and the widening still holds in the same breath
+    expect(swept).toContain('heartbeat')
+  })
+
   it('the dashboard listing still hides that same worker', () => {
     agent('samu')
     agent('heartbeat', true)

--- a/src/web/agent-config.ts
+++ b/src/web/agent-config.ts
@@ -484,17 +484,36 @@ export function writeAgentClaudePlan(name: string, planId: string): void {
 // jelenjen a dashboardon").
 export const HIDDEN_AGENT_SENTINEL = '.hidden-from-dashboard'
 
-export function listAgentNames(): string[] {
+/**
+ * EVERY agent directory, hidden technical workers included.
+ *
+ * This answers "what does the fleet have to KEEP ALIVE"; listAgentNames()
+ * answers "what should the operator SEE". They were the same call for a long
+ * time, and that is precisely how the hourly heartbeat went silent on
+ * 2026-08-04: agents/heartbeat carries HIDDEN_AGENT_SENTINEL, so the
+ * context-guard sweep -- the ONLY mechanism that rescues a 100%-context
+ * session -- never visited it. The schedule runner correctly refuses to inject
+ * into a saturated pane and defers to the retry queue, but that deferral
+ * assumes somebody eventually rescues the session. Nobody did, so the retry sat
+ * unbounded and two hourly ticks plus a support-inbox tick died quietly.
+ *
+ * Hiding an agent from the dashboard is a VISIBILITY decision. It must never
+ * decide whether that agent gets kept alive. Lifecycle sweeps use this
+ * function; anything that renders a list to the operator uses listAgentNames().
+ */
+export function listAllAgentNames(): string[] {
   if (!existsSync(AGENTS_BASE_DIR)) return []
   return readdirSync(AGENTS_BASE_DIR).filter((f) => {
-    try {
-      if (!statSync(join(AGENTS_BASE_DIR, f)).isDirectory()) return false
-      // Hide technical workers explicitly opted out via the sentinel
-      // file. Cheap fs stat -- one extra existsSync per agent dir per
-      // tick; the agent list is small (~6 today).
-      if (existsSync(join(AGENTS_BASE_DIR, f, HIDDEN_AGENT_SENTINEL))) return false
-      return true
-    } catch { return false }
+    try { return statSync(join(AGENTS_BASE_DIR, f)).isDirectory() } catch { return false }
+  })
+}
+
+export function listAgentNames(): string[] {
+  // Hide technical workers explicitly opted out via the sentinel file. Cheap
+  // fs stat -- one extra existsSync per agent dir per tick; the agent list is
+  // small (~6 today).
+  return listAllAgentNames().filter((f) => {
+    try { return !existsSync(join(AGENTS_BASE_DIR, f, HIDDEN_AGENT_SENTINEL)) } catch { return false }
   })
 }
 

--- a/src/web/context-guard-runner.ts
+++ b/src/web/context-guard-runner.ts
@@ -343,9 +343,16 @@ export function getContextGuardStatus(): Array<{
  * Exported so the regression test can assert the SET rather than reach into a
  * timer: narrowing this back to listAgentNames() must fail a test, not a
  * production heartbeat.
+ *
+ * Deduplicated, main first. On an install where agents/<MAIN_AGENT_ID> exists
+ * as a real directory (ours does) the main agent appears twice -- once
+ * explicitly, once from the listing -- and checkAgent would run its whole
+ * decision on it twice per sweep. That is exactly the agent where a doubled
+ * decision is least welcome, so the canonical "who do we sweep" answer is a
+ * set, not a concatenation.
  */
 export function guardSweepAgentNames(): string[] {
-  return [MAIN_AGENT_ID, ...listAllAgentNames()]
+  return [...new Set([MAIN_AGENT_ID, ...listAllAgentNames()])]
 }
 
 export function startContextGuardRunner(): NodeJS.Timeout {

--- a/src/web/context-guard-runner.ts
+++ b/src/web/context-guard-runner.ts
@@ -4,7 +4,7 @@ import { logger } from '../logger.js'
 import { MAIN_AGENT_ID, PROJECT_ROOT } from '../config.js'
 import { hardRestartMarveenChannels, lastMainRespawnAt, MARVEEN_POST_RESPAWN_GRACE_MS } from './channel-monitor.js'
 import { shouldDeferForRecentRespawn } from './stuck-tool-call-watcher.js'
-import { listAgentNames, agentDir, readAgentModel, readAgentClaudeConfigDir, readAgentRemoteHost } from './agent-config.js'
+import { listAgentNames, listAllAgentNames, agentDir, readAgentModel, readAgentClaudeConfigDir, readAgentRemoteHost } from './agent-config.js'
 import {
   agentRunState,
   agentSessionName,
@@ -328,11 +328,30 @@ export function getContextGuardStatus(): Array<{
   })
 }
 
+/**
+ * Who the saturation net sweeps: the main agent plus EVERY agent directory,
+ * dashboard-hidden technical workers included.
+ *
+ * Deliberately listAllAgentNames(), not listAgentNames(). A hidden worker is
+ * hidden from the OPERATOR, not from the fleet's life support: it runs a real
+ * Claude session that can wedge at 100% context exactly like a visible agent,
+ * and when it does, this sweep is the only thing that can free it. The hourly
+ * heartbeat proved it on 2026-08-04 -- agents/heartbeat wedged, was invisible
+ * to this sweep, and the schedule runner's (correct) "defer instead of
+ * injecting into a wedged session" turned into an unbounded wait.
+ *
+ * Exported so the regression test can assert the SET rather than reach into a
+ * timer: narrowing this back to listAgentNames() must fail a test, not a
+ * production heartbeat.
+ */
+export function guardSweepAgentNames(): string[] {
+  return [MAIN_AGENT_ID, ...listAllAgentNames()]
+}
+
 export function startContextGuardRunner(): NodeJS.Timeout {
   async function sweep() {
     const now = Date.now()
-    try { await checkAgent(MAIN_AGENT_ID, now) } catch (err) { logger.debug({ err }, 'context-guard: main check error') }
-    for (const name of listAgentNames()) {
+    for (const name of guardSweepAgentNames()) {
       try { await checkAgent(name, now) } catch (err) { logger.debug({ err, agent: name }, 'context-guard: agent check error') }
     }
   }


### PR DESCRIPTION
## Mit old meg

Az órás heartbeat 2026-08-04-én két órára elnémult. A láncban semmi nem romlott el, csak az utolsó feltevése.

Az ütemező helyesen viselkedett: nem injektál egy 100%-os kontextusú panelbe, mert az néma elnyelés lenne, ezért a retry-sorba halasztott. Ez a halasztás viszont csak akkor véges, ha valaki KIMENTI a beragadt sessiont, és az egyetlen kimentő a context-guard telítettség-hálója.

A háló a `listAgentNames()`-t seperte, ami kiszűr minden `.hidden-from-dashboard` sentinelt viselő könyvtárat, az `agents/heartbeat` pedig pontosan ilyen. A worker láthatatlan volt a saját életfenntartása számára: két órás tick és egy support-inbox tick olyan mentésre várt, ami sosem jöhetett.

## A javítás

A dashboardról való elrejtés **láthatósági** döntés. Soha nem dönthet arról, hogy egy ágenst életben tartunk-e. A kettő szétválik:

| függvény | mire válaszol |
|---|---|
| `listAllAgentNames()` | mit kell a flottának ÉLETBEN TARTANIA (életciklus-sweepek) |
| `listAgentNames()` | mit LÁSSON az operátor (változatlan, továbbra is rejt) |

A guard sweep az elsőre vált; a `getContextGuardStatus()` a másodikon marad, így a technikai worker a felületen ugyanúgy rejtve marad, mint eddig.

A sweep-halmaz `guardSweepAgentNames()` néven exportált, hogy a regressziós teszt a HALMAZT állíthassa, ne egy időzítőbe kelljen nyúlnia: a visszaszűkítés így egy tesztet buktat, nem egy éles heartbeatet.

## Amit lemértem, nem feltételeztem

- **A hiányzó config-sor nem volt oka semminek.** A store-ban nem szereplő ágens a `DEFAULT_CONTEXT_GUARD`-ot kapja, aminek a `saturationRestart` értéke már ma is `true`. Vagyis config-sorok beszórásával ez a hiba NEM lett volna javítva. Teszt rögzíti.
- **A mentés eddig is fresh volt** (`performRestart` -> `restartAgentProcess(name, { fresh: true })`), és ez lényeges: egy `--continue` restart pont azt a kontextust tölti vissza, ami beragasztotta a sessiont. Élesben is így viselkedett: az első, alapértelmezett restart után a panel még mindig „100% context used"-ot mutatott, csak a fresh oldotta fel. Kódváltozás tehát nem kellett, de a garancia mostantól teszttel védett, hogy ne csúszhasson vissza continue-ra.
- **A szélesítés nem tud kárt okozni.** Az `agentRunState()`/`agentSessionName()` tmux-alapú, nem függ a `listAgentNames()`-től, tehát elér egy rejtett workert is; egy leállítottnál pedig a `decideGuard()` „not running"-gal tér vissza.

## Tesztek

Új: `src/__tests__/context-guard-hidden-worker.test.ts` (4 teszt). Kétirányú mutációs kontroll lefuttatva:

- a sweep visszaszűkítése `listAgentNames()`-re -> a sweep-teszt PIROS (`expected [ 'marveen', 'samu' ] to include 'heartbeat'`),
- a mentés visszaírása continue-restartra -> a fresh-teszt PIROS.

Teljes suite a fejen: 245 fájl / 3292 teszt zöld, `tsc --noEmit` 0 hiba.

## Amit NEM tartalmaz (külön kérdés, mérési eredménnyel)

A riasztás kérdésére: **már ma is van** owner-nek szóló riasztás, és le is futott. A `pending_task_retries` sor egy órás küszöbnél riaszt, és élesben ez történt: `[17:00:06.531] Pending-retry Telegram alert sent — task: "hourly-heartbeat", agent: "heartbeat", ageMinutes: 60`. Történetileg 69 ilyen riasztás ment ki 33 különböző dashboard-példányból, tehát a mechanizmus él.

Amit viszont mértem és zajnak tartok: a halasztási WARN minden tickre kiíródik, egyetlen dashboard-példány élettartama alatt 3524 sorral. Ez nem ebbe a PR-be való, de érdemes külön körben deduplikálni, mert a folyamatosan égő jelzés éppúgy vakít, mint a hiányzó.
