### PR TITLE
test(channels): model-precedence fix (#875 impl) + runtime shell<->TS parity test (#884) -- RELSCOPE805 dedup winner

### DIFF
--- a/src/__tests__/main-model-env-precedence.test.ts
+++ b/src/__tests__/main-model-env-precedence.test.ts
@@ -21,14 +21,13 @@
 // alone would otherwise re-open exactly the same gap from the other direction.
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync } from 'node:fs'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
 import { readConfiguredMainModel, readExtraChannelPluginIds } from '../web/channel-monitor.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
-const CHANNELS_SH = join(__dirname, '..', '..', 'scripts', 'channels.sh')
 
 let root: string
 
@@ -106,19 +105,7 @@ describe('readExtraChannelPluginIds (shares the same .env reader)', () => {
   })
 })
 
-describe('scripts/channels.sh resolve_main_model (the path this must mirror)', () => {
-  const sh = readFileSync(CHANNELS_SH, 'utf-8')
-  const fn = sh.slice(sh.indexOf('resolve_main_model() {'))
+// A shell<->TS runtime parity is covered by main-model-resolution-parity.test.ts
+// (executes channels.sh --resolve-main-model and asserts TS === shell). The
+// weaker structural source-inspection that used to live here was dropped.
 
-  it('checks MAIN_AGENT_MODEL before .claude/settings.json', () => {
-    const envIdx = fn.indexOf('MAIN_AGENT_MODEL')
-    const settingsIdx = fn.indexOf('.claude/settings.json')
-    expect(envIdx).toBeGreaterThan(-1)
-    expect(settingsIdx).toBeGreaterThan(-1)
-    expect(envIdx).toBeLessThan(settingsIdx)
-  })
-
-  it('still sources MAIN_AGENT_MODEL from .env', () => {
-    expect(sh).toMatch(/\^MAIN_AGENT_MODEL=.*\$INSTALL_DIR\/\.env/)
-  })
-})

