### PR TITLE
fix(ledger): keep voice/video_note attachment identity so a respawned session can still transcribe

### DIFF
--- a/scripts/hooks/ledger-capture.py
+++ b/scripts/hooks/ledger-capture.py
@@ -39,9 +39,18 @@ def main():
         chat_id = _attr(attrs, "chat_id")
         message_id = _attr(attrs, "message_id")
         ts = _attr(attrs, "ts")
+        # Voice / video_note that arrived WITHOUT a transcript keeps its
+        # attachment identity in the ledger, so a respawned session can still
+        # download + transcribe it (the STT-success path strips these attrs and
+        # carries the transcript in the body instead, so nothing is stored then).
+        att_kind = _attr(attrs, "attachment_kind")
+        att_file_id = _attr(attrs, "attachment_file_id")
         if chat_id and message_id:
             try:
-                ledger_lib.log_inbound(agent_id, chat_id, message_id, text.strip(), ts)
+                ledger_lib.log_inbound(
+                    agent_id, chat_id, message_id, text.strip(), ts,
+                    attachment_kind=att_kind, attachment_file_id=att_file_id,
+                )
             except Exception:
                 pass  # never block the prompt on a ledger error
     sys.exit(0)

--- a/scripts/hooks/ledger-live-drain.py
+++ b/scripts/hooks/ledger-live-drain.py
@@ -68,7 +68,7 @@ def main():
         sys.exit(0)  # ledger unavailable -> silent no-op
     if not oq:
         sys.exit(0)  # nothing open (none, or already answered)
-    chat_id, message_id, text, ts, created_at = oq
+    chat_id, message_id, text, ts, created_at, att_kind, att_file_id = oq
 
     # GRACE: skip a fresh inbound the agent may be answering right now.
     try:
@@ -83,6 +83,12 @@ def main():
         sys.exit(0)
 
     snippet = (text or "").strip()
+    if att_file_id:
+        snippet += (
+            f'\n[Ez egy {att_kind or "voice"} csatolmány átirat nélkül: töltsd le '
+            f'és írasd át (voice-message-transcribe skill, '
+            f'attachment_file_id="{att_file_id}") mielőtt válaszolsz.]'
+        )
     sys.stdout.write(f"OPEN_QUESTION chat_id={chat_id} message_id={message_id}\n{snippet}\n")
     _record_surfaced(path, message_id)
     sys.exit(0)

--- a/scripts/hooks/ledger-replay.py
+++ b/scripts/hooks/ledger-replay.py
@@ -141,7 +141,7 @@ def _build_output(transcript, open_q, owner):
         "betöltött kontextusból folytass, ne kezdd elölről."
     ]
     if open_q:
-        chat_id, message_id, text, ts = open_q
+        chat_id, message_id, text, ts, att_kind, att_file_id = open_q
         snippet = _snippet(text, _max_snippet())
         parts.append(
             f'NYITOTT KÉRDÉS (még NEM válaszoltad meg): {owner} utolsó üzenete '
@@ -149,6 +149,14 @@ def _build_output(transcript, open_q, owner):
             f'MOST a telegram reply tool (mcp__plugin_telegram_telegram__reply) '
             f'meghívásával a megfelelő chat_id-re, a lenti kontextusból folytatva.'
         )
