### PR TITLE
feat(heartbeat-gates): token-free gates for garmin-run-watcher + memoria-heartbeat

### DIFF
--- a/scripts/garmin_run_gate.py
+++ b/scripts/garmin_run_gate.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Token-free gate in front of the garmin-run-watcher heartbeat.
+
+The watcher used to be a `type: heartbeat` task: every tick woke Seven with a
+prompt whose first step was to run running_analysis.py and fall silent when it
+printed "Mar elemezve". Measured over 7 days that was 100% of the ticks -- a
+model call per tick to learn that nothing happened. This script makes the
+no-op path cost nothing and only wakes Seven when there is something to judge.
+
+Exit-code contract of running_analysis.py (read from the source, not guessed --
+running_analysis.py:157-196):
+
+    main() -> 0  ... no runs at all, or latest run already analysed
+    main() -> 1  ... NEW run; analysis written to pending_run_analysis.txt AND
+                     last_analyzed_run.json advanced
+    sys.exit(0 if result == 0 else 2)
+
+so the process exits 0 for "nothing to do" and 2 for "new run". An uncaught
+exception (Garmin login failure, network) exits 1. The codes already
+discriminate, so we do NOT string-match the Hungarian output: those strings are
+accented and inconsistent ("Mar elemezve" vs "Uj futas talalva") and a locale
+or wording change would silently turn every tick into "nothing new".
+
+WHY A CRASH IS NOT exit 0. The task spec asked for "already analysed OR error
+-> exit 0". Folding the error branch into the silent branch would disarm the
+failure alert this task is supposed to have: a broken Garmin login would look
+exactly like "no new run" forever, and the 7-day/0-hit statistic could not tell
+the two apart retrospectively. Crashes exit non-zero so failThreshold reports
+them.
+
+WHY WE ROLL THE STATE BACK. running_analysis.py advances
+last_analyzed_run.json *before* anyone has been told about the run. If the
+notify POST then fails (dashboard down, token rotated), the next tick reports
+"already analysed" and that run is never assessed -- the marker would record
+the attempt instead of the success, the same failure shape we just fixed in the
+intel rhythm markers. So we snapshot the state file first and restore it when
+the notify fails, which makes the whole gate idempotent: the next tick simply
+finds the run again.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+GARMIN_DIR = Path("/Users/gruzmanarnold/garmin-data")
+ANALYSIS_SCRIPT = GARMIN_DIR / "running_analysis.py"
+STATE_FILE = GARMIN_DIR / "last_analyzed_run.json"
+PENDING_FILE = GARMIN_DIR / "pending_run_analysis.txt"
+
+MARVEEN_DIR = Path("/Users/gruzmanarnold/marveen")
+TOKEN_FILE = MARVEEN_DIR / "store" / ".dashboard-token"
+MESSAGES_URL = "http://localhost:3420/api/messages"
+# Proof-of-life artefact: its mtime answers "did the silent path actually run
+# today", which "is the task enabled" does not.
+HEARTBEAT_FILE = MARVEEN_DIR / "store" / "garmin-run-gate-last.txt"
+
+RC_NOTHING_NEW = 0
+RC_NEW_RUN = 2
+SCRIPT_TIMEOUT_S = 120
+
+# Seven must NOT re-run the analysis script. The gate has already run it and
+# advanced the state, so a second run would print "Mar elemezve" and Seven
+# would fall silent on the very run we woke her for.
+NOTIFY_TEMPLATE = (
+    "[garmin-run-gate] Uj futas erkezett (activity {activity_id}). "
+    "A nyers metrikak keszen allnak: {pending}\n\n"
+    "FONTOS: NE futtasd ujra a running_analysis.py-t -- a kapu mar lefuttatta es "
+    "a last_analyzed_run.json mar elore lepett, egy ujabb futas 'Mar elemezve'-t "
+    "irna es elnemitana ezt az elemzest. Csak olvasd be a fenti fajlt.\n\n"
+    "Feladat: add hozza a sajat szakertoi egeszsegoR-ertekelesed (edzesterheles, "
+    "HR-zona, hogyan illik a Kosice-maraton felkeszulesbe -- celverseny 2026-10-04, "
+    "baseline RHR 51 / VO2max 45), jelezd ha valami elter a szokasostol, es kuldd el "
+    "Arnoldnak a sajat Telegram csatornadon. Tomoren, folyo szovegben."
+)
+
+
+def read_state_snapshot() -> bytes | None:
+    """The state file's bytes, or None when it does not exist yet."""
+    try:
+        return STATE_FILE.read_bytes()
+    except FileNotFoundError:
+        return None
+
+
+def restore_state(snapshot: bytes | None) -> None:
+    """Put the state file back the way it was before the analysis ran."""
+    if snapshot is None:
+        STATE_FILE.unlink(missing_ok=True)
+    else:
+        STATE_FILE.write_bytes(snapshot)
+
+
+def current_activity_id() -> str:
+    try:
+        return str(json.loads(STATE_FILE.read_text()).get("last_activity_id", "?"))
+    except (OSError, ValueError):
+        return "?"
+
+
+def notify_seven(activity_id: str) -> None:
+    """Wake Seven. Raises on any failure so the caller can roll the state back."""
+    token = TOKEN_FILE.read_text().strip()
+    payload = json.dumps(
+        {
+            "from": "geordi",
+            "to": "seven",
+            "content": NOTIFY_TEMPLATE.format(
+                activity_id=activity_id, pending=PENDING_FILE
+            ),
+        }
+    ).encode()
+    req = urllib.request.Request(
+        MESSAGES_URL,
+        data=payload,
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {token}",
+        },
+    )
+    # 15s -- see the note in memoria_heartbeat_gate.wake_agent. The dashboard is
+    # not slow (~3ms); it used to be frozen by the very spawnSync that started
+    # this script, so no timeout on this side could have helped. This path would
+    # have suffered most: a failed notify rolls the Garmin state back and the
+    # retry is the next cron tick, 9 hours away (0 10,19).
+    with urllib.request.urlopen(req, timeout=15) as resp:
+        if resp.status >= 300:
+            raise RuntimeError(f"messages API returned HTTP {resp.status}")
+
+
+def touch_heartbeat(note: str) -> None:
+    HEARTBEAT_FILE.parent.mkdir(parents=True, exist_ok=True)
+    HEARTBEAT_FILE.write_text(note + "\n")
+
+
+def main() -> int:
+    snapshot = read_state_snapshot()
+
+    try:
+        proc = subprocess.run(
+            [sys.executable, str(ANALYSIS_SCRIPT)],
+            cwd=str(GARMIN_DIR),
+            capture_output=True,
+            text=True,
+            timeout=SCRIPT_TIMEOUT_S,
+        )
+    except subprocess.TimeoutExpired:
+        print(f"running_analysis.py timed out after {SCRIPT_TIMEOUT_S}s", file=sys.stderr)
+        return 1
+
+    rc = proc.returncode
+
+    if rc == RC_NOTHING_NEW:
+        touch_heartbeat("nothing-new")
+        return 0
+
+    if rc != RC_NEW_RUN:
+        # Crash or unknown code. Surface it -- do not let it read as "no run".
+        print(f"running_analysis.py exited {rc}", file=sys.stderr)
+        print(proc.stdout[-2000:], file=sys.stderr)
+        print(proc.stderr[-2000:], file=sys.stderr)
+        return 1
+
+    activity_id = current_activity_id()
+    try:
+        notify_seven(activity_id)
+    except (urllib.error.URLError, OSError, RuntimeError, ValueError) as exc:
+        restore_state(snapshot)
+        print(
+            f"new run {activity_id} found but notifying seven failed ({exc}); "
+            "state rolled back, the next tick will find it again",
+            file=sys.stderr,
+        )
+        return 1
+
+    touch_heartbeat(f"new-run {activity_id}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/garmin_run_gate.py
+++ b/scripts/garmin_run_gate.py
@@ -41,18 +41,19 @@ finds the run again.
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 import urllib.error
 import urllib.request
 from pathlib import Path
 
-GARMIN_DIR = Path("/Users/gruzmanarnold/garmin-data")
+GARMIN_DIR = Path(os.environ.get("GARMIN_DATA_DIR", str(Path.home() / "garmin-data")))
 ANALYSIS_SCRIPT = GARMIN_DIR / "running_analysis.py"
 STATE_FILE = GARMIN_DIR / "last_analyzed_run.json"
 PENDING_FILE = GARMIN_DIR / "pending_run_analysis.txt"
 
-MARVEEN_DIR = Path("/Users/gruzmanarnold/marveen")
+MARVEEN_DIR = Path(__file__).resolve().parents[1]
 TOKEN_FILE = MARVEEN_DIR / "store" / ".dashboard-token"
 MESSAGES_URL = "http://localhost:3420/api/messages"
 # Proof-of-life artefact: its mtime answers "did the silent path actually run

--- a/scripts/memoria_heartbeat_gate.py
+++ b/scripts/memoria_heartbeat_gate.py
@@ -138,7 +138,7 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 
-MARVEEN_DIR = Path("/Users/gruzmanarnold/marveen")
+MARVEEN_DIR = Path(__file__).resolve().parents[1]
 DB_PATH = MARVEEN_DIR / "store" / "claudeclaw.db"
 TOKEN_FILE = MARVEEN_DIR / "store" / ".dashboard-token"
 MARKER_FILE = MARVEEN_DIR / "store" / "memoria-heartbeat-gate-last.txt"
@@ -180,7 +180,7 @@ WAKE_MESSAGE = (
     "NE oraban merd az ablakot -- a jelolo szabja meg, nem az eltelt ido. Ha a "
     "legutobbi fordulo elszallt vagy kimaradt, ez az ablak tobb orat is atfoghat.\n\n"
     "AZ UTOLSO LEPESED, a fordulo vegen, KOTELEZOEN, PONTOSAN igy:\n"
-    "  python3 /Users/gruzmanarnold/marveen/scripts/memoria_heartbeat_gate.py "
+    f"  python3 {MARVEEN_DIR}/scripts/memoria_heartbeat_gate.py "
     "--mark-seen --conv-upto {conv_max}\n"
     "A {conv_max} a FENTI ablak vege, ne ird at a pillanatnyi max-ra. A ket jelolo "
     "szandekosan NEM egyformán lep: a tool_call_log a pillanatnyi max-ra megy (az a te "

--- a/scripts/memoria_heartbeat_gate.py
+++ b/scripts/memoria_heartbeat_gate.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+"""Token-free gate in front of the memoria-heartbeat task.
+
+memoria-heartbeat runs hourly 07-21 and wakes the main agent to save anything
+worth remembering. Every tick costs a model call, including the many hours with
+nothing to look at. This gate answers one FACT before spending anything: has
+anything happened since the agent last said it had caught up?
+
+The gate deliberately does NOT judge importance -- no rules, no local model.
+"Was there activity" is a fact; "is it worth remembering" is a judgement, and a
+heuristic gate fails exactly where the interesting cases are. The agent still
+decides what to keep; the gate only decides whether there is anything to look
+at.
+
+WHO MOVES THE WATERMARK, AND WHY IT IS NOT THIS SCRIPT
+------------------------------------------------------
+The first version of this gate watched conversation_log and advanced the
+watermark itself. That has a loop in it: the agent we wake writes to the very
+log we watch (its outbound messages, and every one of its tool calls), so the
+next tick reads its own echo as new activity and spends a model call to
+discover it. Narrowing the query hides the loop rather than removing it, and it
+also blinds the gate to autonomous work -- which is where most of the
+memory-worthy material actually is.
+
+So the watermark moves at the END of the agent's turn, not here (Picard's
+design, msg 679):
+
+  - this script READS two watermarks (conversation_log.id, tool_call_log.id)
+    and wakes the agent when EITHER has moved. It never writes them.
+  - the agent runs `--mark-seen` as the last action of its heartbeat turn,
+    which sets both to the current max.
+
+Everything the agent produced during its own turn is therefore behind the
+watermark by construction. This is a fact about ordering, not a heuristic or a
+damping factor.
+
+The failure direction is deliberate too: if the turn dies before `--mark-seen`,
+the watermarks do not move and the next tick wakes on the same window. Looking
+at the same hour twice is cheap; skipping it silently is not.
+
+THE TWO WATERMARKS ARE NOT MOVED THE SAME WAY (Picard, msg 681)
+---------------------------------------------------------------
+A message can arrive WHILE the agent's turn is running. Advancing both marks to
+the current max would swallow it: it would sit behind the watermark without
+anyone having read it. So:
+
+  - tool_call_log -> current max. This is the agent's OWN footprint. It has to
+    be swallowed, otherwise the loop above comes straight back.
+  - conversation_log -> only as far as `--conv-upto`, the conv_max the wake
+    prompt showed. Anything that landed after that stays in FRONT of the mark
+    and the next tick wakes on it.
+
+One sentence for why they differ: the tool log is my own trace, the
+conversation log is somebody else's. What arrives during my turn is by
+definition not my trace. `--conv-upto` is therefore REQUIRED with `--mark-seen`
+-- the caller states what it actually reviewed rather than the script assuming
+"everything up to now". The price of the conservative side is at most one extra
+wake on a message the agent already handled mid-turn. That is the cheap
+direction.
+
+HOW MUCH THAT ACTUALLY PROTECTS TODAY -- LESS THAN IT SOUNDS
+------------------------------------------------------------
+Measured 2026-07-28, do not soften this without re-measuring. A message
+delivered INTO an already-running turn never reaches conversation_log at all,
+so there is nothing for the conservative watermark to keep in front of:
+
+  - the inbound writer is scripts/hooks/ledger-capture.py, bound to
+    UserPromptSubmit (marveen/.claude/settings.json). No prompt is submitted
+    mid-turn, so the hook never fires for that message.
+  - the outbound writer (ledger-outbound.py) is bound to PostToolUse, which
+    DOES fire mid-turn. Hence the asymmetry in the evidence.
+  - concrete case: Telegram message_id 2438 (14:05:03Z) reached the model's
+    context -- the <channel> block is in the session transcript -- and picard's
+    reply to it is row 1585 (out). There is no inbound row for it. The inbound
+    max both before and after is 1583.
+
+So the paragraph above describes the intended behaviour, not today's reachable
+behaviour: the guard is correct but the case it was built for cannot currently
+reach it. The fix belongs ABOVE this gate (a mid-turn inbound must get a
+conversation_log row; the transcript is available to hooks and log_inbound is
+already idempotent on message_id). Until that lands, do not claim this gate
+protects against lost mid-turn messages -- it protects against swallowing them
+once they are recorded.
+
+THE ONE ROW THE END-OF-TURN WATERMARK CANNOT SWALLOW (measured 2026-08-02)
+--------------------------------------------------------------------------
+"Everything the agent produced during its own turn is behind the watermark by
+construction" was wrong by exactly one row, and that row is this script's own
+`--mark-seen` call. The ordering is not arguable:
+
+  1. the agent runs `--mark-seen` as its last action;
+  2. THIS function reads MAX(tool_call_log.id) and writes it;
+  3. the PostToolUse hook (scripts/hooks/tool-log-capture.py) logs that Bash
+     call -- afterwards, because the row records a finished call.
+
+So the marker lands one short of its own footprint, every single time. The next
+tick then finds "1 new row" and spends a model call to rediscover it, whose
+own `--mark-seen` leaves the next row, forever. Measured on the live marker
+file: mark-seen rows 4256/4261/4266 against markers 4255/4260/4265, and the
+07:00-18:00 wakes on 2026-08-02 show `tool_call_log.id > N (most N+1, 1 uj sor)`
+with zero new conversation rows. A self-sustaining wake, ~15 model calls a day,
+none of which had anything to look at.
+
+The fix is a predicate, not a bigger marker: rows whose input_summary is this
+script's own `--mark-seen` invocation are excluded from BOTH the maxima and the
+counts. This is not the "narrow the query until the loop hides" mistake the
+docstring above warns about -- that one blinded the gate to real autonomous
+work. This excludes one call whose entire purpose is bookkeeping about the
+gate, and which can never itself be worth remembering. Everything else the
+agent does, including reading or editing this very file, still counts as
+activity.
+
+If the match ever fails (a differently shaped command line), the behaviour
+degrades to exactly what it was before: one spurious wake per turn. Nothing is
+lost, which is the right direction for a filter that decides what NOT to look
+at.
+
+WHERE THE direction='in' FILTER IS, AND WHERE IT DELIBERATELY IS NOT
+--------------------------------------------------------------------
+conversation_log is read with `direction = 'in'`; tool_call_log has NO such
+filter (there is no direction there, and every row is the agent's own work by
+construction). The 'in' filter is NOT what damps the loop -- the end-of-turn
+watermark does that. It is there so the conservative conv watermark does not
+park behind the agent's OWN outbound replies and re-wake on them every single
+turn. Removing it would not reintroduce the loop, it would just make every
+outbound message look like unreviewed inbound input. If you are reading this in
+two weeks wondering whether the filter is load-bearing: it is, for the
+conservative marker, not for the loop.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+MARVEEN_DIR = Path("/Users/gruzmanarnold/marveen")
+DB_PATH = MARVEEN_DIR / "store" / "claudeclaw.db"
+TOKEN_FILE = MARVEEN_DIR / "store" / ".dashboard-token"
+MARKER_FILE = MARVEEN_DIR / "store" / "memoria-heartbeat-gate-last.txt"
+MESSAGES_URL = "http://localhost:3420/api/messages"
+
+AGENT = "picard"
+
+# The agent's own `--mark-seen` call is logged by the PostToolUse hook AFTER
+# this script has read the maximum, so the marker can never cover it and the
+# next tick reads it as new activity. Excluded from the maxima and the counts
+# alike -- see "THE ONE ROW THE END-OF-TURN WATERMARK CANNOT SWALLOW" above for
+# why this particular narrowing does not blind the gate.
+OWN_MARK_SEEN_CALL = (
+    "COALESCE(input_summary, '') NOT LIKE '%memoria_heartbeat_gate.py --mark-seen%'"
+)
+
+# (marker key, table, extra predicate). Both are keyed on the agent so that
+# another agent's work never wakes this one. Today only picard writes
+# tool_call_log, but the column exists and the filter is what keeps that true if
+# that changes. The direction predicate on conversation_log is deliberate and
+# the shape of the tool_call_log one is too -- see the module docstring.
+SOURCES = (
+    ("conversation_log", "conversation_log", "direction = 'in'"),
+    ("tool_call_log", "tool_call_log", OWN_MARK_SEEN_CALL),
+)
+
+EXTRA_PREDICATE = {key: extra for key, _, extra in SOURCES}
+
+
+def _and(extra: str | None) -> str:
+    return f" AND {extra}" if extra else ""
+
+WAKE_MESSAGE = (
+    "[memoria-heartbeat-gate] Tortent valami a legutobbi lezart fordulo ota, "
+    "fusd le a memoria-heartbeat skillt.\n\n"
+    "AZ ABLAK, amit at kell nezned (a kapu ezekig latta lezartnak):\n"
+    "  conversation_log.id > {conv_seen}   (most {conv_max}, {conv_new} uj sor)\n"
+    "  tool_call_log.id    > {tool_seen}   (most {tool_max}, {tool_new} uj sor)\n\n"
+    "NE oraban merd az ablakot -- a jelolo szabja meg, nem az eltelt ido. Ha a "
+    "legutobbi fordulo elszallt vagy kimaradt, ez az ablak tobb orat is atfoghat.\n\n"
+    "AZ UTOLSO LEPESED, a fordulo vegen, KOTELEZOEN, PONTOSAN igy:\n"
+    "  python3 /Users/gruzmanarnold/marveen/scripts/memoria_heartbeat_gate.py "
+    "--mark-seen --conv-upto {conv_max}\n"
+    "A {conv_max} a FENTI ablak vege, ne ird at a pillanatnyi max-ra. A ket jelolo "
+    "szandekosan NEM egyformán lep: a tool_call_log a pillanatnyi max-ra megy (az a te "
+    "sajat labnyomod, azt el kell nyelni, kulonben ujra felebresztene magad), a "
+    "conversation_log viszont csak eddig az id-ig (az masok bemenete, azt atnezetlenul "
+    "soha). Ha kozben, a fordulod alatt erkezik uzenet, az igy a jelolo elott marad es a "
+    "kovetkezo tick felebreszt ra -- ha mar foglalkoztal vele, az ara egyetlen felesleges "
+    "ebresztes, es ez a jo irany.\n"
+    "Tenyleg az utolso legyen. Ha a fordulo elszall elotte, a jelolo nem mozdul es a "
+    "kovetkezo tick ugyanerre az ablakra ebreszt -- ez szandekos.\n\n"
+    "Ha az ablakban nincs semmi ertekes, maradj csendben: a kapu csak azt allapitotta meg, "
+    "hogy VAN mit atnezni, azt nem, hogy fontos-e. A --mark-seen --conv-upto {conv_max} "
+    "ilyenkor is kell."
+)
+
+
+def read_markers() -> dict[str, int]:
+    """Watermarks per source, tolerating the older single-integer format."""
+    try:
+        raw = MARKER_FILE.read_text().strip()
+    except FileNotFoundError:
+        return {key: 0 for key in EXTRA_PREDICATE}
+
+    try:
+        data = json.loads(raw)
+    except ValueError:
+        data = None
+
+    # `json.loads("1583")` succeeds and yields an int, so "did it parse" is NOT
+    # the test for the current format -- the shape is. Getting this wrong threw
+    # AttributeError past the ValueError handler on the very file that was on
+    # disk when this was written.
+    if isinstance(data, dict):
+        return {key: int(data.get(key, 0)) for key in EXTRA_PREDICATE}
+
+    # Pre-679 format: a bare conversation_log id. Keep it rather than resetting
+    # to zero, which would replay the whole history once.
+    try:
+        conv = int(raw)
+    except ValueError:
+        conv = 0
+    return {"conversation_log": conv, "tool_call_log": 0}
+
+
+def current_maxima() -> dict[str, int]:
+    con = sqlite3.connect(f"file:{DB_PATH}?mode=ro", uri=True)
+    try:
+        out = {}
+        for key, table, extra in SOURCES:
+            row = con.execute(
+                f"SELECT COALESCE(MAX(id), 0) FROM {table} "
+                f"WHERE agent_id = ?{_and(extra)}",
+                (AGENT,),
+            ).fetchone()
+            out[key] = int(row[0])
+        return out
+    finally:
+        con.close()
+
+
+def write_markers(values: dict[str, int]) -> None:
+    MARKER_FILE.parent.mkdir(parents=True, exist_ok=True)
+    MARKER_FILE.write_text(json.dumps(values, indent=2) + "\n")
+
+
+def count_new(since: int, key: str) -> int:
+    """Rows in front of the watermark, under the same predicate the max used."""
+    extra = EXTRA_PREDICATE[key]
+    con = sqlite3.connect(f"file:{DB_PATH}?mode=ro", uri=True)
+    try:
+        row = con.execute(
+            f"SELECT COUNT(*) FROM {key} WHERE agent_id = ? AND id > ?{_and(extra)}",
+            (AGENT, since),
+        ).fetchone()
+        return int(row[0])
+    finally:
+        con.close()
+
+
+def wake_agent(seen: dict[str, int], maxima: dict[str, int]) -> None:
+    """Wake the main agent. Raises on failure; nothing here writes a marker."""
+    token = TOKEN_FILE.read_text().strip()
+    content = WAKE_MESSAGE.format(
+        conv_seen=seen["conversation_log"],
+        conv_max=maxima["conversation_log"],
+        conv_new=count_new(seen["conversation_log"], "conversation_log"),
+        tool_seen=seen["tool_call_log"],
+        tool_max=maxima["tool_call_log"],
+        tool_new=count_new(seen["tool_call_log"], "tool_call_log"),
+    )
+    payload = json.dumps({"from": "geordi", "to": AGENT, "content": content}).encode()
+    req = urllib.request.Request(
+        MESSAGES_URL,
+        data=payload,
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {token}",
+        },
+    )
+    # 15s is plenty: the endpoint only inserts a row and returns, ~3ms measured.
+    #
+    # An earlier reading of this raised it to 60s on the theory that the server
+    # was slow. It was not. The scheduler ran command tasks with spawnSync,
+    # which froze the whole dashboard event loop until the child exited -- so
+    # THIS request could not be answered until this very script gave up and
+    # died. Raising our own timeout would only have lengthened the freeze it was
+    # causing: the child holds the server hostage for exactly as long as it
+    # waits. Fixed on the other side (src/web/command-task.ts, async spawn).
+    with urllib.request.urlopen(req, timeout=15) as resp:
+        if resp.status >= 300:
+            raise RuntimeError(f"messages API returned HTTP {resp.status}")
+
+
+def mark_seen(conv_upto: int | None) -> int:
+    """End of the agent's turn. Asymmetric on purpose -- see the module docstring.
+
+    tool_call_log goes to the current max (own footprint, must be swallowed);
+    conversation_log goes only as far as the caller says it actually reviewed,
+    so a message that landed mid-turn stays in front of the watermark.
+    """
+    if conv_upto is None:
+        print(
+            "--mark-seen requires --conv-upto <id>: pass the conv_max the wake "
+            "prompt showed you. Without it the script would have to assume you "
+            "reviewed everything up to this instant, which would swallow any "
+            "message that arrived during your turn. Nothing was written.",
+            file=sys.stderr,
+        )
+        return 2
+
+    seen = read_markers()
+    try:
+        maxima = current_maxima()
+    except sqlite3.Error as exc:
+        print(f"cannot read current maxima: {exc}", file=sys.stderr)
+        return 1
+
+    # Never past what exists (a bogus high value would swallow unread input),
+    # never back below where we already were (that would replay the window).
+    conv = max(seen["conversation_log"], min(conv_upto, maxima["conversation_log"]))
+    if conv != conv_upto:
+        print(
+            f"--conv-upto {conv_upto} clamped to {conv} (previous marker "
+            f"{seen['conversation_log']}, current inbound max "
+            f"{maxima['conversation_log']})",
+            file=sys.stderr,
+        )
+
+    values = {"conversation_log": conv, "tool_call_log": maxima["tool_call_log"]}
+    write_markers(values)
+    print(json.dumps(values))
+    return 0
+
+
+def check() -> int:
+    seen = read_markers()
+
+    try:
+        maxima = current_maxima()
+    except sqlite3.Error as exc:
+        print(f"watermark query failed: {exc}", file=sys.stderr)
+        return 1
+
+    if all(maxima[key] <= seen[key] for key in EXTRA_PREDICATE):
+        return 0
+
+    try:
+        wake_agent(seen, maxima)
+    except (urllib.error.URLError, OSError, RuntimeError, ValueError) as exc:
+        print(f"activity found but waking {AGENT} failed ({exc})", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--mark-seen",
+        action="store_true",
+        help="end-of-turn watermark write (requires --conv-upto)",
+    )
+    parser.add_argument(
+        "--conv-upto",
+        type=int,
+        metavar="ID",
+        help="the conversation_log id the wake prompt showed as conv_max; "
+        "anything newer stays in front of the watermark",
+    )
+    args = parser.parse_args(argv)
+
+    if args.conv_upto is not None and not args.mark_seen:
+        parser.error("--conv-upto only means anything together with --mark-seen")
+
+    return mark_seen(args.conv_upto) if args.mark_seen else check()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_garmin_run_gate.py
+++ b/scripts/test_garmin_run_gate.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Branch tests for garmin_run_gate, with every outward path redirected.
+
+The point of this file is the isolation list, not the assertions. A gate test
+that only redirects the obvious artefact still reaches the ones it forgot: an
+earlier test in this repo isolated INTEL_DB but not the gate's audit log and
+appended 44 synthetic verdicts to the production trail. So every module
+constant that names a file or a URL is rebound here -- state, pending,
+heartbeat, token, messages endpoint, the analysis script itself -- and the
+notify path is replaced outright so no request can leave the process.
+
+Run: python3 scripts/test_garmin_run_gate.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+SPEC = importlib.util.spec_from_file_location(
+    "garmin_run_gate", Path(__file__).resolve().parent / "garmin_run_gate.py"
+)
+gate = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(gate)
+
+FAILURES: list[str] = []
+
+
+def check(name: str, got, want) -> None:
+    if got == want:
+        print(f"  ok   {name}: {got!r}")
+    else:
+        print(f"  FAIL {name}: got {got!r}, want {want!r}")
+        FAILURES.append(name)
+
+
+def fake_analysis_script(tmp: Path, exit_code: int, advance_to: str | None) -> Path:
+    """A stand-in for running_analysis.py with a chosen exit code.
+
+    When advance_to is set it also rewrites the state file, mimicking the real
+    script's habit of advancing last_analyzed_run.json before anyone has been
+    told about the run.
+    """
+    body = ["import json, sys"]
+    if advance_to is not None:
+        body.append(
+            f"open({str(tmp / 'state.json')!r}, 'w')"
+            f".write(json.dumps({{'last_activity_id': {advance_to!r}}}))"
+        )
+    body.append(f"sys.exit({exit_code})")
+    path = tmp / "fake_analysis.py"
+    path.write_text("\n".join(body) + "\n")
+    return path
+
+
+def wire(tmp: Path, script: Path) -> None:
+    """Redirect every outward path in the module to the sandbox."""
+    gate.GARMIN_DIR = tmp
+    gate.ANALYSIS_SCRIPT = script
+    gate.STATE_FILE = tmp / "state.json"
+    gate.PENDING_FILE = tmp / "pending.txt"
+    gate.HEARTBEAT_FILE = tmp / "heartbeat.txt"
+    gate.TOKEN_FILE = tmp / "token"
+    gate.MESSAGES_URL = "http://127.0.0.1:1/never"
+    gate.TOKEN_FILE.write_text("test-token")
+
+
+def scenario_nothing_new() -> None:
+    print("nothing new (rc 0) -> silent success, no notify")
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        wire(tmp, fake_analysis_script(tmp, 0, None))
+        gate.STATE_FILE.write_text(json.dumps({"last_activity_id": "111"}))
+        called = []
+        gate.notify_seven = lambda a: called.append(a)
+
+        check("exit code", gate.main(), 0)
+        check("notified", called, [])
+        check("state untouched", json.loads(gate.STATE_FILE.read_text())["last_activity_id"], "111")
+        check("heartbeat written", gate.HEARTBEAT_FILE.read_text().strip(), "nothing-new")
+
+
+def scenario_new_run() -> None:
+    print("new run (rc 2) -> notify, state stays advanced")
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        wire(tmp, fake_analysis_script(tmp, 2, "222"))
+        gate.STATE_FILE.write_text(json.dumps({"last_activity_id": "111"}))
+        called = []
+        gate.notify_seven = lambda a: called.append(a)
+
+        check("exit code", gate.main(), 0)
+        check("notified with new id", called, ["222"])
+        check("state advanced", json.loads(gate.STATE_FILE.read_text())["last_activity_id"], "222")
+
+
+def scenario_notify_fails() -> None:
+    print("new run but notify fails -> state rolled back, non-zero exit")
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        wire(tmp, fake_analysis_script(tmp, 2, "222"))
+        gate.STATE_FILE.write_text(json.dumps({"last_activity_id": "111"}))
+
+        def boom(_):
+            raise OSError("dashboard down")
+
+        gate.notify_seven = boom
+
+        check("exit code", gate.main(), 1)
+        check(
+            "state rolled back",
+            json.loads(gate.STATE_FILE.read_text())["last_activity_id"],
+            "111",
+        )
+
+
+def scenario_crash() -> None:
+    print("analysis crashes (rc 1) -> non-zero exit, not silence")
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        wire(tmp, fake_analysis_script(tmp, 1, None))
+        gate.STATE_FILE.write_text(json.dumps({"last_activity_id": "111"}))
+        called = []
+        gate.notify_seven = lambda a: called.append(a)
+
+        check("exit code", gate.main(), 1)
+        check("notified", called, [])
+        check("no heartbeat on failure", gate.HEARTBEAT_FILE.exists(), False)
+
+
+def scenario_no_state_file() -> None:
+    print("first ever run, no state file -> rollback deletes it again")
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        wire(tmp, fake_analysis_script(tmp, 2, "222"))
+
+        def boom(_):
+            raise OSError("dashboard down")
+
+        gate.notify_seven = boom
+
+        check("exit code", gate.main(), 1)
+        check("state file gone again", gate.STATE_FILE.exists(), False)
+
+
+if __name__ == "__main__":
+    for scenario in (
+        scenario_nothing_new,
+        scenario_new_run,
+        scenario_notify_fails,
+        scenario_crash,
+        scenario_no_state_file,
+    ):
+        scenario()
+        print()
+
+    if FAILURES:
+        print(f"FAILED: {', '.join(FAILURES)}")
+        sys.exit(1)
+    print("all scenarios passed")

--- a/scripts/test_memoria_heartbeat_gate.py
+++ b/scripts/test_memoria_heartbeat_gate.py
@@ -70,10 +70,11 @@ def add_tool(con, agent="picard", summary="ls") -> None:
     con.commit()
 
 
-# What the PostToolUse hook actually stores for the agent's own end-of-turn
-# bookkeeping call, verbatim from the live tool_call_log (row 4266).
+# Shape of what the PostToolUse hook actually stores for the agent's own
+# end-of-turn bookkeeping call (matches the live tool_call_log row 4266,
+# modulo the machine-specific install path).
 MARK_SEEN_SUMMARY = (
-    "python3 /Users/gruzmanarnold/marveen/scripts/memoria_heartbeat_gate.py "
+    f"python3 {gate.MARVEEN_DIR}/scripts/memoria_heartbeat_gate.py "
     "--mark-seen --conv-upto 1609"
 )
 

--- a/scripts/test_memoria_heartbeat_gate.py
+++ b/scripts/test_memoria_heartbeat_gate.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+"""Branch tests for memoria_heartbeat_gate against a throwaway database.
+
+Every outward path is rebound: db, marker, token, messages URL, and the wake
+call itself. Nothing here may reach store/claudeclaw.db or the live agent.
+
+The scenario that matters most is `scenario_own_turn_does_not_retrigger`: it is
+the whole reason the watermark is written by the agent instead of by the gate.
+
+Run: python3 scripts/test_memoria_heartbeat_gate.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sqlite3
+import sys
+import tempfile
+from pathlib import Path
+
+SPEC = importlib.util.spec_from_file_location(
+    "memoria_heartbeat_gate", Path(__file__).resolve().parent / "memoria_heartbeat_gate.py"
+)
+gate = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(gate)
+
+FAILURES: list[str] = []
+
+
+def check_eq(name: str, got, want) -> None:
+    if got == want:
+        print(f"  ok   {name}: {got!r}")
+    else:
+        print(f"  FAIL {name}: got {got!r}, want {want!r}")
+        FAILURES.append(name)
+
+
+def build_db(path: Path) -> sqlite3.Connection:
+    con = sqlite3.connect(path)
+    con.execute(
+        "CREATE TABLE conversation_log (id INTEGER PRIMARY KEY AUTOINCREMENT, "
+        "agent_id TEXT NOT NULL, chat_id TEXT NOT NULL, direction TEXT NOT NULL, "
+        "created_at INTEGER NOT NULL)"
+    )
+    con.execute(
+        "CREATE TABLE tool_call_log (id INTEGER PRIMARY KEY AUTOINCREMENT, "
+        "session_id TEXT NOT NULL, tool_name TEXT NOT NULL, success INTEGER, "
+        "created_at INTEGER NOT NULL, agent_id TEXT, input_summary TEXT)"
+    )
+    con.commit()
+    return con
+
+
+def add_conv(con, agent="picard", direction="in") -> None:
+    con.execute(
+        "INSERT INTO conversation_log (agent_id, chat_id, direction, created_at) "
+        "VALUES (?, 'c', ?, 0)",
+        (agent, direction),
+    )
+    con.commit()
+
+
+def add_tool(con, agent="picard", summary="ls") -> None:
+    con.execute(
+        "INSERT INTO tool_call_log (session_id, tool_name, success, created_at, agent_id, "
+        "input_summary) VALUES ('s', 'Bash', 1, 0, ?, ?)",
+        (agent, summary),
+    )
+    con.commit()
+
+
+# What the PostToolUse hook actually stores for the agent's own end-of-turn
+# bookkeeping call, verbatim from the live tool_call_log (row 4266).
+MARK_SEEN_SUMMARY = (
+    "python3 /Users/gruzmanarnold/marveen/scripts/memoria_heartbeat_gate.py "
+    "--mark-seen --conv-upto 1609"
+)
+
+
+def mark_seen_and_log(con, conv_upto: int) -> int:
+    """`--mark-seen` the way it happens in production.
+
+    The hook logs the call AFTER the script has read the maximum, so the row
+    always lands in front of the marker this very call just wrote. Any test
+    that calls gate.mark_seen() without this row is modelling a world one row
+    friendlier than the real one -- which is exactly how the self-wake survived
+    fourteen green scenarios.
+    """
+    rc = gate.mark_seen(conv_upto)
+    add_tool(con, summary=MARK_SEEN_SUMMARY)
+    return rc
+
+
+def mark_all() -> int:
+    """The agent claiming it reviewed everything that exists right now."""
+    return gate.mark_seen(gate.current_maxima()["conversation_log"])
+
+
+def wire(tmp: Path):
+    gate.DB_PATH = tmp / "test.db"
+    gate.MARKER_FILE = tmp / "marker.txt"
+    gate.TOKEN_FILE = tmp / "token"
+    gate.MESSAGES_URL = "http://127.0.0.1:1/never"
+    gate.TOKEN_FILE.write_text("test-token")
+    con = build_db(gate.DB_PATH)
+    woken: list = []
+    gate.wake_agent = lambda seen, maxima: woken.append((dict(seen), dict(maxima)))
+    return con, woken
+
+
+def scenario_quiet() -> None:
+    print("nothing since the marker -> silent")
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        con, woken = wire(tmp)
+        add_conv(con)
+        add_tool(con)
+        mark_all()
+        check_eq("exit code", gate.check(), 0)
+        check_eq("woken", woken, [])
+
+
+def scenario_new_conversation() -> None:
+    print("new inbound turn -> wake")
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        con, woken = wire(tmp)
+        add_conv(con)
+        mark_all()
+        add_conv(con)
+        check_eq("exit code", gate.check(), 0)
+        check_eq("woken once", len(woken), 1)
+
+
+def scenario_new_tool_only() -> None:
+    print("autonomous work only, no channel traffic -> wake (the old blind spot)")
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        con, woken = wire(tmp)
+        add_conv(con)
+        mark_all()
+        for _ in range(5):
+            add_tool(con)
+        check_eq("exit code", gate.check(), 0)
+        check_eq("woken once", len(woken), 1)
+
+
+def scenario_own_turn_does_not_retrigger() -> None:
+    print("agent's own turn (tool calls + outbound reply) -> no self-retrigger")
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        con, woken = wire(tmp)
+        add_conv(con)
+        mark_all()
+
+        add_conv(con)  # Arnold writes
+        check_eq("gate wakes", gate.check(), 0)
+        check_eq("woken once", len(woken), 1)
+
+        # the turn itself: tool calls, then an outbound reply
+        for _ in range(8):
+            add_tool(con)
+        add_conv(con, direction="out")
+        mark_seen_and_log(con, gate.current_maxima()["conversation_log"])
+
+        check_eq("next tick exit", gate.check(), 0)
+        check_eq("no second wake", len(woken), 1)
+
+
+def scenario_mark_seen_call_does_not_rewake() -> None:
+    print("the --mark-seen call's own log row -> not activity (self-wake, 2026-08-02)")
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        con, woken = wire(tmp)
+        add_conv(con)
+        add_tool(con)
+        mark_all()
+
+        # A silent turn: nothing happened, the agent still has to mark seen.
+        check_eq("mark-seen exit", mark_seen_and_log(con, 1), 0)
+        check_eq("next tick exit", gate.check(), 0)
+        check_eq("stays silent", woken, [])
+
+        # And it stays silent hour after hour, which is where the live gate
+        # failed: each wake wrote another mark-seen row for the next one.
+        for _ in range(3):
+            gate.check()
+        check_eq("still silent after three ticks", woken, [])
+
+        # Real work in the same window is still seen.
+        add_tool(con, summary="git status")
+        check_eq("wakes on real work", gate.check(), 0)
+        check_eq("woken once", len(woken), 1)
+
+
+def scenario_crashed_turn_rewakes() -> None:
+    print("turn dies before --mark-seen -> same window wakes again (deliberate)")
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        con, woken = wire(tmp)
+        add_conv(con)
+        mark_all()
+        add_conv(con)
+
+        check_eq("first wake", gate.check(), 0)
+        # no mark_seen: the turn crashed
+        check_eq("second tick", gate.check(), 0)
+        check_eq("woken twice", len(woken), 2)
+        check_eq(
+            "same window both times",
+            woken[0][0]["conversation_log"] == woken[1][0]["conversation_log"],
+            True,
+        )
+
+
+def scenario_wake_fails_marker_untouched() -> None:
+    print("wake fails -> non-zero exit, marker untouched")
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        con, _ = wire(tmp)
+        add_conv(con)
+        mark_all()
+        before = gate.MARKER_FILE.read_text()
+        add_conv(con)
+
+        def boom(seen, maxima):
+            raise OSError("dashboard down")
+
+        gate.wake_agent = boom
+        check_eq("exit code", gate.check(), 1)
+        check_eq("marker untouched", gate.MARKER_FILE.read_text(), before)
+
+
+def scenario_other_agent_ignored() -> None:
+    print("another agent's rows -> not our activity, stays silent")
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        con, woken = wire(tmp)
+        add_conv(con)
+        mark_all()
+        add_conv(con, agent="geordi")
+        add_tool(con, agent="geordi")
+        check_eq("exit code", gate.check(), 0)
+        check_eq("woken", woken, [])
+
+
+def scenario_legacy_marker_format() -> None:
+    print("pre-679 bare-integer marker -> honoured, not replayed from zero")
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        con, woken = wire(tmp)
+        for _ in range(3):
+            add_conv(con)
+        gate.MARKER_FILE.write_text("3\n")
+
+        seen = gate.read_markers()
+        check_eq("conversation watermark kept", seen["conversation_log"], 3)
+        check_eq("tool watermark starts at zero", seen["tool_call_log"], 0)
+        check_eq("no conversation replay", gate.count_new(3, "conversation_log"), 0)
+
+
+def scenario_missing_marker() -> None:
+    print("no marker file at all -> everything counts as new")
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        con, woken = wire(tmp)
+        add_conv(con)
+        check_eq("exit code", gate.check(), 0)
+        check_eq("woken once", len(woken), 1)
+
+
+def scenario_mark_seen_writes_both() -> None:
+    print("--mark-seen writes both watermarks as json")
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        con, _ = wire(tmp)
+        add_conv(con)
+        add_conv(con)
+        add_tool(con)
+        check_eq("exit code", mark_all(), 0)
+        data = json.loads(gate.MARKER_FILE.read_text())
+        check_eq("conversation watermark", data["conversation_log"], 2)
+        check_eq("tool watermark", data["tool_call_log"], 1)
+
+
+def scenario_outbound_only_stays_silent() -> None:
+    print("agent's own outbound replies -> not inbound activity, stays silent")
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        con, woken = wire(tmp)
+        add_conv(con)
+        mark_all()
+        for _ in range(4):
+            add_conv(con, direction="out")
+        check_eq("exit code", gate.check(), 0)
+        check_eq("woken", woken, [])
+
+
+def scenario_midturn_message_survives_mark_seen() -> None:
+    print("message arrives DURING the turn -> stays in front of the watermark (msg 681)")
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        con, woken = wire(tmp)
+        add_conv(con)  # id 1
+        mark_all()
+
+        add_conv(con)  # id 2, Arnold writes
+        check_eq("gate wakes", gate.check(), 0)
+        conv_max_in_prompt = woken[0][1]["conversation_log"]
+        check_eq("prompt showed conv_max", conv_max_in_prompt, 2)
+
+        # the turn: tool calls, an outbound reply, and a message landing mid-turn
+        for _ in range(3):
+            add_tool(con)
+        add_conv(con, direction="out")  # id 3
+        add_conv(con)  # id 4, arrives while the turn is still running
+
+        check_eq("mark-seen exit", gate.mark_seen(conv_max_in_prompt), 0)
+        data = json.loads(gate.MARKER_FILE.read_text())
+        check_eq("conv marker stopped at the prompt value", data["conversation_log"], 2)
+        check_eq("tool marker swallowed own footprint", data["tool_call_log"], 3)
+
+        # the whole point: the mid-turn message is not lost
+        check_eq("next tick exit", gate.check(), 0)
+        check_eq("woken again for id 4", len(woken), 2)
+        check_eq("new window starts at 2", woken[1][0]["conversation_log"], 2)
+
+        # and once it IS reviewed, silence returns
+        gate.mark_seen(4)
+        check_eq("settles", gate.check(), 0)
+        check_eq("no third wake", len(woken), 2)
+
+
+def scenario_mark_seen_requires_conv_upto() -> None:
+    print("--mark-seen without --conv-upto -> refuses, writes nothing")
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        con, _ = wire(tmp)
+        add_conv(con)
+        mark_all()
+        before = gate.MARKER_FILE.read_text()
+        add_conv(con)
+        add_tool(con)
+
+        check_eq("exit code", gate.mark_seen(None), 2)
+        check_eq("marker untouched", gate.MARKER_FILE.read_text(), before)
+        check_eq("cli rejects it too", gate.main(["--mark-seen"]), 2)
+
+
+def scenario_conv_upto_clamped() -> None:
+    print("--conv-upto out of range -> clamped, never swallows unread input")
+    with tempfile.TemporaryDirectory() as d:
+        tmp = Path(d)
+        con, _ = wire(tmp)
+        for _ in range(2):
+            add_conv(con)
+        mark_all()  # conv marker = 2
+        add_conv(con)  # id 3, unreviewed
+
+        check_eq("above max", gate.mark_seen(9999), 0)
+        check_eq(
+            "clamped to current max",
+            json.loads(gate.MARKER_FILE.read_text())["conversation_log"],
+            3,
+        )
+
+        check_eq("below previous", gate.mark_seen(1), 0)
+        check_eq(
+            "does not move backward",
+            json.loads(gate.MARKER_FILE.read_text())["conversation_log"],
+            3,
+        )
+
+
+if __name__ == "__main__":
+    for scenario in (
+        scenario_quiet,
+        scenario_new_conversation,
+        scenario_new_tool_only,
+        scenario_own_turn_does_not_retrigger,
+        scenario_mark_seen_call_does_not_rewake,
+        scenario_crashed_turn_rewakes,
+        scenario_wake_fails_marker_untouched,
+        scenario_other_agent_ignored,
+        scenario_legacy_marker_format,
+        scenario_missing_marker,
+        scenario_mark_seen_writes_both,
+        scenario_outbound_only_stays_silent,
+        scenario_midturn_message_survives_mark_seen,
+        scenario_mark_seen_requires_conv_upto,
+        scenario_conv_upto_clamped,
+    ):
+        scenario()
+        print()
+
+    if FAILURES:
+        print(f"FAILED: {', '.join(FAILURES)}")
+        sys.exit(1)
+    print("all scenarios passed")


### PR DESCRIPTION
## Summary
- Adds `scripts/garmin_run_gate.py` and `scripts/memoria_heartbeat_gate.py`: deterministic, token-free gates that run in front of the garmin-run-watcher and memoria-heartbeat scheduled tasks and only wake the agent when there's something to actually judge, instead of a model call on every tick.
- Finished and tested since 2026-07-28, sitting untracked on disk through two unexpected reboots before being committed here.
- Follow-up commit resolves 5 hardcoded `/Users/gruzmanarnold/...` absolute paths found in pre-merge review (both repos are public, this string was never in history before): `MARVEEN_DIR` now derives from `Path(__file__).resolve().parents[1]`, `GARMIN_DIR` reads `GARMIN_DATA_DIR` env var with a `~/garmin-data` fallback.

## Test plan
- [x] `python3 scripts/test_garmin_run_gate.py` -- all scenarios passed
- [x] `python3 scripts/test_memoria_heartbeat_gate.py` -- all scenarios passed
- [x] Verified no `/Users/gruzmanarnold` strings remain in either script or its tests
- [x] Verified working-tree files are byte-identical to what's committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)