### PR TITLE
fix(self-pace-gate): stop quoted prose from faking a command position

### DIFF
--- a/scripts/self-pace-gate.mjs
+++ b/scripts/self-pace-gate.mjs
@@ -153,6 +153,120 @@ export function splitSegments(command) {
     .map((s) => s.trim())
 }
 
+// Split like splitSegments, but ONLY on separators the shell would actually
+// treat as separators -- never on one that sits inside a quoted string or a
+// heredoc body. Returns null when the quoting cannot be resolved with
+// confidence, and every caller must then fall back to the naive splitter.
+//
+// WHY THIS EXISTS (measured 2026-08-05, five denials in one morning -- three
+// mine, two taric's): splitSegments is not quote-aware, so PROSE can manufacture
+// a command position that never existed. All five denials had the same cause: a
+// grep pattern quoted inside an inter-agent message,
+//   Minta: stop.sh <bar> launchctl <bar> com.janna.dashboard
+// The `<bar>` split it, the middle piece trimmed down to the bare word
+// `launchctl`, and SCHEDULER_RX's end-of-segment branch reads a bare `launchctl`
+// as a real (interactive) invocation -- correctly, for a real command line.
+// Nothing was scheduled; five messages simply never went out. From outside, a
+// hard-gate denial is indistinguishable from an agent that stayed silent.
+//
+// The route decided it: the SAME text passes as `curl -d '<json>'` (the payload
+// is blanked by stripDataPayloads) and is denied when sent from a python
+// heredoc, which has no -d argument to blank. Choosing how to send a message
+// had quietly become a security decision. stripDataPayloads' own comment names
+// this false-positive class as its target -- it is implemented for exactly one
+// route, so the gap is unfinished work, not an oversight.
+//
+// SCOPE, and this is the part that matters: the result feeds ONLY the anchored
+// scheduler check. The unanchored patterns (tmux+send-keys, nohup+claude,
+// claude+/loop) keep scanning naive segments, quoted regions included, because
+// they do NOT depend on a command position that prose can fake -- and because
+// measurement showed the naive scan is what catches a real
+// `subprocess.run(['tmux','send-keys',...])` hidden in a heredoc body. Handing
+// them quote-aware segments would have removed the detection of the very
+// incident vector this gate was built for, under the banner of a structural fix.
+//
+// FAIL-CLOSED in three places, because "could not parse" must mean "scan more",
+// never "scan less":
+//   - unterminated quote or heredoc -> null (caller uses the naive split)
+//   - a double-quoted region containing $(...) or a backtick -> null; the shell
+//     runs what is inside, so a `;` in there IS a real separator
+//   - a heredoc with an UNQUOTED tag whose body contains $(...) or a backtick
+//     -> null, same reason (an unquoted tag expands the body)
+// NOTE ON THE SHAPE OF THIS FIX. The first attempt made the SEGMENTER
+// quote-aware and left the regexes alone. It failed one corpus case:
+//   echo 'grep: foo <bar> crontab <bar> bar'
+// stayed denied, because SCHEDULER_RX carries its OWN boundary anchor
+// (SCHED_BOUNDARY includes the bar), so it re-finds a command position INSIDE a
+// segment. Keeping the quoted text in the segment at all was the mistake. The
+// `launchctl` cases passed only by luck -- LAUNCHCTL_SUBCOMMAND's lookahead
+// happened to reject the following bar. So the primitive is not "split more
+// carefully", it is "the inert text must not be there": mask it out, then let
+// the existing splitter and regexes run unchanged on what remains.
+export function maskInertLiterals(command) {
+  const src = String(command ?? '').replace(/\\\r?\n/g, ' ')
+  let cur = ''
+  let i = 0
+
+  // Inert regions collapse to spaces: the text is gone, and with it every
+  // separator inside it -- which is precisely what prose was faking.
+  const blank = (s) => ' '.repeat(s.length)
+
+  while (i < src.length) {
+    const c = src[i]
+
+    // backslash escape outside quotes: consumes the next character
+    if (c === '\\' && i + 1 < src.length) { cur += src.slice(i, i + 2); i += 2; continue }
+
+    // heredoc: <<TAG / <<-TAG / <<'TAG' / <<"TAG"
+    const here = /^<<-?\s*(?:'([^']*)'|"([^"]*)"|([A-Za-z_]\w*))/.exec(src.slice(i))
+    if (here) {
+      const tag = here[1] ?? here[2] ?? here[3]
+      const quotedTag = here[1] != null || here[2] != null
+      cur += here[0]
+      i += here[0].length
+      // the body starts after the rest of THIS line
+      const nl = src.indexOf('\n', i)
+      if (nl === -1) return null // heredoc announced but no body -> cannot resolve
+      cur += src.slice(i, nl + 1)
+      i = nl + 1
+      // find the terminator line (leading tabs allowed for <<-)
+      const endRx = new RegExp(`^[ \\t]*${tag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}[ \\t]*$`, 'm')
+      const rel = endRx.exec(src.slice(i))
+      if (!rel) return null // unterminated heredoc
+      const body = src.slice(i, i + rel.index)
+      if (!quotedTag && /\$\(|`/.test(body)) return null // unquoted tag expands the body
+      cur += blank(body) + rel[0]
+      i += rel.index + rel[0].length
+      continue
+    }
+
+    if (c === "'") { // literal until the next ' -- a backslash is NOT special here
+      const end = src.indexOf("'", i + 1)
+      if (end === -1) return null
+      cur += blank(src.slice(i, end + 1)); i = end + 1; continue
+    }
+
+    if (c === '$' && src[i + 1] === "'") { // ANSI-C: \' does escape
+      let j = i + 2
+      while (j < src.length && src[j] !== "'") { j += src[j] === '\\' ? 2 : 1 }
+      if (j >= src.length) return null
+      cur += blank(src.slice(i, j + 1)); i = j + 1; continue
+    }
+
+    if (c === '"') {
+      let j = i + 1
+      while (j < src.length && src[j] !== '"') { j += src[j] === '\\' ? 2 : 1 }
+      if (j >= src.length) return null
+      const inner = src.slice(i + 1, j)
+      if (/\$\(|`/.test(inner)) return null // may run a command -> not inert
+      cur += blank(src.slice(i, j + 1)); i = j + 1; continue
+    }
+
+    cur += c; i++
+  }
+  return cur
+}
+
 // Blank out curl/HTTP DATA-PAYLOAD arguments before self-pace matching. A -d /
 // --data body is data sent over the wire, NEVER a shell invocation, so a trigger
 // token that only appears INSIDE the payload must not false-deny. The classic
