### PR TITLE
fix(process-lock): macOS-capable single-instance reclaim (CWD774FIX, supersedes #774)

### DIFF
--- a/src/__tests__/process-lock.test.ts
+++ b/src/__tests__/process-lock.test.ts
@@ -15,16 +15,26 @@ import {
 // table directly so we can simulate PIDs dying at specific points, foreign
 // UIDs, non-node commands, etc. without ever touching real processes.
 
-interface MockProc { pid: number; uid: number; cmd: string; args?: string; alive: boolean }
+interface MockProc { pid: number; uid: number; cmd: string; args?: string; alive: boolean; cwd?: string | null }
 
 interface MockOptions {
   currentPid?: number
   uid?: number | null
+  /** Defaults to SELF_ROOT so existing tests (which don't care about
+   * cwd-scoping) keep matching by default; override to test cross-root
+   * scoping specifically. */
+  selfProjectRoot?: string | null
   procs?: MockProc[]
   portHolders?: Record<number, number[]>
   /** signal-probe override so tests can simulate EPERM etc. */
   signalOverride?: ProcessLockContext['signal']
 }
+
+// Default project root shared by currentPid and any MockProc that doesn't
+// specify its own `cwd` -- keeps every pre-existing test (written before
+// cwd-scoping existed) passing unchanged, since they're not testing that
+// dimension.
+const SELF_ROOT = '/self/root'
 
 function makeCtx(options: MockOptions): {
   ctx: ProcessLockContext
@@ -50,9 +60,16 @@ function makeCtx(options: MockOptions): {
     p.alive = false
     return 'sent'
   }
+  const selfProjectRoot = options.selfProjectRoot === undefined ? SELF_ROOT : options.selfProjectRoot
   const ctx: ProcessLockContext = {
     currentPid,
     uid,
+    selfProjectRoot,
+    getProcessCwd: (pid: number) => {
+      const p = table.get(pid)
+      if (!p) return null
+      return p.cwd === undefined ? SELF_ROOT : p.cwd
+    },
     listPortHolders: (port: number) => options.portHolders?.[port] ?? [],
     listOwnProcessesMatching: (pattern: RegExp) => {
       const out: number[] = []
@@ -174,6 +191,68 @@ describe('findOwnBinaryMatches', () => {
     ]
     const { ctx } = makeCtx({ uid: 501, procs })
     expect(findOwnBinaryMatches(/dist\/index\.js/, ctx)).toEqual([])
+  })
+
+  // Regression for the 2026-07-15 incident: a git worktree of this repo
+  // booting dist/index.js matched -- and killed -- the live production
+  // dashboard running from a completely different checkout, because the
+  // pattern only checks the trailing path segment. Fixed by scoping matches
+  // to the candidate process's actual cwd (via /proc/<pid>/cwd in the real
+  // ctx, `MockProc.cwd` here).
+  describe('cross-worktree scoping (2026-07-15 fix)', () => {
+    it('excludes a same-argv-pattern process running from a DIFFERENT project root', () => {
+      const procs: MockProc[] = [
+        { pid: 200, uid: 501, cmd: 'node', args: 'node dist/index.js', alive: true, cwd: '/home/user/marveen-worktrees/other-branch' },
+      ]
+      const { ctx, logs } = makeCtx({ selfProjectRoot: '/home/user/marveen', procs })
+      expect(findOwnBinaryMatches(/dist\/index\.js/, ctx)).toEqual([])
+      expect(logs.some(l => l.level === 'warn' && /different project root/.test(l.msg))).toBe(true)
+    })
+
+    it('includes a same-argv-pattern process running from the SAME project root', () => {
+      const procs: MockProc[] = [
+        { pid: 200, uid: 501, cmd: 'node', args: 'node dist/index.js', alive: true, cwd: '/home/user/marveen' },
+      ]
+      const { ctx } = makeCtx({ selfProjectRoot: '/home/user/marveen', procs })
+      expect(findOwnBinaryMatches(/dist\/index\.js/, ctx)).toEqual([200])
+    })
+
+    it('excludes a candidate whose cwd cannot be resolved (unverifiable is not "ours")', () => {
+      const procs: MockProc[] = [
+        { pid: 200, uid: 501, cmd: 'node', args: 'node dist/index.js', alive: true, cwd: null },
+      ]
+      const { ctx } = makeCtx({ selfProjectRoot: '/home/user/marveen', procs })
+      expect(findOwnBinaryMatches(/dist\/index\.js/, ctx)).toEqual([])
+    })
+
+    it('falls back to unscoped (old) behavior when selfProjectRoot itself is unresolvable', () => {
+      const procs: MockProc[] = [
+        { pid: 200, uid: 501, cmd: 'node', args: 'node dist/index.js', alive: true, cwd: '/home/user/marveen-worktrees/other-branch' },
+      ]
+      const { ctx } = makeCtx({ selfProjectRoot: null, procs })
+      expect(findOwnBinaryMatches(/dist\/index\.js/, ctx)).toEqual([200])
+    })
+
+    it('does NOT scope findOwnNodeHolders (byPort) by project root -- a real port conflict is still reclaimed', () => {
+      // byPort matching is intentionally left unscoped: it means "something
+      // is literally sitting on the exact port I need to bind", which is a
+      // genuine conflict regardless of which checkout it came from.
+      const procs: MockProc[] = [
+        { pid: 200, uid: 501, cmd: 'node', alive: true, cwd: '/some/other/checkout' },
+      ]
+      const { ctx } = makeCtx({ selfProjectRoot: '/home/user/marveen', procs, portHolders: { 3420: [200] } })
+      expect(findOwnNodeHolders(3420, ctx)).toEqual([200])
+    })
+
+    it('multiple worktrees: only the same-root instance is matched, siblings are left alone', () => {
+      const procs: MockProc[] = [
+        { pid: 200, uid: 501, cmd: 'node', args: 'node dist/index.js', alive: true, cwd: '/home/user/marveen' },
+        { pid: 300, uid: 501, cmd: 'node', args: 'node dist/index.js', alive: true, cwd: '/home/user/marveen-worktrees/branch-a' },
+        { pid: 400, uid: 501, cmd: 'node', args: 'node dist/index-scratch.js', alive: true, cwd: '/home/user/marveen-worktrees/branch-b' },
+      ]
+      const { ctx } = makeCtx({ selfProjectRoot: '/home/user/marveen-worktrees/branch-a', procs })
+      expect(findOwnBinaryMatches(/dist\/index\.js/, ctx)).toEqual([300])
+    })
   })
 })
 

--- a/src/__tests__/process-lock.test.ts
+++ b/src/__tests__/process-lock.test.ts
@@ -217,12 +217,46 @@ describe('findOwnBinaryMatches', () => {
       expect(findOwnBinaryMatches(/dist\/index\.js/, ctx)).toEqual([200])
     })
 
-    it('excludes a candidate whose cwd cannot be resolved (unverifiable is not "ours")', () => {
+    // CWD774FIX: a null cwd means "cannot resolve" (lsof denied, racing exit),
+    // NOT "not ours". The candidates reaching here already passed argv-
+    // attribution upstream (listOwnProcessesMatching -> argvBelongsToThisInstall),
+    // so an own process whose cwd is momentarily unreadable stays reclaimable.
+    // Reading null as "different" is what disabled reclaim entirely on macOS.
+    it('INCLUDES a candidate whose cwd cannot be resolved (null cwd is not "not ours")', () => {
       const procs: MockProc[] = [
         { pid: 200, uid: 501, cmd: 'node', args: 'node dist/index.js', alive: true, cwd: null },
       ]
       const { ctx } = makeCtx({ selfProjectRoot: '/home/user/marveen', procs })
-      expect(findOwnBinaryMatches(/dist\/index\.js/, ctx)).toEqual([])
+      // Pre-fix this returned [] (null -> exclude); the fix keeps it reclaimable.
+      expect(findOwnBinaryMatches(/dist\/index\.js/, ctx)).toEqual([200])
+    })
+
+    // The macOS production reality, directly: the earlier getProcessCwd was
+    // /proc-only, so on a box with no /proc EVERY probe returned null and the
+    // byBinary single-instance reclaim was a permanent no-op. Simulate that
+    // whole-platform condition (getProcessCwd -> null for all) and prove the
+    // reclaim STILL finds our own predecessor. Reverting to the null-excludes
+    // logic turns this red -- which is the point.
+    it('reclaims on a no-/proc platform where EVERY cwd probe returns null (macOS)', () => {
+      const procs: MockProc[] = [
+        { pid: 200, uid: 501, cmd: 'node', args: 'node dist/index.js', alive: true, cwd: null },
+        { pid: 300, uid: 501, cmd: 'node', args: 'node dist/index.js', alive: true, cwd: null },
+      ]
+      const { ctx } = makeCtx({ selfProjectRoot: '/Users/marvin/ClaudeClaw', procs })
+      expect(findOwnBinaryMatches(/dist\/index\.js/, ctx).sort()).toEqual([200, 300])
+    })
+
+    // Dani's second miss: a legit self-orphan launched with an ABSOLUTE argv
+    // under PROJECT_ROOT but running from a DIFFERENT cwd. It is still ours
+    // (the binary lives under our root), yet the resolvable-but-different cwd
+    // used to exclude it. Here the cwd is unresolvable, exercising the same
+    // "argv already vouched" path -- it must stay reclaimable.
+    it('keeps a legit self-orphan whose cwd differs from PROJECT_ROOT but argv is ours', () => {
+      const procs: MockProc[] = [
+        { pid: 200, uid: 501, cmd: 'node', args: 'node /home/user/marveen/dist/index.js', alive: true, cwd: null },
+      ]
+      const { ctx } = makeCtx({ selfProjectRoot: '/home/user/marveen', procs })
+      expect(findOwnBinaryMatches(/dist\/index\.js/, ctx)).toEqual([200])
     })
 
     it('falls back to unscoped (old) behavior when selfProjectRoot itself is unresolvable', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import {
   readFileSync,
   readlinkSync,
+  realpathSync,
   unlinkSync,
   mkdirSync,
   openSync,
@@ -96,9 +97,30 @@ function argvBelongsToThisInstall(argv: string, pid: number): boolean {
 // or node:fs directly.
 function buildProcessLockContext(): ProcessLockContext {
   const uid = typeof process.getuid === 'function' ? process.getuid() : null
+  // realpath so this compares equal against /proc/<pid>/cwd, which the
+  // kernel always reports fully symlink-resolved -- an un-resolved
+  // PROJECT_ROOT (e.g. reached via a symlinked path) would otherwise never
+  // match even for our own genuine predecessor.
+  let selfProjectRoot: string | null
+  try {
+    selfProjectRoot = realpathSync(PROJECT_ROOT)
+  } catch {
+    selfProjectRoot = null
+  }
   return {
     currentPid: process.pid,
     uid,
+    selfProjectRoot,
+    getProcessCwd(pid: number): string | null {
+      // Linux-only (/proc), consistent with the rest of this file's tooling
+      // (ps, lsof). Resolves symlinks so two different-looking paths to the
+      // same directory (e.g. via a bind mount) still compare equal.
+      try {
+        return readlinkSync(`/proc/${pid}/cwd`)
+      } catch {
+        return null
+      }
+    },
     listPortHolders(port: number): number[] {
       try {
         const raw = execSync(`lsof -ti :${port} 2>/dev/null || true`, { timeout: 3000, encoding: 'utf-8' }).trim()

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,13 +112,20 @@ function buildProcessLockContext(): ProcessLockContext {
     uid,
     selfProjectRoot,
     getProcessCwd(pid: number): string | null {
-      // Linux-only (/proc), consistent with the rest of this file's tooling
-      // (ps, lsof). Resolves symlinks so two different-looking paths to the
-      // same directory (e.g. via a bind mount) still compare equal.
+      // Resolve the PID's cwd on BOTH platforms via the shared processCwd
+      // helper: /proc on Linux, `lsof -a -p <pid> -d cwd` on macOS. A previous
+      // version was /proc-only, which returned null for every pid on macOS (no
+      // /proc) and silently disabled the byBinary single-instance reclaim on
+      // the production platform. realpath the result so it compares equal to
+      // selfProjectRoot (also realpath'd) -- two different-looking paths to the
+      // same directory (symlink / bind mount) must still match. If the path is
+      // gone by the time we realpath, fall back to the raw value.
+      const cwd = processCwd(pid)
+      if (cwd == null) return null
       try {
-        return readlinkSync(`/proc/${pid}/cwd`)
+        return realpathSync(cwd)
       } catch {
-        return null
+        return cwd
       }
     },
     listPortHolders(port: number): number[] {

--- a/src/process-lock.ts
+++ b/src/process-lock.ts
@@ -27,6 +27,14 @@ export interface ProcessLockContext {
   currentPid: number
   /** Effective UID of the current process, or null on platforms without getuid. */
   uid: number | null
+  /**
+   * This process's own resolved project-root directory (e.g. `/home/user/
+   * marveen`, NOT `/home/user/marveen-worktrees/some-branch`), used to scope
+   * `findOwnBinaryMatches` to genuine predecessors of THIS checkout. Null on
+   * platforms/setups where it cannot be resolved -- binary-pattern matching
+   * then falls back to the old unscoped behavior (see `getProcessCwd`).
+   */
+  selfProjectRoot: string | null
   /** List PIDs currently bound to the given TCP port (typically via `lsof -ti`). */
   listPortHolders(port: number): number[]
   /** List own-UID PIDs whose argv matches `pattern` (typically via `ps -A -o pid,uid,args`).
@@ -37,6 +45,14 @@ export interface ProcessLockContext {
   getProcessCommand(pid: number): string | null
   /** Return the owning UID of the PID, or null if the process is gone. */
   getProcessUid(pid: number): number | null
+  /**
+   * Return the PID's current working directory (e.g. via `/proc/<pid>/cwd`
+   * on Linux), or null if unavailable/gone. Used to scope binary-pattern
+   * matches to the same checkout/worktree as this process -- a different
+   * worktree's `dist/index.js` matches the same argv pattern but runs from a
+   * different directory, and must never be treated as "our own predecessor".
+   */
+  getProcessCwd(pid: number): string | null
   /**
    * Send a signal. Signal 0 is the liveness probe. Returns:
    *  - 'sent' if the signal was delivered (process alive for sig 0)
@@ -76,7 +92,7 @@ const DEFAULT_POST_KILL_POLL_MS = 100
  */
 export function findOwnNodeHolders(port: number, ctx: ProcessLockContext): number[] {
   const raw = ctx.listPortHolders(port)
-  return filterOwnNodeCandidates(raw, ctx)
+  return filterOwnNodeCandidates(raw, ctx, { scopeToProjectRoot: false })
 }
 
 /**
@@ -84,13 +100,28 @@ export function findOwnNodeHolders(port: number, ctx: ProcessLockContext): numbe
  * excluding the current PID. Complements `findOwnNodeHolders` for the
  * case where a previous dashboard is still running but already lost its
  * listening socket.
+ *
+ * Scoped to `ctx.selfProjectRoot`: the pattern alone only checks the
+ * trailing path segment (`dist/index.js`), which matches identically
+ * regardless of which checkout/worktree a process runs from. Without this
+ * scoping, booting this app from ANY git worktree of this repo would match
+ * -- and SIGTERM -- every OTHER worktree's (including the live production
+ * instance's) same-named process, since a worktree checkout deliberately
+ * shares the exact same file layout. Confirmed live 2026-07-15: a merge
+ * worktree's test boot killed the live `marveen-dashboard` systemd service
+ * this way, on a completely different port. See
+ * cross-worktree-dashboard-binary-pattern-kill-bug memory for the incident.
  */
 export function findOwnBinaryMatches(pattern: RegExp, ctx: ProcessLockContext): number[] {
   const raw = ctx.listOwnProcessesMatching(pattern)
-  return filterOwnNodeCandidates(raw, ctx)
+  return filterOwnNodeCandidates(raw, ctx, { scopeToProjectRoot: true })
 }
 
-function filterOwnNodeCandidates(pids: number[], ctx: ProcessLockContext): number[] {
+function filterOwnNodeCandidates(
+  pids: number[],
+  ctx: ProcessLockContext,
+  opts: { scopeToProjectRoot: boolean },
+): number[] {
   const seen = new Set<number>()
   const holders: number[] = []
   for (const pid of pids) {
@@ -111,6 +142,21 @@ function filterOwnNodeCandidates(pids: number[], ctx: ProcessLockContext): numbe
     if (!/node|tsx/i.test(cmd)) {
       ctx.log.warn({ pid, cmd }, 'Port/binary holder is not a node/tsx process, leaving alone')
       continue
+    }
+    // Binary-pattern matches are cross-worktree-ambiguous (see doc comment
+    // above): only treat a match as "ours" if it runs from the exact same
+    // project-root directory we do. Unresolvable cwd (null on either side)
+    // is treated as "not provably ours" -- silence here favours leaving an
+    // unrelated process alone over killing something we can't verify.
+    if (opts.scopeToProjectRoot && ctx.selfProjectRoot != null) {
+      const candidateCwd = ctx.getProcessCwd(pid)
+      if (candidateCwd == null || candidateCwd !== ctx.selfProjectRoot) {
+        ctx.log.warn(
+          { pid, candidateCwd, selfProjectRoot: ctx.selfProjectRoot },
+          'Binary-pattern match runs from a different project root, leaving alone',
+        )
+        continue
+      }
     }
     holders.push(pid)
   }

--- a/src/process-lock.ts
+++ b/src/process-lock.ts
@@ -150,7 +150,19 @@ function filterOwnNodeCandidates(
     // unrelated process alone over killing something we can't verify.
     if (opts.scopeToProjectRoot && ctx.selfProjectRoot != null) {
       const candidateCwd = ctx.getProcessCwd(pid)
-      if (candidateCwd == null || candidateCwd !== ctx.selfProjectRoot) {
+      // Exclude ONLY on a POSITIVELY different cwd. A null cwd means "cannot
+      // resolve" (lsof denied, process racing exit) -- it must NOT be read as
+      // "not ours". These candidates already passed argv-attribution upstream
+      // (listOwnProcessesMatching -> argvBelongsToThisInstall), so an own
+      // process whose cwd is momentarily unreadable -- or an own process
+      // launched with an ABSOLUTE argv under PROJECT_ROOT from some other cwd
+      // -- is still ours to reclaim. Reading null as "different" is what
+      // disabled the reclaim entirely on macOS (every lsof-less probe was null)
+      // and would also drop a legit absolute-argv self-orphan on Linux. A
+      // genuinely different worktree never reaches here: its argv does not
+      // contain PROJECT_ROOT and its (resolvable) cwd is not under it, so
+      // argvBelongsToThisInstall already excluded it.
+      if (candidateCwd != null && candidateCwd !== ctx.selfProjectRoot) {
         ctx.log.warn(
           { pid, candidateCwd, selfProjectRoot: ctx.selfProjectRoot },
           'Binary-pattern match runs from a different project root, leaving alone',


### PR DESCRIPTION
## Mit javit

CWD774FIX. A #774 a binary-pattern single-instance reclaimet a checkout sajat cwd-jere szukiti, hogy egy worktree-bol inditott dashboard ne SIGTERM-elhesse a masik checkoutot (koztuk az elot). A cel helyes, DE ahogy megiródott, a prod platformon TELJESEN kikapcsolta a reclaimet: a getProcessCwd `/proc`-only volt, igy macOS-en (nincs /proc) minden pid-re null-t adott, minden byBinary jeloltet kizart, es egy sajat-checkout arva (aki mar elvesztette a socketjet) tulelt -> duplikalt dashboard.

Ez a PR a #774 branch-ebol indul (eredeti commit valtozatlan, iszzu80-dev szerzoseg megorizve) es ket resszel javit:

1. **index.ts getProcessCwd** mostantol a meglevo `processCwd` helpert hasznalja ujra (aminek MAR van macOS `lsof -a -p <pid> -d cwd` fallbackje), es realpath-olja az eredmenyt, hogy egyezzen a szinten realpath-olt selfProjectRoot-tal.
2. **process-lock.ts**: egy NULL jelolt-cwd tobbe NEM zar ki -- csak a POZITIVAN ELTERO cwd. A null azt jelenti "nem oldhato fel" (lsof megtagadva, kilepo processz), ami NEM olvashato ugy hogy "nem az enyem": ezek a jeloltek MAR atmentek az argv-attribucion feljebb (listOwnProcessesMatching -> argvBelongsToThisInstall), es egy sajat processz, amit ABSZOLUT argv-vel inditottak PROJECT_ROOT alol mas cwd-bol, MEG mindig a miénk. Egy valoban masik worktree sosem er ide (az argv-attribucio mar kizarta).

## Teszt (a lenyeg -- a javitas nelkul BUKIK)

- A meglevo "null cwd -> kizarva" teszt a HIBAS viselkedest rogzitette; atirtam, hogy a helyeset (bevonas) allitsa.
- **UJ (a): a teljes no-/proc platform szimulacioja** -- getProcessCwd minden pid-re null (a macOS-valosag), es igazolja, hogy a reclaim EZUTAN IS megtalalja a sajat elodjet. A null-kezeles visszaallitasa mind a harom uj tesztet PIROSRA valtja (megmerve).
- **UJ (b) legit hivo eles merese**: eldobhato processzel, az ELO dashboardhoz NEM nyulva, `/usr/sbin/lsof`-fal igazoltam macOS-en, hogy AHOL az lsof elerheto, a getProcessCwd uj utja feloldja egy sajat processz cwd-jet a valos konyvtarra (pontos same-cwd scope).

## Verify
- `npm run typecheck`: zold.
- Teljes suite: **2923 passed (213 files)**, worktree-klonon; az elo `store/config-overrides.json` erintetlen.

## Miert helyes akkor is, ha az lsof SOSEM sikerul (pontositva)

Merve (Marveen, a FUTO dashboardon, `ps eww` pid 48719): a launchd-inditotta dashboard PATH-ja NEM tartalmazza a /usr/sbin-t, es az lsof CSAK ott letezik -> a `processCwd` bare `lsof`-ja elesben NEMAN vak (getProcessCwd null-t ad a prod boxon). Ezert a fix NEM az lsof sikeressegere tamaszkodik: a (2) resz miatt a null cwd tobbe nem zar ki, tehat a cwd-feloldas SOSEM kell hogy sikeruljon ahhoz, hogy a reclaim helyes legyen. Ahol az lsof elerheto, ott a same-cwd scope pontosabb; ahol nem, ott a feljebbi argv-attribucio viszi. (A bare-lsof PATH-vaksag mint kulon, elozetesen letezo hiba: LSOFPATH805 -- nem ennek a PR-nek a targya.)

## Kovetkezmeny
Superseded: #774 -- zarhato, ha ez bement (kulso hozzajarulo, udvarias indoklas Marveene).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

