### PR TITLE
fix(isolated-config): keep main-agent-only settings keys across the rewrite (STATUSLINE806)

### DIFF
--- a/src/__tests__/main-agent-isolated-config.test.ts
+++ b/src/__tests__/main-agent-isolated-config.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest'
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync } from 'node:fs'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 
@@ -81,5 +81,40 @@ describe('ensureMainAgentIsolatedConfigDir', () => {
   it('darwin + setting off (default) -> null (unchanged, no regression)', () => {
     SETTING = '0'
     expect(ensureMainAgentIsolatedConfigDir(undefined, 'darwin')).toBeNull()
+  })
+
+  // The settings.json rewrite runs on EVERY main-agent start. It used to be a
+  // pure copy of the shared ~/.claude/settings.json, so a key configured for
+  // the MAIN AGENT ALONE was dropped at the next restart -- silently, because
+  // the agent still starts, it just stops doing whatever that key drove.
+  // `statusLine` was lost that way three times (2026-07-28, 07-30, 08-03),
+  // each time taking context monitoring blind mid-work with no error anywhere.
+  it('keeps isolated-only settings keys the shared file never mentions', () => {
+    const dir = ensureMainAgentIsolatedConfigDir(undefined, 'linux')!
+    const own = join(dir, 'settings.json')
+    writeFileSync(own, JSON.stringify({
+      statusLine: { type: 'command', command: 'ctx.sh' },
+      model: 'agent-only-model',
+    }, null, 2) + '\n')
+
+    // Second start: the shared file still says nothing about statusLine.
+    ensureMainAgentIsolatedConfigDir(undefined, 'linux')
+
+    const after = JSON.parse(readFileSync(own, 'utf-8')) as Record<string, unknown>
+    expect(after.statusLine).toEqual({ type: 'command', command: 'ctx.sh' })
+    expect(after.model).toBe('agent-only-model')
+  })
+
+  it('lets the shared file win for every key it DOES define', () => {
+    writeFileSync(join(HOME, '.claude', 'settings.json'), JSON.stringify({ model: 'shared-model' }))
+    const dir = ensureMainAgentIsolatedConfigDir(undefined, 'linux')!
+    const own = join(dir, 'settings.json')
+    writeFileSync(own, JSON.stringify({ model: 'stale-model', statusLine: 'keep-me' }, null, 2) + '\n')
+
+    ensureMainAgentIsolatedConfigDir(undefined, 'linux')
+
+    const after = JSON.parse(readFileSync(own, 'utf-8')) as Record<string, unknown>
+    expect(after.model).toBe('shared-model')   // shared wins on conflict
+    expect(after.statusLine).toBe('keep-me')   // target-only key still survives
   })
 })

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -500,7 +500,43 @@ function provisionIsolatedConfigDir(
       settings.enabledPlugins as Record<string, boolean> | undefined,
     )
     settings.enabledPlugins = scopedPlugins
