### PR TITLE
fix(scheduler): a pending retry survives a missing target session

### DIFF
--- a/src/__tests__/schedule-runner-retry-missing.test.ts
+++ b/src/__tests__/schedule-runner-retry-missing.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ScheduledTask } from '../web/scheduled-tasks-io.js'
+
+// A pending retry whose target session is MISSING (and whose auto-start fails)
+// must survive the tick, not be deleted. Deleting it was a silent abandonment
+// that contradicts the never-abandon policy the queue exists for: the one
+// real-world window where it bites is a target session vanishing during a
+// main-agent restart -- auto-start fails once, and a queued daily task (e.g. a
+// morning briefing) is dropped with only a debug log.
+//
+// What this pins:
+//   * result 'missing' does NOT delete the retry row;
+//   * the run-log records the TRANSITION into missing exactly once
+//     ('missing-retrying'), not one row per 60s tick;
+//   * the row's last_reason is refreshed to 'missing' so the age-based
+//     operator alert path keeps working;
+//   * result 'fired' still deletes the row (the queue drains normally).
+
+const mockAppendTaskRun = vi.fn()
+const mockDeletePendingRetry = vi.fn()
+// Mirrors the real DB: refreshing the row updates its last_reason, so the
+// NEXT tick sees the state this tick wrote (the transition-dedup depends on
+// exactly that).
+const mockUpdatePendingRetry = vi.fn((taskName: unknown, _agent: unknown, _now: unknown, reason: unknown) => {
+  for (const row of mockListPendingRetries() as Array<Record<string, unknown>>) {
+    if (row.task_name === taskName) row.last_reason = reason
+  }
+  return true
+})
+const mockListPendingRetries = vi.fn(() => [] as unknown[])
+const mockSendPrompt = vi.fn(() => 'sent')
+const mockSessionExists = vi.fn(() => true)
+const mockStartAgent = vi.fn(() => ({ ok: false, error: 'tmux unavailable' }))
+const mockListScheduledTasks = vi.fn(() => [] as ScheduledTask[])
+
+vi.mock('../logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+}))
+
+// The runner persists its last-run map to store/schedule-last-run.json on every
+// fire. Stub the writer so the suite never touches the operator's real store.
+vi.mock('../web/atomic-write.js', () => ({
+  atomicWriteFileSync: vi.fn(),
+}))
+
+vi.mock('../db.js', () => ({
+  appendTaskRun: (...a: unknown[]) => mockAppendTaskRun(...a),
+  listPendingTaskRetries: () => mockListPendingRetries(),
+  deletePendingTaskRetry: (...a: unknown[]) => mockDeletePendingRetry(...a),
+  updatePendingTaskRetry: mockUpdatePendingRetry,
+  insertPendingTaskRetryIfNew: vi.fn(),
+  markPendingTaskRetryAlert: vi.fn(() => false),
+  clearPendingTaskRetryAlert: vi.fn(),
+  markScheduledTaskKanbanWaiting: vi.fn(),
+}))
+
+// The runner's alert paths resolve a REAL bot token from install-level config
+// (HOME-based, so a test worktree does not isolate them) and send to the real
+// owner chat. Neutralize the sink entirely: a green suite must never cost the
+// operator's attention.
+vi.mock('../web/telegram.js', () => ({
+  sendTelegramMessage: vi.fn(async () => {}),
+  sendTelegramPhoto: vi.fn(async () => {}),
+}))
+
+vi.mock('../web/scheduled-tasks-io.js', () => ({
+  listScheduledTasks: () => mockListScheduledTasks(),
+  SCHEDULED_TASKS_DIR: '/tmp/marveen-retry-missing-no-tasks-dir',
+}))
+
+vi.mock('../web/agent-process.js', () => ({
+  agentSessionName: (name: string) => `agent-${name}`,
+  isAgentRunning: () => true,
+  isSessionReadyForPrompt: () => true,
+  sendPromptToSession: (...a: unknown[]) => mockSendPrompt(...(a as [])),
+  startAgentProcess: (...a: unknown[]) => mockStartAgent(...(a as [])),
+  sessionExistsOnHost: () => mockSessionExists(),
+  // null capture => the post-send resubmit loop sees nothing parked and stops.
+  capturePane: () => null,
+  sendEnterToSession: vi.fn(),
+  clearStaleParkedInput: vi.fn(() => false),
+}))
+
+function task(overrides: Partial<ScheduledTask> & { name: string; schedule: string }): ScheduledTask {
+  return {
+    description: 'retry-missing fixture',
+    prompt: 'Do the thing.',
+    agent: 'retryagent',
+    enabled: true,
+    createdAt: 0,
+    type: 'task',
+    targetSession: 'retry-test-session',
+    ...overrides,
+  }
+}
+
+const DAILY = task({ name: 'retry-missing-e2e-daily', schedule: '0 8 * * *' })
+
+function retryRow(overrides: Record<string, unknown> = {}) {
+  return {
+    task_name: DAILY.name,
+    agent_name: 'retryagent',
+    first_attempt: Date.now() - 5 * 60000,
+    last_attempt: Date.now() - 60000,
+    attempt_count: 5,
+    last_reason: 'busy',
+    alerted_at: null,
+    ...overrides,
+  }
+}
+
+async function loadRunner() {
+  vi.resetModules()
+  return await import('../web/schedule-runner.js')
+}
+
+async function runOneTick() {
+  const { startScheduleRunner } = await loadRunner()
+  const stop = startScheduleRunner()
+  // First tick is scheduled, not immediate: advance past the 60s interval and
+  // let the async tick body drain.
+  await vi.advanceTimersByTimeAsync(61_000)
+  clearInterval(stop)
+}
+
+describe('schedule runner: pending retry survives a missing target session', () => {
+  beforeEach(() => {
+    vi.stubEnv('SCHEDULER_TZ', 'Europe/Budapest')
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    // A quiet moment (no cron occurrence for the fixture) so only the
+    // pending-retry loop acts.
+    vi.setSystemTime(new Date('2026-07-31T10:30:00.000Z'))
+    mockListScheduledTasks.mockReturnValue([DAILY])
+    // The target session is gone and auto-start fails => attemptFireTask
+    // resolves 'missing'.
+    mockSessionExists.mockReturnValue(false)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllEnvs()
+  })
+
+  it("keeps the retry row on 'missing' and logs the transition once across ticks", async () => {
+    mockListPendingRetries.mockReturnValue([retryRow()])
+    await runOneTick()
+
+    // The row survives...
+    expect(mockDeletePendingRetry).not.toHaveBeenCalled()
+    // ...its live state is refreshed to 'missing' (feeds the age-based alert)...
+    expect(mockUpdatePendingRetry).toHaveBeenCalledWith(DAILY.name, 'retryagent', expect.any(Number), 'missing')
+    // ...and the run-log records the TRANSITION exactly once, even though the
+    // runner ticked several times inside the window -- a stuck-missing task
+    // must not write a run-log row per tick.
+    const runs = mockAppendTaskRun.mock.calls.filter(c => c[0] === DAILY.name).map(c => String(c[2]))
+    expect(runs).toEqual(['missing-retrying'])
+  })
+
+  it('does not re-log a retry already known to be missing', async () => {
+    mockListPendingRetries.mockReturnValue([retryRow({ last_reason: 'missing' })])
+    await runOneTick()
+
+    expect(mockDeletePendingRetry).not.toHaveBeenCalled()
+    const runs = mockAppendTaskRun.mock.calls.filter(c => c[0] === DAILY.name).map(c => String(c[2]))
+    expect(runs).toEqual([])
+  })
+
+  it("still deletes the row when the retry finally fires", async () => {
+    mockSessionExists.mockReturnValue(true)
+    mockListPendingRetries.mockReturnValue([retryRow()])
+    await runOneTick()
+
+    expect(mockDeletePendingRetry).toHaveBeenCalledWith(DAILY.name, 'retryagent')
+  })
+})

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -1170,9 +1170,22 @@ export function startScheduleRunner(): NodeJS.Timeout {
 
       const view = toPendingRetryView(row, now)
       const result = await attemptFireTask(taskDef, row.agent_name, now, retryPc.prefix)
-      if (result === 'fired' || result === 'missing') {
+      if (result === 'fired') {
         deletePendingTaskRetry(row.task_name, row.agent_name)
         continue
+      }
+      // 'missing' used to DELETE the retry row here -- a silent abandonment
+      // that contradicts the never-abandon policy above. The one real-world
+      // window where it bites: the target session vanishes during a main-agent
+      // restart, auto-start fails once, and a queued daily task (e.g. a
+      // morning briefing, 2026-07-13) is dropped with only a debug log. Keep
+      // the row instead; the alertDue path below surfaces a long-stuck one to
+      // the operator, and the run-log records the state.
+      if (result === 'missing' && row.last_reason !== 'missing') {
+        // Log the TRANSITION into missing only (a stuck-missing task would
+        // otherwise write a row per 60s tick); the pending row itself keeps
+        // the live state.
+        appendTaskRun(row.task_name, row.agent_name, 'missing-retrying')
       }
       // Still busy or errored: refresh the retry row and alert ONCE if
       // the age crossed the threshold. `updatePendingTaskRetry` returns


### PR DESCRIPTION
### What this changes

The pending-retry loop currently deletes the retry row when `attemptFireTask`
resolves `'missing'` (target session gone and auto-start failed):

```ts
if (result === 'fired' || result === 'missing') {
  deletePendingTaskRetry(row.task_name, row.agent_name)
```

That is a silent abandonment, and it contradicts the queue's own contract,
stated at the top of the same loop: *"We NEVER abandon -- the operator can
cancel from the UI if a retry has become obsolete."*

This PR keeps the row on `'missing'`, refreshes its `last_reason` (so the
age-based operator alert keeps working on it), and appends a
`'missing-retrying'` run-log row on the *transition* into missing only -- a
stuck-missing task does not write a run-log row per 60s tick.

### Why

The one real-world window where the deletion bites: the target session
vanishes while the main agent is restarting, auto-start fails exactly once
(tmux briefly unavailable), and a queued daily task is dropped with only a
debug log. Measured on a live install of this project: over a 26-day window
the daily morning briefing left a run-log row on 24 days. Exactly two days
have no row at all. One of them is fully explained by host downtime spanning
the slot; the other has no such explanation -- a single silent day inside an
otherwise unbroken series, the operator's first sign being the briefing not
arriving. At the time of that silent day the code had no status with which to
record the transition -- which is exactly this PR's point.

The behavior this PR proposes (keep the row on `'missing'`, log the
transition once) has been live on that install for three weeks; its run
history contains `missing-retrying` transition rows throughout -- nine rows
in total. Nine is a small number, and it is meant as exactly that: evidence
that the path is exercised and behaves as described, not a high-traffic
endurance claim.

With the row kept, the existing machinery does the rest: the next tick
retries (auto-start usually succeeds seconds later), and if the session
stays gone, the age-threshold alert names the task instead of dropping it.

### Evidence / verification

- New test file `schedule-runner-retry-missing.test.ts` (3 tests, driving the
  real runner loop): the row survives `'missing'`, `last_reason` is refreshed,
  the transition is logged exactly once across multiple ticks, and a retry
  that finally fires still deletes its row.
- `tsc` clean; the touched-file test set is green.

### Changed files

- `src/web/schedule-runner.ts` (+14/-1)
- `src/__tests__/schedule-runner-retry-missing.test.ts` (new, 176)

### Note on the test notification sink

The new test mocks `src/web/telegram.js`. The runner's alert paths resolve a
real bot token from install-level (HOME-based) config, so a test worktree does
not isolate them -- worth knowing before running the suite on an install that
has a bot configured.