### PR TITLE
fix(agents): report the main agent's model from its launch source everywhere

### DIFF
--- a/src/__tests__/main-agent-model-reporting.test.ts
+++ b/src/__tests__/main-agent-model-reporting.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// The fleet list must report the MAIN agent's model from its actual launch
+// source (.env MAIN_AGENT_MODEL -> .claude/settings.json, the channels.sh
+// precedence readConfiguredMainModel mirrors), NOT from
+// agents/<name>/agent-config.json. On a real install the two can diverge --
+// e.g. a stale agent-config.json model key left behind by an older workflow --
+// and the fleet list then shows a model the main agent is not running on: a
+// silent split-brain between the dashboard and the process, in exactly the
+// place an operator would look to verify a model decision.
+
+const mockReadConfiguredMainModel = vi.fn(() => '')
+const mockResolveDetailed = vi.fn(() => ({ model: 'claude-sonnet-5', source: 'default' as const }))
+
+vi.mock('../web/channel-monitor.js', () => ({
+  hardRestartMarveenChannels: vi.fn(),
+  readConfiguredMainModel: () => mockReadConfiguredMainModel(),
+}))
+
+vi.mock('../web/agent-config.js', async (importOriginal) => {
+  const orig = await importOriginal<typeof import('../web/agent-config.js')>()
+  return {
+    ...orig,
+    resolveAgentModelDetailed: () => mockResolveDetailed(),
+  }
+})
+
+async function load() {
+  vi.resetModules()
+  return await import('../web/routes/agents.js')
+}
+
+describe('main-agent model reporting resolves from the launch source', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('uses the launch source when it names a model, even when agent-config resolution disagrees', async () => {
+    mockReadConfiguredMainModel.mockReturnValue('claude-opus-5')
+    const { mainAgentModelResolution } = await load()
+    expect(mainAgentModelResolution()).toEqual({ model: 'claude-opus-5', source: 'launch_config' })
+    // The agent-config path must not have been consulted at all.
+    expect(mockResolveDetailed).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the ordinary resolution when neither launch source names a model', async () => {
+    mockReadConfiguredMainModel.mockReturnValue('')
+    const { mainAgentModelResolution } = await load()
+    expect(mainAgentModelResolution()).toEqual({ model: 'claude-sonnet-5', source: 'default' })
+  })
+})

--- a/src/model-profiles.ts
+++ b/src/model-profiles.ts
@@ -65,7 +65,11 @@ export function validateModelProfileMap(raw: unknown): ModelProfileMapState {
   };
 }
 