--- a/src/__tests__/main-model-env-precedence.test.ts
+++ b/src/__tests__/main-model-env-precedence.test.ts
@@ -1,0 +1,124 @@
+// Regression tests for the split-brain between the LAUNCH and the RESPAWN path
+// when resolving the main agent's model.
+//
+// Background (2026-08-04): scripts/channels.sh resolves the main model from
+// `.env MAIN_AGENT_MODEL` first and only then from `.claude/settings.json` --
+// deliberately, because .env is gitignored while settings.json is tracked, so an
+// install that wants its own model can set it without dirtying a tracked file
+// (which would otherwise block the update preflight and be reverted by the next
+// update). `readConfiguredMainModel()` in channel-monitor.ts read ONLY
+// settings.json, so the two paths agreed just as long as someone kept both files
+// in sync by hand.
+//
+// Why that is worse than a plain inconsistency: the tracked settings.json ships a
+// model of its own. An update reverts local edits to tracked files, so the very
+// next respawn can hand the main session a DIFFERENT model than the one it
+// launched with -- silently, with no dialog, no error and no log line, while the
+// launch path keeps reporting the intended value.
+//
+// The asserts below lock BOTH sides: the TS behaviour, and the shell function it
+// is supposed to mirror. A future edit that flips the precedence in channels.sh
+// alone would otherwise re-open exactly the same gap from the other direction.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { readConfiguredMainModel, readExtraChannelPluginIds } from '../web/channel-monitor.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const CHANNELS_SH = join(__dirname, '..', '..', 'scripts', 'channels.sh')
+
+let root: string
+
+function writeEnv(contents: string): void {
+  writeFileSync(join(root, '.env'), contents)
+}
+
+function writeSettings(obj: unknown): void {
+  mkdirSync(join(root, '.claude'), { recursive: true })
+  writeFileSync(join(root, '.claude', 'settings.json'), JSON.stringify(obj, null, 2))
+}
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'main-model-precedence-'))
+})
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true })
+})
+
+describe('readConfiguredMainModel', () => {
+  it('prefers .env MAIN_AGENT_MODEL over the tracked .claude/settings.json', () => {
+    writeEnv('SOMETHING_ELSE=1\nMAIN_AGENT_MODEL=claude-opus-5\n')
+    writeSettings({ model: 'claude-opus-4-8[1m]' })
+    expect(readConfiguredMainModel(root)).toBe('claude-opus-5')
+  })
+
+  it('falls back to settings.json when .env has no MAIN_AGENT_MODEL', () => {
+    writeEnv('CHANNEL_PLUGINS_EXTRA=slack-channel@marveen-marketplace\n')
+    writeSettings({ model: 'claude-opus-4-8[1m]' })
+    expect(readConfiguredMainModel(root)).toBe('claude-opus-4-8[1m]')
+  })
+
+  it('falls back to settings.json when .env is absent entirely', () => {
+    writeSettings({ model: 'claude-opus-5' })
+    expect(readConfiguredMainModel(root)).toBe('claude-opus-5')
+  })
+
+  // An EMPTY value must not win: `MAIN_AGENT_MODEL=` is how a half-edited .env
+  // looks, and treating it as a real answer would drop the --model flag and hand
+  // the session to claude-code's built-in default -- the drift this function
+  // exists to prevent.
+  it('ignores an empty MAIN_AGENT_MODEL and falls through', () => {
+    writeEnv('MAIN_AGENT_MODEL=\n')
+    writeSettings({ model: 'claude-opus-5' })
+    expect(readConfiguredMainModel(root)).toBe('claude-opus-5')
+  })
+
+  it('returns empty string when neither source names a model', () => {
+    writeEnv('MAIN_AGENT_MODEL_SOMETHINGELSE=x\n')
+    writeSettings({ enabledPlugins: {} })
+    expect(readConfiguredMainModel(root)).toBe('')
+  })
+
+  it('survives an unparseable settings.json', () => {
+    writeEnv('MAIN_AGENT_MODEL=claude-opus-5\n')
+    mkdirSync(join(root, '.claude'), { recursive: true })
+    writeFileSync(join(root, '.claude', 'settings.json'), '{ not json')
+    expect(readConfiguredMainModel(root)).toBe('claude-opus-5')
+  })
+})
+
+describe('readExtraChannelPluginIds (shares the same .env reader)', () => {
+  it('still splits a space-separated list', () => {
+    writeEnv('CHANNEL_PLUGINS_EXTRA=slack-channel@marveen-marketplace  discord@x\n')
+    expect(readExtraChannelPluginIds(root)).toEqual([
+      'slack-channel@marveen-marketplace',
+      'discord@x',
+    ])
+  })
+
+  it('returns [] when unset, absent or empty', () => {
+    writeEnv('MAIN_AGENT_MODEL=claude-opus-5\n')
+    expect(readExtraChannelPluginIds(root)).toEqual([])
+  })
+})
+
+describe('scripts/channels.sh resolve_main_model (the path this must mirror)', () => {
+  const sh = readFileSync(CHANNELS_SH, 'utf-8')
+  const fn = sh.slice(sh.indexOf('resolve_main_model() {'))
+
+  it('checks MAIN_AGENT_MODEL before .claude/settings.json', () => {
+    const envIdx = fn.indexOf('MAIN_AGENT_MODEL')
+    const settingsIdx = fn.indexOf('.claude/settings.json')
+    expect(envIdx).toBeGreaterThan(-1)
+    expect(settingsIdx).toBeGreaterThan(-1)
+    expect(envIdx).toBeLessThan(settingsIdx)
+  })
+
+  it('still sources MAIN_AGENT_MODEL from .env', () => {
+    expect(sh).toMatch(/\^MAIN_AGENT_MODEL=.*\$INSTALL_DIR\/\.env/)
+  })
+})

