### PR TITLE
fix(stuck-input): stop the lossy rescue of head-dropped parked prompts (STUCKINPUT805)

### DIFF
--- a/src/__tests__/stuck-input-action.test.ts
+++ b/src/__tests__/stuck-input-action.test.ts
@@ -50,6 +50,7 @@ function facts(over: Partial<StuckInputActionFacts>): StuckInputActionFacts {
     allowPlainReinject: false,
     hasPlainText: false,
     scheduledTaskBlock: false,
+    machineOrigin: false,
     ...over,
   }
 }
@@ -69,11 +70,53 @@ describe('decideStuckInputAction (recovery-decision unit)', () => {
     expect(a).toBe('hold')
   })
 
-  it('multi-row sub-agent plain text -> re-inject plain, never enter', () => {
+  it('multi-row sub-agent MACHINE-marked plain text -> re-inject plain, never enter', () => {
     const a = decideStuckInputAction(
-      facts({ rowCount: 2, allowPlainReinject: true, hasPlainText: true }),
+      facts({ rowCount: 2, allowPlainReinject: true, hasPlainText: true, machineOrigin: true }),
     )
     expect(a).toBe('reinject-plain')
+  })
+
+  // -------------------------------------------------------------------------
+  // STUCKINPUT805: the lossy-rescue regression measured live on 2026-08-05.
+  // The visible-box scrape drops the HEAD rows of an overfull box, so a
+  // re-inject of it is deterministic corruption (10,509-char prompt delivered
+  // as its last ~400 chars, byte-identically at 15:06 and 16:00).
+  // -------------------------------------------------------------------------
+
+  it('STUCKINPUT805: a parked scheduled tick on a SUB-AGENT is clear-only, never reinject-plain', () => {
+    // The old branch order routed this into reinject-plain (the sub-agent
+    // check sat above the scheduled check) -- the exact bug. The scheduler
+    // re-fires the tick whole; the scrape never contains the whole prompt.
+    const a = decideStuckInputAction(facts({
+      rowCount: 5, allowPlainReinject: true, hasPlainText: true,
+      scheduledTaskBlock: true, machineOrigin: true, escalate: true,
+    }))
+    expect(a).toBe('clear-scheduled')
+  })
+
+  it('STUCKINPUT805: uncertain-origin park on a sub-agent -> hold, never clear or re-inject', () => {
+    // "Sub-agent means no human draft" is false: agent-terminal types into
+    // sub-agent panes too. A human's text has no re-delivery; destroying it is
+    // strictly worse than a wedged box. Simulates the human-typed overflow:
+    // long multi-row text, no machine marker anywhere.
+    const a = decideStuckInputAction(facts({
+      rowCount: 8, allowPlainReinject: true, hasPlainText: true,
+      machineOrigin: false, escalate: true,
+    }))
+    expect(a).toBe('hold')
+  })
+
+  it('STUCKINPUT805: box so short even the tail marker is cut -> no machine evidence -> default path', () => {
+    // scheduledTaskBlock and machineOrigin both read false when every marker
+    // is outside the visible box. Multi-row holds; single-row keeps the
+    // harmless legacy Enter. Neither destroys anything.
+    expect(decideStuckInputAction(facts({
+      rowCount: 3, allowPlainReinject: true, hasPlainText: true, escalate: true,
+    }))).toBe('hold')
+    expect(decideStuckInputAction(facts({
+      rowCount: 1, allowPlainReinject: true, hasPlainText: true, escalate: true,
+    }))).toBe('enter')
   })
 
   it('multi-row with nothing safely re-injectable -> hold (never corrupt via Enter)', () => {
@@ -119,11 +162,19 @@ describe('decideStuckInputAction (recovery-decision unit)', () => {
     expect(decideStuckInputAction(facts({ rowCount: 1, scheduledTaskBlock: true, escalate: false }))).toBe('enter')
   })
 
-  it('sub-agent plain re-inject keeps precedence over clear-scheduled (existing path preserved)', () => {
+  it('STUCKINPUT805 precedence FLIP: clear-scheduled beats plain re-inject on sub-agents too', () => {
+    // The previous version of this test pinned the OPPOSITE ("existing path
+    // preserved") -- and that precedence WAS the bug: on a sub-agent pane a
+    // parked scheduled tick took the reinject-plain branch, whose payload is a
+    // scrape of the VISIBLE box. The TUI drops the head rows of an overfull
+    // box, so the scrape was the tail fragment -- re-injected byte-identically
+    // at 15:06 and 16:00 on 2026-08-05 (10,509-char prompt as its last ~400
+    // chars). clear-scheduled is strictly better on every session: the next
+    // schedule fire re-delivers the WHOLE prompt.
     const a = decideStuckInputAction(
-      facts({ rowCount: 3, scheduledTaskBlock: true, allowPlainReinject: true, hasPlainText: true }),
+      facts({ rowCount: 3, scheduledTaskBlock: true, allowPlainReinject: true, hasPlainText: true, machineOrigin: true }),
     )
-    expect(a).toBe('reinject-plain')
+    expect(a).toBe('clear-scheduled')
   })
 })
 

--- a/src/__tests__/welcome-screen-recovery.test.ts
+++ b/src/__tests__/welcome-screen-recovery.test.ts
@@ -49,17 +49,27 @@ describe('welcome-screen wedge: detection -> recovery decision (real fixture)', 
     expect(parkedInputRowCount(QWEN_WELCOME_WEDGE)).toBeGreaterThan(1)
   })
 
-  it('recovery decides reinject-plain for the multi-row sub-agent message (not hold/bare-Enter)', () => {
+  it('recovery HOLDS the wedge: the parked fragment has no surviving machine marker (STUCKINPUT805)', () => {
+    // POLICY CHANGE 2026-08-05: this fixture's parked text begins mid-sentence
+    // ("kepet: /Users/marvin/...") -- the head rows were already dropped by
+    // the TUI, and no machine marker survives in the visible box. The old
+    // decision re-injected it (reinject-plain), which is exactly the lossy
+    // rescue that delivered byte-identical truncated prompts at 15:06/16:00:
+    // the scrape IS a fragment, re-injecting it ships corruption. And origin
+    // is genuinely uncertain here (agent-terminal reaches sub-agent panes), so
+    // clearing could destroy a human's un-re-deliverable text. Hands off, log;
+    // the down-cascade's own agent recovery handles a persistently wedged pane.
     const action = decideStuckInputAction({
-      escalate: false,
+      escalate: true,
       rowCount: parkedInputRowCount(QWEN_WELCOME_WEDGE),
       blockComplete: false,
       blockTruncated: false,
       truncatedPreamble: false,
-      allowPlainReinject: true, // sub-agent box: no human draft
+      allowPlainReinject: true,
       hasPlainText: parkedInputText(QWEN_WELCOME_WEDGE) != null,
       scheduledTaskBlock: false,
+      machineOrigin: false, // computed: no prefix, no truncated marker survives
     })
-    expect(action).toBe('reinject-plain')
+    expect(action).toBe('hold')
   })
 })

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -1540,6 +1540,12 @@ export interface StuckInputActionFacts {
   allowPlainReinject: boolean
   /** parkedInputText(pane) != null -- there is collapsed text to re-inject. */
   hasPlainText: boolean
+  /** parkedMachineOriginInput(pane): the park is POSITIVELY machine-injected.
+   * STUCKINPUT805: reinject-plain requires this. Without positive origin the
+   * park may be a human draft (agent-terminal reaches sub-agent panes too),
+   * and clearing or re-injecting a human's text destroys work nothing will
+   * re-deliver. Uncertain origin -> hands off. */
+  machineOrigin: boolean
   /** parkedScheduledTaskInput(pane): a scheduled-task tick is parked. Clear-only
    * is safe on ANY session (the next schedule fire re-delivers). */
   scheduledTaskBlock: boolean
@@ -1567,16 +1573,29 @@ export function decideStuckInputAction(f: StuckInputActionFacts): StuckInputActi
   if (f.blockComplete) {
     return f.escalate || multiRow ? 'reinject-block' : 'enter'
   }
-  // Sub-agent non-channel parked text: clear + re-inject is safe (no human draft).
-  if (f.allowPlainReinject && f.hasPlainText && !f.blockTruncated) {
-    return f.escalate || multiRow ? 'reinject-plain' : 'enter'
-  }
-  // Parked scheduled-task tick (main session reaches here: no plain re-inject).
-  // Clear-only -- re-injecting risks TUI mid-text truncation corrupting the
-  // instruction, while a dropped tick is re-delivered by the next schedule
-  // fire. Single-row still tries the harmless Enter first.
+  // Parked scheduled-task tick: clear-only on EVERY session, and this check
+  // must sit ABOVE the plain-reinject branch. STUCKINPUT805: on a sub-agent
+  // pane the old order routed a parked tick into reinject-plain, whose text is
+  // parkedInputText = a scrape of the VISIBLE box -- and the TUI drops the
+  // HEAD rows of an overfull box, so the scrape is a tail fragment. That
+  // produced the byte-identical head-lost/tail-doubled deliveries measured at
+  // 15:06 and 16:00 on 2026-08-05 (10,509-char prompt reduced to its last
+  // ~400 chars, twice). A dropped tick is re-delivered WHOLE by the next
+  // schedule fire; a re-injected fragment is corruption nothing repairs.
+  // Single-row still tries the harmless Enter first.
   if (f.scheduledTaskBlock) {
     return f.escalate || multiRow ? 'clear-scheduled' : 'enter'
+  }
+  // Sub-agent non-channel parked text: clear + re-inject, but ONLY with
+  // POSITIVE machine origin (prefix or unmistakable wrapper marker). The old
+  // "sub-agent means no human draft" assumption is false -- agent-terminal
+  // types into sub-agent panes too -- and an uncertain park must not be
+  // destroyed: a human's text has no re-delivery. Machine-but-unrecognized
+  // (e.g. a head-lost inter-agent frame with no surviving marker) lands in
+  // 'hold' below: it cannot be re-injected whole (the scrape is lossy) and
+  // must not be cleared (the queue will not re-send a delivered message).
+  if (f.allowPlainReinject && f.hasPlainText && !f.blockTruncated && f.machineOrigin) {
+    return f.escalate || multiRow ? 'reinject-plain' : 'enter'
   }
   // Truncated safety preamble: clear only (never re-inject a stale preamble).
   if (f.truncatedPreamble && f.escalate) return 'clear-preamble'
@@ -1606,6 +1625,7 @@ export function parkedMainInputHasRemedy(pane: string): boolean {
     allowPlainReinject: false,
     hasPlainText: false,
     scheduledTaskBlock: parkedScheduledTaskInput(pane),
+    machineOrigin: parkedMachineOriginInput(pane),
   }
   return decideStuckInputAction(facts) !== 'hold'
 }

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -329,6 +329,7 @@ export async function recoverStuckInputForSession(
       allowPlainReinject,
       hasPlainText: allowPlainReinject && parkedInputText(pane) != null,
       scheduledTaskBlock: parkedScheduledTaskInput(pane),
+      machineOrigin: parkedMachineOriginInput(pane),
     }
     const action = decideStuckInputAction(facts)
     await performStuckInputAction(session, action, pane, block, sig, attempt)


### PR DESCRIPTION
## Summary
- The dominant truncation source, proven live 2026-08-05: a parked long scheduled prompt overfills the input box, the TUI drops the HEAD rows from view, `capture-pane -p` returns only the visible screen, and reinject-plain re-injected that tail scrape -- byte-identically at 15:06 (old code) and 16:00 (new code, c9d87266): the 10,509-char pr-figyeles delivered as its last ~400 chars, twice. The head-drop also blinded both guards (the #894 ladder's marker check and the machine-origin prefix anchor), which is why no resubmit log line ever appeared.
- Decision-table fix (the review constraint: POSITIVE identification or hands off):
  - **machine + scheduled park** (incl. head-dropped, via the already-existing truncated-marker detection): `clear-scheduled` on EVERY session -- the branch moved ABOVE the sub-agent plain-reinject check, whose precedence WAS the bug (a test even pinned the old order; flipped with in-test rationale). The next schedule fire re-delivers the whole prompt.
  - **machine-marked intact plain text on a sub-agent**: reinject-plain, now positively gated on `parkedMachineOriginInput` -- "sub-agent means no human draft" is false, agent-terminal types into sub-agent panes too.
  - **uncertain origin**: hold + log, never clear, never re-inject -- a human's text has no re-delivery, destroying it is strictly worse than a wedged box.
- Error branches simulated on realistic fixtures: box so short even the tail marker is cut (default enter/hold, nothing destroyed); human-typed overflow (hold); the historical head-dropped welcome-wedge fixture (was reinject-plain, now hold, rationale documented in-test).

## Test plan
- [x] Full suite 3389/3389 green (4 new STUCKINPUT805 cases + 2 policy-flip updates with in-test rationale)
- [x] tsc clean
- [ ] Live proof after the next host update: the 17:00+ pr-figyeles deliveries byte-diffed against the canonical prompt (the measurement protocol from today continues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)