### PR TITLE
feat(scheduler): dashboard-kapcsoló a catch-up értesítésre (SCHEDULER_CATCHUP_ALERT)

### DIFF
--- a/src/__tests__/config-registry.test.ts
+++ b/src/__tests__/config-registry.test.ts
@@ -16,6 +16,18 @@ describe('config-registry', () => {
     expect(getSettingDefinition('KANBAN_WIP_PLANNED')?.module).toBe('kanban')
   })
 
+  it('registers SCHEDULER_CATCHUP_ALERT as a 0..2 int, module=scheduler, hot-reloadable', () => {
+    const def = getSettingDefinition('SCHEDULER_CATCHUP_ALERT')
+    expect(def).toBeDefined()
+    expect(def!.type).toBe('int')
+    expect(def!.default).toBe(2)
+    expect(def!.min).toBe(0)
+    expect(def!.max).toBe(2)
+    expect(def!.module).toBe('scheduler')
+    expect(def!.secret).toBe(false)
+    expect(def!.requiresRestart).toBe(false)
+  })
+
   it('getSettingDefinition finds a known key and returns undefined for unknown', () => {
     expect(getSettingDefinition('KANBAN_WIP_PLANNED')?.type).toBe('int')
     expect(getSettingDefinition('NOT_A_REAL_KEY')).toBeUndefined()

--- a/src/__tests__/schedule-catchup.test.ts
+++ b/src/__tests__/schedule-catchup.test.ts
@@ -9,6 +9,7 @@ import {
   catchUpMaxAgeMs,
   computeCatchUpStart,
   decideCatchUp,
+  shouldReportCatchUp,
 } from '../web/schedule-runner.js'
 import { cronDueBetween, cronPrevOccurrence } from '../web/cron.js'
 
@@ -119,6 +120,45 @@ describe('decideCatchUp: run it, or say it was missed -- never neither', () => {
   })
 })
 