--- a/src/__tests__/main-model-resolution-parity.test.ts
+++ b/src/__tests__/main-model-resolution-parity.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, mkdirSync, writeFileSync, copyFileSync, rmSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { tmpdir } from 'node:os'
+import { fileURLToPath } from 'node:url'
+
+import { readConfiguredMainModel } from '../web/channel-monitor.js'
+
+// The main agent's model is resolved by TWO independent implementations:
+//
+//   LAUNCH   scripts/channels.sh   resolve_main_model()      (shell)
+//   RESPAWN  src/web/channel-monitor.ts readConfiguredMainModel()  (TS)
+//
+// They must agree. When they disagree the failure is SILENT in the worst way:
+// the agent boots on the model the operator chose and comes back on a DIFFERENT
+// one after the nightly restart / a recovery resume / a hard respawn. Nothing
+// throws, no probe goes red -- the agent simply answers as another model.
+//
+// That is not hypothetical. Until 2026-08-03 readConfiguredMainModel() read
+// ONLY .claude/settings.json, while its own comment claimed to mirror
+// channels.sh. channels.sh had honoured MAIN_AGENT_MODEL from .env since
+// 2026-07-29 (that route exists because settings.json is TRACKED: a per-install
+// model written there is a permanent local diff that blocks the update
+// preflight's clean-tree check and is reverted by the next update). So any
+// install using the supported .env route drifted on every respawn.
+//
+// The defect was MASKED on the install where it was found: settings.json
+// happened to be dirty with the same value the .env carried, so both paths
+// agreed by accident. Restoring a clean tree would have ACTIVATED it. A test
+// that only exercised the TS side would have gone green through all of that --
+// hence parity: same fixtures through BOTH implementations, asserted equal.
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = join(__dirname, '..', '..')
+const CHANNELS_SH = join(REPO_ROOT, 'scripts', 'channels.sh')
+
+const roots: string[] = []
+afterEach(() => {
+  while (roots.length) rmSync(roots.pop() as string, { recursive: true, force: true })
+})
+
+/** Build a throwaway install root. channels.sh derives INSTALL_DIR from its own
+ *  path, so a copy under <root>/scripts sees <root> as the install. */
+function fixture(envBody: string | null, settingsBody: string | null): string {
+  const root = mkdtempSync(join(tmpdir(), 'mainmodel-'))
+  roots.push(root)
+  mkdirSync(join(root, 'scripts'), { recursive: true })
+  mkdirSync(join(root, '.claude'), { recursive: true })
+  copyFileSync(CHANNELS_SH, join(root, 'scripts', 'channels.sh'))
+  if (envBody !== null) writeFileSync(join(root, '.env'), envBody + '\n')
+  if (settingsBody !== null) writeFileSync(join(root, '.claude', 'settings.json'), settingsBody + '\n')
+  return root
+}
+
+/** The shell answer, via the script's own side-effect-free test seam. */
+function shellResolves(root: string): string {
+  return execFileSync('bash', [join(root, 'scripts', 'channels.sh'), '--resolve-main-model'], {
+    encoding: 'utf-8',
+  })
+    .split('\n')[0]
+    .trim()
+}
+
+// label, .env body, settings.json body, expected model
+const CASES: Array<[string, string | null, string | null, string]> = [
+  ['settings.json alone is honoured (the shipped default)', null, '{"model":"claude-opus-4-8[1m]"}', 'claude-opus-4-8[1m]'],
+  // The regression case. These are the REAL values of the install where the
+  // drift was found: .env said opus-5, the tracked file said opus-4-8[1m].
+  ['.env wins over settings.json (the whole point)', 'MAIN_AGENT_MODEL=claude-opus-5', '{"model":"claude-opus-4-8[1m]"}', 'claude-opus-5'],
+  ['.env alone works with no settings.json', 'MAIN_AGENT_MODEL=claude-sonnet-5', null, 'claude-sonnet-5'],
+  ['neither present -> empty, so the launcher omits --model', null, null, ''],
+  ['an EMPTY MAIN_AGENT_MODEL does not shadow settings.json', 'MAIN_AGENT_MODEL=', '{"model":"claude-opus-5"}', 'claude-opus-5'],
+  // `[1m]` must survive intact: it is a glob in shell and would silently vanish
+  // if either side let a bare word through an unquoted expansion.
+  ['a bracketed 1M suffix survives the .env route', 'MAIN_AGENT_MODEL=claude-opus-4-8[1m]', null, 'claude-opus-4-8[1m]'],
+  ['a similarly named key does not leak in', 'NOT_MAIN_AGENT_MODEL=wrong-model', '{"model":"claude-opus-5"}', 'claude-opus-5'],
+  ['settings.json without a model key falls back to empty', null, '{"enabledPlugins":{}}', ''],
+]
+
+describe('main-agent model resolution: launch and respawn agree', () => {
+  it.each(CASES)('%s', (_label, envBody, settingsBody, want) => {
+    const root = fixture(envBody, settingsBody)
+    const fromShell = shellResolves(root)
+    const fromTs = readConfiguredMainModel(root)
+
+    // Each side is right on its own...
+    expect(fromShell).toBe(want)
+    expect(fromTs).toBe(want)
+    // ...and, the invariant that actually matters, they are right TOGETHER.
+    expect(fromTs).toBe(fromShell)
+  })
+})
+
+describe('the respawn path reads .env at all (guards the 2026-08-03 defect directly)', () => {
+  // Pinned separately from the table above so the specific regression stays
+  // legible in a failure report: a settings.json-only implementation returns
+  // 'claude-opus-4-8[1m]' here and this assertion names why that is wrong.
+  it('does NOT return the tracked settings.json value when .env overrides it', () => {
+    const root = fixture('MAIN_AGENT_MODEL=claude-opus-5', '{"model":"claude-opus-4-8[1m]"}')
+    expect(readConfiguredMainModel(root)).not.toBe('claude-opus-4-8[1m]')
+    expect(readConfiguredMainModel(root)).toBe('claude-opus-5')
+  })
+
+  it('survives an unreadable .env by falling back, not by throwing', () => {
+    const root = fixture(null, '{"model":"claude-opus-5"}')
+    mkdirSync(join(root, '.env')) // a directory where a file is expected
+    expect(readConfiguredMainModel(root)).toBe('claude-opus-5')
+  })
+})

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -502,13 +502,47 @@ async function triggerMarveenMemorySave(): Promise<void> {
   }
 }
 
