### PR TITLE
fix(pane-writers): six unlocked pane writers under the send lane (PANEWRITERS805)

### DIFF
--- a/src/__tests__/pane-writers-under-send-lock.test.ts
+++ b/src/__tests__/pane-writers-under-send-lock.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import {
+  tryAcquireSessionSendLane,
+  withSessionSendLock,
+  __resetSessionSendLocks,
+} from '../web/session-send-lock.js'
+
+// PANEWRITERS805: after DELIVLOCK805 serialized the sendPromptToSession emit
+// span, six in-process writers still hit the same panes with direct tmux
+// send-keys OUTSIDE the lane: the /mcp reconnect healer, the plugin-unlock
+// healer, the reauth /login sequence, the agent-worker /clear, and the three
+// modal dismissals that ran before the lock. Each could splice keystrokes into
+// a delivery mid-chunk-stream. These tests pin (a) the sync fail-closed
+// acquire primitive the sync writers use, and (b) that every site actually
+// routes through a lane acquire.
+
+afterEach(() => {
+  __resetSessionSendLocks()
+})
+
+describe('tryAcquireSessionSendLane: sync fail-closed acquire', () => {
+  it('acquires a free lane and blocks recover-mode callers until released', async () => {
+    const release = tryAcquireSessionSendLane('sess', null)
+    expect(release).not.toBeNull()
+    const during = await withSessionSendLock('sess', null, 'recover', async () => {})
+    expect(during.ran).toBe(false)
+    release!()
+    const after = await withSessionSendLock('sess', null, 'recover', async () => {})
+    expect(after.ran).toBe(true)
+  })
+
+  it('returns null while an async holder owns the lane (fail-closed, never queues)', async () => {
+    let unblock!: () => void
+    const wedged = new Promise<void>(res => { unblock = res })
+    const holder = withSessionSendLock('sess', null, 'deliver', async () => { await wedged })
+    await Promise.resolve()
+    expect(tryAcquireSessionSendLane('sess', null)).toBeNull()
+    unblock()
+    await holder
+    expect(tryAcquireSessionSendLane('sess', null)).not.toBeNull()
+  })
+
+  it('release is idempotent: a double call cannot hand the lane to a phantom holder', async () => {
+    const release = tryAcquireSessionSendLane('sess', null)!
+    release()
+    release()
+    // Lane is free exactly once: one acquire succeeds, a second concurrent one fails.
+    const again = tryAcquireSessionSendLane('sess', null)
+    expect(again).not.toBeNull()
+    expect(tryAcquireSessionSendLane('sess', null)).toBeNull()
+    again!()
+  })
+
+  it('hands the lane to a queued deliver-mode waiter on release, not to a barger', async () => {
+    const release = tryAcquireSessionSendLane('sess', null)!
+    const order: string[] = []
+    const waiter = withSessionSendLock('sess', null, 'deliver', async () => { order.push('waiter') })
+    await Promise.resolve()
+    release()
+    await waiter
+    expect(order).toEqual(['waiter'])
+  })
+
+  it('lane keys are host-scoped: a remote lane does not contend with the local one', () => {
+    const local = tryAcquireSessionSendLane('sess', null)
+    const remote = tryAcquireSessionSendLane('sess', 'vps1')
+    expect(local).not.toBeNull()
+    expect(remote).not.toBeNull()
+    local!(); remote!()
+  })
+})
+
+describe('every unguarded pane writer routes through the send lane', () => {
+  const read = (rel: string): string => readFileSync(join(__dirname, rel), 'utf-8')
+
+  it('channel-mcp-reconnect takes the lane for the whole /mcp menu walk and releases in finally', () => {
+    const src = read('../web/channel-mcp-reconnect.ts')
+    expect(src).toMatch(/tryAcquireSessionSendLane\(session, null\)/)
+    expect(src).toMatch(/deferring reconnect \(fail-closed\)/)
+    expect(src).toMatch(/finally \{\s*releaseLane\(\)\s*\}/)
+  })
+
+  it('channel-plugin-unlock gates the keystroke fire on the lane and reuses its retry ladder', () => {
+    const src = read('../web/channel-plugin-unlock.ts')
+    expect(src).toMatch(/tryAcquireSessionSendLane\(state\.session, null\)/)
+    // Busy lane consumes retriesLeft exactly like the not-idle branch.
+    expect(src).toMatch(/pane send lane busy \(delivery in flight\), retrying/)
+    expect(src).toMatch(/sendUnlockKeystrokes\(state\.session, state\.provider\)\s*\} finally \{\s*releaseLane\(\)/)
+  })
+
+  it('reauth-healer wraps the /login sequence in recover-mode and logs the skip', () => {
+    const src = read('../web/reauth-healer.ts')
+    expect(src).toMatch(/withSessionSendLock\(session, null, 'recover'/)
+    expect(src).toMatch(/\/login send-keys skipped/)
+  })
+
+  it('agent-worker runs /clear + prompt-send as ONE deliver-mode span with a held inner send', () => {
+    const src = read('../web/agent-worker.ts')
+    expect(src).toMatch(/withSessionSendLock\(ctx\.session, null, 'deliver'/)
+    const span = src.slice(src.indexOf("withSessionSendLock(ctx.session, null, 'deliver'"))
+    const clearIdx = span.indexOf('clearWorkerContext(ctx)')
+    const sendIdx = span.indexOf("lockMode: 'held'")
+    expect(clearIdx).toBeGreaterThan(-1)
+    expect(sendIdx).toBeGreaterThan(clearIdx)
+    expect(src).toMatch(/failedOpen/)
+  })
+
+  it('the modal dismissals acquire the lane fail-closed, except when the caller already holds it', () => {
+    const src = read('../web/agent-process.ts')
+    expect(src).toMatch(/releaseDismissLane = tryAcquireSessionSendLane\(session, host\)/)
+    expect(src).toMatch(/modal dismissals skipped/)
+    // 'held' callers run the dismissals WITHOUT re-acquiring (self-deadlock guard):
+    // the held branch must dismiss directly, before any acquire.
+    const heldIdx = src.indexOf("if (lockMode === 'held') {\n    await dismissSurveyModalIfPresent")
+    expect(heldIdx).toBeGreaterThan(-1)
+  })
+})

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -28,7 +28,7 @@ import { resolveAgentConfigDir } from './claude-plans.js'
 import { provisionMemoryBoundaryDir } from './memory-boundary.js'
 import { renameSharedCredentialsIfSafe } from './claude-credentials-guard.js'
 import { atomicWriteFileSync } from './atomic-write.js'
-import { withSessionSendLock, type SendLockMode } from './session-send-lock.js'
+import { withSessionSendLock, tryAcquireSessionSendLane, type SendLockMode } from './session-send-lock.js'
 import {
   buildTmuxInvocation,
   buildSshExec,
@@ -1728,9 +1728,34 @@ export async function sendPromptToSession(
   host: string | null = null,
   opts: { waitForIdle?: boolean; onBusyTimeout?: 'send' | 'abort'; idleTimeoutMs?: number; lockMode?: SendLockMode } = {},
 ): Promise<'sent' | 'aborted-busy' | 'skipped-locked'> {
-  await dismissSurveyModalIfPresent(session, host)
-  await dismissResumeSummaryModalIfPresent(session, host)
-  await dismissModelConsentDialogIfPresent(session, host)
+  const lockMode: SendLockMode = opts.lockMode ?? 'deliver'
+  // PANEWRITERS805: the three modal dismissals are probe+act keystroke writers
+  // that ran BEFORE the lane lock -- so they could press Escape/Enter into a
+  // pane mid-delivery (an Enter on the model-consent dialog confirms its
+  // DEFAULT, the FABLEFALL1 model switch). They must stay BEFORE the idle gate
+  // (a modal keeps the pane non-idle, so dismiss-after-wait would always time
+  // out), so they get their own fail-closed acquire instead of moving into the
+  // emit span. Skipping on a busy lane is safe: if a modal is really up, the
+  // idle gate below times out and the emit still queues behind the holder.
+  // 'held' callers already own the lane -- acquiring again would deadlock.
+  if (lockMode === 'held') {
+    await dismissSurveyModalIfPresent(session, host)
+    await dismissResumeSummaryModalIfPresent(session, host)
+    await dismissModelConsentDialogIfPresent(session, host)
+  } else {
+    const releaseDismissLane = tryAcquireSessionSendLane(session, host)
+    if (releaseDismissLane) {
+      try {
+        await dismissSurveyModalIfPresent(session, host)
+        await dismissResumeSummaryModalIfPresent(session, host)
+        await dismissModelConsentDialogIfPresent(session, host)
+      } finally {
+        releaseDismissLane()
+      }
+    } else {
+      logger.info({ session }, 'sendPromptToSession: modal dismissals skipped -- a delivery holds this pane send lane (fail-closed); emit will queue behind it')
+    }
+  }
 
   // Pre-flight wait-until-idle (root-cause gate). Placed here -- inside
   // sendPromptToSession, AFTER the modal dismissals (a modal keeps the pane
@@ -1772,7 +1797,6 @@ export async function sendPromptToSession(
   // is the per-session critical section. Held under a per-pane in-process mutex
   // (session-send-lock): normal delivery is fail-open (a stuck holder must not
   // silence the fleet); a `recover` caller skips instead of racing a live send.
-  const lockMode: SendLockMode = opts.lockMode ?? 'deliver'
   const emitToPane = async (): Promise<'sent'> => {
   // Pre-flight buffer-clear when a stale preamble is detected. Reading
   // the pane is best-effort: a capture failure here means we cannot

--- a/src/web/agent-worker.ts
+++ b/src/web/agent-worker.ts
@@ -14,6 +14,7 @@ import {
   hasFleetOauthToken,
   FLEET_OAUTH_TOKEN_PATH,
 } from './agent-process.js'
+import { withSessionSendLock } from './session-send-lock.js'
 import { readClaudeCodeOauthJson } from './claude-credentials.js'
 import { detectPaneState } from '../pane-state.js'
 import { notifyChannel } from '../notify.js'
@@ -662,8 +663,18 @@ async function runWorkerAttempt(ctx: WorkerCtx, message: string, timeoutMs: numb
   const donePath = join(ctx.scratchDir, `${reqId}.done`)
   for (const p of [outPath, donePath]) { try { rmSync(p, { force: true }) } catch { /* none */ } }
 
-  clearWorkerContext(ctx)
-  await sendPromptToSession(ctx.session, buildWorkerPrompt(message, outPath, donePath))
+  // PANEWRITERS805: /clear + prompt-send is ONE atomic delivery. Unlocked, the
+  // /clear could eat another writer's in-flight text, and a writer slipping in
+  // between the clear and our send would land its text into the freshly
+  // cleared context ahead of ours. Deliver mode (not recover): a dispatch must
+  // deliver; on a wedged holder we fail open past the budget, logged.
+  const sendRes = await withSessionSendLock(ctx.session, null, 'deliver', async () => {
+    clearWorkerContext(ctx)
+    await sendPromptToSession(ctx.session, buildWorkerPrompt(message, outPath, donePath), null, { lockMode: 'held' })
+  })
+  if (sendRes.failedOpen) {
+    logger.warn({ session: ctx.session, reqId }, 'agent-worker: dispatch ran without the send lane (fail-open past wait budget)')
+  }
 
   const start = Date.now()
   try {

--- a/src/web/channel-mcp-reconnect.ts
+++ b/src/web/channel-mcp-reconnect.ts
@@ -6,6 +6,7 @@ import { readAgentChannelProvider } from './agent-config.js'
 import { agentSessionName, capturePane } from './agent-process.js'
 import { MAIN_CHANNELS_SESSION } from './main-agent.js'
 import { getProvider, type ChannelProviderType } from '../channel-provider.js'
+import { tryAcquireSessionSendLane } from './session-send-lock.js'
 import { paneLooksIdle, detectPaneState } from '../pane-state.js'
 
 const TMUX = resolveFromPath('tmux')
@@ -176,6 +177,18 @@ export function attemptChannelMcpReconnect(agentName: string): ReconnectResult {
     return { ok: false, message: 'Pane busy -- reconnect deferred to avoid interrupting active work' }
   }
 
+  // PANEWRITERS805: the whole /mcp menu walk (Escape, /mcp, Up/Down/Enter) is
+  // direct keystrokes into a pane that also receives locked deliveries. Take
+  // the pane's send lane fail-closed for the entire sequence: a busy lane means
+  // a delivery is mid-chunk-stream, and our Escape/Enter would land inside its
+  // framed text. Skip and let the caller's tick retry -- same contract as the
+  // busy-pane defer above.
+  const releaseLane = tryAcquireSessionSendLane(session, null)
+  if (!releaseLane) {
+    logger.info({ agentName, session }, 'channel-mcp-reconnect: pane send lane busy (delivery in flight) -- deferring reconnect (fail-closed)')
+    return { ok: false, message: 'A delivery is in flight into this pane -- reconnect deferred' }
+  }
+
   try {
     execFileSync(TMUX, ['send-keys', '-t', session, 'Escape'], { timeout: 3000 })
     execFileSync('/bin/sleep', ['1'], { timeout: 2000 })
@@ -264,5 +277,7 @@ export function attemptChannelMcpReconnect(agentName: string): ReconnectResult {
     logger.warn({ err, agentName, session }, 'channel-mcp-reconnect failed')
     try { dismissMcpMenu(session) } catch { /* best effort */ }
     return { ok: false, message: err instanceof Error ? err.message : String(err) }
+  } finally {
+    releaseLane()
   }
 }

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -360,6 +360,12 @@ async function performStuckInputAction(
         // submit the wrong buffer). Run the clear+re-inject as ONE recover-mode
         // critical section; if a delivery holds the lane, skip and log -- a
         // stuck box recovers on the next tick once the delivery finishes.
+        // HOST-KEY CAVEAT (PANEWRITERS805): the lane key is host-scoped
+        // (`local::sess` here vs `vps1::sess` for a remote delivery). This
+        // recovery only ever targets LOCAL sessions today, so null is correct;
+        // if stuck-input recovery is ever extended to remote agents, the real
+        // host MUST be threaded here or the fail-closed guarantee silently
+        // evaporates (two different keys never contend).
         const res = await withSessionSendLock(session, null, 'recover', async () => {
           await clearInputBuffer(session)
           await sendPromptToSession(session, block!.block!, null, { lockMode: 'held' })

--- a/src/web/channel-plugin-unlock.ts
+++ b/src/web/channel-plugin-unlock.ts
@@ -36,6 +36,7 @@ import { execFileSync } from 'node:child_process'
 import { resolveFromPath } from '../platform.js'
 import { logger } from '../logger.js'
 import type { ChannelProviderType } from '../channel-provider.js'
+import { tryAcquireSessionSendLane } from './session-send-lock.js'
 
 const TMUX = resolveFromPath('tmux')
 
@@ -259,11 +260,33 @@ function runUnlockProbe(state: UnlockProbeState): void {
     return
   }
 
+  // PANEWRITERS805: the unlock sequence is direct keystrokes (/mcp, Up, Enter)
+  // into a pane that also receives locked deliveries. Fail-closed on a busy
+  // send lane, reusing the existing not-idle retry ladder: a delivery finishes
+  // within seconds, well inside the ladder's budget.
+  const releaseLane = tryAcquireSessionSendLane(state.session, null)
+  if (!releaseLane) {
+    if (state.retriesLeft > 0) {
+      logger.info(
+        { session: state.session, retriesLeft: state.retriesLeft },
+        'channel-plugin-unlock: pane send lane busy (delivery in flight), retrying',
+      )
+      setTimeout(() => runUnlockProbe({ ...state, retriesLeft: state.retriesLeft - 1 }), UNLOCK_PROBE_RETRY_DELAY_MS)
+      return
+    }
+    logger.warn({ session: state.session }, 'channel-plugin-unlock: pane send lane never freed up, abandoning')
+    return
+  }
+
   logger.warn(
     { session: state.session, claudePid, provider: state.provider },
     'channel-plugin-unlock: bun child absent after cold-start window, firing /mcp unlock sequence',
   )
-  sendUnlockKeystrokes(state.session, state.provider)
+  try {
+    sendUnlockKeystrokes(state.session, state.provider)
+  } finally {
+    releaseLane()
+  }
 }
 
 /**

--- a/src/web/reauth-healer.ts
+++ b/src/web/reauth-healer.ts
@@ -10,6 +10,7 @@ import { resolveAgentSession } from './channel-mcp-reconnect.js'
 import { MAIN_CHANNELS_SESSION } from './main-agent.js'
 import { detectReauthNeeded } from './reauth-detect.js'
 import { loginSequence, literalKeyArgs, specialKeyArgs } from './tmux-keys.js'
+import { withSessionSendLock } from './session-send-lock.js'
 
 // Autonomous re-auth healer (Adam stability-fix #1, scoped 2026-06-03).
 //
@@ -151,14 +152,23 @@ function sleep(ms: number): Promise<void> { return new Promise((r) => setTimeout
 // Fire-and-forget best-effort /login into a sub-agent session. Reuses the same
 // scripted sequence as the dashboard button (loginSequence('start')).
 async function sendBestEffortLogin(session: string): Promise<void> {
-  for (const step of loginSequence('start')) {
-    const args = step.kind === 'literal' ? literalKeyArgs(session, step.text) : specialKeyArgs(session, step.key)
-    if (args) {
-      await new Promise<void>((resolve) => {
-        execFile(TMUX, args, { timeout: 5000 }, () => resolve())
-      })
+  // PANEWRITERS805: the /login sequence is direct keystrokes into a pane that
+  // also receives locked deliveries. Recover-mode (fail-closed): a busy lane
+  // means a delivery is mid-chunk-stream and our keys would splice into its
+  // framed text. Skip and log; the healer's own sweep cadence retries.
+  const res = await withSessionSendLock(session, null, 'recover', async () => {
+    for (const step of loginSequence('start')) {
+      const args = step.kind === 'literal' ? literalKeyArgs(session, step.text) : specialKeyArgs(session, step.key)
+      if (args) {
+        await new Promise<void>((resolve) => {
+          execFile(TMUX, args, { timeout: 5000 }, () => resolve())
+        })
+      }
+      if (step.delayMs > 0) await sleep(step.delayMs)
     }
-    if (step.delayMs > 0) await sleep(step.delayMs)
+  })
+  if (!res.ran) {
+    logger.info({ session }, 'reauth-healer: /login send-keys skipped -- a delivery is in flight into this pane (fail-closed); next sweep retries')
   }
 }
 

--- a/src/web/session-send-lock.ts
+++ b/src/web/session-send-lock.ts
@@ -154,6 +154,24 @@ export async function withSessionSendLock<T>(
   }
 }
 
+// PANEWRITERS805: synchronous recover-mode acquire for the LEGACY SYNC writers
+// (the /mcp reconnect + plugin-unlock healers and the worker /clear are
+// execFileSync keystroke sequences that cannot await). Same fail-closed
+// contract as mode 'recover': a busy lane returns null and the caller MUST
+// skip-and-log, never write anyway. On success the returned release fn frees
+// the lane; it is idempotent so a finally block cannot double-hand-off.
+export function tryAcquireSessionSendLane(session: string, host: string | null): (() => void) | null {
+  const lane = laneFor(keyFor(session, host))
+  if (lane.busy) return null
+  lane.busy = true
+  let released = false
+  return () => {
+    if (released) return
+    released = true
+    handOff(lane)
+  }
+}
+
 // Test-only: reset lane state between cases.
 export function __resetSessionSendLocks(): void {
   lanes.clear()


### PR DESCRIPTION
## Summary
- PANEWRITERS805: brings the six in-process pane writers that bypassed the DELIVLOCK805 send lane under it. Same defect class as the scheduler resubmit fixed in #894: direct `send-keys` into a pane mid-delivery splices keystrokes into a framed message (and an Enter on the model-consent dialog confirms its DEFAULT, the FABLEFALL1 model switch).
- New sync primitive `tryAcquireSessionSendLane` in session-send-lock: recover-mode (fail-closed) semantics for the legacy `execFileSync` writers that cannot await; idempotent release; hands the lane to queued deliver-mode waiters on release.
- Per site:
  - **channel-mcp-reconnect**: the whole /mcp menu walk (Escape, /mcp, Up/Down/Enter) holds the lane; a busy lane defers exactly like the existing busy-pane preflight, the caller's tick retries.
  - **channel-plugin-unlock**: the keystroke fire gates on the lane and reuses the existing not-idle retry ladder for the busy case (no new retry mechanism).
  - **reauth-healer**: the /login sequence runs under async `recover` mode; the skip is logged and the healer's own sweep cadence retries.
  - **agent-worker**: `/clear` + prompt-send is ONE atomic `deliver`-mode span -- unlocked, the /clear could eat another writer's in-flight text, and a writer slipping between clear and send would land ahead of the fresh prompt. Inner send uses `lockMode: 'held'`; fail-open past the budget is logged.
  - **sendPromptToSession modal dismissals**: they must stay BEFORE the idle gate (a modal keeps the pane non-idle), so they get their own fail-closed acquire instead of moving into the emit span; `held` callers dismiss directly (self-deadlock guard). Skipping on a busy lane is safe: the emit still queues behind the holder.
  - **channel-monitor**: documented the host-scoped lane-key caveat -- recovery targets local sessions only today; a future remote extension must thread the real host or `local::sess` vs `vps1::sess` never contend and the fail-closed guarantee silently evaporates.
- Deliberately NOT wrapped: `routes/agent-terminal.ts` (interactive human keystrokes, char-by-char; serializing echo behind multi-second deliveries buys no framing guarantee and degrades the terminal -- risk accepted on the card).

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] 10 new tests: behavioral coverage of `tryAcquireSessionSendLane` (fail-closed vs async holders, idempotent release, FIFO hand-off to deliver waiters, host-scoped keys) + per-site wiring assertions
- [x] Full vitest suite: 255 files, 3386 tests, all green (worktree under `~/ClaudeClaw-wt`, not /tmp)
- [ ] Live-host evidence: like #894, the hermes soak does not cover the channel stack -- real proof accrues on the live host's healer firings and long scheduled prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