-    writeFileSync(join(cfg, 'settings.json'), JSON.stringify(settings, null, 2) + '\n')
+    // Keys the isolated file already carries that the shared file never
+    // mentions must SURVIVE this rewrite. The rewrite runs on every main-agent
+    // start, so a straight copy silently drops agent-only configuration. That
+    // is how `statusLine` went missing three times (2026-07-28, 07-30, 08-03):
+    // it is configured for the main agent alone, the shared file never names
+    // it, and the symptom is invisible -- the agent starts fine, it just stops
+    // reporting context usage, so nothing alerts.
+    //
+    // Shared wins on conflict: for every key the shared file DOES define it
+    // stays the source of truth (that is the point of the copy). Target-only
+    // keys are purely additive, so this cannot resurrect a key the shared file
+    // deliberately changed.
+    // The asymmetry is the tell: all four SUB-agents kept their statusLine
+    // through the same restarts, because their path
+    // (ensureIsolatedClaudeConfigDir in claude-config-isolate.ts) merges over
+    // its own previous file. Only this one was a pure copy.
+    //
+    // enabledPlugins is explicitly never inherited -- it is decided by the
+    // scope call above and must not survive from the dir's own older copy.
+    const ownSettingsPath = join(cfg, 'settings.json')
+    if (existsSync(ownSettingsPath)) {
+      try {
+        const own = JSON.parse(readFileSync(ownSettingsPath, 'utf-8')) as Record<string, unknown>
+        // A JSON array or `null` parses fine but is not a settings object;
+        // spreading one would invent numeric keys instead of failing.
+        if (own && typeof own === 'object' && !Array.isArray(own)) {
+          for (const [key, value] of Object.entries(own)) {
+            if (key !== 'enabledPlugins' && !(key in settings)) settings[key] = value
+          }
+        }
+      } catch (err) {
+        // Deliberately loud: rewriting an unparseable own-settings file from
+        // the shared one is exactly the silent-loss shape this block fixes.
+        logger.warn({ err, name, path: ownSettingsPath }, 'isolated-config: unparseable own settings.json, rewriting from shared')
+      }
+    }
+    writeFileSync(ownSettingsPath, JSON.stringify(settings, null, 2) + '\n')
 
     // 3. Own plugins/ dir: symlink the heavy shared parts, own the install state.
     const pluginsDir = join(cfg, 'plugins')


### PR DESCRIPTION
## The bug

`provisionIsolatedConfigDir` rewrites the main agent's isolated `settings.json` on **every** start by
copying the shared `~/.claude/settings.json` over it. A key configured for the main agent *alone* is
therefore dropped at the next restart -- silently, because the agent still starts, it just stops
doing whatever that key drove.

`statusLine` was lost exactly this way three times (2026-07-28, 07-30, 08-03), each time taking
context monitoring blind mid-work with nothing logged and nothing alerting.

The asymmetry is the tell: all four sub-agents kept their `statusLine` through the same restarts,
because their path (`ensureIsolatedClaudeConfigDir` in `claude-config-isolate.ts`) merges over its
own previous file. Only this one path was a pure copy.

## The fix

Before the write, fold in every key the target file already carries that the shared file does not
mention. Shared still wins on conflict -- that is the point of the copy -- so the merge is purely
additive and cannot resurrect a key the shared file deliberately changed. `enabledPlugins` is
explicitly excluded: it is decided by the scope call above and must not survive from an older copy.
An unparseable own-settings file logs a WARN instead of being quietly overwritten, since a silent
rewrite is the very shape being fixed.

## Measured on a live install

After a dashboard restart at **09:30:12** (2026-08-06) the provisioning rewrote
`.channels-config/settings.json` -- mtime equals the second the daemon came up, so the file *was*
rewritten, this is not a "nothing touched it" result -- and **both** main-agent-only keys survived:

- `statusLine`
- an `effortLevel` written seven minutes earlier

The shared file names neither, so on the old path both would have been dropped. Two independent
survivors, not one.

## Guards

Two tests, and they **fail without the change** (verified by stashing the fix and re-running):

- target-only keys survive a second start
- the shared file still wins for every key it *does* define

`npx tsc --noEmit` clean; the suite for this module passes (7 tests).

## Note on provenance

This change was authored in the fleet's working tree and has been running there since 2026-08-03 --
it is what kept `statusLine` alive through this morning's restart. A branch carrying an equivalent
fix (`fix/isolated-settings-merge`, 32c477b, Aug 3) was pushed back then but **no PR was ever
opened**, and it now sits on a three-day-old base, so a PR from it would carry a large unrelated
diff. This branch is the same fix rebuilt on current `develop`. Without it upstream, the next
git-based system update takes `statusLine` for the fourth time.

## Test status

The full suite has 19 pre-existing failures in 4 files (`governance-gates`, `hook-path-guard`,
`hook-command-quoting`, `email-send-gate`), unrelated to this change and present on clean `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)