-// Read the main agent's configured model from .claude/settings.json so a
-// soft resume passes --model explicitly, mirroring scripts/channels.sh. Without
-// it the respawned session falls back to claude-code's built-in default and
-// silently drifts off the model the user picked. Returns '' when unset.
-function readConfiguredMainModel(): string {
+// Single `KEY=value` lookup in the install's .env, used by the readers below.
+// Deliberately dumb (first matching line, trimmed): it mirrors the `grep -E
+// '^KEY=' | head -1 | cut -d= -f2-` that scripts/channels.sh already does, so
+// both sides read the same file the same way.
+function readEnvValue(projectRoot: string, key: string): string {
   try {
-    const settingsPath = join(PROJECT_ROOT, '.claude', 'settings.json')
+    const envPath = join(projectRoot, '.env')
+    if (!existsSync(envPath)) return ''
+    const line = readFileSync(envPath, 'utf-8')
+      .split('\n')
+      .find((l) => l.startsWith(`${key}=`))
+    return line ? line.slice(key.length + 1).trim() : ''
+  } catch {
+    return ''
+  }
+}
+
+// Read the main agent's configured model so a soft resume passes --model
+// explicitly, mirroring scripts/channels.sh. Without it the respawned session
+// falls back to claude-code's built-in default and silently drifts off the model
+// the user picked. Returns '' when unset.
+//
+// PRECEDENCE MUST MATCH channels.sh resolve_main_model(): .env MAIN_AGENT_MODEL
+// (per-install, gitignored) wins over .claude/settings.json (tracked, shipped
+// with the repo). Reading ONLY settings.json here was a silent split-brain: an
+// install that sets its model the documented way -- in .env, precisely so the
+// tracked file stays clean for the update preflight -- got that choice honoured
+// on the LAUNCH path and ignored on the RESPAWN path. The two only agreed while
+// someone kept both files in sync by hand, and nothing detected the drift.
+//
+// The failure is not hypothetical and not symmetric: the tracked settings.json
+// ships a model of its own, so a respawn after an update (which reverts local
+// edits to tracked files) can silently move the main agent to a DIFFERENT model
+// than the one it launched with -- below the operator's required floor, with no
+// dialog, no error and no log line. The launch path would keep saying the right
+// thing, which is exactly what makes it hard to see.
+export function readConfiguredMainModel(projectRoot: string = PROJECT_ROOT): string {
+  const fromEnv = readEnvValue(projectRoot, 'MAIN_AGENT_MODEL')
+  if (fromEnv) return fromEnv
+  try {
+    const settingsPath = join(projectRoot, '.claude', 'settings.json')
     if (!existsSync(settingsPath)) return ''
     const parsed = JSON.parse(readFileSync(settingsPath, 'utf-8'))
     const model = parsed?.model
@@ -530,17 +564,7 @@ function readConfiguredMainModel(): string {
 // Observed in practice: a context-saturation hard restart dropped the secondary
 // inbound for ~20 minutes while the primary channel kept working normally.
 export function readExtraChannelPluginIds(projectRoot: string = PROJECT_ROOT): string[] {
-  try {
-    const envPath = join(projectRoot, '.env')
-    if (!existsSync(envPath)) return []
-    const line = readFileSync(envPath, 'utf-8')
-      .split('\n')
-      .find((l) => l.startsWith('CHANNEL_PLUGINS_EXTRA='))
-    if (!line) return []
-    return line.slice('CHANNEL_PLUGINS_EXTRA='.length).trim().split(/\s+/).filter(Boolean)
-  } catch {
-    return []
-  }
+  return readEnvValue(projectRoot, 'CHANNEL_PLUGINS_EXTRA').split(/\s+/).filter(Boolean)
 }
 
 // Build the claude command used to (re)spawn the main channels session via


### PR DESCRIPTION
## Mit ad

RELSCOPE805 duplikatum-par lezarasa: **#875 implementacioja + #884 runtime-paritas tesztje** egy self-contained PR-ben (base=develop).

Mindket eredeti PR ugyanazt a split-brain hibat javitja: a respawn-ut a fo agens modelljet csak a `settings.json`-bol olvasta, mikozben a launch-ut (channels.sh) a `.env MAIN_AGENT_MODEL`-t is honoralja. Diff-szintu review utan a verdikt: **#875 impl a jobb** (kozos `readEnvValue` helper, dedup-olja a `readExtraChannelPluginIds`-t, es a HELYES branchre, developre megy), **#884 TESZTJE a jobb** (tenylegesen futtatja a `channels.sh --resolve-main-model` seam-et es TS===shell===elvart paritast allit 8 fixture + 2 pinned eseten).

Ez a PR a #875 branch-ebol indul (impl valtozatlan, szerzoseg megorizve), es:
- HOZZAADJA `main-model-resolution-parity.test.ts`-t (a #884 runtime-paritas tesztje valtozatlanul -- ugyanazt az exportalt `readConfiguredMainModel(root)` szignaturat importalja).
- ELDOBJA a #875 gyengebb, csak-string-ellenorzo paritas-blokkjat (az csak a channels.sh forrasszoveget regexelte, runtime divergenciat nem fogott volna).
- MEGTARTJA a #875 TS unit-eseteit es a `readExtraChannelPluginIds` refaktor-guardjat.

## Miert a runtime-paritas teszt a helyes guard

A hiba MASZKOLVA volt azon a telepitesen, ahol megtalaltak: a `settings.json` veletlenul ugyanazt az erteket tartalmazta, mint a `.env`, igy a ket ut egyetertett. Egy csak-TS teszt vegig zold maradt volna. A `channels.sh --resolve-main-model` tenyleges futtatasa a ket implementaciot egymas ellen meri -- pontosan ez a split-brain osztaly guardja.

## Verify
- `npm run typecheck`: zold.
- `main-model-env-precedence.test.ts` (8) + `main-model-resolution-parity.test.ts` (10, benne a 8-eset tabla + 2 pinned regresszio, valos shell-futtatassal): **18 passed**.

## Kovetkezmeny
Superseded: #875 es #884 -- mindketto zarhato, ha ez bement (a #884 kulso hozzajarulo, a zaras udvarias indoklassal Marveene).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
