### PR TITLE
fix(channel-monitor): respawn must honour MAIN_AGENT_MODEL, like the launch path

### DIFF
--- a/src/__tests__/main-model-resolution-parity.test.ts
+++ b/src/__tests__/main-model-resolution-parity.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, mkdirSync, writeFileSync, copyFileSync, rmSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { tmpdir } from 'node:os'
+import { fileURLToPath } from 'node:url'
+
+import { readConfiguredMainModel } from '../web/channel-monitor.js'
+
+// The main agent's model is resolved by TWO independent implementations:
+//
+//   LAUNCH   scripts/channels.sh   resolve_main_model()      (shell)
+//   RESPAWN  src/web/channel-monitor.ts readConfiguredMainModel()  (TS)
+//
+// They must agree. When they disagree the failure is SILENT in the worst way:
+// the agent boots on the model the operator chose and comes back on a DIFFERENT
+// one after the nightly restart / a recovery resume / a hard respawn. Nothing
+// throws, no probe goes red -- the agent simply answers as another model.
+//
+// That is not hypothetical. Until 2026-08-03 readConfiguredMainModel() read
+// ONLY .claude/settings.json, while its own comment claimed to mirror
+// channels.sh. channels.sh had honoured MAIN_AGENT_MODEL from .env since
+// 2026-07-29 (that route exists because settings.json is TRACKED: a per-install
+// model written there is a permanent local diff that blocks the update
+// preflight's clean-tree check and is reverted by the next update). So any
+// install using the supported .env route drifted on every respawn.
+//
+// The defect was MASKED on the install where it was found: settings.json
+// happened to be dirty with the same value the .env carried, so both paths
+// agreed by accident. Restoring a clean tree would have ACTIVATED it. A test
+// that only exercised the TS side would have gone green through all of that --
+// hence parity: same fixtures through BOTH implementations, asserted equal.
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = join(__dirname, '..', '..')
+const CHANNELS_SH = join(REPO_ROOT, 'scripts', 'channels.sh')
+
+const roots: string[] = []
+afterEach(() => {
+  while (roots.length) rmSync(roots.pop() as string, { recursive: true, force: true })
+})
+
+/** Build a throwaway install root. channels.sh derives INSTALL_DIR from its own
+ *  path, so a copy under <root>/scripts sees <root> as the install. */
+function fixture(envBody: string | null, settingsBody: string | null): string {
+  const root = mkdtempSync(join(tmpdir(), 'mainmodel-'))
+  roots.push(root)
+  mkdirSync(join(root, 'scripts'), { recursive: true })
+  mkdirSync(join(root, '.claude'), { recursive: true })
+  copyFileSync(CHANNELS_SH, join(root, 'scripts', 'channels.sh'))
+  if (envBody !== null) writeFileSync(join(root, '.env'), envBody + '\n')
+  if (settingsBody !== null) writeFileSync(join(root, '.claude', 'settings.json'), settingsBody + '\n')
+  return root
+}
+
+/** The shell answer, via the script's own side-effect-free test seam. */
+function shellResolves(root: string): string {
+  return execFileSync('bash', [join(root, 'scripts', 'channels.sh'), '--resolve-main-model'], {
+    encoding: 'utf-8',
+  })
+    .split('\n')[0]
+    .trim()
+}
+
+// label, .env body, settings.json body, expected model
+const CASES: Array<[string, string | null, string | null, string]> = [
+  ['settings.json alone is honoured (the shipped default)', null, '{"model":"claude-opus-4-8[1m]"}', 'claude-opus-4-8[1m]'],
+  // The regression case. These are the REAL values of the install where the
+  // drift was found: .env said opus-5, the tracked file said opus-4-8[1m].
+  ['.env wins over settings.json (the whole point)', 'MAIN_AGENT_MODEL=claude-opus-5', '{"model":"claude-opus-4-8[1m]"}', 'claude-opus-5'],
+  ['.env alone works with no settings.json', 'MAIN_AGENT_MODEL=claude-sonnet-5', null, 'claude-sonnet-5'],
+  ['neither present -> empty, so the launcher omits --model', null, null, ''],
+  ['an EMPTY MAIN_AGENT_MODEL does not shadow settings.json', 'MAIN_AGENT_MODEL=', '{"model":"claude-opus-5"}', 'claude-opus-5'],
+  // `[1m]` must survive intact: it is a glob in shell and would silently vanish
+  // if either side let a bare word through an unquoted expansion.
+  ['a bracketed 1M suffix survives the .env route', 'MAIN_AGENT_MODEL=claude-opus-4-8[1m]', null, 'claude-opus-4-8[1m]'],
+  ['a similarly named key does not leak in', 'NOT_MAIN_AGENT_MODEL=wrong-model', '{"model":"claude-opus-5"}', 'claude-opus-5'],
+  ['settings.json without a model key falls back to empty', null, '{"enabledPlugins":{}}', ''],
+]
+
+describe('main-agent model resolution: launch and respawn agree', () => {
+  it.each(CASES)('%s', (_label, envBody, settingsBody, want) => {
+    const root = fixture(envBody, settingsBody)
+    const fromShell = shellResolves(root)
+    const fromTs = readConfiguredMainModel(root)
+
+    // Each side is right on its own...
+    expect(fromShell).toBe(want)
+    expect(fromTs).toBe(want)
+    // ...and, the invariant that actually matters, they are right TOGETHER.
+    expect(fromTs).toBe(fromShell)
+  })
+})
+
+describe('the respawn path reads .env at all (guards the 2026-08-03 defect directly)', () => {
+  // Pinned separately from the table above so the specific regression stays
+  // legible in a failure report: a settings.json-only implementation returns
+  // 'claude-opus-4-8[1m]' here and this assertion names why that is wrong.
+  it('does NOT return the tracked settings.json value when .env overrides it', () => {
+    const root = fixture('MAIN_AGENT_MODEL=claude-opus-5', '{"model":"claude-opus-4-8[1m]"}')
+    expect(readConfiguredMainModel(root)).not.toBe('claude-opus-4-8[1m]')
+    expect(readConfiguredMainModel(root)).toBe('claude-opus-5')
+  })
+
+  it('survives an unreadable .env by falling back, not by throwing', () => {
+    const root = fixture(null, '{"model":"claude-opus-5"}')
+    mkdirSync(join(root, '.env')) // a directory where a file is expected
+    expect(readConfiguredMainModel(root)).toBe('claude-opus-5')
+  })
+})

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -502,13 +502,45 @@ async function triggerMarveenMemorySave(): Promise<void> {
   }
 }
 
