### PR TITLE
feat(alerts): report wedge recoveries and long channel outages to the owner

### DIFF
--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -1418,8 +1418,17 @@ function handleMarveenUp(): void {
     const stage = marveenDownState.stage
     const providerLabel = getMainAgentProvider()
     logger.info({ stage, downedFor, provider: providerLabel }, 'Marveen channel plugin recovered')
-    if (stage !== 'soft' && stage !== 'save' && stage !== 'resume') {
-      sendAlert(`✅ ${BOT_NAME} ${providerLabel} plugin helyrealt (${stage} utan, ${downedFor}s kieses).`)
+    // Owner transparency (2026-07-30, "reggeli leallas"): a resume-stage
+    // recovery means the main session was actually respawned -- the owner's
+    // in-flight messages may have been dropped, so it must not be silent. Short
+    // soft/save blips stay quiet, but a LONG outage is reported even when the
+    // fix itself was soft: messages sent into that window went unanswered.
+    const disruptive = stage !== 'soft' && stage !== 'save'
+    if (disruptive || downedFor >= 180) {
+      sendAlert(
+        `✅ ${BOT_NAME} ${providerLabel} kapcsolat helyreallt (${downedFor}s kieses, ${stage} szint). ` +
+        `Ha a kieses alatt irtal es nem jott valasz, mindjart potolom.`,
+      )
     }
     marveenDownState = null
   }

--- a/src/web/stuck-tool-call-watcher.ts
+++ b/src/web/stuck-tool-call-watcher.ts
@@ -42,7 +42,7 @@ import { logger } from '../logger.js'
 import { resolveFromPath } from '../platform.js'
 import { capturePane } from './agent-process.js'
 import { MAIN_CHANNELS_SESSION } from './main-agent.js'
-import { resumeMarveenSession, lastMainRespawnAt, MARVEEN_POST_RESPAWN_GRACE_MS } from './channel-monitor.js'
+import { resumeMarveenSession, sendAlert, lastMainRespawnAt, MARVEEN_POST_RESPAWN_GRACE_MS } from './channel-monitor.js'
 import {
   stuckToolCallSignature,
   decideStuckToolCallRecovery,
@@ -234,6 +234,16 @@ async function checkSession(label: string, session: string): Promise<void> {
     if (!ok) {
       logger.error({ label, session }, 'stuck-tool-call-watcher: respawn-pane recovery failed')
     }
+    // Owner transparency (2026-07-30, "reggeli leallas"): every wedge recovery
+    // used to be silent, so the owner discovered a dead morning session only by
+    // messaging into the void and then spent the morning pasting logs. One
+    // proactive report replaces that whole loop. Sent on both outcomes -- a
+    // FAILED recovery is exactly when the owner must know.
+    sendAlert(
+      ok
+        ? `🔧 A fő session beragadt (${Math.round(next.lastSeconds ?? 0)}s óta nem haladt), automatikusan újraindítottam a beszélgetés megtartásával. Ha volt megválaszolatlan üzeneted, mindjárt válaszolok rá.`
+        : `🚨 A fő session beragadt, és az automatikus újraindítás NEM sikerült. Kézi beavatkozás kellhet: tmux attach -t ${session}, vagy scripts/stop.sh && scripts/start.sh a marveen mappából.`,
+    )
   }
 }
 


### PR DESCRIPTION
## Miért

Mindkét helyreállítási út **néma** volt, ezért egy halott session megkülönböztethetetlen volt egy lassútól. Nálunk ez két nap alatt kétszer okozott elvesztegetett fél délelőttöt: a tulajdonos csak abból vette észre a bajt, hogy üzent „a semmibe", majd logokat kezdett másolgatni.

## Mit csinál

- **`stuck-tool-call-watcher`**: beragadt session kimentése után Telegram-riport megy a tulajdonosnak — **mindkét kimenetelnél**. Egy *sikertelen* mentés épp az az eset, amiről tudnia kell.
- **`channel-monitor`**: a `resume` szakaszú helyreállítás azt jelenti, hogy a fő session tényleg újraindult, tehát a repülő üzenetek elveszhettek — ez nem maradhat néma. A rövid `soft`/`save` zökkenők továbbra is csendben maradnak, de a **hosszú kiesésről** akkor is szól, ha a javítás maga „soft" volt: az abban az ablakban küldött üzenetek megválaszolatlanok maradtak.

## Tesztelés

Éles telepítésen (macOS, 8 ágenses flotta) fut; a riportok pontosan a valós reggeli leállásoknál jelentek meg. `npm run build` tiszta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)