### PR TITLE
fix(scheduler): don't replay overnight slots when a suspended host resumes

### DIFF
--- a/src/__tests__/schedule-catchup-window.test.ts
+++ b/src/__tests__/schedule-catchup-window.test.ts
@@ -1,0 +1,305 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import {
+  computeCatchUpWindow,
+  NORMAL_CATCH_UP_MS,
+  QUIET_BAND_END_HOUR,
+  QUIET_BAND_START_HOUR,
+  TICK_GAP_THRESHOLD_MS,
+} from '../web/cron.js'
+
+// Tests for the tick-gap catch-up window (host-suspend replay).
+//
+// Reference scenario (laptop/WSL-class host): the machine sleeps 06:00-09:05
+// while the dashboard process -- the schedule runner's host -- stays alive the
+// whole time. No restart, so the persisted-stamp cold-start path never arms;
+// the scan window is contiguous with the previous tick, so on resume the
+// runner scans three hours of schedule in one go. Nothing is lost, but
+// everything comes back at once -- and the same shape shifted into the night
+// would push every occurrence still inside its staleness budget, plus a
+// missed-slot report for the rest, into a sleeping operator's chat at 03:00.
+//
+// Everything time-dependent is injected, so nothing here depends on the clock
+// or the timezone of the machine running the suite.
+
+const RUNNER_SRC = readFileSync(join(__dirname, '../web/schedule-runner.ts'), 'utf-8')
+
+const TZ = 'Europe/Budapest'
+const MIN = 60_000
+const HOUR = 60 * MIN
+
+// Europe/Budapest is UTC+2 in July (CEST). Local wall-clock is written in the
+// helper names; the ISO strings stay UTC so the fixtures are unambiguous.
+const at = (iso: string): number => Date.parse(iso)
+
+const SUMMER_RESUME_0905 = at('2026-07-31T07:05:00.000Z') // 09:05 local
+const SUMMER_LASTTICK_0600 = at('2026-07-31T04:00:00.000Z') // 06:00 local
+const SUMMER_GAP_MS = SUMMER_RESUME_0905 - SUMMER_LASTTICK_0600 // 3h05m
+
+describe('computeCatchUpWindow: gap detection', () => {
+  it('(d) a sub-threshold gap keeps the normal one-tick window', () => {
+    const now = at('2026-07-31T12:00:00.000Z') // 14:00 local
+    const w = computeCatchUpWindow(now, now - 4 * MIN, TZ)
+    expect(w.catchUpMs).toBe(NORMAL_CATCH_UP_MS)
+    expect(w.gapResume).toBe(false)
+    expect(w.quietSkipped).toBe(false)
+    expect(w.gapMs).toBe(4 * MIN)
+  })
+
+  it('a gap of EXACTLY the threshold is still ordinary jitter, one ms more is a gap', () => {
+    const now = at('2026-07-31T12:00:00.000Z') // 14:00 local
+    expect(computeCatchUpWindow(now, now - TICK_GAP_THRESHOLD_MS, TZ).gapResume).toBe(false)
+    expect(computeCatchUpWindow(now, now - TICK_GAP_THRESHOLD_MS - 1, TZ).gapResume).toBe(true)
+  })
+
+  it('(a) a daytime gap between two daytime ticks yields exactly the gap', () => {
+    const lastTick = at('2026-07-31T11:00:00.000Z') // 13:00 local
+    const now = at('2026-07-31T12:30:00.000Z') // 14:30 local
+    const w = computeCatchUpWindow(now, lastTick, TZ)
+    expect(w.gapResume).toBe(true)
+    expect(w.quietSkipped).toBe(false)
+    expect(w.gapMs).toBe(90 * MIN)
+    // The whole gap is outside the band, so the runner's window is unchanged.
+    expect(w.catchUpMs).toBe(90 * MIN)
+  })
+
+  it('daytime suspend: a 06:00 -> 09:05 resume gets a 3h05m window', () => {
+    const w = computeCatchUpWindow(SUMMER_RESUME_0905, SUMMER_LASTTICK_0600, TZ)
+    expect(w.gapResume).toBe(true)
+    expect(w.gapMs).toBe(SUMMER_GAP_MS)
+    expect(w.catchUpMs).toBe(SUMMER_GAP_MS)
+  })
+
+  it('no previous tick (first tick of the process) means no gap window', () => {
+    const w = computeCatchUpWindow(SUMMER_RESUME_0905, null, TZ)
+    expect(w.catchUpMs).toBe(NORMAL_CATCH_UP_MS)
+    expect(w.gapResume).toBe(false)
+    expect(w.gapMs).toBe(0)
+  })
+})
+
+describe('computeCatchUpWindow: quiet band', () => {
+  it('(b) a gap spanning the night is clipped at the local band end, not replayed whole', () => {
+    const lastTick = at('2026-07-30T21:00:00.000Z') // 23:00 local, previous day
+    const now = at('2026-07-31T07:00:00.000Z') // 09:00 local
+    const w = computeCatchUpWindow(now, lastTick, TZ)
+    expect(w.gapMs).toBe(10 * HOUR)
+    // Reaches back to 06:00 local only -- the 23:00-06:00 slots stay missed.
+    expect(w.catchUpMs).toBe(3 * HOUR)
+    expect(w.gapResume).toBe(true)
+    expect(w.quietSkipped).toBe(false)
+  })
+
+  it('(c) waking INSIDE the quiet band performs no catch-up at all', () => {
+    const lastTick = at('2026-07-30T20:30:00.000Z') // 22:30 local
+    const now = at('2026-07-31T01:00:00.000Z') // 03:00 local
+    const w = computeCatchUpWindow(now, lastTick, TZ)
+    expect(w.catchUpMs).toBe(NORMAL_CATCH_UP_MS)
+    expect(w.gapResume).toBe(false)
+    expect(w.quietSkipped).toBe(true)
+    expect(w.gapMs).toBe(4.5 * HOUR)
+  })
+
+  it('the band closes at 22:00 local and opens at 06:00 local', () => {
+    const gap = (nowIso: string) =>
+      computeCatchUpWindow(at(nowIso), at(nowIso) - 2 * HOUR, TZ)
+    expect(QUIET_BAND_START_HOUR).toBe(22)
+    expect(QUIET_BAND_END_HOUR).toBe(6)
+    // 21:59 local -- still a working hour, catch-up allowed.
+    expect(gap('2026-07-31T19:59:00.000Z').quietSkipped).toBe(false)
+    // 22:00 local sharp -- quiet.
+    expect(gap('2026-07-31T20:00:00.000Z').quietSkipped).toBe(true)
+    // 05:59 local -- quiet.
+    expect(gap('2026-07-31T03:59:00.000Z').quietSkipped).toBe(true)
+    // 06:00 local sharp -- open again (though the window is clipped to ~0).
+    expect(gap('2026-07-31T04:00:00.000Z').quietSkipped).toBe(false)
+  })
+
+  it('waking just past 06:00 collapses back to the normal window, not a catch-up tick', () => {
+    const now = at('2026-07-31T04:00:30.000Z') // 06:00:30 local
+    const lastTick = at('2026-07-31T03:00:00.000Z') // 05:00 local
+    const w = computeCatchUpWindow(now, lastTick, TZ)
+    // Only 30s of the gap is outside the quiet band -> nothing was enlarged.
+    expect(w.catchUpMs).toBe(NORMAL_CATCH_UP_MS)
+    expect(w.gapResume).toBe(false)
+    expect(w.quietSkipped).toBe(false)
+  })
+
+  it('the band end is derived from local wall-clock, so CET and CEST behave alike', () => {
+    // Same 06:00 -> 09:05 shape in January (Europe/Budapest is UTC+1 then).
+    const now = at('2026-01-15T08:05:00.000Z') // 09:05 local
+    const lastTick = at('2026-01-15T05:00:00.000Z') // 06:00 local
+    const w = computeCatchUpWindow(now, lastTick, TZ)
+    expect(w.catchUpMs).toBe(SUMMER_GAP_MS)
+    expect(w.gapResume).toBe(true)
+  })
+
+  it('an unusable timezone fails SAFE (no catch-up) instead of throwing', () => {
+    const w = computeCatchUpWindow(SUMMER_RESUME_0905, SUMMER_LASTTICK_0600, 'Not/AZone')
+    expect(w.catchUpMs).toBe(NORMAL_CATCH_UP_MS)
+    expect(w.gapResume).toBe(false)
+    expect(w.quietSkipped).toBe(true)
+  })
+})
+
+// The two invariants the band-clipped window rests on. Verified against the
+// real cron matcher rather than assumed, because both are the difference
+// between "catch up once" and "replay three hours".
+describe('a gap window fires ONCE and never reaches behind the band edge', () => {
+  let cron: typeof import('../web/cron.js')
+
+  beforeAll(async () => {
+    // cron.ts freezes CRON_TZ at import from SCHEDULER_TZ (or the host zone),
+    // so pin the zone and re-import to keep this suite host-independent.
+    vi.stubEnv('SCHEDULER_TZ', TZ)
+    vi.resetModules()
+    cron = await import('../web/cron.js')
+  })
+  afterAll(() => {
+    vi.unstubAllEnvs()
+    vi.resetModules()
+  })
+  beforeEach(() => {
+    vi.useFakeTimers()
+    // 09:07:31 local, deliberately OFF the */5 boundary: the contiguous
+    // half-open (from, now] window (#621 + boundary nudge) makes a
+    // boundary-exact occurrence match the NORMAL window too -- that fire is
+    // on-time, not swallowed, so probing there would test the wrong premise.
+    vi.setSystemTime(new Date(SUMMER_RESUME_0905 + 151_000))
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('cronMatchesNow is a boolean "was the last occurrence inside the window", not an enumeration', () => {
+    // A 5-minute heartbeat had 37 of its slots inside the 3h05m sleep. The
+    // matcher still answers with a single boolean, and the runner does one
+    // attemptFireTask per matching task per tick -- so 37 missed slots become
+    // exactly one fire, never 37 prompts dumped into the session.
+    const match = cron.cronMatchesNow('*/5 6-21 * * *', SUMMER_GAP_MS)
+    expect(typeof match).toBe('boolean')
+    expect(match).toBe(true)
+  })
+
+  it('slots swallowed by the sleep match the gap window but not the normal one', () => {
+    for (const schedule of [
+      '*/5 6-21 * * *', // short-cadence heartbeat
+      '*/15 6-21 * * *', // quarter-hourly heartbeat
+      '30 7 * * *', // morning briefing
+      '0 8 * * *', // daily audit
+      '15 8 * * *', // daily backup upload
+      '0 9 * * *', // daily token health check
+    ]) {
+      expect(cron.cronMatchesNow(schedule, SUMMER_GAP_MS)).toBe(true)
+      // Not matched by the normal window -> the runner stamps it 'fired_late'.
+      expect(cron.cronMatchesNow(schedule, NORMAL_CATCH_UP_MS)).toBe(false)
+    }
+  })
+
+  it('a slot the PREVIOUS tick already fired falls outside the new window', () => {
+    // The window starts at the later of the previous tick and the band edge, so
+    // any slot that tick could have matched is >= catchUpMs old and cannot match
+    // again. This is what makes a false gap-resume harmless: if a slow tick
+    // (rather than a real suspend) trips the threshold, the window still only
+    // picks up slots that genuinely went unserved.
+    expect(cron.cronMatchesNow('0 6 * * *', SUMMER_GAP_MS)).toBe(false) // slot AT the last tick
+    expect(cron.cronMatchesNow('59 5 * * *', SUMMER_GAP_MS)).toBe(false) // slot just before it
+  })
+
+  it('slots behind the band edge are not resurrected', () => {
+    // An evening job that fired at 20:15 the previous day -- far outside a
+    // window that is clipped at 06:00 local.
+    expect(cron.cronMatchesNow('15 20 * * *', SUMMER_GAP_MS)).toBe(false)
+    // A weekly job whose day is not today.
+    expect(cron.cronMatchesNow('30 6 * * 3', SUMMER_GAP_MS)).toBe(false)
+  })
+})
+
+// The runner guards a double fire with `lastRun >= occurrenceMs` -- anchored to
+// the OCCURRENCE the selection gate picked, not to the scan-window start. (The
+// window-start form skipped a genuinely new occurrence on any long-gap tick
+// whenever the task had fired on the last healthy tick: fromMs IS that tick's
+// timestamp, so `lastRun >= fromMs` held for a slot that had never run.) The
+// boundary arithmetic is pinned here with the same expression the runner uses.
+describe('the lastRun guard neither double-fires nor swallows a catch-up', () => {
+  const OCC_0800 = at('2026-07-31T06:00:00.000Z') // 08:00 local, swallowed by the sleep
+  const skippedByGuard = (lastRun: number, occurrenceMs: number): boolean =>
+    lastRun >= occurrenceMs
+
+  it('does not swallow a task whose last run was the last healthy tick', () => {
+    // Worst case: the task fired on the very last tick before the host slept
+    // (06:00). The swallowed 08:00 occurrence is NEWER, so the guard passes.
+    expect(skippedByGuard(SUMMER_LASTTICK_0600, OCC_0800)).toBe(false)
+  })
+
+  it('cannot swallow anything that last ran before the gap started', () => {
+    // Nothing fires while the host is asleep, so every lastRun is at or before
+    // the gap start -- always older than an occurrence inside the sleep.
+    for (const minutesBeforeGap of [0, 1, 30, 24 * 60]) {
+      const lastRun = SUMMER_LASTTICK_0600 - minutesBeforeGap * MIN
+      expect(skippedByGuard(lastRun, OCC_0800)).toBe(false)
+    }
+  })
+
+  it('still blocks a later tick from re-firing the caught-up occurrence', () => {
+    // The catch-up fire stamps lastRun with the resume tick time, which is at
+    // or after the swallowed occurrence -- so re-scanning it cannot re-fire.
+    expect(skippedByGuard(SUMMER_RESUME_0905, OCC_0800)).toBe(true)
+  })
+
+  it('yet the NEXT genuine occurrence still fires on its own tick', () => {
+    // The property the old window-start guard could not express: a fresh
+    // occurrence after the catch-up is newer than lastRun, so it passes.
+    const OCC_0910 = at('2026-07-31T07:10:00.000Z') // 09:10 local
+    expect(skippedByGuard(SUMMER_RESUME_0905, OCC_0910)).toBe(false)
+  })
+
+  it('the runner still uses that exact guard expression', () => {
+    // If this drifts, the arithmetic above stops describing production.
+    expect(RUNNER_SRC).toMatch(/if \(lastRun >= occurrenceMs\) continue/)
+  })
+})
+
+describe('schedule-runner wiring', () => {
+  it('keeps the previous tick time in the runner closure (in-memory by design)', () => {
+    expect(RUNNER_SRC).toMatch(/let lastTickAt: number \| null = null/)
+    // Stamped from the tick's own start time, immediately after the decision.
+    expect(RUNNER_SRC).toMatch(/computeCatchUpWindow\(now, lastTickAt\)/)
+    expect(RUNNER_SRC).toMatch(/lastTickAt = now/)
+    // NOT persisted: the last-run map is the only runner state written to disk.
+    expect(RUNNER_SRC).not.toMatch(/lastTickAt[\s\S]{0,80}atomicWriteFileSync/)
+  })
+
+  it('clamps the scan window only on a gap tick, never on the cold-start one', () => {
+    // The cold-start window comes from the persisted tick stamp and is capped
+    // there; clamping it here would silently shrink a legitimate downtime scan.
+    expect(RUNNER_SRC).toMatch(
+      /const fromMs = \(gap\.gapResume \|\| gap\.quietSkipped\)\s*\n\s*\? Math\.max\(lastCheckMs, now - catchUp\)\s*\n\s*: lastCheckMs/,
+    )
+  })
+
+  it('marks gap-resume fires late too, not just cold-start ones', () => {
+    // Lateness is occurrence-based (decideCatchUp over the same occurrence the
+    // selection gate used), so any fire whose decision is 'catch-up' is recorded
+    // late regardless of WHICH kind of tick (cold-start, gap-resume, dropped
+    // tick) scanned it.
+    const idx = RUNNER_SRC.indexOf('const lateCatchUpMs =')
+    expect(idx).toBeGreaterThan(0)
+    const expr = RUNNER_SRC.slice(idx, idx + 200)
+    expect(expr).toMatch(/decision === 'catch-up'/)
+  })
+
+  it('logs the gap, the effective window and the catch-up fire count', () => {
+    const idx = RUNNER_SRC.indexOf('if (gap.gapResume) {')
+    expect(idx).toBeGreaterThan(0)
+    const block = RUNNER_SRC.slice(idx, idx + 900)
+    expect(block).toMatch(/logger\.info/)
+    expect(block).toMatch(/gapMinutes/)
+    expect(block).toMatch(/catchUpMinutes/)
+    expect(block).toMatch(/catchUpFires/)
+    // The quiet-band suppression is logged too -- a silent no-op is what made
+    // the original incident invisible.
+    expect(block).toMatch(/gap\.quietSkipped/)
+  })
+})

--- a/src/__tests__/schedule-runner-gap-catchup.test.ts
+++ b/src/__tests__/schedule-runner-gap-catchup.test.ts
@@ -1,0 +1,244 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ScheduledTask } from '../web/scheduled-tasks-io.js'
+
+// End-to-end test of the host-suspend catch-up gate, driving the REAL runCheck
+// loop.
+//
+// Scenario: the runner ticks normally at 06:00, the host then sleeps for three
+// hours while the process stays alive (fake timers let the wall clock jump
+// WITHOUT firing the skipped intervals -- exactly what a suspend does), and
+// the next tick has to decide what part of the gap is still worth acting on.
+// A second scenario suspends across the quiet band and resumes at 02:00.
+//
+// What this pins that a pure-function test cannot:
+//   * a daily 08:00 slot swallowed by the sleep really does fire on resume,
+//     and is recorded 'fired_late' rather than as a normal run;
+//   * a */5 heartbeat with 37 swallowed slots fires ONCE, not 37 times --
+//     and fires AT ALL, which the window-start double-fire guard prevented;
+//   * an evening slot from behind the quiet band is NOT resurrected;
+//   * the following normal tick does not replay anything;
+//   * a resume INSIDE the quiet band fires nothing at all.
+
+const mockAppendTaskRun = vi.fn()
+const mockInsertPendingRetry = vi.fn()
+const mockListPendingRetries = vi.fn(() => [] as unknown[])
+const mockSendPrompt = vi.fn(() => 'landed')
+const mockIsSessionReady = vi.fn(() => true)
+const mockLoggerInfo = vi.fn()
+const mockListScheduledTasks = vi.fn(() => [] as ScheduledTask[])
+
+vi.mock('../logger.js', () => ({
+  logger: { info: mockLoggerInfo, warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+}))
+
+// The runner persists its last-run map to store/schedule-last-run.json on every
+// fire. Stub the writer so the suite never touches the operator's real store.
+vi.mock('../web/atomic-write.js', () => ({
+  atomicWriteFileSync: vi.fn(),
+}))
+
+vi.mock('../db.js', () => ({
+  appendTaskRun: (...a: unknown[]) => mockAppendTaskRun(...a),
+  listPendingTaskRetries: () => mockListPendingRetries(),
+  deletePendingTaskRetry: vi.fn(),
+  updatePendingTaskRetry: vi.fn(() => true),
+  insertPendingTaskRetryIfNew: (...a: unknown[]) => mockInsertPendingRetry(...a),
+  markPendingTaskRetryAlert: vi.fn(() => false),
+  clearPendingTaskRetryAlert: vi.fn(),
+  markScheduledTaskKanbanWaiting: vi.fn(),
+}))
+
+vi.mock('../web/scheduled-tasks-io.js', () => ({
+  listScheduledTasks: () => mockListScheduledTasks(),
+  SCHEDULED_TASKS_DIR: '/tmp/marveen-gap-catchup-no-tasks-dir',
+}))
+
+// The runner's catch-up summary and alert paths resolve a REAL bot token from
+// install-level config (HOME-based, so a test worktree does not isolate them)
+// and send to the real owner chat -- this exact test once delivered two
+// "[TESZT]" catch-up summaries to the operator's phone. Neutralize the sink:
+// a green suite must never cost the operator's attention.
+vi.mock('../web/telegram.js', () => ({
+  sendTelegramMessage: vi.fn(async () => {}),
+  sendTelegramPhoto: vi.fn(async () => {}),
+}))
+
+vi.mock('../web/agent-process.js', () => ({
+  agentSessionName: (name: string) => `agent-${name}`,
+  isAgentRunning: () => true,
+  isSessionReadyForPrompt: () => mockIsSessionReady(),
+  sendPromptToSession: (...a: unknown[]) => mockSendPrompt(...(a as [])),
+  startAgentProcess: vi.fn(() => ({ ok: true })),
+  sessionExistsOnHost: () => true,
+  // null capture => the post-send resubmit loop sees nothing parked and stops.
+  capturePane: () => null,
+  sendEnterToSession: vi.fn(),
+  clearStaleParkedInput: vi.fn(() => false),
+}))
+
+const TZ = 'Europe/Budapest'
+
+// A task whose name cannot collide with anything in the operator's real
+// store/schedule-last-run.json (which the runner reloads on start).
+function task(overrides: Partial<ScheduledTask> & { name: string; schedule: string }): ScheduledTask {
+  return {
+    description: 'gap catch-up fixture',
+    prompt: 'Do the thing.',
+    agent: 'gapagent',
+    enabled: true,
+    createdAt: 0,
+    type: 'heartbeat',
+    // Pins the target session so the fire path needs no agent-config lookup.
+    targetSession: 'gap-test-session',
+    ...overrides,
+  }
+}
+
+// type 'task' mirrors an operator-facing daily (morning briefing, daily audit):
+// the per-type staleness budget (task: 180 min) is what lets a ~67-min-late
+// occurrence still fire as a catch-up; a 'heartbeat' fixture would hit the
+// 30-min budget and be recorded 'missed' instead.
+const DAILY_0800 = task({ name: 'catchup-e2e-daily-0800', schedule: '0 8 * * *', type: 'task' })
+const HB_5MIN = task({ name: 'catchup-e2e-hb-5min', schedule: '*/5 6-21 * * *' })
+const EVENING_2015 = task({ name: 'catchup-e2e-evening-2015', schedule: '15 20 * * *', type: 'task' })
+
+// 06:00:00 local (CEST) -- the last healthy tick before the host slept.
+const BEFORE_SLEEP = new Date('2026-07-31T04:00:00.000Z')
+// 09:06:10 local; the first pending interval then fires ten seconds later.
+const AFTER_SLEEP = new Date('2026-07-31T07:06:10.000Z')
+// 20:00:00 local the previous evening -- the last tick before an overnight
+// suspend, placed BEFORE the 20:15 slot so that slot genuinely falls in the gap.
+const BEFORE_SLEEP_EVENING = new Date('2026-07-30T18:00:00.000Z')
+// 02:00:10 local -- a resume in the middle of the quiet band.
+const AFTER_SLEEP_QUIET = new Date('2026-07-31T00:00:10.000Z')
+
+async function loadRunner() {
+  vi.resetModules()
+  return await import('../web/schedule-runner.js')
+}
+
+function runsFor(name: string): string[] {
+  return mockAppendTaskRun.mock.calls.filter(c => c[0] === name).map(c => String(c[2]))
+}
+
+describe('schedule runner: host-suspend catch-up', () => {
+  let stop: NodeJS.Timeout | null = null
+
+  beforeEach(() => {
+    vi.stubEnv('SCHEDULER_TZ', TZ)
+    vi.clearAllMocks()
+    mockIsSessionReady.mockReturnValue(true)
+    mockListPendingRetries.mockReturnValue([])
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    if (stop) clearInterval(stop)
+    stop = null
+    vi.useRealTimers()
+    vi.unstubAllEnvs()
+  })
+
+  it('fires the slots the sleep swallowed -- once each -- and marks them late', async () => {
+    mockListScheduledTasks.mockReturnValue([DAILY_0800, HB_5MIN, EVENING_2015])
+    vi.setSystemTime(BEFORE_SLEEP)
+    const { startScheduleRunner } = await loadRunner()
+    stop = startScheduleRunner()
+
+    // First tick, 06:00:05 local. Only the */5 heartbeat is due here -- note
+    // that this stamps its lastRun with the tick time, which is exactly the
+    // scan-window start the NEXT tick would have used.
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(runsFor(HB_5MIN.name)).toEqual(['fired'])
+    expect(runsFor(DAILY_0800.name)).toEqual([])
+    mockAppendTaskRun.mockClear()
+    mockSendPrompt.mockClear()
+    mockLoggerInfo.mockClear()
+
+    // The host sleeps. Wall clock jumps ~3h; NO interval fires meanwhile.
+    vi.setSystemTime(AFTER_SLEEP)
+    await vi.advanceTimersByTimeAsync(60_000)
+
+    // The 08:00 daily slot was inside the sleep -> caught up, flagged late.
+    expect(runsFor(DAILY_0800.name)).toEqual(['fired_late'])
+    // 37 heartbeat slots were inside the sleep -> exactly ONE fire. Whether it
+    // stamps 'fired' or 'fired_late' depends on where the resume tick lands
+    // relative to the 90s late threshold (the selection gate picks the MOST
+    // RECENT occurrence, 09:05); the guarded property is the single fire. That
+    // it fires at all is the occurrence-guard fix: its lastRun equals the scan
+    // window start, so the old `lastRun >= fromMs` form dropped it.
+    expect(runsFor(HB_5MIN.name)).toHaveLength(1)
+    expect(runsFor(HB_5MIN.name)[0]).toMatch(/^fired(_late)?$/)
+    // The 20:15 slot sits behind the quiet band -> stays missed.
+    expect(runsFor(EVENING_2015.name)).toEqual([])
+    expect(mockSendPrompt).toHaveBeenCalledTimes(2)
+
+    // The gap is auditable: without this line a suspend leaves no trace at all.
+    const summary = mockLoggerInfo.mock.calls.find(c =>
+      String(c[1]).includes('Schedule tick gap detected (host suspend?)'),
+    )
+    expect(summary).toBeDefined()
+    // ~3h06m depending on where the resume tick lands; the audited facts are
+    // the gap magnitude and that at least the daily counted as a catch-up (the
+    // heartbeat's most-recent occurrence may classify on-time, see above).
+    expect(summary?.[0].gapMinutes).toBeGreaterThanOrEqual(185)
+    expect(summary?.[0].catchUpFires).toBeGreaterThanOrEqual(1)
+
+    // The NEXT normal tick must not replay anything.
+    mockSendPrompt.mockClear()
+    mockAppendTaskRun.mockClear()
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(mockSendPrompt).not.toHaveBeenCalled()
+    expect(mockAppendTaskRun).not.toHaveBeenCalled()
+  })
+
+  it('waking inside the quiet band fires nothing and says so', async () => {
+    mockListScheduledTasks.mockReturnValue([DAILY_0800, HB_5MIN, EVENING_2015])
+    vi.setSystemTime(BEFORE_SLEEP_EVENING)
+    const { startScheduleRunner } = await loadRunner()
+    stop = startScheduleRunner()
+    await vi.advanceTimersByTimeAsync(5000)
+    mockAppendTaskRun.mockClear()
+    mockSendPrompt.mockClear()
+    mockLoggerInfo.mockClear()
+
+    vi.setSystemTime(AFTER_SLEEP_QUIET)
+    await vi.advanceTimersByTimeAsync(60_000)
+
+    // The 20:15 slot and six hours of heartbeats fell inside the gap, and the
+    // contiguous scan window would have swept every one of them -- but the
+    // resume is at 02:00, so night slots stay missed rather than landing in a
+    // sleeping operator's chat (or as a burst of 'missed' rows).
+    expect(mockSendPrompt).not.toHaveBeenCalled()
+    expect(mockAppendTaskRun).not.toHaveBeenCalled()
+    const quiet = mockLoggerInfo.mock.calls.find(c =>
+      String(c[1]).includes('inside the quiet band'),
+    )
+    expect(quiet).toBeDefined()
+  })
+
+  it('an ordinary tick sequence logs no gap and fires on its own cadence', async () => {
+    mockListScheduledTasks.mockReturnValue([HB_5MIN])
+    // 09:00:15 local, so the first tick lands at 09:00:20. Deliberately
+    // mid-minute: cron-parser's prev() is exclusive, so a tick landing exactly
+    // ON a slot boundary reads the PREVIOUS slot and would be classed late by
+    // the (pre-existing) cold-start window.
+    vi.setSystemTime(new Date('2026-07-31T07:00:15.000Z'))
+    const { startScheduleRunner } = await loadRunner()
+    stop = startScheduleRunner()
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(runsFor(HB_5MIN.name)).toEqual(['fired']) // 09:00:00 slot, on time
+    expect(mockSendPrompt).toHaveBeenCalledTimes(1)
+
+    mockSendPrompt.mockClear()
+    for (let i = 0; i < 4; i++) vi.advanceTimersByTime(60_000) // 09:01..09:04
+    expect(mockSendPrompt).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(60_000) // 09:05
+    expect(mockSendPrompt).toHaveBeenCalledTimes(1)
+    // Nothing was late, so no 'fired_late' rows and no gap log.
+    expect(runsFor(HB_5MIN.name)).toEqual(['fired', 'fired'])
+    expect(
+      mockLoggerInfo.mock.calls.some(c => String(c[1]).includes('Schedule tick gap')),
+    ).toBe(false)
+  })
+})

--- a/src/web/cron.ts
+++ b/src/web/cron.ts
@@ -129,6 +129,153 @@ export function cronPrevOccurrence(cron: string, fromMs: number, toMs: number, t
   }
 }
 
+// --- Tick-gap catch-up window ------------------------------------------------
+//
+// The runner scans the half-open (previous tick, now] interval, so the windows
+// are contiguous and no occurrence can slip between two ticks. That is right
+// while the ticks keep coming -- but it also means a tick that arrives HOURS
+// late scans hours of schedule in one go, and ticks do NOT survive a host
+// SUSPEND. A host that sleeps through the evening and wakes at 03:00 replays
+// every backlog occurrence still inside its staleness budget into a sleeping
+// operator's chat -- for a command-type task that budget is 24h, and a custom
+// catchUpMaxAgeMinutes can be anything -- and records/alerts everything past
+// its budget as missed, which is chat noise about slots whose whole point was
+// to run last night. The staleness policy is per-TYPE and night-blind; it has
+// no notion that a 20:15 slot recovered at 03:00 should not exist. Nothing is lost
+// here -- the loss case is the process being DOWN, which the persisted tick
+// stamp already covers -- what is wrong is the timing of what comes back.
+//
+// So the size of the gap has to be a decision rather than an accident. A tick
+// more than TICK_GAP_THRESHOLD_MS after the previous one is a "gap-resume"
+// tick, and its window is trimmed to the part of the gap still worth acting on:
+//
+//   * The window NEVER reaches into the quiet band (QUIET_BAND_START_HOUR ->
+//     QUIET_BAND_END_HOUR, operator-local). A morning resume scans back to the
+//     band end only -- the night's slots were night slots and staying missed IS
+//     the correct outcome. A resume INSIDE the band gets no catch-up at all.
+//   * Everything outside the band keeps today's behaviour: an ordinary tick,
+//     and a gap lying entirely within the working day, get the full
+//     (previous tick, now] window untouched.
+//   * The COLD-START window is deliberately NOT gated here. Real process
+//     downtime is owned by the persisted tick stamp (see computeCatchUpStart in
+//     schedule-runner), which is capped separately and reported to the operator.
+//   * In-memory only, by design -- the caller holds lastTickMs. A restart is
+//     covered by that persisted stamp, and a suspend keeps the process, and
+//     therefore the variable, alive.
+
+// The window a tick gets when nothing was enlarged: one 60 s tick of tolerance
+// around a slot. Exported so the runner and this module cannot drift apart on
+// what "not enlarged" means -- the runner clamps its scan window only when the
+// value computed here is a real, band-safe catch-up.
+export const NORMAL_CATCH_UP_MS = 60_000
+
+// A tick this much later than the previous one is treated as a host-sleep gap
+// rather than ordinary scheduler jitter. Well above the tick cadence plus the
+// worst realistic tick duration (blocking tmux captures + idle waits), well
+// below any schedule cadence anyone runs.
+export const TICK_GAP_THRESHOLD_MS = 5 * 60_000
+
+// Quiet band in operator-local wall-clock time: no catch-up fires inside it,
+// and no catch-up window may reach back into it. Overnight a replayed slot is
+// pure cost -- the work behind it waits for the morning anyway, so the only
+// thing the fire buys is a woken operator.
+export const QUIET_BAND_START_HOUR = 22 // inclusive
+export const QUIET_BAND_END_HOUR = 6 // exclusive
+
+export interface CatchUpWindow {
+  /** Window to scan on this tick. Never below NORMAL_CATCH_UP_MS. */
+  catchUpMs: number
+  /** Wall-clock distance from the previous tick (0 when there was none). */
+  gapMs: number
+  /** True when the window was enlarged because of a tick gap. */
+  gapResume: boolean
+  /** True when a real gap was detected but suppressed by the quiet band. */
+  quietSkipped: boolean
+}
+
+// Local wall-clock hour/minute/second in `timeZone`. Returns null if the zone
+// is unusable (a typo'd SCHEDULER_TZ makes Intl throw) so the caller can fall
+// back to the conservative no-catch-up answer instead of killing the tick.
+function localWallClock(
+  ms: number,
+  timeZone: string,
+): { hour: number; minute: number; second: number } | null {
+  try {
+    const parts = new Intl.DateTimeFormat('en-US', {
+      timeZone,
+      hourCycle: 'h23',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    }).formatToParts(new Date(ms))
+    const get = (type: string): number => Number(parts.find(p => p.type === type)?.value ?? NaN)
+    const hour = get('hour')
+    const minute = get('minute')
+    const second = get('second')
+    if (!Number.isFinite(hour) || !Number.isFinite(minute) || !Number.isFinite(second)) return null
+    return { hour, minute, second }
+  } catch {
+    return null
+  }
+}
+
+// Decide the catch-up window for a tick. Pure: everything time-dependent is a
+// parameter, so the quiet-band and gap edges are unit-tested without waiting
+// for a real 06:00.
+//
+// lastTickMs is null on the very first tick of a process; the cold-start window
+// seeded from the persisted tick stamp owns that case, so we return the normal
+// one and the caller leaves its own window alone.
+export function computeCatchUpWindow(
+  nowMs: number,
+  lastTickMs: number | null,
+  timeZone: string = CRON_TZ,
+): CatchUpWindow {
+  const normal: CatchUpWindow = {
+    catchUpMs: NORMAL_CATCH_UP_MS,
+    gapMs: 0,
+    gapResume: false,
+    quietSkipped: false,
+  }
+  if (lastTickMs == null || !Number.isFinite(lastTickMs)) return normal
+
+  const gapMs = nowMs - lastTickMs
+  if (gapMs <= TICK_GAP_THRESHOLD_MS) return { ...normal, gapMs: Math.max(gapMs, 0) }
+
+  const local = localWallClock(nowMs, timeZone)
+  // Unusable zone -> we cannot prove we are outside the quiet band, so we do
+  // not catch up. Losing a catch-up is recoverable; firing the night's backlog
+  // into the operator's chat is not.
+  if (!local) return { ...normal, gapMs, quietSkipped: true }
+
+  if (local.hour >= QUIET_BAND_START_HOUR || local.hour < QUIET_BAND_END_HOUR) {
+    // The gap-resume tick itself landed in the quiet band (the host woke at
+    // 03:00). No catch-up at all: the missed slots were night slots.
+    return { ...normal, gapMs, quietSkipped: true }
+  }
+
+  // Most recent local QUIET_BAND_END_HOUR:00:00 at or before now. We are
+  // provably outside the quiet band here, so that boundary is today's. Derived
+  // by subtracting the elapsed local time-of-day rather than by inverting the
+  // zone offset: exact for every zone whose UTC offset does not change between
+  // 06:00 and 22:00 local (i.e. all of them in practice -- DST transitions run
+  // at night), and a 1 h window-size error, not a wrong decision, if one ever did.
+  const sinceBandEndMs =
+    ((local.hour - QUIET_BAND_END_HOUR) * 3600 + local.minute * 60 + local.second) * 1000
+    + (nowMs % 1000)
+  const bandEndMs = nowMs - sinceBandEndMs
+  const catchUpStart = Math.max(lastTickMs, bandEndMs)
+  const catchUpMs = Math.max(NORMAL_CATCH_UP_MS, nowMs - catchUpStart)
+  return {
+    catchUpMs,
+    gapMs,
+    // A gap whose window collapses back to the normal one (the host woke a few
+    // seconds past 06:00) is not a catch-up tick -- nothing was enlarged.
+    gapResume: catchUpMs > NORMAL_CATCH_UP_MS,
+    quietSkipped: false,
+  }
+}
+
 // Back-compat shim faithful to the old fixed-window semantics -- "did an
 // occurrence happen in the last catchUpMs". Kept for callers/tests that ask
 // the question that way; the scheduler loop itself uses cronDueBetween with

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -27,7 +27,7 @@ import {
   SCHEDULED_TASK_PREAMBLE,
   wrapScheduledTask,
 } from '../prompt-safety.js'
-import { cronPrevOccurrence, effectiveCronTz } from './cron.js'
+import { computeCatchUpWindow, cronPrevOccurrence, effectiveCronTz } from './cron.js'
 import {
   listScheduledTasks,
   SCHEDULED_TASKS_DIR,
@@ -1034,6 +1034,12 @@ export function startScheduleRunner(): NodeJS.Timeout {
   // Reload the persisted last-run times so a restart inside a task's catch-up
   // window does not re-fire an already-run task.
   loadScheduleLastRun()
+  // Wall-clock time of the previous tick, used to detect a host-suspend gap
+  // (see computeCatchUpWindow in cron.ts). In-memory ON PURPOSE: a process
+  // restart is covered by the persisted tick stamp below, and the case this
+  // exists for -- a suspended host -- keeps the process, and this variable,
+  // alive.
+  let lastTickAt: number | null = null
 
   // Surface the effective cron timezone at startup. A silent UTC fallback (no
   // SCHEDULER_TZ/TZ in the env) shifts every fixed-time cron off its intended
@@ -1101,10 +1107,33 @@ export function startScheduleRunner(): NodeJS.Timeout {
     try {
     const tasks = listScheduledTasks()
     const now = Date.now()
+    // Wall-clock distance from the previous tick, decided on the tick's START
+    // time and stamped immediately: the window then means "everything since we
+    // last looked", however long this tick itself takes.
+    const gap = computeCatchUpWindow(now, lastTickAt)
+    lastTickAt = now
+    const catchUp = gap.catchUpMs
     // Scan the real interval elapsed since the previous tick (30 min on the
     // first tick), not a fixed 60s window -- a late/dropped tick must not let a
     // sparse daily cron's single occurrence slip through a gap unscanned (#621).
-    const fromMs = lastCheckMs
+    //
+    // QUIET-BAND CLAMP: that contiguity is right for a dropped tick and wrong
+    // for a host that suspends overnight and wakes at 03:00 -- scanning back to
+    // the last tick would replay every evening occurrence still inside its
+    // staleness budget (24h for command-type, unbounded for a custom
+    // catchUpMaxAgeMinutes) into a sleeping operator's chat, and record/alert
+    // the rest as missed. computeCatchUpWindow returns a band-safe window (collapsed to
+    // the normal one when the resume itself lands in the band), so on a genuine
+    // in-process gap tick the scan starts no earlier than that boundary. The
+    // COLD-START tick is deliberately NOT clamped: real process downtime is
+    // owned by the persisted lastCheckMs (computeCatchUpStart), which is capped
+    // separately and is what the downtime report reads.
+    const fromMs = (gap.gapResume || gap.quietSkipped)
+      ? Math.max(lastCheckMs, now - catchUp)
+      : lastCheckMs
+    // Counted for the end-of-tick summary log, so a gap-resume is auditable:
+    // how long the host was away, and what the resume tick actually pulled in.
+    let catchUpFires = 0
     // Catch-up bookkeeping for this tick's one-line report (see below). Empty
     // on every normal tick, so the operator only ever hears about real gaps.
     const caughtUpThisTick: Array<{ task: string; ageMs: number }> = []
@@ -1195,11 +1224,14 @@ export function startScheduleRunner(): NodeJS.Timeout {
       const occurrenceMs = cronPrevOccurrence(task.schedule, fromMs, now)
       if (occurrenceMs == null) continue
 
-      // Prevent double-firing across a restart: skip if the task already ran at
-      // or after the start of this scan window (its occurrence is already
-      // recorded, so re-scanning the catch-up window must not fire it again).
+      // Prevent double-firing across a restart: skip only if the task already
+      // ran at or after THIS occurrence. Comparing against the window START
+      // (fromMs) instead drops a genuinely new occurrence on any long-gap tick:
+      // fromMs is the previous tick's timestamp, so a task that fired on that
+      // tick has lastRun === fromMs, and a slot that then came due while the
+      // host was suspended is skipped as if it had already run.
       const lastRun = scheduleLastRun.get(task.name) || 0
-      if (lastRun >= fromMs) continue
+      if (lastRun >= occurrenceMs) continue
 
       // How late is this occurrence, and is it still worth running? An
       // occurrence the owning tick never scanned (process down, dropped tick)
@@ -1233,6 +1265,7 @@ export function startScheduleRunner(): NodeJS.Timeout {
         runCommandTask(task, now)
         scheduleLastRun.set(task.name, now)
         persistScheduleLastRun()
+        if (lateCatchUpMs != null) catchUpFires++
         continue
       }
 
@@ -1264,6 +1297,7 @@ export function startScheduleRunner(): NodeJS.Timeout {
         // the retry handler -- don't re-queue or double-fire.
         if (pendingKeys.has(key)) continue
         const result = await attemptFireTask(task, agentName, now, cronPc.prefix, lateCatchUpMs)
+        if (lateCatchUpMs != null && result === 'fired') catchUpFires++
         if (result === 'starting') {
           // Agent was auto-started this tick. ALWAYS enqueue the retry that
           // delivers the prompt once the session is ready -- skipIfBusy must
@@ -1308,6 +1342,27 @@ export function startScheduleRunner(): NodeJS.Timeout {
           insertPendingTaskRetryIfNew(task.name, agentName, now, 'first-run')
         }
       }
+    }
+
+    // Gap-resume summary. Logged AFTER the loops so `catchUpFires` is real, and
+    // only on a tick that actually saw a gap -- an ordinary tick stays silent.
+    // Without these lines a host suspend leaves no trace at all in the log: the
+    // operator sees either a burst of late fires or a pointed absence of them,
+    // with nothing to explain which one was the deliberate outcome.
+    if (gap.gapResume) {
+      logger.info(
+        {
+          gapMinutes: Math.round(gap.gapMs / 60000),
+          catchUpMinutes: Math.round(catchUp / 60000),
+          catchUpFires,
+        },
+        'Schedule tick gap detected (host suspend?) -- catch-up window clamped to the quiet-band edge',
+      )
+    } else if (gap.quietSkipped) {
+      logger.info(
+        { gapMinutes: Math.round(gap.gapMs / 60000) },
+        'Schedule tick gap detected inside the quiet band -- no catch-up (night slots stay missed)',
+      )
     }
 
     // Tell the operator, in one line, what the gap cost. Only fires when this


### PR DESCRIPTION
### What this changes

The scheduler's catch-up window (`lastCheckMs` -> `now`) currently replays
every missed occurrence the staleness policy still considers current
(`decideCatchUp`) after a host-suspend gap, and records/reports the rest as
missed. This PR adds a quiet-band clamp on top of the existing window
mechanics: when the process detects that a tick gap crossed or ended inside
the operator's night band (22:00-06:00 local), the scan window is clamped so
overnight slots are not replayed. Everything else -- including cold-start
catch-up via the persisted `lastCheckMs` (`computeCatchUpStart`) -- is
deliberately untouched.

This is a **narrowing** gate, purely additive: on a normal tick the window is
exactly what it was before. The existing window-scan mechanics
(`cronPrevOccurrence` over `(lastCheckMs, now]`, `decideCatchUp` staleness
policy) stay the authority on what a catch-up is; the clamp only decides how
far back a suspend-resume tick may look.

### Why

The catch-up staleness policy (`DEFAULT_CATCHUP_MAX_AGE_MIN` + `decideCatchUp`)
is per-type and night-blind: it bounds how OLD an occurrence may be (task
180 min, heartbeat 30 min, command 1440 min, and `catchUpMaxAgeMinutes` can be
anything), but it has no notion that a slot recovered at 03:00 should not fire
at all. Concretely, on a laptop-class host that suspends through the evening
and wakes inside the night band:

- a command-type task (24h budget) or any task with a custom/unbounded
  `catchUpMaxAgeMinutes` REPLAYS its evening occurrences into a sleeping
  operator's chat;
- every task/heartbeat occurrence past its budget is recorded and reported
  as missed -- a missed-slot report at 03:00 about slots whose whole point
  was to run last evening.

Both are checkable from the code alone (no install state needed). Night slots
missed because the host was asleep are noise, not debt: the tasks that matter
in the morning have morning occurrences.

### How

- `src/web/cron.ts`: new `computeCatchUpWindow(nowMs, lastTickAtMs)` helper +
  `QUIET_BAND_START_HOUR`/`QUIET_BAND_END_HOUR` constants. Returns a band-safe
  catch-up window: collapsed to the normal 60s window when the resume itself
  lands inside the band ("the night stays missed"), clamped to the band's end
  edge when the gap crossed it.
- `src/web/schedule-runner.ts`: an in-memory `lastTickAt` stamp detects the
  in-process gap (a process restart is a different path and stays owned by the
  persisted `lastCheckMs`); the scan `fromMs` is clamped on gap-resume ticks
  only; a one-line `logger.info` summary makes the gap and what it pulled back
  auditable (gap minutes, window minutes, catch-up fires).
- Double-fire guard fix required by the clamp: the guard now compares the
  task's `lastRun` against the *occurrence* being fired (`lastRun >=
  occurrenceMs`) instead of the window start (`lastRun >= fromMs`). With the
  old comparison, a task that fired on the last healthy tick before the
  suspend had `lastRun === fromMs` after the clamp, and its genuinely new
  occurrence inside the gap was silently dropped. Covered by a regression test
  (`schedule-runner-gap-catchup.test.ts`: "suspend catch-up fires the swallowed
  slot exactly once").

### Evidence / verification

- 24 unit tests for `computeCatchUpWindow` (`schedule-catchup-window.test.ts`)
  and 3 end-to-end runner tests (`schedule-runner-gap-catchup.test.ts`), all
  green; `tsc` clean; full suite shows zero new failures vs base.
- Both key lines are mutation-tested: reverting the clamp
  (`const fromMs = lastCheckMs`) fails the quiet-band test; reverting the
  guard (`lastRun >= fromMs`) fails the swallowed-slot test.

### Base note

The touched window-mechanics region was not changed upstream between 2be77cc
and de2537c -- the only upstream change to these files in that range is
ea3f7c7, which reworks the resubmit lane-locking; verified with
`git log 2be77cc..de2537c -- src/web/schedule-runner.ts src/web/cron.ts`
-> exactly one commit.

### Open questions for maintainers

- The codebase already carries two night-band notions: `reauth-healer.ts`
  (`QUIET_START_HOUR` 23 / `QUIET_END_HOUR` 6, `isQuietHour`) and the
  heartbeat's 22:00 evening cutoff (`src/heartbeat.ts`). This PR introduces
  its band as separate exported constants in `cron.ts` (22/6) rather than
  reusing `reauth-healer`'s, deliberately: importing from the healer would
  pull its runtime dependencies (agent-process, session-send-lock) into
  `cron.ts`, a module that currently has none, and the healer's 23:00 start
  is tuned to reauth prompts, not schedule replay. If you would rather
  hoist a single shared quiet-band module (or make the edges env-configurable
  -- night-shift operators would get exactly the wrong defaults), happy to
  restructure; flagging the overlap so the third notion is a decision, not an
  accident.
- A gap longer than ~26h clips to today's band edge, so the previous day's
  working-hour slots are also dropped. Conservative direction; flagging it
  explicitly.

### Changed files

- `src/web/cron.ts` (+147)
- `src/web/schedule-runner.ts` (+61/-6)
- `src/__tests__/schedule-catchup-window.test.ts` (new, 305)
- `src/__tests__/schedule-runner-gap-catchup.test.ts` (new, 244)

### Note on the test notification sink

Both e2e test files mock `src/web/telegram.js`. The runner's catch-up summary
resolves a real bot token from install-level (HOME-based) config, so a test
worktree does not isolate it; without the mock a full-suite run delivers
test-marked catch-up summaries through the install's real bot token. A
structural guard (refuse to send under a test run, not just mark) is a
separate follow-up.