-// Read the main agent's configured model from .claude/settings.json so a
-// soft resume passes --model explicitly, mirroring scripts/channels.sh. Without
-// it the respawned session falls back to claude-code's built-in default and
-// silently drifts off the model the user picked. Returns '' when unset.
-function readConfiguredMainModel(): string {
+// Read the main agent's configured model so a soft resume passes --model
+// explicitly. Without it the respawned session falls back to claude-code's
+// built-in default and silently drifts off the model the user picked.
+// Returns '' when unset, so the caller omits the flag.
+//
+// PRECEDENCE, mirroring scripts/channels.sh resolve_main_model() EXACTLY:
+// MAIN_AGENT_MODEL from .env (per-install, gitignored) wins over
+// .claude/settings.json (tracked, shipped with the repo). An EMPTY
+// MAIN_AGENT_MODEL does not shadow settings.json -- same as the `[ -n ... ]`
+// test in the shell.
+//
+// 2026-08-03: this function read ONLY settings.json while its comment already
+// claimed to mirror channels.sh -- it did not. The launch path honoured .env,
+// this respawn path did not, so an install whose model lives in .env came up
+// correct on boot and drifted to the REPOSITORY's model on every nightly
+// restart, recovery resume and hard respawn (the three call sites below).
+// Silent, because nothing fails: the agent just answers as another model.
+//
+// The .env route exists precisely because settings.json is TRACKED -- writing
+// a per-install choice there carries a permanent local diff, which blocks the
+// update preflight's clean-tree check and gets reverted by the next update
+// (see the header of scripts/__tests__/channels-main-model.test.sh).
+//
+// projectRoot is a test seam, matching readExtraChannelPluginIds() below.
+export function readConfiguredMainModel(projectRoot: string = PROJECT_ROOT): string {
   try {
-    const settingsPath = join(PROJECT_ROOT, '.claude', 'settings.json')
+    const envPath = join(projectRoot, '.env')
+    if (existsSync(envPath)) {
+      const line = readFileSync(envPath, 'utf-8')
+        .split('\n')
+        .find((l) => l.startsWith('MAIN_AGENT_MODEL='))
+      const fromEnv = line ? line.slice('MAIN_AGENT_MODEL='.length).trim() : ''
+      if (fromEnv) return fromEnv
+    }
+  } catch {
+    // Unreadable .env must not break the respawn -- fall through to settings.json.
+  }
+  try {
+    const settingsPath = join(projectRoot, '.claude', 'settings.json')
     if (!existsSync(settingsPath)) return ''
     const parsed = JSON.parse(readFileSync(settingsPath, 'utf-8'))
     const model = parsed?.model


### PR DESCRIPTION
> AI-generated by Marveen dev agent (forge, Claude Opus 5).

Refs #697. Completes option (a): the non-versioned override exists and now
takes precedence in EVERY consumer, not just the launch path. Does not
implement option (b) -- `.claude/settings.json` stays tracked. The override
lives in `.env MAIN_AGENT_MODEL` rather than the suggested
`store/settings.local.json`: different file, same principle.

## Problem

The main agent's model is resolved by two independent implementations:

| | | |
|---|---|---|
| launch | `scripts/channels.sh` | `resolve_main_model()` |
| respawn | `src/web/channel-monitor.ts` | `readConfiguredMainModel()` |

Since 2026-07-29 the shell honours `MAIN_AGENT_MODEL` from `.env` and falls back
to `.claude/settings.json`. The TypeScript side read **only** `settings.json`,
while its own comment claimed to be "mirroring scripts/channels.sh". It was not.

So an install that uses the supported `.env` route boots on the operator's model
and comes back on the **repository's** model after every nightly restart,
recovery resume and hard respawn (the three call sites this function feeds).
The failure is silent in the worst way: nothing throws, no probe goes red, the
agent simply answers as another model.

This installation is a live reproduction of #697. Before the fix, `git status`
showed exactly the permanent local diff the issue describes:

```
 M .claude/settings.json
-  "model": "claude-opus-4-8[1m]"
+  "model": "claude-opus-5"
```

That diff could not be dropped, because dropping it is what activated the bug.

## Fix

`readConfiguredMainModel()` now applies the shell's precedence exactly:

- `MAIN_AGENT_MODEL` from `.env` wins over `.claude/settings.json`
- an **empty** `MAIN_AGENT_MODEL` does not shadow `settings.json` -- the `[ -n ... ]` semantics
- an anchored `MAIN_AGENT_MODEL=` prefix, so a similarly named key cannot leak in
- an unreadable `.env` falls through to `settings.json` instead of breaking the respawn
- exported with a `projectRoot` test seam, matching `readExtraChannelPluginIds()` below it

`main-model-resolution-parity.test.ts` drives 8 fixtures through **both**
implementations -- the TS function and `channels.sh --resolve-main-model` -- and
asserts each is right *and* that they agree. A TS-only test would have stayed
green through the entire defect, because the defect was a divergence.

## Verification

Before/after on the reporting installation, restoring the clean tree that #697
asks for:

```
.claude/settings.json  claude-opus-4-8[1m]   (repository default, tracked, tree CLEAN)
.env MAIN_AGENT_MODEL  claude-opus-5         (per-install override)

launch  path (channels.sh)              -> claude-opus-5
respawn path (readConfiguredMainModel)  -> claude-opus-5
```

The permanent local diff is gone and both paths agree. Before this change the
respawn path returned `claude-opus-4-8[1m]` from the same state.

- Negative control: with the previous `settings.json`-only body exported unchanged, exactly the 4 `.env`-dependent fixtures fail and the other 6 pass -- the suite discriminates on logic, not on the new export.
- Tests: `npm run test` -> 3224 passed, 1 skipped.
- `npm run typecheck` -> exit 0.

One unrelated test fails on this branch: `installer-start-and-fallback.test.ts`
expects `TRAP:6` from an ERR trap's `$LINENO`, which is bash-version dependent
(bash 5.2.21 reports `TRAP:5`, the failing assignment itself). It reproduces on
a clean `upstream/main` checkout at 6add7da with none of these changes applied,
so it is pre-existing and untouched here. Happy to send it as a separate PR.