+describe('shouldReportCatchUp: the SCHEDULER_CATCHUP_ALERT level gates the downtime ping', () => {
+  // 2026-08-05 operator request: a configurable dashboard switch (int 0/1/2) for
+  // the "[scheduler] Kimaradt ütemezés / Pótlás elindítva" downtime line, replacing
+  // the reverted hardcoded #872. 0 = never, 1 = only when a stale (silently
+  // skipped) occurrence exists, 2 = every gap (the legacy default).
+  it('level 0 (never): stays silent even when something was missed', () => {
+    expect(shouldReportCatchUp(0, 5, 0)).toBe(false)
+    expect(shouldReportCatchUp(3, 0, 0)).toBe(false)
+    expect(shouldReportCatchUp(2, 1, 0)).toBe(false)
+  })
+
+  it('level 1 (only-missed): pings on a stale occurrence, silent on a pure catch-up', () => {
+    expect(shouldReportCatchUp(0, 1, 1)).toBe(true)
+    expect(shouldReportCatchUp(2, 1, 1)).toBe(true)
+    expect(shouldReportCatchUp(3, 0, 1)).toBe(false)
+    expect(shouldReportCatchUp(0, 0, 1)).toBe(false)
+  })
+
+  it('level 2 (every gap, legacy default): pings on any caught-up or missed occurrence', () => {
+    expect(shouldReportCatchUp(3, 0, 2)).toBe(true)
+    expect(shouldReportCatchUp(0, 1, 2)).toBe(true)
+    expect(shouldReportCatchUp(2, 1, 2)).toBe(true)
+    expect(shouldReportCatchUp(0, 0, 2)).toBe(false)
+  })
+
+  it('an out-of-range level >= 2 behaves as the legacy default; < 0 as never', () => {
+    expect(shouldReportCatchUp(3, 0, 99)).toBe(true)
+    expect(shouldReportCatchUp(3, 0, -1)).toBe(false)
+  })
+})
+
+describe('the runner reads the SCHEDULER_CATCHUP_ALERT setting and gates the summary', () => {
+  it('resolves the level from settings and delegates to shouldReportCatchUp', () => {
+    expect(SRC).toMatch(/getEffectiveSettingValue\('SCHEDULER_CATCHUP_ALERT'\)/)
+    expect(SRC).toMatch(/shouldReportCatchUp\(caughtUpThisTick\.length, staleThisTick\.length/)
+    expect(SRC).not.toMatch(/if \(caughtUpThisTick\.length \|\| staleThisTick\.length\) \{/)
+  })
+})
+
 describe('cronPrevOccurrence: the age the decision is made on', () => {
   // 2026-07-29 08:40 local, a Wednesday -- one occurrence of "40 6 * * *" is in
   // the window (06:40 that morning), and it is 2h late.
@@ -175,7 +215,11 @@ describe('the runner wires the policy in', () => {
     expect(SRC).toMatch(/sendCatchUpSummary\(caughtUpThisTick, staleThisTick/)
   })
 
-  it('stays silent on a tick that caught nothing up', () => {
-    expect(SRC).toMatch(/if \(caughtUpThisTick\.length \|\| staleThisTick\.length\) \{/)
+  it('gates the summary on config-driven shouldReportCatchUp, not the legacy unconditional guard', () => {
+    // 2026-08-05: the old `if (caughtUp || stale)` guard is replaced by the
+    // SCHEDULER_CATCHUP_ALERT-gated shouldReportCatchUp (see the dedicated
+    // describe above). An empty gap still stays silent (level 2: caughtUp||stale).
+    expect(SRC).toMatch(/shouldReportCatchUp\(caughtUpThisTick\.length, staleThisTick\.length, catchUpAlertLevel\)/)
+    expect(SRC).not.toMatch(/if \(caughtUpThisTick\.length \|\| staleThisTick\.length\) \{/)
   })
 })

--- a/src/config-registry.ts
+++ b/src/config-registry.ts
@@ -160,6 +160,18 @@ export const SETTINGS_REGISTRY: SettingDefinition[] = [
     secret: false,
     requiresRestart: false,
   },
+  // --- Scheduler ---
+  {
+    key: 'SCHEDULER_CATCHUP_ALERT',
+    type: 'int',
+    default: 2,
+    min: 0,
+    max: 2,
+    description: 'Downtime utáni catch-up értesítés a Telegramon ("Kimaradt ütemezés / Pótlás elindítva"): 0 = soha, 1 = csak ha volt némán kihagyott (stale) feladat, 2 = minden kiesésnél (alapértelmezett).',
+    module: 'scheduler',
+    secret: false,
+    requiresRestart: false,
+  },
   // --- Kanban aging thresholds and colours (hot-reload via settings-store) ---
   {
     key: 'KANBAN_AGING_WARN_H',

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -48,6 +48,7 @@ import {
 } from './agent-process.js'
 import { MAIN_CHANNELS_SESSION } from './main-agent.js'
 import { sendTelegramMessage } from './telegram.js'
+import { getEffectiveSettingValue } from '../settings-store.js'
 import { runCommandTask } from './command-task.js'
 import { paneShowsContextSaturation, detectsFirstRunGate, detectPaneState, type PaneState } from '../pane-state.js'
 
@@ -328,6 +329,18 @@ export function decideCatchUp(
 ): CatchUpDecision {
   if (ageMs <= lateThresholdMs) return 'on-time'
   return ageMs <= catchUpMaxAgeMs(task) ? 'catch-up' : 'stale'
+}
+
+// Pure: whether a downtime catch-up gap warrants a Telegram ping, given the
+// operator's SCHEDULER_CATCHUP_ALERT level (2026-08-05, dashboard-configurable,
+// replacing the reverted hardcoded #872). 0 = never; 1 = only when a stale
+// (silently-skipped) occurrence exists; 2 = every non-empty gap (legacy
+// default). Out-of-range is clamped by the setting bounds, but the predicate is
+// defensive: any level >= 2 reads as the legacy default, < 0 as never.
+export function shouldReportCatchUp(caughtUpCount: number, staleCount: number, alertLevel: number): boolean {
+  if (alertLevel <= 0) return false
+  if (alertLevel === 1) return staleCount > 0
+  return caughtUpCount > 0 || staleCount > 0
 }
 
 /** Pure: where the first post-start scan window begins. */
@@ -1275,7 +1288,10 @@ export function startScheduleRunner(): NodeJS.Timeout {
     // Tell the operator, in one line, what the gap cost. Only fires when this
     // tick actually caught something up or declared something too stale, which
     // in steady state is never.
-    if (caughtUpThisTick.length || staleThisTick.length) {
+    // Downtime catch-up ping: gated by the SCHEDULER_CATCHUP_ALERT dashboard
+    // setting (0 never / 1 only-missed / 2 every gap; hot-reloaded per tick).
+    const catchUpAlertLevel = Number(getEffectiveSettingValue('SCHEDULER_CATCHUP_ALERT'))
+    if (shouldReportCatchUp(caughtUpThisTick.length, staleThisTick.length, catchUpAlertLevel)) {
       sendCatchUpSummary(caughtUpThisTick, staleThisTick, pendingStartupGapMs || (now - fromMs))
     }
     pendingStartupGapMs = 0


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [ ] Bug fix (hibajavítás / bug fix)
- [x] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

HU: A downtime utáni catch-up összefoglaló (`[<bot> scheduler] Kimaradt ütemezés / Pótlás elindítva`) mostantól egy **dashboard-beállítással** szabályozható a config-registry-n keresztül: `SCHEDULER_CATCHUP_ALERT` (int, 0/1/2, hot-reload, nem igényel restartot). Értékek: **0 = soha**, **1 = csak ha volt némán KIHAGYOTT (stale) feladat**, **2 = minden kiesésnél** (alapértelmezett — a jelenlegi viselkedés, hogy meglévő telepítéseknél ne változzon semmi). A döntést egy új, tiszta és unit-tesztelt `shouldReportCatchUp(caughtUpCount, staleCount, alertLevel)` predikátum hozza (a meglévő `decideCatchUp` policy-mintája szerint); a scheduler tick guard-ja a beállítás hatásos értékét olvassa (`getEffectiveSettingValue`, per-tick hot-reload).

Ez a **visszavont #872** (hardcode-olt only-missed viselkedés) **beállítás-alapú** változata: a karbantartó jelezte, hogy ez konfiguráció, nem hardcode-olt policy legyen. A dashboard /Beállítások oldalán a `SCHEDULER_CATCHUP_ALERT` 0-ra állításával az értesítés teljesen elnémítható.

EN: The post-downtime catch-up summary is now controlled by a **dashboard setting** via the config-registry: `SCHEDULER_CATCHUP_ALERT` (int 0/1/2, hot-reloadable, no restart). 0 = never, 1 = only when a stale (silently skipped) occurrence exists, 2 = every gap (legacy default, so existing installs are unchanged). The decision lives in a new pure, unit-tested `shouldReportCatchUp()` predicate; the tick guard reads the effective setting value per tick. This is the configuration-based replacement for the reverted #872 (hardcoded only-missed), at the maintainer's request.

Változott / Changed:
- `src/config-registry.ts`: új `SCHEDULER_CATCHUP_ALERT` mező (module `scheduler`, non-secret, hot-reload).
- `src/web/schedule-runner.ts`: `shouldReportCatchUp()` export + a tick guard a beállításra delegál (`getEffectiveSettingValue`).
- `src/__tests__/schedule-catchup.test.ts`: behavioral tesztek a predikátumra (3 szint × kombinációk) + a wiring-teszt frissítése az új guard-ra.
- `src/__tests__/config-registry.test.ts`: a `SCHEDULER_CATCHUP_ALERT` mező invariánsai (0..2 int, module scheduler, hot-reload).

## Kapcsolódó issue / Related issue

Nincs GitHub issue — a kérés Telegramon érkezett. A visszavont `#872` beállítás-alapú utódja.

## Ellenőrzőlista / Checklist

- [ ] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard) — **automata teszttel igazoltam, nem éles dashboard-teszttel**: `vitest run` RED→GREEN (schedule-catchup + config-registry, 50 teszt), regresszió zöld (settings-store), `tsc --noEmit` exit 0. Node 22 alatt futtatva. A beállítás a Settings UI-ban automatikusan megjelenik a registry-ből.
- [x] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Nem érinti — új opcionális config-kulcs, alapból a jelenlegi viselkedés.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets.
- [x] Saját, beszédes nevű branch-ről nyitom (`fix/scheduler-catchup-alert-config`, nem közvetlenül `develop`-ra). / Opened from an own branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
