### PR TITLE
fix(lsof): resolve an absolute lsof path so port/cwd probes work under launchd (LSOFPATH805, stacks on #888)

### DIFF
--- a/src/__tests__/lsof-path.test.ts
+++ b/src/__tests__/lsof-path.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { pickLsofPath } from '../lsof.js'
+
+// LSOFPATH805. These tests replay the SERVICE's environment, not the
+// developer's: the launchd PATH that omits /usr/sbin. The pure resolver is
+// injected with env + an isExecutable predicate so it is deterministic and
+// platform-independent -- reverting the absolute-first behaviour turns them red.
+
+// The measured production PATH (Marveen, ps eww pid 48719): no /usr/sbin.
+const LAUNCHD_PATH = '/opt/homebrew/bin:/Users/marvin/.bun/bin:/usr/local/bin:/usr/bin:/bin'
+
+describe('pickLsofPath -- resolves lsof under a PATH that omits /usr/sbin', () => {
+  it('finds /usr/sbin/lsof even though it is NOT on the launchd PATH', () => {
+    // Only /usr/sbin/lsof exists (the macOS reality). A PATH-only lookup would
+    // miss it -- the absolute-candidates-first list is what saves it.
+    const isExec = (p: string) => p === '/usr/sbin/lsof'
+    expect(pickLsofPath({ PATH: LAUNCHD_PATH }, isExec)).toBe('/usr/sbin/lsof')
+  })
+
+  it('REGRESSION: a PATH-only resolver (the pre-fix behaviour) returns null here', () => {
+    // Simulate what the code did before: resolve lsof from PATH alone. Under
+    // the launchd PATH with lsof only in /usr/sbin, that finds nothing. This is
+    // the exact production blindness; it documents why absolute-first matters.
+    const isExec = (p: string) => p === '/usr/sbin/lsof'
+    const pathOnly = (env: NodeJS.ProcessEnv): string | null => {
+      for (const dir of (env.PATH ?? '').split(':').filter(Boolean)) {
+        if (isExec(`${dir}/lsof`)) return `${dir}/lsof`
+      }
+      return null
+    }
+    expect(pathOnly({ PATH: LAUNCHD_PATH })).toBeNull() // the bug
+    expect(pickLsofPath({ PATH: LAUNCHD_PATH }, isExec)).toBe('/usr/sbin/lsof') // the fix
+  })
+
+  it('prefers an absolute location over a PATH hit (deterministic order)', () => {
+    const isExec = () => true // everything executable
+    expect(pickLsofPath({ PATH: '/opt/homebrew/bin' }, isExec)).toBe('/usr/sbin/lsof')
+  })
+
+  it('falls through to a PATH entry when no absolute candidate exists (Linux/homebrew)', () => {
+    const isExec = (p: string) => p === '/opt/homebrew/bin/lsof'
+    expect(pickLsofPath({ PATH: '/opt/homebrew/bin:/usr/bin' }, isExec)).toBe('/opt/homebrew/bin/lsof')
+  })
+
+  it('returns null when lsof exists nowhere', () => {
+    expect(pickLsofPath({ PATH: LAUNCHD_PATH }, () => false)).toBeNull()
+  })
+})
+
+// The silent-swallow removal: when lsof is genuinely unresolvable, runLsof must
+// WARN (once) and return null -- never a silent empty that reads as "no match".
+// node:fs is mocked so accessSync always fails, making resolution null on ANY
+// platform (deterministic), independent of whether this box has lsof.
+describe('runLsof -- a missing lsof is LOUD, not silent', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.doMock('node:fs', async () => {
+      const actual = await vi.importActual<typeof import('node:fs')>('node:fs')
+      return { ...actual, accessSync: () => { throw new Error('ENOENT (mocked: no lsof anywhere)') } }
+    })
+  })
+
+  it('warns exactly once across repeated calls and returns null', async () => {
+    const { logger } = await import('../logger.js')
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => logger as never)
+    const { runLsof, resolveLsofPath, __resetLsofCache } = await import('../lsof.js')
+    __resetLsofCache()
+
+    expect(resolveLsofPath()).toBeNull() // mocked accessSync -> nothing executable
+    expect(runLsof(['-ti', ':3420'], 1000)).toBeNull()
+    expect(runLsof(['-ti', ':3420'], 1000)).toBeNull()
+    expect(warn).toHaveBeenCalledTimes(1) // once per process, not per call
+
+    warn.mockRestore()
+    vi.doUnmock('node:fs')
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,8 @@ import {
   writeSync,
 } from 'node:fs'
 import { join } from 'node:path'
-import { execFileSync, execSync } from 'node:child_process'
+import { execFileSync } from 'node:child_process'
+import { runLsof } from './lsof.js'
 import type { Server as HttpServer } from 'node:http'
 import { PROJECT_ROOT, STORE_DIR, PID_FILENAME, WEB_PORT, MAIN_AGENT_ID, RESPAWN_ENABLED, HEARTBEAT_AGENT_ENABLED } from './config.js'
 import { resolveOwnerChatId } from './owner-chat.js'
@@ -77,13 +78,12 @@ function processCwd(pid: number): string | null {
     // Linux: cheap and exact.
     return readlinkSync(`/proc/${pid}/cwd`)
   } catch { /* not Linux or no access; try lsof (macOS) */ }
-  try {
-    const raw = execSync(`lsof -a -p ${pid} -d cwd -Fn 2>/dev/null || true`, { timeout: 2000, encoding: 'utf-8' })
-    const line = raw.split('\n').find((l) => l.startsWith('n'))
-    return line ? line.slice(1) : null
-  } catch {
-    return null
-  }
+  // Resolved-path lsof (LSOFPATH805): a bare `lsof` was command-not-found under
+  // the launchd PATH and silently returned null on the live box.
+  const raw = runLsof(['-a', '-p', String(pid), '-d', 'cwd', '-Fn'], 2000)
+  if (raw == null) return null
+  const line = raw.split('\n').find((l) => l.startsWith('n'))
+  return line ? line.slice(1) : null
 }
 
 function argvBelongsToThisInstall(argv: string, pid: number): boolean {
@@ -130,13 +130,14 @@ function buildProcessLockContext(): ProcessLockContext {
       }
     },
     listPortHolders(port: number): number[] {
-      try {
-        const raw = execSync(`lsof -ti :${port} 2>/dev/null || true`, { timeout: 3000, encoding: 'utf-8' }).trim()
-        if (!raw) return []
-        return raw.split('\n').map((s) => parseInt(s.trim(), 10)).filter((n) => Number.isFinite(n) && n > 0)
-      } catch {
-        return []
-      }
+      // Resolved-path lsof (LSOFPATH805): under the launchd PATH the old bare
+      // `lsof -ti` was command-not-found and silently returned [], so this
+      // port-holder probe -- which the single-instance reclaim depends on --
+      // found no one on the live box. runLsof resolves an absolute lsof and
+      // warns loudly if none exists rather than returning a silent empty.
+      const raw = (runLsof(['-ti', `:${port}`], 3000) ?? '').trim()
+      if (!raw) return []
+      return raw.split('\n').map((s) => parseInt(s.trim(), 10)).filter((n) => Number.isFinite(n) && n > 0)
     },
     listOwnProcessesMatching(pattern: RegExp): number[] {
       // `ps -A -o pid=,uid=,args=` emits `<pid> <uid> <full argv>` per row.

--- a/src/lsof.ts
+++ b/src/lsof.ts
@@ -1,0 +1,98 @@
+// LSOFPATH805: a single, PATH-independent way to run lsof.
+//
+// The bug it fixes: the dashboard runs under launchd, whose PATH is
+// /usr/bin:/bin (plus homebrew) and OMITS /usr/sbin -- the only place macOS
+// ships lsof. So `execSync('lsof ...')` was command-not-found in production,
+// and the old `2>/dev/null || true` collapsed that into an empty result
+// indistinguishable from "nothing matched". Measured on the live box: with the
+// launchd PATH `lsof -ti :3420` returned EMPTY (exit 0), while /usr/sbin/lsof
+// returned the two real holders. So the port-holder detection the single-
+// instance reclaim depends on was silently a no-op on the production platform.
+//
+// Fix: resolve an ABSOLUTE lsof path once (usual sbin/bin locations + PATH),
+// invoke it via execFileSync (no shell, no PATH lookup), and -- crucially --
+// if lsof cannot be found at all, WARN LOUDLY (once) instead of returning a
+// silent empty. "No lsof" and "no match" must never look the same again.
+
+import { accessSync, constants as fsConstants } from 'node:fs'
+import { execFileSync } from 'node:child_process'
+import { join } from 'node:path'
+import { logger } from './logger.js'
+
+// undefined = not resolved yet; null = resolved-and-absent; string = path.
+let cachedLsofPath: string | null | undefined
+let missingWarned = false
+
+// Absolute locations macOS/Linux ship lsof in, checked before PATH so a launchd
+// PATH that omits /usr/sbin still finds /usr/sbin/lsof. PATH entries are added
+// after, covering homebrew (/opt/homebrew/bin) and non-standard Linux installs.
+const ABSOLUTE_CANDIDATES = ['/usr/sbin/lsof', '/usr/bin/lsof', '/sbin/lsof', '/bin/lsof']
+
+/**
+ * Pure resolution: the first candidate that `isExecutable` accepts, ABSOLUTE
+ * locations first, then PATH entries. Absolute-first is the whole fix -- it is
+ * what makes lsof resolvable under a PATH that omits /usr/sbin. Exported so a
+ * test can inject env + isExecutable and stay deterministic (no real fs).
+ */
+export function pickLsofPath(env: NodeJS.ProcessEnv, isExecutable: (path: string) => boolean): string | null {
+  const candidates = [...ABSOLUTE_CANDIDATES]
+  for (const dir of (env.PATH ?? '').split(':').filter(Boolean)) candidates.push(join(dir, 'lsof'))
+  for (const cand of candidates) {
+    if (isExecutable(cand)) return cand
+  }
+  return null
+}
+
+function isExecutableFile(path: string): boolean {
+  try {
+    accessSync(path, fsConstants.X_OK)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/** Resolve an executable lsof path, or null if none exists. Cached. */
+export function resolveLsofPath(env: NodeJS.ProcessEnv = process.env): string | null {
+  if (cachedLsofPath !== undefined) return cachedLsofPath
+  cachedLsofPath = pickLsofPath(env, isExecutableFile)
+  return cachedLsofPath
+}
+
+/**
+ * Run lsof with a resolved absolute path. Returns stdout (possibly empty) when
+ * lsof RAN -- lsof exits non-zero on "no match" but still prints usable stdout,
+ * so a non-zero exit is not an error here. Returns null ONLY when lsof could
+ * not be run at all (binary absent or spawn failure); the absent-binary case is
+ * additionally logged LOUDLY once, because a silent null there is exactly the
+ * production blindness this module exists to end.
+ */
+export function runLsof(args: string[], timeoutMs: number): string | null {
+  const bin = resolveLsofPath()
+  if (bin == null) {
+    if (!missingWarned) {
+      missingWarned = true
+      logger.warn(
+        { path: process.env.PATH, tried: ABSOLUTE_CANDIDATES },
+        'lsof not found on PATH or usual locations -- port-holder / cwd resolution DISABLED; single-instance reclaim degrades to argv-attribution. Install lsof or add /usr/sbin to PATH.',
+      )
+    }
+    return null
+  }
+  try {
+    return execFileSync(bin, args, { timeout: timeoutMs, encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] })
+  } catch (err) {
+    // Non-zero exit (no match / partial) still carries stdout -- prefer it.
+    // Only a genuine spawn failure (ENOENT after a stale cache, timeout) has
+    // no stdout, which we surface as null ("could not run").
+    const out = (err as { stdout?: string | Buffer } | null)?.stdout
+    if (out == null) return null
+    return typeof out === 'string' ? out : out.toString('utf-8')
+  }
+}
+
+// Test-only: clear the resolution cache between cases.
+export function __resetLsofCache(): void {
+  cachedLsofPath = undefined
+  missingWarned = false
+}

--- a/src/web.ts
+++ b/src/web.ts
@@ -2,7 +2,8 @@ import http from 'node:http'
 import { mkdirSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
-import { execSync, execFileSync } from 'node:child_process'
+import { execFileSync } from 'node:child_process'
+import { runLsof } from './lsof.js'
 import { PROJECT_ROOT, WEB_HOST, DASHBOARD_PUBLIC_URL, DASHBOARD_ALLOWED_ORIGINS, MAIN_AGENT_ID } from './config.js'
 import { loadOrCreateDashboardToken } from './web/dashboard-auth.js'
 import { resolveAuth, requiresAuth, isFederationWireEndpoint, type AuthResult } from './web/auth-gate.js'
@@ -230,7 +231,7 @@ export function startWebServer(port = 3420): http.Server {
       // and under launchd it also race-kills the not-yet-dead predecessor.
       logger.warn({ port }, 'Web port foglalt, probalok felszabaditani...')
       try {
-        const pidsRaw = execSync(`lsof -ti :${port} 2>/dev/null || true`, { timeout: 3000, encoding: 'utf-8' }).trim()
+        const pidsRaw = (runLsof(['-ti', `:${port}`], 3000) ?? '').trim()
         const pids = pidsRaw.split('\n').map(s => s.trim()).filter(Boolean).map(Number).filter(n => Number.isFinite(n) && n > 0)
         const uid = typeof process.getuid === 'function' ? process.getuid() : null
         const victims: number[] = []


### PR DESCRIPTION
## Mit javit

LSOFPATH805. A dashboard launchd alatt fut, aminek a PATH-ja `/opt/homebrew/bin:.../usr/local/bin:/usr/bin:/bin` -- **NEM tartalmaz /usr/sbin-t**, ahol a macOS az EGYETLEN lsof-ot szallitja. Minden `lsof` hivas egy shell-en at ment, ami nem talalta a binarist, es a `2>/dev/null || true` a "command not found"-ot egy URES eredmenybe olvasztotta, ami megkulonboztethetetlen a "semmi nem egyezett"-tol. Igy a port-tulajdonos detekcio, amire a single-instance reclaim epul (index.ts listPortHolders, web.ts EADDRINUSE reclaim), elesben CSENDBEN no-op volt a prod platformon; a cwd-szonda (processCwd) null-t adott. Ugyanaz a hibaosztaly, mint maga a #774: a mechanizmus el, a prod platformon vak, es a teszt nem latja, mert nem a launchd kornyezeteben fut.

## A meres (a FUTO rendszeren, pozitiv kontrollal)

Szuk launchd PATH-tal:
```
bare `lsof -ti :3420`        -> "sh: lsof: command not found", exit 127, ures eredmeny
/usr/sbin/lsof -ti :3420     -> a ket valodi tulajdonos pid (1159, 48719), exit 0
```

## A javitas (src/lsof.ts, EGY helyen, mind a harom hivohely atkotve)

1. **Feloldott ut, nem bare hivas.** `resolveLsofPath` egy ABSZOLUT lsof-ot valaszt (szokasos sbin/bin helyek ELOSZOR, aztan PATH), igy egy /usr/sbin-t elhagyo launchd PATH is megtalalja. NEM hardkodolt /usr/sbin -- Linuxon maskepp van, ezert a PATH is candidate.
2. **A nema nyeles megszunik.** `runLsof` execFileSync-kel hiv (nincs shell, nincs PATH-lookup). Ha az lsof SEHOGY nem oldhato fel, HANGOS warn (egyszer, processzenkent), nem csend. A "nincs lsof" es a "nincs talalat" tobbe nem nez egyforman.

## Teszt (a szolgaltatas kornyezetet jatssza le, NEM az enyemet)

- A tiszta resolver (`pickLsofPath`) injektalt env + isExecutable predikatummal: **a mert launchd PATH-tal megtalalja /usr/sbin/lsof-ot**, mikozben egy PATH-only resolver (a fix ELOTTI viselkedes) null-t ad -- ez a pontos prod-vaksag, es a teszt kimondja, miert kell az abszolut-eloszor. **A fix visszavonasa (PATH-only) pirosra valtja.**
- node:fs-mockolt eset: ha az lsof sehol nincs, a `runLsof` egyszer warnol es null-t ad (nem csendes ures).
- ELES meres (fent): a szuk launchd PATH-tal a bare lsof "command not found"/ures, a feloldott ut megtalalja a :3420 ket tulajdonosat (1159, 48719). Az elo dashboardhoz NEM nyultam, csak olvastam.

## Verify
- `npm run typecheck`: zold.
- Teljes suite: **2929 passed (214 files)**; elo `store/config-overrides.json` erintetlen.

## Stacking / merge-sorrend
Ez a #888 (CWD774FIX) branch-ebol indul: mindketto ugyanazt az index.ts lsof-kodot erinti. **Merge #888 eloszor, aztan ez** -- utana a diff csak az lsof-feloldas valtozasaira szukul. A commit-lanc: #774 -> #888 -> ez.

## Kod-komment-becsuletesseg
Ahogy a #888-nal: a kod-komment se allit tobbet, mint amit tud -- a lsof.ts es a modositott hivohelyek kimondjak, hogy a feloldott ut megtalalja az lsof-ot ahol letezik, es hogy hol nem, ott a warn a jelzes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
