### PR TITLE
fix(onboarding): restore the Slack half-configured wiring dropped by #883

### DIFF
--- a/src/web/routes/onboarding.ts
+++ b/src/web/routes/onboarding.ts
@@ -2,7 +2,7 @@ import { readFileSync, writeFileSync, mkdirSync } from 'node:fs'
 import { join } from 'node:path'
 import { homedir, userInfo } from 'node:os'
 import { execFileSync } from 'node:child_process'
-import { PROJECT_ROOT, STORE_DIR, CHANNEL_PROVIDER } from '../../config.js'
+import { PROJECT_ROOT, STORE_DIR, CHANNEL_PROVIDER, MAIN_AGENT_ID } from '../../config.js'
 import { logger } from '../../logger.js'
 import { resolveFromPath } from '../../platform.js'
 import { atomicWriteFileSync } from '../atomic-write.js'
@@ -16,6 +16,7 @@ import {
 } from '../channel-monitor.js'
 import { liveProbeAuth, stampTokenVerified } from '../claude-credentials-guard.js'
 import { json, readBody } from '../http-helpers.js'
+import { isManagedSettingsReady, getManagedSettingsSudoCommand } from './agents.js'
 import type { RouteContext } from './types.js'
 
 // First-run onboarding for the "pre-install now, configure later" flow: the