+        if att_file_id:
+            parts.append(
+                f'A nyitott kérdés egy {att_kind or "voice"} csatolmány, aminek '
+                f'a TARTALMA nem veszett el: töltsd le és írasd át MIELŐTT '
+                f'válaszolsz (voice-message-transcribe skill; '
+                f'attachment_file_id="{att_file_id}"). NE kérd a küldőtől hogy '
+                f'ismételje meg.'
+            )
     if recent:
         parts.append(
             "LEGFRISSEBB FORDULÓK (időrendben, a beszélgetés vége -- innen "
@@ -210,9 +218,14 @@ def main():
 
     max_snippet = _max_snippet()
     transcript = []
-    for direction, chat_id, text, ts in rows:
+    for direction, chat_id, text, ts, att_kind, att_file_id in rows:
         who = owner if direction == "in" else "Te"
         snippet = _snippet(text, max_snippet)
+        # A transcript-less voice turn carries its file_id so the fresh session
+        # can still fetch the audio content instead of seeing an opaque
+        # "(voice message)" placeholder.
+        if att_file_id:
+            snippet = f'{snippet} [{att_kind or "voice"} file_id={att_file_id}]'
         transcript.append(f'  [{ts}] {who}: "{snippet}"')
 
     # Coarse char pre-trim (cheap): drop the OLDEST turns until the transcript

--- a/scripts/hooks/ledger_lib.py
+++ b/scripts/hooks/ledger_lib.py
@@ -28,10 +28,20 @@ CREATE TABLE IF NOT EXISTS conversation_log (
   text TEXT,
   ts TEXT,
   created_at INTEGER NOT NULL,
+  attachment_kind TEXT,
+  attachment_file_id TEXT,
   UNIQUE(agent_id, chat_id, direction, message_id)
 )
 """
 INDEX = "CREATE INDEX IF NOT EXISTS idx_convlog_agent ON conversation_log(agent_id, created_at)"
+
+# Columns added after the initial schema shipped. connect() retrofits them onto
+# existing DBs with idempotent ALTERs (CREATE TABLE IF NOT EXISTS is a no-op on
+# an already-created table, so the SCHEMA text alone never upgrades old DBs).
+_MIGRATION_COLUMNS = (
+    ("attachment_kind", "TEXT"),
+    ("attachment_file_id", "TEXT"),
+)
 
 RECENT_LIMIT = 20
 
@@ -114,18 +124,29 @@ def connect():
     con.execute("PRAGMA busy_timeout=10000")
     con.execute(SCHEMA)
     con.execute(INDEX)
+    existing = {row[1] for row in con.execute("PRAGMA table_info(conversation_log)")}
+    for col, coltype in _MIGRATION_COLUMNS:
+        if col not in existing:
+            con.execute(f"ALTER TABLE conversation_log ADD COLUMN {col} {coltype}")
     return con
 
 
-def log_inbound(agent_id, chat_id, message_id, text, ts):
-    """Record an inbound user message. Idempotent on (agent_id, chat_id, in, message_id)."""
+def log_inbound(agent_id, chat_id, message_id, text, ts,
+                attachment_kind=None, attachment_file_id=None):
+    """Record an inbound user message. Idempotent on (agent_id, chat_id, in, message_id).
+
+    attachment_kind/file_id: set for voice / video_note messages that arrived
+    WITHOUT a transcript, so a respawned session can still download and
+    transcribe the audio instead of losing the message content forever."""
     con = connect()
     try:
         con.execute(
             "INSERT OR IGNORE INTO conversation_log"
-            " (agent_id, chat_id, direction, message_id, text, ts, created_at)"
-            " VALUES (?, ?, 'in', ?, ?, ?, ?)",
-            (str(agent_id), str(chat_id), str(message_id), text, ts, int(time.time())),
+            " (agent_id, chat_id, direction, message_id, text, ts, created_at,"
+            "  attachment_kind, attachment_file_id)"
+            " VALUES (?, ?, 'in', ?, ?, ?, ?, ?, ?)",
+            (str(agent_id), str(chat_id), str(message_id), text, ts, int(time.time()),
+             attachment_kind, attachment_file_id),
         )
         con.commit()
     finally:
@@ -149,11 +170,13 @@ def log_outbound(agent_id, chat_id, text):
 
 
 def recent(agent_id, limit=RECENT_LIMIT):
-    """The last `limit` turns for this agent, oldest-first. Rows: (direction, chat_id, text, ts)."""
+    """The last `limit` turns for this agent, oldest-first.
+    Rows: (direction, chat_id, text, ts, attachment_kind, attachment_file_id)."""
     con = connect()
     try:
         rows = con.execute(
-            "SELECT direction, chat_id, text, ts FROM conversation_log"
+            "SELECT direction, chat_id, text, ts, attachment_kind, attachment_file_id"
+            " FROM conversation_log"
             " WHERE agent_id=? ORDER BY created_at DESC, id DESC LIMIT ?",
             (str(agent_id), int(limit)),
         ).fetchall()
@@ -164,18 +187,21 @@ def recent(agent_id, limit=RECENT_LIMIT):
 
 def open_question_with_age(agent_id):
     """Like open_question() but also returns the open inbound's created_at (unix
-    epoch). Returns (chat_id, message_id, text, ts, created_at) or None. Used by
-    the live-drain hook, which needs the age for its grace window."""
+    epoch). Returns (chat_id, message_id, text, ts, created_at, attachment_kind,
+    attachment_file_id) or None. Used by the live-drain hook, which needs the
+    age for its grace window."""
     con = connect()
     try:
         row = con.execute(
-            "SELECT chat_id, message_id, text, ts, created_at, id FROM conversation_log"
+            "SELECT chat_id, message_id, text, ts, created_at, id,"
+            "       attachment_kind, attachment_file_id"
+            " FROM conversation_log"
             " WHERE agent_id=? AND direction='in' ORDER BY created_at DESC, id DESC LIMIT 1",
             (str(agent_id),),
         ).fetchone()
         if not row:
             return None