@@ -252,17 +366,31 @@ export function gateDecision(toolName, toolInput) {
     const safeCommand = stripDataPayloads(stripGitCommitMessages(String(toolInput?.command ?? '')))
     // Per-segment so an unrelated token elsewhere in a compound command cannot
     // turn a legit read (store inspection, schedule-API GET) into a false deny.
-    for (const seg of splitSegments(safeCommand)) {
+    const naiveSegs = splitSegments(safeCommand)
+    for (const seg of naiveSegs) {
       // Match the self-pace bash patterns against the shell-normalised segment so a
       // `\/loop` / `$IFS/loop` evasion (which bash resolves to `/loop` at exec) is
       // still caught; the scheduler/store/API checks below use the RAW seg (scoped).
+      //
+      // These stay on the NAIVE segments ON PURPOSE. They are unanchored, so a
+      // quoted region is not a hiding place for them -- and the naive scan is
+      // what catches a real `subprocess.run(['tmux','send-keys',...])` inside a
+      // heredoc body (measured 2026-08-05). Quote-aware segments here would have
+      // dropped the detection of this gate's own founding incident vector.
       if (SELF_PACE_BASH_PATTERNS.some((re) => re.test(normalizeShellEvasion(seg)))) return { deny: true }
-      // scheduler binaries: deny the exec/submit forms, allow pure read-listing
-      if (SCHEDULER_RX.test(seg) && !SCHEDULER_READ_RX.test(seg)) return { deny: true }
       // self-schedule store: block WRITE only (a read/grep is legit diagnostics)
       if (SCHEDULE_STORE_RX.test(seg) && WRITE_INTENT_RX.test(seg)) return { deny: true }
       // dashboard schedule API: block WRITE methods only (GET list/pending is legit)
       if (SCHEDULE_API_RX.test(seg) && HTTP_WRITE_RX.test(seg)) return { deny: true }
+    }
+    // The scheduler check is the ANCHORED one -- it fires on what sits at a
+    // segment START -- so it is the one a fake segment boundary can mislead, and
+    // the only one that gets quote-aware segments. Null (unresolvable quoting)
+    // falls back to the naive split, i.e. to scanning strictly more.
+    const masked = maskInertLiterals(safeCommand)
+    for (const seg of (masked == null ? naiveSegs : splitSegments(masked))) {
+      // scheduler binaries: deny the exec/submit forms, allow pure read-listing
+      if (SCHEDULER_RX.test(seg) && !SCHEDULER_READ_RX.test(seg)) return { deny: true }
     }
   }
   return { deny: false }

--- a/src/__tests__/governance-gates.test.ts
+++ b/src/__tests__/governance-gates.test.ts
@@ -368,3 +368,63 @@ describe('self-pace-gate backtick command-substitution boundary', () => {
     expect(selfPaceDecision('Bash', { command: 'echo `crontab -l`' }).deny).toBe(false)
   })
 })
