### PR TITLE
fix(effort): set the fleet effort level via env, not settings.json (EFFORT806)

### DIFF
--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -281,6 +281,9 @@ fi
 # source removes the phantom entirely. Inherited by every sub-agent via the tmux
 # global env set below.
 export CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false
+# Effort level for THIS shell (the main channels claude inherits it). See the
+# set-environment -g block below for why this is an env var and not settings.json.
+export CLAUDE_CODE_EFFORT_LEVEL=max
 
 CLAUDE="$(command -v claude)"
 TMUX="$(command -v tmux)"
@@ -533,6 +536,16 @@ if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
 fi
 # Propagate the prompt-suggestion disable to every sub-agent tmux session.
 $TMUX set-environment -g CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION false 2>/dev/null || true
+# Effort level for the whole fleet, propagated the same way. It MUST be an env
+# var: Claude Code's settings.json schema validates effortLevel as
+# enum(["low","medium","high","xhigh"]).catch(void 0), so "max" written into a
+# settings file is dropped SILENTLY and the default "high" wins -- measured
+# 2026-08-06, seven config files claimed max while every agent ran at high
+# (card cb42ad6d). The env var parses against the wider list (which includes
+# "max") and outranks every other source. Keep in sync with FLEET_EFFORT_LEVEL
+# in src/model-id.ts -- that constant governs the TS launch paths, this line the
+# tmux-inherited ones.
+$TMUX set-environment -g CLAUDE_CODE_EFFORT_LEVEL max 2>/dev/null || true
 
 # Hybrid channel-coordinator model: the native plugin stays the PRIMARY inbound
 # path (it always polls getUpdates here -- never outbound-only). The standalone