-        chat_id, message_id, text, ts, created_at, rid = row
+        chat_id, message_id, text, ts, created_at, rid, att_kind, att_file_id = row
         later_out = con.execute(
             "SELECT 1 FROM conversation_log"
             " WHERE agent_id=? AND direction='out'"
@@ -184,13 +210,17 @@ def open_question_with_age(agent_id):
         ).fetchone()
         if later_out:
             return None  # the last inbound has already been answered
-        return (chat_id, message_id, text, ts, created_at)
+        return (chat_id, message_id, text, ts, created_at, att_kind, att_file_id)
     finally:
         con.close()
 
 
 def open_question(agent_id):
     """The most recent inbound with NO later outbound (the unanswered question),
-    or None. Returns (chat_id, message_id, text, ts)."""
+    or None. Returns (chat_id, message_id, text, ts, attachment_kind,
+    attachment_file_id)."""
     oq = open_question_with_age(agent_id)
-    return oq[:4] if oq else None
+    if not oq:
+        return None
+    chat_id, message_id, text, ts, _created_at, att_kind, att_file_id = oq
+    return (chat_id, message_id, text, ts, att_kind, att_file_id)

--- a/src/__tests__/conversation-ledger-schema.test.ts
+++ b/src/__tests__/conversation-ledger-schema.test.ts
@@ -32,7 +32,7 @@ describe('conversation_log schema: db.ts migration == ledger_lib.py (no drift)',
   it('the column sets are identical and complete', () => {
     const a = logColumns(dbts).sort()
     const b = logColumns(lib).sort()
-    expect(a).toEqual(['agent_id', 'chat_id', 'created_at', 'direction', 'id', 'message_id', 'text', 'ts'])
+    expect(a).toEqual(['agent_id', 'attachment_file_id', 'attachment_kind', 'chat_id', 'created_at', 'direction', 'id', 'message_id', 'text', 'ts'])
     expect(b).toEqual(a)
   })
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -262,10 +262,21 @@ export function initDatabase(dbPathOverride?: string): void {
       text TEXT,
       ts TEXT,
       created_at INTEGER NOT NULL,
+      attachment_kind TEXT,
+      attachment_file_id TEXT,
       UNIQUE(agent_id, chat_id, direction, message_id)
     )
   `)
   db.exec(`CREATE INDEX IF NOT EXISTS idx_convlog_agent ON conversation_log(agent_id, created_at)`)
+  // Migration for pre-existing DBs: transcript-less voice/video_note inbounds
+  // keep their attachment identity so a respawned session can still download
+  // and transcribe them (mirrors _MIGRATION_COLUMNS in scripts/hooks/ledger_lib.py).
+  for (const col of ['attachment_kind', 'attachment_file_id']) {
+    const cols = db.prepare("PRAGMA table_info(conversation_log)").all() as { name: string }[]
+    if (!cols.some(c => c.name === col)) {
+      db.exec(`ALTER TABLE conversation_log ADD COLUMN ${col} TEXT`)
+    }
+  }
 
   // Migration: hot/warm/cold/shared tier system with an enforced CHECK.
   // Rebuilds the table whenever its current schema doesn't include the


### PR DESCRIPTION
## A hiba

Bejövő Telegram **hang- és körvideó-üzeneteknél** a napló nem őrizte meg a csatolmány azonosítóját. Ha a fő session újraindult (watchdog-mentés, plugin-restart, kézi restart) **mielőtt az STT lefutott volna**, az átirat nélküli bejegyzés használhatatlan „[hangüzenet]" sorként játszódott vissza — maga a hang elveszett, mert a `file_id`-t csak a channel plugin memóriája ismerte.

Nálunk ez konkrét kárt okozott: a session 06:25-kor meghalt, a watchdog újraindította, és a közvetlenül előtte küldött két hangüzenet visszahozhatatlan volt.

## A javítás

A `conversation_log` bejegyzés eltárolja az `attachment_kind` és `attachment_file_id` mezőket, így egy friss session **utólag is le tudja tölteni és át tudja írni** a hangot.

Tartalmaz egy `PRAGMA table_info`-val védett migrációt a meglévő adatbázisokhoz (a `scripts/hooks/ledger_lib.py` `_MIGRATION_COLUMNS` mintáját követve), így az oszlopok frissítéskor maguktól megjelennek, kézi lépés nélkül.

## Tesztelés

Éles telepítésen (macOS, 8 ágenses flotta) v1.27.0 óta fut, a v1.30.0-ra rebase-elve konfliktus nélkül. A séma-teszt frissítve; `npm run build` tiszta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)