@@ -93,8 +94,41 @@ function claudeAuthPresent(): boolean {
 // Discord-switched (or Slack/etc.) install has no telegram/ state dir, so a
 // telegram-only probe would report "not configured" forever and pop the wizard
 // over a working dashboard. readChannelToken knows each provider's env key.
+//
+// Slack also needs the managed-settings.json plugin allowlist (see isManagedSettingsReady in agents.ts) before its
+// channel session can ever come up. A token saved on a machine where that allowlist is still missing
+// must NOT read as "configured" -- otherwise step 3 skips straight to Pairing, the wizard never re-surfaces the 
+// sudo-command prompt (it only fires from the step-3 save handler), and the operator is left staring at
+// an empty pairing list with no explanation for why Slack never connects.
 function channelConfigured(): boolean {
-  return readChannelToken(CHANNEL_PROVIDER, join(channelStateDir(CHANNEL_PROVIDER), '.env')) != null
+  const hasToken = readChannelToken(CHANNEL_PROVIDER, join(channelStateDir(CHANNEL_PROVIDER), '.env')) != null
+  if (!hasToken) return false
+  if (CHANNEL_PROVIDER === 'slack') return isManagedSettingsReady()
+  return true
+}
+
+// Step 3 pre-fill: a bot (and, for Slack, app) token can already sit in the provider's .env from a prior save whose
+// managed-settings.json gate wasn't satisfied yet (channelConfigured() reads that as "not configured"  -- see the
+// comment above it). Without this the operator has to dig the token back out of ~/.claude/channels/<provider>/.env
+// and repaste it just to get past a  step that already has it on disk. Presence-only elsewhere in this file stays
+// presence-only; this is the one spot that hands the value back, and only to the already dashboard-token-gated status
+// endpoint the operator is looking at.
+function existingChannelTokens(): { botToken: string | null; appToken: string | null } {
+  const envPath = join(channelStateDir(CHANNEL_PROVIDER), '.env')
+  const botToken = readChannelToken(CHANNEL_PROVIDER, envPath)
+  let appToken: string | null = null
+  if (CHANNEL_PROVIDER === 'slack') {
+    try {
+      for (const line of readFileSync(envPath, 'utf-8').split('\n')) {
+        if (line.startsWith('SLACK_APP_TOKEN=')) {
+          const v = line.slice('SLACK_APP_TOKEN='.length).trim()
+          appToken = v.length > 0 ? v : null
+          break
+        }
+      }
+    } catch { /* no .env yet */ }
+  }
+  return { botToken, appToken }
 }
 
 function paired(): boolean {
@@ -170,6 +204,17 @@ export async function tryHandleOnboarding(ctx: RouteContext): Promise<boolean> {
     const running = agentsRunning()
     const ch = channelConfigured()
     const pr = paired()
+    // Only surface an already-saved token while step 3 (channel setup) is the one still pending --  once the
+    // channel is configured there is nothing to pre-fill and no reason to hand the value back over the wire.
+    const existingTokens = !ch ? existingChannelTokens() : { botToken: null, appToken: null }
+    // Slack pre-flight, surfaced passively (GET, no probe/write/restart): when  a token is already on disk
+    // but the managed-settings.json plugin allowlist isn't, the wizard can show the sudo command immediately
+    // instead of making the operator hit Save just to learn it's needed. Kept null whenever there's nothing to
+    // say (no provider/no token/already ready), so the frontend's check stays a single truthiness test.
+    const managedSettingsReady = CHANNEL_PROVIDER === 'slack' && existingTokens.botToken
+      ? isManagedSettingsReady()
+      : null
+    const sudoCommand = managedSettingsReady === false ? getManagedSettingsSudoCommand() : null
     json(res, {
       identityConfirmed: identityConfirmed(),
       currentAgentName: readEnvValue('BRAND_NAME') || readEnvValue('BOT_NAME') || 'Marveen',
@@ -177,6 +222,12 @@ export async function tryHandleOnboarding(ctx: RouteContext): Promise<boolean> {
       claudeAuthPresent: claude,
       agentsRunning: running,
       channelConfigured: ch,
+      channelProvider: CHANNEL_PROVIDER,
+      agentId: MAIN_AGENT_ID,
+      existingBotToken: existingTokens.botToken,
+      existingAppToken: existingTokens.appToken,
+      managedSettingsReady,
+      sudoCommand,
       paired: pr,
       // The identity step never re-opens the wizard on an already-configured
       // install: it only participates while first-run setup is incomplete.

--- a/web/app.js
+++ b/web/app.js
@@ -658,6 +658,7 @@ function renderStaticI18n() {
   document.querySelectorAll('[data-i18n-html]').forEach(el => {
     el.innerHTML = t(el.dataset.i18nHtml)
   })
+  if (typeof applyOnboardingProviderTab === 'function') applyOnboardingProviderTab()
 }
 
 // Initial render on page load.
@@ -11918,10 +11919,21 @@ async function refreshOnboarding() {
   const s = await fetchOnboardingStatus()
   if (s) renderOnboarding(s)
 }
+let onboardingChannelProvider = 'telegram'
+let onboardingAgentId = null
+// The step-3 tab is a static HTML label ("Telegram bot") that renderStaticI18n's generic data-i18n sweep would otherwise reset
+// to the Telegram wording on every language switch, so both call sites re-apply the provider-specific text here.
+function applyOnboardingProviderTab() {
+  const el = document.querySelector('#onboardingSteps .onboarding-step[data-ostep="3"] span:last-child')
+  if (el) el.textContent = onboardingChannelProvider === 'slack' ? t('onboarding.step2.tab_slack') : t('onboarding.step2.tab')
+}
 function renderOnboarding(s) {
   if (onboardingDismissed()) return
   const overlay = document.getElementById('onboardingOverlay')
   if (!overlay) return
+  if (s.channelProvider) onboardingChannelProvider = s.channelProvider
+  if (s.agentId) onboardingAgentId = s.agentId
+  applyOnboardingProviderTab()
   const step = onboardingCurrentStep(s)
   if (step === 0) { overlay.classList.remove('active'); overlay.hidden = true; document.body.style.overflow = ''; return }
   overlay.hidden = false
@@ -11940,9 +11952,12 @@ function renderOnboarding(s) {
   const body = document.getElementById('onboardingBody')
   if (step === 1) body.innerHTML = onbIdentityHtml(s)
   else if (step === 2) body.innerHTML = onbStep1Html(s)
-  else if (step === 3) body.innerHTML = onbStep2Html()
+  else if (step === 3) body.innerHTML = onbStep2Html(s)
   else body.innerHTML = onbStep3Html(s)
   wireOnboarding(step)
+  // Step 3, token already on disk, managed-settings.json still missing: the status GET already knows this (no probe/write/restart triggered),
+  // so show the sudo command right away instead of waiting for a Save click. Retry just re-polls status -- no token POST, no channel restart.
+  if (step === 3 && s.sudoCommand) showSudoModal(s.sudoCommand, () => refreshOnboarding())
 }
 function onbMsg(text, isErr) {
   const el = document.getElementById('onbMsg')
@@ -11971,11 +11986,26 @@ function onbStep1Html(s) {
       : '')
     + `<div id="onbMsg" class="onb-msg"></div>`
 }
-function onbStep2Html() {
-  return `<p>${escapeHtml(t('onboarding.step2.desc'))}</p>`
-    + `<label class="form-label-sm">${escapeHtml(t('onboarding.step2.token_label'))}</label>`
-    + `<input id="onbBotToken" type="password" class="onb-input" placeholder="123456:ABC..." autocomplete="off">`
-    + `<div class="onb-hint">${escapeHtml(t('onboarding.step2.token_hint'))}</div>`
+function onbStep2Html(s) {
+  const isSlack = onboardingChannelProvider === 'slack'
+  const desc = isSlack ? t('onboarding.step2.desc_slack') : t('onboarding.step2.desc')
+  const tokenLabel = isSlack ? t('onboarding.step2.token_label_slack') : t('onboarding.step2.token_label')
+  const tokenHint = isSlack ? t('onboarding.step2.token_hint_slack') : t('onboarding.step2.token_hint')
+  const placeholder = isSlack ? 'xoxb-...' : '123456:ABC...'
+  // Pre-fill from a token already on disk (e.g. a prior save that stopped at the managed-settings.json gate) so the operator isn't forced to dig it
+  // back out of ~/.claude/channels/<provider>/.env and repaste it. Saving still re-runs the managed-settings check server-side either way.
+  const existingBotToken = (s && s.existingBotToken) || ''
+  const existingAppToken = (s && s.existingAppToken) || ''
+  const appTokenFields = isSlack
+    ? `<label class="form-label-sm">${escapeHtml(t('onboarding.step2.app_token_label_slack'))}</label>`
+      + `<input id="onbSlackAppToken" type="password" class="onb-input" placeholder="xapp-..." value="${escapeHtml(existingAppToken)}" autocomplete="off" required>`
+      + `<div class="onb-hint">${escapeHtml(t('onboarding.step2.app_token_hint_slack'))}</div>`
+    : ''
+  return `<p>${escapeHtml(desc)}</p>`
+    + `<label class="form-label-sm">${escapeHtml(tokenLabel)}</label>`
+    + `<input id="onbBotToken" type="password" class="onb-input" placeholder="${placeholder}" value="${escapeHtml(existingBotToken)}" autocomplete="off">`
+    + `<div class="onb-hint">${escapeHtml(tokenHint)}</div>`
+    + appTokenFields
     + `<button class="btn-primary btn-compact" id="onbBotBtn">${escapeHtml(t('onboarding.step2.save_btn'))}</button>`
     + `<div id="onbMsg" class="onb-msg"></div>`
 }
@@ -12071,10 +12101,23 @@ function wireOnboarding(step) {
     if (botBtn) botBtn.addEventListener('click', async () => {
       const botToken = (document.getElementById('onbBotToken').value || '').trim()
       if (!botToken) { onbMsg(t('onboarding.step2.token_empty'), true); return }
+      const payload = { botToken }
+      if (onboardingChannelProvider === 'slack') {
+        const appToken = (document.getElementById('onbSlackAppToken')?.value || '').trim()
+        // Required, not optional: without SLACK_APP_TOKEN the channel session starts but Socket Mode never connects,
+        // so "saved" would read as success while Slack silently never comes online.
+        if (!appToken) { onbMsg(t('onboarding.step2.app_token_empty_slack'), true); return }
+        payload.appToken = appToken
+      }
       botBtn.disabled = true; onbMsg(t('onboarding.saving'))
       try {
-        const res = await fetch(`/api/agents/${encodeURIComponent(mainAgentId())}/channels/telegram`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ botToken }) })
+        const res = await fetch(`/api/agents/${encodeURIComponent(onboardingAgentId || mainAgentId())}/channels/${onboardingChannelProvider}`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) })
         const d = await res.json().catch(() => ({}))
+        if (res.status === 409 && d.error === 'managed-settings-missing') {
+          botBtn.disabled = false
+          showSudoModal(d.sudoCommand, () => botBtn.click())
+          return
+        }
         if (!res.ok) { botBtn.disabled = false; onbMsg(d.error || t('onboarding.error'), true); return }
         // The server restarts the channels session so the new bot token goes
         // live -- say so, and give the respawn a beat before advancing so the
@@ -12105,7 +12148,7 @@ function wireOnboarding(step) {
         // wizard rendered that as "no pending pairing" while the Channel view,
         // which uses the selected agent, listed the very same request.
         await ensureMarveenLoaded()
-        const res = await fetch(`/api/agents/${encodeURIComponent(mainAgentId())}/channels/telegram/pending`)
+        const res = await fetch(`/api/agents/${encodeURIComponent(onboardingAgentId || mainAgentId())}/channels/${onboardingChannelProvider}/pending`)
         // Surface the failure instead of rendering it as an empty list. This is
         // a separate defect from the id race: without it a 404 or an auth error
         // reads as "nobody is waiting for approval", which is the one answer the
@@ -12134,7 +12177,7 @@ function wireOnboarding(step) {
         box.querySelectorAll('.onb-approve').forEach((b) => b.addEventListener('click', async () => {
           b.disabled = true
           try {
-            const res = await fetch(`/api/agents/${encodeURIComponent(mainAgentId())}/channels/telegram/approve`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ code: b.dataset.code }) })
+            const res = await fetch(`/api/agents/${encodeURIComponent(onboardingAgentId || mainAgentId())}/channels/${onboardingChannelProvider}/approve`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ code: b.dataset.code }) })
             const d = await res.json().catch(() => ({}))
             if (!res.ok) { b.disabled = false; onbMsg(d.error || t('onboarding.error'), true); return }
             onbMsg(t('onboarding.step3.approved'))
@@ -12173,12 +12216,12 @@ document.getElementById('deepseekConfigLink')?.addEventListener('click', (e) => 
 })
 
 // === Sudo modal for managed-settings.json (Slack setup pre-flight) ===
-function showSudoModal(sudoCommand) {
+function showSudoModal(sudoCommand, onRetry) {
   let overlay = document.getElementById('sudoModalOverlay')
   if (overlay) overlay.remove()
   overlay = document.createElement('div')
   overlay.id = 'sudoModalOverlay'
-  overlay.style.cssText = 'position:fixed;inset:0;background:rgba(0,0,0,.55);z-index:9999;display:flex;align-items:center;justify-content:center'
+  overlay.style.cssText = 'position:fixed;inset:0;background:rgba(0,0,0,.55);z-index:10001;display:flex;align-items:center;justify-content:center'
   const card = document.createElement('div')
   card.style.cssText = 'background:var(--bg-card);border:1px solid var(--border);border-radius:12px;padding:24px;max-width:560px;width:90%'
   card.innerHTML = `
@@ -12205,7 +12248,8 @@ function showSudoModal(sudoCommand) {
   document.getElementById('sudoCancelBtn').addEventListener('click', () => overlay.remove())
   document.getElementById('sudoDoneBtn').addEventListener('click', () => {
     overlay.remove()
-    document.getElementById('chConnectBtn').click()
+    if (onRetry) onRetry()
+    else document.getElementById('chConnectBtn').click()
   })
   overlay.addEventListener('click', (e) => { if (e.target === overlay) overlay.remove() })
 }


### PR DESCRIPTION
## Mi tortent (tenyszeruen, nem szepitve)

A #883 vevo-facing fixe -- a Slack felig-konfiguralt onboarding kezelese (channelConfigured() az isManagedSettingsReady-re kapuzva, a status-endpoint sudoCommand-derivalasa, es a web/app.js step-3 felszinre hozasa + ures app-token elutasitasa) -- **NEM ment ki**. Az EN teszt-commitom torolte a szerzo javitasat a #883-on.

A gyoker-ok: mikozben bizonyitottam, hogy a strukturalis teszt a fix ELOTTI forrason bukik, a ket fajlt `git checkout origin/develop -- <fajlok>`-kal allitottam vissza a base-re -- ez a base-verziot az INDEXBE is stage-eli --, majd csak a WORKING TREE-t allitottam vissza `cp`-vel. Az index megtartotta a base-verziot, igy a commit (e451d6be) onboarding.ts -55 / web/app.js -68 sort rogzitett, torolve a szerzo fixet. A squash (b37d614) ezert CSAK a tesztet + a ket lang-fajlt vitte a developre.

Nettó hatas: a fix hianyzott a developrol, ES a mergelt tesztem piros volt vele szemben -- a rosszabbik kombinacio, mert ugy nezett ki, mintha szallitottunk volna.

## Mit csinal ez a PR

Visszaallitja a `src/web/routes/onboarding.ts` es `web/app.js` fajlokat PONTOSAN a szerzo fix-commitjanak (8daa2f58) tartalmara. Semmi mas nem valtozik -- a teszt es a lang-fajlok mar a developen vannak.

Diff: csak a ket fajl (onboarding.ts, app.js), a #883 eredeti +55/+68 tartalma vissza.

## Verify (a mi hostunkon)
- `slack-half-configured-onboarding.test.ts`: **4/4 ZOLD** (a visszaallitott fixszel; korabban piros volt).
- `npm run typecheck`: zold.
- Teljes suite: **3372 passed (254 files)**; elo `store/config-overrides.json` erintetlen.

## Tanulsag (a merge-eloellenorzeshez)
A `git checkout <ref> -- <path>` az INDEXBE is stage-el; a `cp`-restore csak a working tree-t frissiti. Prove-fail lepes utan a helyreallitast `git checkout <fix-sha> -- <path>` (index+worktree) vagy explicit `git add` kell. Es: a merge-elotti ellenorzesbe bekerul a TELJES fajl-lista + a VART fajlok jelenlete, szures nelkul -- egy teszt-fajlra szurt grep pont azt nem latja, ami hianyzik.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