-export type ModelResolutionSource = 'explicit_model' | 'model_profile' | 'default';
+// 'launch_config': the model was read from the MAIN agent's actual launch
+// source (.env MAIN_AGENT_MODEL, then the tracked .claude/settings.json --
+// the same precedence scripts/channels.sh resolves --model from), not from
+// agents/<name>/agent-config.json.
+export type ModelResolutionSource = 'explicit_model' | 'model_profile' | 'default' | 'launch_config';
 
 export interface ModelResolution {
   model: string;

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -3,7 +3,7 @@ import { join, extname, dirname } from 'node:path'
 import { homedir, platform, tmpdir } from 'node:os'
 import { execSync } from 'node:child_process'
 import { logger } from '../../logger.js'
-import { isModelProfileId, MODEL_PROFILE_IDS } from '../../model-profiles.js'
+import { isModelProfileId, MODEL_PROFILE_IDS, type ModelResolution } from '../../model-profiles.js'
 import { MAIN_AGENT_ID, currentBotName, PROJECT_ROOT } from '../../config.js'
 import { createAgentMessage, listPendingChannelRequests, updateChannelRequestStatus, getDb, claimPendingForAgent, markMessageFailed } from '../../db.js'
 import { classifyAgentMessage, wrapAgentMessageForDelivery } from '../agent-message-wrap.js'
@@ -74,7 +74,7 @@ import {
   revokeInvite,
   agentChannelDir,
 } from '../channel-invites.js'
-import { hardRestartMarveenChannels } from '../channel-monitor.js'
+import { hardRestartMarveenChannels, readConfiguredMainModel } from '../channel-monitor.js'
 import { isMainChannelsAgent, MAIN_CHANNELS_SESSION } from '../main-agent.js'
 import {
   getProvider,
@@ -386,7 +386,7 @@ interface AgentSummary {
   /** Card c755f4b2 Block B: how `model` was arrived at. Metadata only -- it
    *  reports the existing resolution, it does not change it. */
   modelProfile: string | null
-  modelSource: 'explicit_model' | 'model_profile' | 'default'
+  modelSource: 'explicit_model' | 'model_profile' | 'default' | 'launch_config'
   modelProfileError: string | null
   activeModel: string | null
   runningSince: number | null
@@ -430,6 +430,20 @@ interface AgentDetail extends AgentSummary {
   hasApiKey: boolean
 }
 
+// The MAIN agent is not launched from agents/<name>/agent-config.json:
+// scripts/channels.sh resolves its --model from .env MAIN_AGENT_MODEL and then
+// the tracked .claude/settings.json (readConfiguredMainModel mirrors that
+// exact precedence, parity-tested against the shell). Reporting
+// agent-config.json for it can therefore show a model the main agent is not
+// running on -- a silent split-brain between the fleet list and the process.
+// Fall back to the ordinary resolution only when neither launch source names a
+// model (fresh install with no settings.json).
+export function mainAgentModelResolution(): ModelResolution {
+  const launch = readConfiguredMainModel()
+  if (launch) return { model: launch, source: 'launch_config' }
+  return resolveAgentModelDetailed(MAIN_AGENT_ID)
+}
+
 function getAgentSummary(name: string): AgentSummary {
   const dir = agentDir(name)
   const configRoot = agentConfigRoot(name)
@@ -445,7 +459,7 @@ function getAgentSummary(name: string): AgentSummary {
   // was reached, so "configured" and "resolved" are never conflated in the API.
   let agentModelConfig: { model?: unknown; modelProfile?: unknown } = {}
   try { agentModelConfig = JSON.parse(readFileOr(join(dir, 'agent-config.json'), '{}')) } catch { /* defaults */ }
-  const modelResolution = resolveAgentModelDetailed(name)
+  const modelResolution = name === MAIN_AGENT_ID ? mainAgentModelResolution() : resolveAgentModelDetailed(name)
 
   // Resolve run state through the cache (remote agents) so listing the fleet
   // never blocks on a sleeping laptop's ssh timeout. `running` is derived from

--- a/src/web/routes/federation.ts
+++ b/src/web/routes/federation.ts
@@ -21,6 +21,15 @@ import { createAgentMessage, failPendingFederatedMessages } from '../../db.js'
 import { logger } from '../../logger.js'
 import { readBody, json, RequestBodyTooLargeError } from '../http-helpers.js'
 import { isKnownAgent, readAgentDisplayName, readAgentModel } from '../agent-config.js'
+import { readConfiguredMainModel } from '../channel-monitor.js'
+
+// The MAIN agent's model comes from its launch source (.env MAIN_AGENT_MODEL ->
+// tracked .claude/settings.json, the channels.sh precedence readConfiguredMainModel
+// mirrors), not from agents/<name>/agent-config.json -- the directory and peer
+// catalog otherwise advertise a model the main agent is not running on.
+function mainAgentModel(): string {
+  return readConfiguredMainModel() || readAgentModel(MAIN_AGENT_ID)
+}
 import { parseQualifiedId, isValidIdSegment, formatQualifiedId } from '../federation/address.js'
 import { catalogAgentNames, listAgentLocalSkills } from '../federation/local-catalog.js'
 import { containsPrivateData, getCapabilitySummary, mainAgentCapabilitySummary, purgeCapabilityCache } from '../federation/capabilities.js'
@@ -225,7 +234,7 @@ function buildManifest(cfg: FederationConfig, callerPeerId: string | null): unkn
     federationVersion: FEDERATION_VERSION,
     agents: [
       {
-        id: MAIN_AGENT_ID, displayName: BOT_NAME, model: readAgentModel(MAIN_AGENT_ID),
+        id: MAIN_AGENT_ID, displayName: BOT_NAME, model: mainAgentModel(),
         ...(share ? { capabilitySummary: mainAgentCapabilitySummary(resolveLang()) } : {}),
       },
       ...names.map((n) => ({ id: n, displayName: readAgentDisplayName(n), model: readAgentModel(n), ...summaryFor(n) })),
@@ -387,7 +396,7 @@ export async function tryHandleFederation(ctx: RouteContext): Promise<boolean> {
       {
         id: MAIN_AGENT_ID,
         displayName: BOT_NAME,
-        model: readAgentModel(MAIN_AGENT_ID),
+        model: mainAgentModel(),
         capabilitySummary: mainAgentCapabilitySummary(lang),
         skills: [] as Array<{ name: string; description: string }>,
       },


### PR DESCRIPTION
### What this changes

Upstream commit 9aa26f4 ("test(channels): model-precedence fix (#875 impl) +
runtime shell<->TS parity test") fixed the respawn path:
`readConfiguredMainModel()` now mirrors the `scripts/channels.sh` precedence
(`.env MAIN_AGENT_MODEL` -> tracked `.claude/settings.json`), parity-tested
against the shell. This PR closes the remaining read sites that still report
the MAIN agent's model from `agents/<name>/agent-config.json`:

- `/api/agents` summary (`routes/agents.ts`) -- the fleet list;
- the federation directory and peer catalog (`routes/federation.ts`).

Each now resolves the main agent's model through `readConfiguredMainModel()`
(new `modelSource` value `'launch_config'` on the summary), falling back to
the ordinary resolution only when neither launch source names a model.

### Why

The main agent is not launched from `agent-config.json`, so whenever the two
sources diverge -- e.g. a stale `agent-config.json` model key left behind by
an older workflow -- the dashboard fleet list and the federation directory
show a model the main agent is not running on: a silent split-brain in
exactly the places an operator would look to verify a model decision.

The defect takes ten seconds to reproduce on any install: write different
model ids into the two files and GET `/api/agents` -- the summary reports
the agent-config value, not the one the launch path resolves.

### Evidence / verification

- New test `main-agent-model-reporting.test.ts` (2 tests): the launch source
  wins when it names a model (and the agent-config path is not consulted at
  all); the resolution falls back when neither launch source names one.
- `tsc` clean. `main-model-env-precedence.test.ts` is green.

### A separate finding, surfaced while testing this

`main-model-resolution-parity.test.ts` shows 3 failures on the clean base too
-- but **only on a host without `jq`**. `resolve_main_model` guards the
settings.json read behind `command -v jq` and silently resolves EMPTY without
it; a host with `jq` sees all green. On a jq-less host a real launch therefore
also omits `--model` entirely and the main agent silently runs on the CLI
default, with no error and no log line.

That is a separate defect from the one this PR fixes and wants its own small
change (a python3 fallback in `resolve_main_model`). Mentioned here only so
the parity-suite result is not mistaken for a regression introduced by this
PR. Happy to send it separately if useful.

### Changed files

- `src/web/routes/agents.ts` (+18/-4)
- `src/web/routes/federation.ts` (+11/-2)
- `src/model-profiles.ts` (+5/-1)
- `src/__tests__/main-agent-model-reporting.test.ts` (new, 51)