### PR TITLE
fix(model-credit): escalate instead of guessing when no option names the configured model

### DIFF
--- a/src/__tests__/channel-monitor-model-credit-dialog.test.ts
+++ b/src/__tests__/channel-monitor-model-credit-dialog.test.ts
@@ -1,0 +1,172 @@
+// The model usage-credit dialog branch in the blocking-menu recovery pass.
+//
+// FABLEFALL1 established that the credit consent dialog must never get the
+// generic recovery Escape: the CLI records Escape as `cancelled` and continues
+// on the FALLBACK model, silently. Its answer is to press option 1, which is
+// correct for the one dialog shape it detects -- there, option 1 IS "Continue
+// with <configured model>".
+//
+// The gap this branch closes is the shape where that assumption does not hold:
+// a dialog whose options do not include the configured model. Pressing 1 there
+// either buys credits or moves the agent onto a model nobody chose, and because
+// the modal then disappears, the pane, the dashboard and agent-config.json all
+// keep naming the configured model. Such a dialog must ESCALATE, not guess.
+//
+// The pure decision is tested behaviourally below. A real tmux interaction
+// cannot be driven from a unit test, so the wiring asserts read the source and
+// lock in the structural invariants -- ordering, the absence of an Escape, and
+// the send-lane discipline. This file deliberately does NOT import
+// channel-monitor: loading it would pull in the live notification sinks.
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import {
+  detectsModelConsentDialog,
+  detectsModelCreditDialog,
+  findModelCreditDialogOption,
+} from '../pane-state.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const MONITOR_PATH = join(__dirname, '..', 'web', 'channel-monitor.ts')
+const src = readFileSync(MONITOR_PATH, 'utf-8')
+
+// The blocking-menu recovery pass, from its banner comment to the next pass.
+function menuRecoveryRegion(): string {
+  const start = src.indexOf('// Blocking-menu recovery')
+  const end = src.indexOf('// Stuck channel-input recovery', start)
+  expect(start, 'menu-recovery region start not found').toBeGreaterThan(0)
+  expect(end, 'menu-recovery region end not found').toBeGreaterThan(start)
+  return src.slice(start, end)
+}
+
+describe('model-credit dialog: escalate instead of guessing an option', () => {
+  // A dialog BOTH detectors match, offering Fable and Sonnet. The agent parked
+  // on it is configured for Haiku -- neither row names its model.
+  const FABLE_SONNET_DIALOG = [
+    '  Fable 5 now uses usage credits',
+    "  You've used your included Fable 5 usage for this week. Continuing on Fable 5",
+    '  uses usage credits, purchased separately from your plan.',
+    '  ❯ 1. Continue with Fable 5',
+    '    2. Switch to Sonnet 5 and continue',
+    '  Enter to confirm · Esc to cancel',
+  ].join('\n')
+
+  it('a dialog offering no row for the configured model yields NO option (-> escalate)', () => {
+    expect(detectsModelCreditDialog(FABLE_SONNET_DIALOG)).toBe(true)
+    expect(findModelCreditDialogOption(FABLE_SONNET_DIALOG, 'claude-haiku-4-5-20251001')).toBeNull()
+  })
+
+  it('option 1 here would silently switch the agent -- which is why the branch runs first', () => {
+    // This is the incident class in one assertion. The pane satisfies the
+    // FABLEFALL1 detector too, so without this branch chained ahead of it the
+    // monitor would press option 1 -- "Continue with Fable 5" -- on an agent
+    // configured for Haiku, and nothing in the pane or the config would show it.
+    expect(detectsModelConsentDialog(FABLE_SONNET_DIALOG)).toBe(true)
+    const blindOptionOne = 1
+    const configuredOption = findModelCreditDialogOption(FABLE_SONNET_DIALOG, 'claude-haiku-4-5-20251001')
+    expect(configuredOption).not.toBe(blindOptionOne)
+    expect(configuredOption).toBeNull()
+  })
+
+  it('still navigates when a row DOES name the configured model (escalation is not the default)', () => {
+    expect(findModelCreditDialogOption(FABLE_SONNET_DIALOG, 'claude-fable-5')).toBe(1)
+    expect(findModelCreditDialogOption(FABLE_SONNET_DIALOG, 'claude-sonnet-5')).toBe(2)
+  })
+})
+
+describe('channel-monitor: model-credit dialog branch', () => {
+  it('imports the pure detectors from pane-state', () => {
+    expect(src).toMatch(/import\s*{[^}]*\bdetectsModelCreditDialog\b[^}]*}\s*from\s*['"]\.\.\/pane-state\.js['"]/s)
+    expect(src).toMatch(/import\s*{[^}]*\bfindModelCreditDialogOption\b[^}]*}\s*from\s*['"]\.\.\/pane-state\.js['"]/s)
+  })
+
+  it('reads the configured model through the existing resolvers, main vs sub-agent', () => {
+    // readConfiguredMainModel already encodes the .env-over-settings.json
+    // precedence for the main session, and readAgentModel resolves a sub-agent's
+    // model profile; re-implementing either here would drift.
+    expect(src).toMatch(/import\s*{[^}]*\breadAgentModel\b[^}]*}\s*from\s*['"]\.\/agent-config\.js['"]/s)
+    const region = menuRecoveryRegion()
+    expect(region).toContain('const configuredModel = t.isMarveen')
+    expect(region).toContain('? readConfiguredMainModel()')
+    expect(region).toContain(": (t.agentName ? readAgentModel(t.agentName) : '')")
+  })
+
+  it('runs BEFORE the FABLEFALL1 branch and BEFORE the generic Escape branch', () => {
+    // Ordering is the whole contract: FABLEFALL1 presses option 1, so it must
+    // only see dialogs this branch has already declined to handle.
+    const region = menuRecoveryRegion()
+    const creditIdx = region.indexOf('} else if (pane != null && detectsModelCreditDialog(pane)) {')
+    const fablefallIdx = region.indexOf('detectsModelConsentDialog(paneNow)')
+    const genericEscapeIdx = region.indexOf("send-keys', '-t', t.session, 'Escape'")
+    expect(creditIdx).toBeGreaterThan(0)
+    expect(fablefallIdx).toBeGreaterThan(creditIdx)
+    expect(genericEscapeIdx).toBeGreaterThan(fablefallIdx)
+  })
+
+  it('sends NO Escape and no blind option 1 in the credit branch (the whole point)', () => {
+    const region = menuRecoveryRegion()
+    // Still exactly one Escape send in the entire pass, and it is the generic
+    // one -- the credit branch adds none.
+    const escapes = region.match(/send-keys', '-t', t\.session, 'Escape'/g) ?? []
+    expect(escapes.length).toBe(1)
+    const creditIdx = region.indexOf('detectsModelCreditDialog(pane)')
+    const fablefallIdx = region.indexOf('// FABLEFALL1:')
+    const creditBranch = region.slice(creditIdx, fablefallIdx)
+    // Match the CALL, not the word: the branch comment explains why Escape is
+    // wrong here, so a bare substring check would flag its own rationale.
+    expect(creditBranch).not.toContain("send-keys', '-t', t.session, 'Escape'")
+    // The blind option-1 answer belongs to FABLEFALL1 only. Again the CALL,
+    // not the name -- the navigation comment cites that helper's key sequence.
+    expect(creditBranch).not.toContain('await dismissModelConsentDialogIfPresent(')
+  })
+
+  it('escalates with NO keystrokes when no option names the configured model', () => {
+    const region = menuRecoveryRegion()
+    const creditIdx = region.indexOf('detectsModelCreditDialog(pane)')
+    const escalate = region.slice(region.indexOf('if (optionNum == null) {', creditIdx), region.indexOf('} else {', creditIdx))
+    expect(escalate).toContain('NO keystrokes sent')
+    expect(escalate).toContain('sendAlert(')
+    // Nothing may be typed into the pane on this path.
+    expect(escalate).not.toContain('send-keys')
+  })
+
+  it('navigates with digit + settle + Enter, under the send lane in recover mode', () => {
+    const region = menuRecoveryRegion()
+    expect(region).toContain('const optionNum = configuredModel ? findModelCreditDialogOption(pane, configuredModel) : null')
+    // PANEWRITERS805: a probe+act keystroke writer takes the lane fail-closed.
+    expect(region).toContain("await withSessionSendLock(t.session, null, 'recover'")
+    const navIdx = region.indexOf("await withSessionSendLock(t.session, null, 'recover'")
+    const nav = region.slice(navIdx)
+    expect(nav).toContain("execFileSync(TMUX, ['send-keys', '-t', t.session, String(optionNum)], { timeout: 5000 })")
+    expect(nav).toContain('await delay(150)')
+    expect(nav).toContain("execFileSync(TMUX, ['send-keys', '-t', t.session, 'Enter'], { timeout: 5000 })")
+    // Ordering within the sequence: digit, then settle, then Enter.
+    const digitIdx = nav.indexOf('String(optionNum)], { timeout: 5000 })')
+    const settleIdx = nav.indexOf('await delay(150)')
+    const enterIdx = nav.indexOf("t.session, 'Enter'], { timeout: 5000 })")
+    expect(settleIdx).toBeGreaterThan(digitIdx)
+    expect(enterIdx).toBeGreaterThan(settleIdx)
+  })
+
+  it('re-probes INSIDE the lane and only presses when the option number is unchanged', () => {
+    // A digit selects by POSITION. The detection capture predates the debounce
+    // decision, so pressing on it could confirm a row that has since moved.
+    const region = menuRecoveryRegion()
+    const navIdx = region.indexOf("await withSessionSendLock(t.session, null, 'recover'")
+    const nav = region.slice(navIdx)
+    const reprobeIdx = nav.indexOf('const paneNow = capturePane(t.session)')
+    const guardIdx = nav.indexOf('findModelCreditDialogOption(paneNow, configuredModel) !== optionNum')
+    const pressIdx = nav.indexOf('String(optionNum)], { timeout: 5000 })')
+    expect(reprobeIdx).toBeGreaterThan(-1)
+    expect(guardIdx).toBeGreaterThan(reprobeIdx)
+    expect(pressIdx).toBeGreaterThan(guardIdx)
+  })
+
+  it('logs the fail-closed skip when a delivery holds the lane (a skip nobody logs is not a skip)', () => {
+    const region = menuRecoveryRegion()
+    expect(region).toContain('if (!nav.ran) {')
+    expect(region).toContain('holds this pane send lane (fail-closed)')
+  })
+})

--- a/src/__tests__/pane-state.test.ts
+++ b/src/__tests__/pane-state.test.ts
@@ -4,6 +4,10 @@ import {
   detectPermissionMode,
   detectsThinkingBlockError,
   detectsBlockingMenu,
+  detectsModelConsentDialog,
+  detectsModelCreditDialog,
+  findModelCreditDialogOption,
+  MODEL_CREDIT_DIALOG_LABELS,
   detectsPastePlaceholder,
   isReadyForPrompt,
   shouldRetrySubmit,
@@ -2166,5 +2170,179 @@ describe('parkedPasteSignature (stuck [Pasted text #N] recovery)', () => {
     ].join('\n')
     expect(stuckInputSignature(auraShape)).toBeNull()
     expect(parkedPasteSignature(auraShape)).not.toBeNull()
+  })
+})
+
+describe('detectsModelCreditDialog / findModelCreditDialogOption', () => {
+  // The shape detectsModelConsentDialog already covers: option 1 IS "Continue
+  // with <model>", so pressing 1 keeps the configured model. Note the hard wrap
+  // inside the body ("Continuing on Fable 5" / "uses usage credits, ...") --
+  // the phrase the detector keys on straddles the line break.
+  const CREDIT_DIALOG = [
+    '  ⎿  $ date && ls -la',
+    SEP,
+    "  You've reached your Fable 5 limit",
+    "  You've used your included Fable 5 usage for this week. Continuing on Fable 5",
+    '  uses usage credits, purchased separately from your plan.',
+    '  Learn more: https://support.claude.com/en/articles/12429409-extra-usage-for-',
+    '  paid-claude-plans',
+    '  ❯ 1. Continue with Fable 5',
+    '    2. Switch to Sonnet 5 and continue',
+    '  Enter to confirm · Esc to cancel',
+  ].join('\n')
+
+  // The variant that motivates this pair: option 1 names NO model at all, so a
+  // blind option-1 answer buys credits instead of choosing a model.
+  const CREDIT_DIALOG_ALT = [
+    '  Fable 5 now uses usage credits',
+    '  Fable 5 runs on usage credits, purchased separately from your plan.',
+    "  You don't have usage credits yet.",
+    '  ❯ 1. Buy usage credits',
+    '    2. Switch to Opus 5 and continue',
+    '  Enter to confirm · Esc to cancel',
+  ].join('\n')
+
+  it('detects the credit dialog even though the body phrase is line-wrapped', () => {
+    expect(detectsModelCreditDialog(CREDIT_DIALOG)).toBe(true)
+  })
+
+  it('detects the alternate ("runs on usage credits") wording', () => {
+    expect(detectsModelCreditDialog(CREDIT_DIALOG_ALT)).toBe(true)
+  })
+
+  it('catches the shape detectsModelConsentDialog misses -- the reason it exists', () => {
+    // The consent detector requires `1. Continue with `, so the "Buy usage
+    // credits" variant slips past it and would reach the generic Escape
+    // recovery, which the CLI answers as "continue on the fallback model".
+    expect(detectsModelConsentDialog(CREDIT_DIALOG_ALT)).toBe(false)
+    expect(detectsModelCreditDialog(CREDIT_DIALOG_ALT)).toBe(true)
+  })
+
+  it('is a strict SUBSET of detectsBlockingMenu (the branch it splits off from)', () => {
+    // The monitor only reaches the new branch inside the blocking-menu pass, so
+    // a credit dialog that is not a blocking menu would be unreachable.
+    expect(detectsBlockingMenu(CREDIT_DIALOG)).toBe(true)
+    expect(detectsBlockingMenu(CREDIT_DIALOG_ALT)).toBe(true)
+  })
+
+  it('is false for other blocking menus, idle, busy and empty panes', () => {
+    const MCP_MENU = [
+      '   Manage MCP servers',
+      '   ❯ claude.ai Canva · ✔ connected · 39 tools',
+      '   ↑/↓ to navigate · Enter to confirm · Esc to cancel',
+    ].join('\n')
+    expect(detectsModelCreditDialog(MCP_MENU)).toBe(false)
+    expect(detectsModelCreditDialog(IDLE_BYPASS)).toBe(false)
+    expect(detectsModelCreditDialog(IDLE_STRICT)).toBe(false)
+    expect(detectsModelCreditDialog(BUSY_FULL_FOOTER)).toBe(false)
+    expect(detectsModelCreditDialog(BUSY_TOKENS_ONLY)).toBe(false)
+    expect(detectsModelCreditDialog('')).toBe(false)
+    expect(detectsModelCreditDialog('   \n  ')).toBe(false)
+  })
+
+  it('is false for a non-interactive credit BANNER (no numbered options)', () => {
+    // Claude Code also prints credit prose without a select; only the modal
+    // with >= 2 numbered rows may be navigated.
+    const banner = [
+      '  Fast mode requires usage credits',
+      '  Press Esc to exit',
+    ].join('\n')
+    expect(detectsBlockingMenu(banner)).toBe(true)
+    expect(detectsModelCreditDialog(banner)).toBe(false)
+  })
+
+  it('does not trigger on a reply that merely quotes the dialog above a live prompt', () => {
+    // Region-scoping + the idle-footer guard: agents discuss this very dialog,
+    // so a quoted copy in the transcript must never be actioned.
+    const quoted = [
+      "  A watchdog reported: \"You've reached your Fable 5 limit\"; per the modal",
+      '  text, continuing would run on usage credits.',
+      '  1. Continue with Fable 5',
+      '  2. Switch to Sonnet 5 and continue',
+      '',
+      SEP,
+      '❯ ',
+      SEP,
+      '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+    ].join('\n')
+    expect(detectsModelCreditDialog(quoted)).toBe(false)
+  })
+
+  it('does not trigger under a live "esc to interrupt" footer (busy guard)', () => {
+    const busyQuote = [
+      '  Continuing on Fable 5 uses usage credits, purchased separately.',
+      '  1. Continue with Fable 5',
+      '  2. Switch to Sonnet 5 and continue',
+      '  Esc to cancel',
+      '  ⏵⏵ bypass permissions on (shift+tab to cycle) · esc to interrupt',
+    ].join('\n')
+    expect(detectsModelCreditDialog(busyQuote)).toBe(false)
+  })
+
+  it('finds the "Continue with <model>" option for the configured model', () => {
+    expect(findModelCreditDialogOption(CREDIT_DIALOG, 'claude-fable-5')).toBe(1)
+  })
+
+  it('finds the "Switch to <model> and continue" option for the configured model', () => {
+    expect(findModelCreditDialogOption(CREDIT_DIALOG, 'claude-sonnet-5')).toBe(2)
+    expect(findModelCreditDialogOption(CREDIT_DIALOG_ALT, 'claude-opus-5')).toBe(2)
+  })
+
+  it('normalises the [1m] and dated-release suffixes agent configs carry', () => {
+    const pane = [
+      '  Fable 5 now uses usage credits',
+      '  ❯ 1. Continue with Fable 5',
+      '    2. Switch to Opus 4.8 and continue',
+      '  Enter to confirm · Esc to cancel',
+    ].join('\n')
+    expect(findModelCreditDialogOption(pane, 'claude-opus-4-8[1m]')).toBe(2)
+    const haiku = pane.replace('Opus 4.8', 'Haiku 4.5')
+    expect(findModelCreditDialogOption(haiku, 'claude-haiku-4-5-20251001')).toBe(2)
+  })
+
+  it('returns null for a model id that is not in the label map', () => {
+    // Non-Claude provider models can never be named by this dialog.
+    expect(findModelCreditDialogOption(CREDIT_DIALOG, 'deepseek-v4-pro')).toBeNull()
+    expect(findModelCreditDialogOption(CREDIT_DIALOG, '')).toBeNull()
+  })
+
+  it('returns null when no offered option names the configured model', () => {
+    // The escalate path: agent configured for Haiku, dialog offers Fable/Sonnet.
+    expect(findModelCreditDialogOption(CREDIT_DIALOG, 'claude-haiku-4-5-20251001')).toBeNull()
+    // ...and the credit-buying row names no model at all, so an agent on Fable
+    // parked on that variant must escalate rather than press 1.
+    expect(findModelCreditDialogOption(CREDIT_DIALOG_ALT, 'claude-fable-5')).toBeNull()
+  })
+
+  it('returns null when the label would only match mid-label, not as the option target', () => {
+    // "Sonnet 4.6" must not be satisfied by an option naming "Sonnet 4.65".
+    const pane = [
+      '  Fable 5 now uses usage credits',
+      '  ❯ 1. Continue with Fable 5',
+      '    2. Switch to Sonnet 4.65 and continue',
+      '  Enter to confirm · Esc to cancel',
+    ].join('\n')
+    expect(findModelCreditDialogOption(pane, 'claude-sonnet-4-6')).toBeNull()
+  })
+
+  it('returns null when more than one option matches (ambiguous, never guess)', () => {
+    const pane = [
+      '  Fable 5 now uses usage credits',
+      '  ❯ 1. Continue with Fable 5',
+      '    2. Switch to Fable 5 and continue',
+      '  Enter to confirm · Esc to cancel',
+    ].join('\n')
+    expect(findModelCreditDialogOption(pane, 'claude-fable-5')).toBeNull()
+  })
+
+  it('every label in the map is the display name the model picker offers', () => {
+    // Pins the source of truth: these strings are what the dialog prints, so a
+    // silent drift here would turn every navigation into an escalation.
+    expect(MODEL_CREDIT_DIALOG_LABELS['claude-fable-5']).toBe('Fable 5')
+    expect(MODEL_CREDIT_DIALOG_LABELS['claude-opus-5']).toBe('Opus 5')
+    expect(MODEL_CREDIT_DIALOG_LABELS['claude-sonnet-5']).toBe('Sonnet 5')
+    expect(MODEL_CREDIT_DIALOG_LABELS['claude-sonnet-4-6']).toBe('Sonnet 4.6')
+    expect(MODEL_CREDIT_DIALOG_LABELS['claude-opus-4-8']).toBe('Opus 4.8')
+    expect(MODEL_CREDIT_DIALOG_LABELS['claude-haiku-4-5']).toBe('Haiku 4.5')
   })
 })

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -613,6 +613,145 @@ export function detectsModelConsentDialog(pane: string): boolean {
     && MODEL_CONSENT_CONFIRM_RX.test(footerRegion)
 }
 
+// The WIDER credit-dialog surface, and why it needs a detector of its own.
+//
+// detectsModelConsentDialog above pins the one shape that has been captured in
+// the field: title + `1. Continue with <model>` + the confirm hint. Answering
+// it by pressing option 1 is safe precisely BECAUSE that shape's option 1 is
+// known to mean "stay on the configured model".
+//
+// Claude Code also renders credit-gated modals that wear the same footer but
+// NOT that layout -- e.g. a picker whose first row is "Buy usage credits", or
+// a dialog that only offers models this agent is not configured for (an agent
+// pinned to Haiku parked on a Fable/Sonnet dialog). There, a blind option 1
+// either spends money or moves the agent onto a model nobody chose. The modal
+// then disappears and the pane, the dashboard and agent-config.json all keep
+// naming the configured model, so the switch is invisible until someone reads
+// the session transcript. A consent dialog whose options do not include the
+// configured model must ESCALATE, not guess.
+//
+// Hence a deliberately LOOSER detector (any credit phrase + >= 2 numbered
+// rows) paired with an explicit option lookup, so a caller can act only when a
+// row unambiguously names the configured model and otherwise has a defined
+// "escalate" answer instead of a default keypress.
+const MODEL_CREDIT_PHRASE_RX = /\b(?:uses?|runs on|requires?) usage credits\b/i
+// A rendered select row: optional focus caret, the 1-based index, a dot, the
+// label.
+const MODEL_CREDIT_OPTION_RX = /^\s*❯?\s*(\d+)\.\s+(\S.*)$/
+// How many trailing lines the credit scan inspects. Counted against the widest
+// variant the bundle can render: border + title + gap + wrapped body + the
+// "you don't have usage credits yet" note + a wrapped Help-Center line + gap +
+// three options + footer + border ~= 18 lines. 24 keeps margin for narrower
+// panes (more wrapping) while staying far short of the transcript rendered
+// above the modal. Sizing this too small is the dangerous direction: the phrase
+// sits at the TOP of the modal, so an under-sized region silently drops the
+// pane back to the generic Escape recovery.
+const MODEL_CREDIT_REGION_LINES = 24
+
+// Model id -> the SHORT name the dialog prints. Source of truth: the Claude
+// entries of /api/models/available (src/web/routes/agents.ts), which is the set
+// an agent can actually be configured to. Ids outside it -- including every
+// non-Claude provider model -- resolve to null, and the caller escalates rather
+// than guessing a "closest" model.
+export const MODEL_CREDIT_DIALOG_LABELS: Record<string, string> = {
+  'claude-opus-5': 'Opus 5',
+  'claude-sonnet-5': 'Sonnet 5',
+  'claude-sonnet-4-6': 'Sonnet 4.6',
+  'claude-fable-5': 'Fable 5',
+  'claude-opus-4-8': 'Opus 4.8',
+  'claude-haiku-4-5': 'Haiku 4.5',
+}
+
+// Agent configs carry variant suffixes the labels do not: the 1M-context marker
+// (`claude-opus-4-8[1m]`) and the dated release pin
+// (`claude-haiku-4-5-20251001`). Both name the SAME model in the dialog, so
+// strip them before the lookup.
+function baseModelId(modelId: string): string {
+  return modelId.trim().replace(/\[1m\]$/i, '').replace(/-\d{8}$/, '')
+}
+
+function escapeForRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+interface ModelCreditOption {
+  num: number
+  text: string
+}
+
+function parseModelCreditOptions(lines: string[]): ModelCreditOption[] {
+  const out: ModelCreditOption[] = []
+  for (const line of lines) {
+    const m = line.match(MODEL_CREDIT_OPTION_RX)
+    if (!m) continue
+    const num = Number.parseInt(m[1], 10)
+    if (!Number.isFinite(num) || num < 1) continue
+    out.push({ num, text: m[2].trim() })
+  }
+  return out
+}
+
+/**
+ * True when the pane is parked in a Claude Code usage-credit consent modal --
+ * the navigable dialog shown when continuing draws paid usage credits. Pure +
+ * dependency-free.
+ *
+ * Callers must treat a match as "do NOT auto-Escape": Escape is answered as
+ * `cancelled`, which the CLI resolves by switching the session onto the
+ * fallback model and continuing -- a silent, invisible downgrade. Navigate
+ * explicitly (findModelCreditDialogOption) or escalate instead.
+ *
+ * Guards, in order:
+ *   (a) detectsBlockingMenu() must hold. Reusing it inherits the busy /
+ *       idle-footer / footer-region discipline instead of re-inlining it, AND
+ *       makes every match a strict SUBSET of the panes the generic Escape
+ *       recovery already handled -- so this can never fire somewhere the old
+ *       code did nothing.
+ *   (b) The credit phrase must appear in the live bottom region, matched on a
+ *       whitespace-FLATTENED join rather than per line: the TUI hard-wraps the
+ *       body ("Continuing on Fable 5\n  uses usage credits").
+ *   (c) At least two numbered option rows in the same region. This separates
+ *       the interactive modal from the non-interactive "... requires usage
+ *       credits" banners Claude Code also prints.
+ */
+export function detectsModelCreditDialog(pane: string): boolean {
+  if (!detectsBlockingMenu(pane)) return false
+  const region = pane.split('\n').slice(-MODEL_CREDIT_REGION_LINES)
+  // Flatten before matching: the body wraps mid-phrase at pane width.
+  if (!MODEL_CREDIT_PHRASE_RX.test(region.join(' ').replace(/\s+/g, ' '))) return false
+  return parseModelCreditOptions(region).length >= 2
+}
+
+/**
+ * The 1-based option number in a credit dialog that selects `modelId`, or null
+ * when there is no UNAMBIGUOUS match.
+ *
+ * Only the two row shapes that actually name a model count -- "Continue with
+ * <label>" (stay on the credit-gated model) and "Switch to <label> and
+ * continue" (move to the offered alternative). The other labels the dialog can
+ * render ("Buy usage credits", "Request usage credits from your admin", an
+ * upsell row) name no model and must never be selected by a watchdog.
+ *
+ * Returns null -- i.e. "escalate, do not act" -- when the id is not in
+ * MODEL_CREDIT_DIALOG_LABELS, when no row names it (e.g. the agent is
+ * configured for Haiku but the dialog only offers Fable/Sonnet), or when more
+ * than one row would match. Guessing a "closest" model is deliberately not
+ * attempted: picking the wrong row here spends money or downgrades the agent
+ * silently, which is the failure this pair exists to prevent.
+ *
+ * Wrapped option labels are NOT reassembled across lines. A wrap yields null,
+ * which routes to escalation -- the safe direction.
+ */
+export function findModelCreditDialogOption(pane: string, modelId: string): number | null {
+  if (!pane || !modelId) return null
+  const label = MODEL_CREDIT_DIALOG_LABELS[baseModelId(modelId)]
+  if (label == null) return null
+  const rx = new RegExp(`^(?:Continue with|Switch to)\\s+${escapeForRegExp(label)}\\b`, 'i')
+  const matches = parseModelCreditOptions(pane.split('\n').slice(-MODEL_CREDIT_REGION_LINES))
+    .filter((o) => rx.test(o.text))
+  return matches.length === 1 ? matches[0].num : null
+}
+
 export interface DetectPaneStateOptions {
   /** If true, the 'typing' state (text parked in input box) is
    * merged into 'busy'. Default false -- callers that care about

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -6,7 +6,7 @@ import { resolveFromPath } from '../platform.js'
 import { WEB_PORT } from '../config.js'
 import { logger } from '../logger.js'
 import { MAIN_AGENT_ID, SERVICE_ID, BOT_NAME, CHANNEL_PROVIDER, PROJECT_ROOT, RESPAWN_ENABLED } from '../config.js'
-import { agentDir, listAgentNames, readAgentChannelProvider } from './agent-config.js'
+import { agentDir, listAgentNames, readAgentChannelProvider, readAgentModel } from './agent-config.js'
 import {
   agentHasChannel,
   agentSessionName,
@@ -33,7 +33,8 @@ import { reapChannelOrphans, reapDetachedChannelClaudes, collectPollerEvidence }
 import { probeTelegramConflict } from './channel-conflict-probe.js'
 import { schedulePluginUnlockAfterRespawn, wasPluginConfirmedAbsent, clearPluginAbsent } from './channel-plugin-unlock.js'
 import {
-  detectPaneState, decidePaneErrorAlert, detectsBlockingMenu, detectsFirstRunGate, detectsModelConsentDialog, type PaneErrorAlertState, type PaneState,
+  detectPaneState, decidePaneErrorAlert, detectsBlockingMenu, detectsFirstRunGate, detectsModelConsentDialog,
+  detectsModelCreditDialog, findModelCreditDialogOption, type PaneErrorAlertState, type PaneState,
   stuckInputSignature, decideStuckInputRecovery, parkedChannelInput,
   parkedInputText, shouldClearTruncatedPreamble,
   parkedInputRowCount, submitLanded, decideStuckInputAction,
@@ -1557,6 +1558,81 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
             sendAlert(`🔑 A(z) ${label} agent első-indítási dialogjait továbbléptettem, de Claude-belépés kell ("Select login method"). Lépj be: tmux attach -t ${t.session}. Utána minden várakozó feladat magától kézbesítődik.`)
           } else {
             sendAlert(`🧭 A(z) ${label} session a Claude Code első-indítási képernyőjén parkolt (${firstRunGate}); automatikusan továbbléptettem. A várakozó ütemezett feladatok a következő körben kézbesítődnek.`)
+          }
+        } else if (pane != null && detectsModelCreditDialog(pane)) {
+          // A credit dialog whose options do not include the configured model
+          // must ESCALATE, not guess.
+          //
+          // The FABLEFALL1 branch below answers the one measured dialog shape
+          // by pressing option 1, which is safe only because that shape's
+          // option 1 IS "Continue with <configured model>". On the other shapes
+          // Claude Code renders -- a first row reading "Buy usage credits", or
+          // a dialog offering only models this agent is not configured for -- a
+          // blind option 1 spends money or silently switches the fleet's model.
+          // The modal then vanishes and the pane, the dashboard and
+          // agent-config.json all keep naming the configured model, so nothing
+          // surfaces the change until someone reads the session transcript.
+          //
+          // Escape is not an out either: the CLI records it as `cancelled` and
+          // continues on the FALLBACK model (the measurement in FABLEFALL1
+          // below). So this branch either navigates to a row that unambiguously
+          // names the configured model, or it sends NO keystrokes at all and
+          // alerts. Both paths are throttled by the menu-recovery debounce that
+          // already gates this whole block.
+          const configuredModel = t.isMarveen
+            ? readConfiguredMainModel()
+            : (t.agentName ? readAgentModel(t.agentName) : '')
+          const optionNum = configuredModel ? findModelCreditDialogOption(pane, configuredModel) : null
+          if (optionNum == null) {
+            // No row unambiguously names the configured model (unknown or
+            // non-Claude model id, none offered, or two rows would match). Do
+            // NOT guess a "closest" model and do NOT fall through to the Escape
+            // below -- leave the dialog parked and let a human choose.
+            logger.warn({ session: t.session, agent: label, configuredModel },
+              'Model usage-credit dialog offers no unambiguous option for the configured model -- escalating, NO keystrokes sent')
+            sendAlert(`💳 A(z) ${label} session usage-credit dialóguson parkol, de nincs benne egyértelmű opció a beállított modellre (${configuredModel || 'ismeretlen'}). Nem tippelek: a dialógus nyitva maradt, a választás a tiéd. tmux attach -t ${t.session}`)
+          } else {
+            // PANEWRITERS805: a probe+act keystroke writer, so the re-probe and
+            // the digit+Enter it authorises run as ONE recover-mode critical
+            // section -- a delivery streaming into this pane must not get a
+            // digit spliced into it, and nothing may move the pane between the
+            // check and the press. Fail-closed: a busy lane sends nothing and
+            // the dialog is re-detected on a later sweep.
+            const nav = await withSessionSendLock(t.session, null, 'recover', async () => {
+              // Re-probe INSIDE the lane. `pane` was captured before the
+              // debounce decision, and a digit selects by POSITION -- acting on
+              // a stale capture could confirm a row that has since moved. Only
+              // an unchanged option number authorises the press.
+              const paneNow = capturePane(t.session)
+              if (paneNow == null || !detectsModelCreditDialog(paneNow)) return 'gone'
+              if (findModelCreditDialogOption(paneNow, configuredModel) !== optionNum) return 'moved'
+              try {
+                // Digit + settle + Enter, the same select-modal sequence
+                // dismissModelConsentDialogIfPresent uses. If the digit alone
+                // confirms, the trailing Enter lands on an empty prompt and is
+                // a no-op; if it only moves focus, the Enter confirms.
+                execFileSync(TMUX, ['send-keys', '-t', t.session, String(optionNum)], { timeout: 5000 })
+                await delay(150)
+                execFileSync(TMUX, ['send-keys', '-t', t.session, 'Enter'], { timeout: 5000 })
+                return 'navigated'
+              } catch (err) {
+                logger.warn({ err, session: t.session }, 'Model usage-credit dialog navigation keystrokes failed')
+                return 'failed'
+              }
+            })
+            if (!nav.ran) {
+              logger.info({ session: t.session, agent: label },
+                'Model usage-credit dialog navigation skipped: a delivery holds this pane send lane (fail-closed); re-detected on a later sweep')
+            } else if (nav.value === 'navigated') {
+              logger.warn({ session: t.session, agent: label, configuredModel, optionNum },
+                'Model usage-credit dialog answered on the option naming the configured model (never a blind option 1)')
+              sendAlert(`💳 A(z) ${label} session usage-credit dialóguson parkolt; a beállított modellt (${configuredModel}) néven nevező opciót (${optionNum}.) választottam -- a session a konfigurált modelljén fut tovább. Ha ez a credit-köteles modell, innentől usage-creditet fogyaszt.`)
+            } else if (nav.value === 'failed') {
+              sendAlert(`💳 A(z) ${label} session usage-credit dialógusán a beállított modell (${configuredModel}) opciójára navigálás HIBÁZOTT -- a dialógus valószínűleg nyitva maradt. Kézi feloldás kell: tmux attach -t ${t.session}`)
+            } else {
+              logger.info({ session: t.session, agent: label, outcome: nav.value },
+                'Model usage-credit dialog changed between detection and the send lane -- no keystrokes sent')
+            }
           }
         } else {
           // FABLEFALL1: the model usage-credit consent dialog is indistinguishable


### PR DESCRIPTION
### What this changes

The FABLEFALL1 consent-dialog handler answers the one dialog shape captured in
the field by pressing option 1 -- safe only because that shape's option 1 *is*
"Continue with &lt;configured model&gt;". Nothing constrains the CLI to that one
shape: variants where the first row is a purchase action (e.g. "Buy usage
credits") or where the options list only models the agent is not configured
for are possible renderings of the same dialog family. Only the shape whose
option 1 is "Continue with &lt;configured model&gt;" has been field-captured; both
variants above are anticipated, not observed, as the diff's own comments
state. On those, a blind option 1 spends money or silently switches the
fleet's model -- and the modal then vanishes while the pane, the dashboard
and agent-config.json all keep naming the configured model, so nothing
surfaces the change until someone reads the transcript. Escape is not an out
either: the CLI records it as `cancelled` and continues on the FALLBACK model.

This PR chains a stricter detector *before* FABLEFALL1:

- `detectsModelCreditDialog` + `findModelCreditDialogOption` (pane-state.ts,
  pure string functions): find the option that unambiguously names the
  CONFIGURED model.
- If found: navigate to it -- as one recover-mode critical section on the
  session send lane (`withSessionSendLock`), with a re-probe inside the lane
  (a digit selects by position; a stale capture could confirm a row that
  moved). Fail-closed: a busy lane sends nothing, the dialog is re-detected on
  a later sweep.
- If NOT found (unknown model id, none offered, or two rows would match): NO
  keystrokes at all -- log + `sendAlert`, dialog left parked for a human.

FABLEFALL1 stays as the second net, unchanged, for the shape it measured.

### Why

A model switch that happens as the side effect of a dialog auto-dismissal is
the worst kind of configuration change: nobody chose it, nothing logged it,
and every status surface keeps reporting the old model.

### Evidence / verification

- 11 decision-level tests (`channel-monitor-model-credit-dialog.test.ts`) --
  including "the no-option shape escalates instead of pressing 1", against a
  fixture verified to satisfy the upstream detector -- plus detector unit
  tests in `pane-state.test.ts`. 465 tests green across the 17 files that
  read channel-monitor as source; `tsc` clean.
- The lane integration mirrors the existing recover-mode users
  (channel-monitor reauth/recovery writers), not a new locking scheme.

### Notes for maintainers

- The pre-existing writers in this same recovery loop (the consent dismissal,
  the generic Escape, the first-run gate answers) still write to the pane
  without acquiring the send lane -- PANEWRITERS805 did not enumerate them.
  Deliberately NOT retrofitted here (separate concern, real blast radius);
  flagging it.
- The escalate path re-alerts on the existing menu-recovery debounce (5 min),
  matching the login-picker branch's cadence.
- The accept path can move the session onto a usage-credit-consuming model
  WITHOUT a new human confirmation -- that is inherent to auto-answering a
  billing-adjacent dialog, and worth saying plainly. The mitigations are
  structural: it only ever selects the operator's pre-configured model (never
  a different one, never a purchase row), anything ambiguous escalates with
  zero keystrokes, and a busy send lane fails closed.
- On our fleet, the per-event owner alert on a successful navigation proved
  too noisy and was later folded into a digest; the alert cadence here is a
  reasonable default, not a proven one.
- The escalation is single-phase: the no-option case goes straight to the
  owner alert (`sendAlert`), because that is the only operator channel this
  file has. A staged escalation (a coordinator/supervisor process gets a
  chance to resolve the dialog before the owner is paged) would need an
  inter-agent messaging path that channel-monitor does not currently use;
  flagging the reduction explicitly rather than inventing that path here.

### Changed files

- `src/pane-state.ts` (+139)
- `src/web/channel-monitor.ts` (+78/-2)
- `src/__tests__/channel-monitor-model-credit-dialog.test.ts` (new, 172)
- `src/__tests__/pane-state.test.ts` (+178)