+
+// --- inert quoted / heredoc text must not be able to fake a command position ---
+//
+// Five denials in one morning (2026-08-05, three jayce + two taric), all one
+// cause: an inter-agent message quoting the grep pattern
+//   Minta: stop.sh | launchctl | com.janna.dashboard
+// The bars split it, the middle piece trimmed to the bare word `launchctl`, and
+// the anchored scheduler check read that as a real interactive invocation. The
+// messages never went out, and from outside a denial looks like an agent that
+// simply stayed silent.
+//
+// What made it a design bug rather than a bad pattern: the SAME text passed as
+// `curl -d '<json>'` (payload blanked) and was denied from a python heredoc
+// (nothing to blank). The send route had become a security decision.
+const BAR = String.fromCharCode(124)
+const Q = String.fromCharCode(39)
+const heredoc = (body: string) => `python3 - <<${Q}PY${Q}\n${body}\nPY`
+const PATTERN = `Minta: stop.sh ${BAR} launchctl ${BAR} com.janna.dashboard`
+
+describe('self-pace-gate: quoted prose cannot fake a command position', () => {
+  it('allows the measured pattern inside a heredoc body', () => {
+    expect(selfPaceDecision('Bash', { command: heredoc(`t = "${PATTERN}"`) }).deny).toBe(false)
+  })
+  it('allows it in single quotes, double quotes, and a python triple-quote', () => {
+    expect(selfPaceDecision('Bash', { command: `echo ${Q}${PATTERN}${Q}` }).deny).toBe(false)
+    expect(selfPaceDecision('Bash', { command: `echo "${PATTERN}"` }).deny).toBe(false)
+    expect(selfPaceDecision('Bash', { command: heredoc(`t = """${PATTERN}"""`) }).deny).toBe(false)
+  })
+  it('allows a bar-separated pattern naming crontab too', () => {
+    // This is the case that proved masking is the right primitive: with only a
+    // quote-aware SPLITTER this stayed denied, because SCHEDULER_RX carries its
+    // own boundary anchor and re-found a command position inside the segment.
+    expect(selfPaceDecision('Bash', { command: `echo ${Q}foo ${BAR} crontab ${BAR} bar${Q}` }).deny)
+      .toBe(false)
+  })
+
+  // --- and the whole point: none of the above may cost real detection ---
+  it('still denies a real scheduler call after a genuine separator', () => {
+    expect(selfPaceDecision('Bash', { command: `echo ${Q}harmless${Q} ; crontab -r` }).deny).toBe(true)
+  })
+  it('still denies tmux injection hidden inside a heredoc body', () => {
+    // The unanchored patterns deliberately keep scanning the RAW segments.
+    // Handing them masked text would have removed the detection of this gate's
+    // founding incident vector -- measured before the change, not assumed.
+    expect(selfPaceDecision('Bash', {
+      command: heredoc(`subprocess.run([${Q}tmux${Q},${Q}send-keys${Q},${Q}-t${Q},${Q}x${Q}])`),
+    }).deny).toBe(true)
+  })
+  it('fails CLOSED on an unterminated quote', () => {
+    // Unresolvable quoting must mean "scan more", never "scan less".
+    expect(selfPaceDecision('Bash', { command: `echo ${Q}oops ; crontab -r` }).deny).toBe(true)
+  })
+  it('fails CLOSED when a double-quoted region can command-substitute', () => {
+    expect(selfPaceDecision('Bash', { command: 'echo "$(date)" ; crontab -r' }).deny).toBe(true)
+  })
+  it('fails CLOSED on an UNQUOTED heredoc tag whose body substitutes', () => {
+    // <<PY (no quotes) expands the body, so its contents are not inert.
+    expect(selfPaceDecision('Bash', { command: 'cat <<PY\n$(crontab -r)\nPY' }).deny).toBe(true)
+  })
+})