--- a/src/__tests__/remote-launch-command.test.ts
+++ b/src/__tests__/remote-launch-command.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { buildRemoteLaunchCommand, classifyRunState, classifyRunStateFromExit, buildContinueProbeCommand } from '../web/ssh-tmux.js'
+import { FLEET_EFFORT_LEVEL, EFFORT_LEVELS } from '../model-id.js'
 
 describe('classifyRunStateFromExit (failed list-sessions probe)', () => {
   it('remote ssh transport failure (exit 255) is unreachable', () => {
@@ -59,6 +60,25 @@ describe('buildRemoteLaunchCommand', () => {
   it('omits --continue when continue is false', () => {
     const cmd = buildRemoteLaunchCommand({ workdir: '/p', model: 'm', continue: false })
     expect(cmd).not.toContain('--continue')
+  })
+
+  // The effort level MUST ride the env var. Claude Code's settings.json schema
+  // accepts only low|medium|high|xhigh and silently drops anything else, so the
+  // fleet's "max" written into a settings file runs at high with no error and no
+  // log -- measured 2026-08-06, seven config files claimed max while every agent
+  // ran at high. If a future edit moves this back into settings.json or drops
+  // the export, the regression is invisible in behaviour; this test is the alarm.
+  it('exports the fleet effort level as an env var', () => {
+    const cmd = buildRemoteLaunchCommand({ workdir: '/p', model: 'm', continue: false })
+    expect(cmd).toContain(`export CLAUDE_CODE_EFFORT_LEVEL='${FLEET_EFFORT_LEVEL}'`)
+  })
+
+  // A typo here ('maximum', 'MAX', 'ultra') would NOT fail loudly: the CLI parses
+  // the env var against its own list and falls back to the default. Pin the value
+  // to the known-good set so the mistake is caught here instead of silently
+  // costing the whole fleet its effort level.
+  it('uses an effort level the CLI actually recognises', () => {
+    expect(EFFORT_LEVELS).toContain(FLEET_EFFORT_LEVEL)
   })
 
   it('never carries channel/token scaffolding (launch-only, channel-less)', () => {

--- a/src/model-id.ts
+++ b/src/model-id.ts
@@ -31,6 +31,28 @@ export function isValidModelId(model: unknown): model is string {
   return typeof model === 'string' && MODEL_ID_RE.test(model)
 }
 
+/**
+ * Every effort level the Claude Code CLI accepts, in ascending order (claude.exe 2.1.220, `vO`).
+ *
+ * NOT the same list settings.json accepts. The settings schema is NARROWER --
+ * `effortLevel: enum(["low","medium","high","xhigh"]).catch(void 0)` -- so `"max"` written into a
+ * settings file is dropped SILENTLY (no error, no log) and the default `"high"` takes over. Measured
+ * 2026-08-06 (card cb42ad6d): seven settings files said "max" while every agent actually ran at high.
+ * `"max"` only reaches the model through the `CLAUDE_CODE_EFFORT_LEVEL` env var or the `--effort`
+ * flag, which parse against THIS list and outrank settings.
+ */
+export const EFFORT_LEVELS = ['low', 'medium', 'high', 'xhigh', 'max'] as const
+
+export type EffortLevel = (typeof EFFORT_LEVELS)[number]
+
+/**
+ * The effort level every Claude agent in the fleet launches with (Balázs, 2026-08-06: "mindenkinél
+ * max"). Set as an env var at the launch sites, never in settings.json -- see {@link EFFORT_LEVELS}
+ * for why the file is the wrong lever. A model without the `max_effort` capability downgrades itself
+ * to high, so this is safe for every Claude model.
+ */
+export const FLEET_EFFORT_LEVEL: EffortLevel = 'max'
+
 /** Thrown when a caller tries to persist a malformed id. Routes map it to 400. */
 export class InvalidModelIdError extends Error {
   constructor(model: unknown) {

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -50,6 +50,7 @@ import { resolveAgentSecurityProfile } from './agent-team.js'
 import { writeAgentSettingsFromProfile, ensureFleetRosterSection, ensureAutonomySection } from './agent-scaffold.js'
 import { schedulePluginUnlockAfterRespawn } from './channel-plugin-unlock.js'
 import { getSecret } from './vault.js'
+import { FLEET_EFFORT_LEVEL } from '../model-id.js'
 import { resolveOpenRouterModel } from './openrouter-models.js'
 import { reapChannelOrphans, reapDetachedChannelClaudes } from './channel-poller-reap.js'
 import { MAIN_CHANNELS_SESSION } from './main-agent.js'
@@ -1310,11 +1311,29 @@ export function startAgentProcess(name: string, opts: { fresh?: boolean } = {}):
     // member. Killing the suggestion at the source removes the ghost the recovery
     // misreads. Env var verified present in claude.exe (CLAUDE_CODE_ENABLE_*).
     const promptSuggestionEnv = 'export CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false && '
+    // Effort level. Claude Code's settings.json schema validates `effortLevel`
+    // as enum(["low","medium","high","xhigh"]).catch(void 0) -- "max" is NOT in
+    // that list, and the .catch SILENTLY drops an unknown value (no error, no
+    // log), so the default "high" takes over. Measured 2026-08-06: every agent
+    // ran at high while seven settings files claimed "max" -- CLAUDE_EFFORT=high
+    // in each launched subprocess and effort:"high" on every transcript message
+    // since 07-28. Writing the file was never the switch. "max" IS a valid
+    // level, but only through the env var / --effort flag, which go through a
+    // wider parser (the CLI's own list includes "max") and outrank every other
+    // source. Claude models lacking the max_effort capability downgrade
+    // themselves to high, so this is safe to set unconditionally for Claude
+    // launches; non-Claude models (Ollama/DeepSeek/OpenRouter) never see it.
+    //
+    // Trade-off, deliberate: env pins the level for the whole session -- an
+    // in-session `/effort` then reports "Not applied: CLAUDE_CODE_EFFORT_LEVEL
+    // overrides effort this session". That is the intent (a fleet-wide floor set
+    // by the operator), not a side effect.
+    const effortEnv = isClaude ? `export CLAUDE_CODE_EFFORT_LEVEL=${shSingleQuote(FLEET_EFFORT_LEVEL)} && ` : ''
     // shSingleQuote(model) (card b7fa5281): the model is POSIX single-quote ESCAPED, which both keeps
     // values like `claude-opus-4-8[1m]` (1M-context suffix) from being glob-expanded AND makes a `'`
     // in the value inert rather than a quote-break -> command injection. Same escape at the three
     // ANTHROPIC_MODEL env sites above.
-    const cmd = `export PATH="/opt/homebrew/bin:$HOME/.bun/bin:/usr/local/bin:/usr/bin:/bin:$PATH" && ${unsetTokens} && ${promptSuggestionEnv}${mcpEnv}${channelSetup}${apiKeyEnv}${claudeConfigEnv}${oauthTokenEnv}${ollamaEnv}${deepseekEnv}${openrouterEnv}cd "${dir}" && ${claudeBin()} ${continueFlag}${skipFlag}--model ${shSingleQuote(model)} ${channelFlag}`.trimEnd()
+    const cmd = `export PATH="/opt/homebrew/bin:$HOME/.bun/bin:/usr/local/bin:/usr/bin:/bin:$PATH" && ${unsetTokens} && ${promptSuggestionEnv}${effortEnv}${mcpEnv}${channelSetup}${apiKeyEnv}${claudeConfigEnv}${oauthTokenEnv}${ollamaEnv}${deepseekEnv}${openrouterEnv}cd "${dir}" && ${claudeBin()} ${continueFlag}${skipFlag}--model ${shSingleQuote(model)} ${channelFlag}`.trimEnd()
     runTmux(null, ['new-session', '-d', '-s', session, cmd], { timeout: 10000 })
 
     logger.info({ name, session, channelDir: agentChannelDir }, 'Agent tmux session started')

--- a/src/web/agent-worker.ts
+++ b/src/web/agent-worker.ts
@@ -18,6 +18,7 @@ import { withSessionSendLock } from './session-send-lock.js'
 import { readClaudeCodeOauthJson } from './claude-credentials.js'
 import { detectPaneState } from '../pane-state.js'
 import { notifyChannel } from '../notify.js'
+import { FLEET_EFFORT_LEVEL } from '../model-id.js'
 
 // =============================================================================
 // Interactive-tmux agent worker (jun.15 subscription migration).
@@ -484,6 +485,10 @@ function startWorkerSessionFor(ctx: WorkerCtx): void {
   const launch =
     (hasFleetOauthToken() ? `export CLAUDE_CODE_OAUTH_TOKEN="$(cat ${shArg(FLEET_OAUTH_TOKEN_PATH)})"; ` : '') +
     `export CLAUDE_CONFIG_DIR=${shArg(ctx.configDir)}; ` +
+    // Effort as an ENV var, never settings.json: the CLI's settings schema
+    // accepts only low|medium|high|xhigh and silently drops anything else, so a
+    // file saying "max" runs at high (card cb42ad6d). See FLEET_EFFORT_LEVEL.
+    `export CLAUDE_CODE_EFFORT_LEVEL=${shArg(FLEET_EFFORT_LEVEL)}; ` +
     `cd ${shArg(ctx.home)} && ` +
     `${shArg(claudeLaunchBin)} --dangerously-skip-permissions --model ${shArg(WORKER_MODEL)}`
   execFileSync(TMUX, ['new-session', '-d', '-s', ctx.session, '-c', ctx.home, 'bash', '-lc', launch], { timeout: 8000 })

--- a/src/web/ssh-tmux.ts
+++ b/src/web/ssh-tmux.ts
@@ -2,6 +2,7 @@ import { mkdirSync } from 'node:fs'
 import { join } from 'node:path'
 import { userInfo } from 'node:os'
 import { execFileSync } from 'node:child_process'
+import { FLEET_EFFORT_LEVEL } from '../model-id.js'
 
 // SSH + tmux transport primitives.
 //
@@ -147,7 +148,11 @@ export function buildRemoteLaunchCommand(opts: {
 }): string {
   const path = 'export PATH="$HOME/.bun/bin:$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"'
   const cont = opts.continue ? '--continue ' : ''
-  return `${path} && cd ${shQuote(opts.workdir)} && claude ${cont}--dangerously-skip-permissions --model ${shQuote(opts.model)}`
+  // Effort comes from the env var, NOT settings.json: the CLI's settings schema
+  // accepts only low|medium|high|xhigh and silently drops anything else, so a
+  // file saying "max" runs at high (card cb42ad6d). See FLEET_EFFORT_LEVEL.
+  const effort = `export CLAUDE_CODE_EFFORT_LEVEL=${shQuote(FLEET_EFFORT_LEVEL)}`
+  return `${path} && ${effort} && cd ${shQuote(opts.workdir)} && claude ${cont}--dangerously-skip-permissions --model ${shQuote(opts.model)}`
 }
 
 /**


### PR DESCRIPTION
## The bug

Claude Code validates `effortLevel` in `settings.json` as
`enum(["low","medium","high","xhigh"]).catch(void 0)`. `"max"` is **not** in that list, and the
`.catch` drops an unknown value **silently** -- no error, no log -- so the default `"high"` wins.

A settings file that says `max` therefore runs at `high`, and nothing anywhere reports the gap.

## The measurement

Measured 2026-08-06 on a live install. Seven settings files said `"max"`; every agent actually ran
at `high`. Two independent readable signals agreed:

- `CLAUDE_EFFORT=high` in every launched subprocess (the CLI writes this itself for children)
- `effort: "high"` on every transcript message, across all agents, since 07-28 -- ~90 sessions, no
  other value ever recorded

Control: a probe session launched with `CLAUDE_CODE_EFFORT_LEVEL=max` recorded `effort: "max"` on
`claude-opus-5`. So the env path works, the signal does react, and the model does not downgrade it.

## The fix

`"max"` **is** a valid level -- but only through the env var / `--effort` flag, which parse against
the CLI's wider list (that one does include `max`) and outrank settings. So the level moves to an
env export at every launch site:

| file | path |
|---|---|
| `src/model-id.ts` | `FLEET_EFFORT_LEVEL` + `EFFORT_LEVELS`, one source of truth |
| `src/web/agent-process.ts` | local sub-agent launch (Claude models only) |
| `src/web/agent-worker.ts` | worker sessions |
| `src/web/ssh-tmux.ts` | remote agent launch |
| `scripts/channels.sh` | main session + the tmux global env every session inherits |

Models without the `max_effort` capability downgrade themselves to `high`, so the export is safe to
set unconditionally for Claude launches. Non-Claude models (Ollama/DeepSeek/OpenRouter) never see it.

## Guards

Two tests, both aimed at the silent-failure class:

- the remote launch command must carry the export -- if a later edit moves this back into
  `settings.json` or drops it, behaviour changes with no visible symptom
- `FLEET_EFFORT_LEVEL` must be a level the CLI recognises -- a typo (`maximum`, `MAX`) would not
  fail loudly, it would quietly cost the whole fleet its effort level

## Trade-off (deliberate)

The env var pins the level for the whole session, so an in-session `/effort` reports
`Not applied: CLAUDE_CODE_EFFORT_LEVEL overrides effort this session`. That is the intent -- an
operator-set fleet floor -- not a side effect.

## Test status

`npx tsc --noEmit` clean. New and neighbouring suites pass (30 tests).

The full suite has 19 failures in 4 files (`governance-gates`, `hook-path-guard`,
`hook-command-quoting`, `email-send-gate`). Those are **pre-existing**: verified by stashing this
change and re-running the same four files on clean `develop` -- identical 19 failures. Not touched
by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)