### PR DESCRIPTION
## What happened

Five hard-gate denials in one morning (2026-08-05), three mine and two taric's. None of them scheduled anything. Each was an inter-agent message or a kanban write whose **text** quoted the same grep pattern:

```
Minta: stop.sh | launchctl | com.janna.dashboard
```

`splitSegments` is not quote-aware, so those bars split the prose. The middle piece trimmed down to the bare word `launchctl`, and `SCHEDULER_RX`'s end-of-segment branch reads a bare `launchctl` as a real interactive invocation -- which is correct for a real command line.

The expensive part is not the denial, it is its shape: from outside, a hard-gate denial is indistinguishable from an agent that simply stayed silent. Two peers spent a round each hunting the wrong hypothesis (heredoc? `subprocess.run`? a cron-like token? reading the dashboard token?) before the cause was measured.

## Why it is a design bug, not a bad pattern

The same text **passes** as `curl -d '<json>'` and is **denied** from a python heredoc. `stripDataPayloads` blanks the first; the second has no `-d` argument to blank. Choosing how to send a message had quietly become a security decision, and no one designed it that way.

`stripDataPayloads`' own comment names this false-positive class as its target. It is implemented for exactly one route -- so this is unfinished work, and every future send route inherits the same gap.

## The fix

Mask inert literal text to spaces before the **anchored** scheduler check: single-quoted, ANSI-C `$'...'`, double-quoted without a substitution, and quoted-tag heredoc bodies. The text is gone, and with it the separators it was faking. `splitSegments` and every regex are untouched and run unchanged on what remains.

### Scope, which is a measurement and not caution

The masked text feeds **only** the anchored scheduler check. The unanchored patterns (`tmux`+send-keys, `nohup`+claude, `claude`+`/loop`) keep scanning the raw segments, quoted regions included.

My first design handed quote-aware output to every check, on the assumption that the gate does not catch a real vector inside a heredoc anyway. Three of four probes agreed:

| probe | today |
|---|---|
| `subprocess.run(['crontab','-e'])` in a heredoc | ALLOW |
| `os.system("crontab -e")` in a heredoc | ALLOW |
| `python3 -c "... os.system('crontab -e')"` | ALLOW |
| `subprocess.run(['tmux','send-keys',...])` in a heredoc | **DENY** |

The fourth is the one that matters: the tmux pattern is unanchored and matches anywhere, so the tidy version of this change would have removed the detection of this gate's **founding incident vector** while calling itself a structural fix.

### Fail-closed in three places

"Cannot parse" must mean *scan more*, never *scan less*:

- unterminated quote or heredoc -> `null`, caller falls back to the naive split
- a double-quoted region containing `$(...)` or a backtick is not inert -- the shell runs what is inside, so a separator in there is a real one
- a heredoc with an **unquoted** tag whose body substitutes is not inert either

### One corpus case drove the shape

With only a quote-aware *splitter*, `echo 'foo | crontab | bar'` stayed denied: `SCHEDULER_RX` carries its own boundary anchor and re-finds a command position **inside** a segment. Leaving the quoted text in the segment at all was the mistake. The `launchctl` cases had passed by luck -- `LAUNCHCTL_SUBCOMMAND`'s lookahead happened to reject the following bar.

## Verification

- 30-case corpus: every vector the gate exists to stop, the legitimate reads, the three fail-closed paths, and the five measured false positives. All as expected.
- Committed suite: **65 -> 73 passing**. The 3 failures in `governance gate scaffold wiring` are present on untouched `develop` too -- measured by re-running with the change stashed, not assumed.
- `tsc --noEmit` clean.
- taric's two exact blocked commands are preserved as reproduction material and both now pass.

## Separate decision, deliberately NOT in this PR

`os.system("crontab -e")` and `python3 -c` scheduler calls pass the Bash layer **today** (see the table above). Closing that is a **strictness increase**, not a false-positive fix. It does not belong in a PR whose subject is over-blocking, and it needs its own decision -- I am not smuggling a behaviour change into a bug fix.

The Bash hook is documented as the second layer (the runtime tool-deny is primary) and the file already lists accepted limitations, so this may well be a known trade-off. It was not written down, so now it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
