### PR TITLE
fix(channels): resolve_main_model falls back to python3 when jq is absent

### DIFF
--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -125,8 +125,19 @@ resolve_main_model() {
     printf '%s' "$MAIN_AGENT_MODEL"
     return 0
   fi
-  if [ -f "$INSTALL_DIR/.claude/settings.json" ] && command -v jq >/dev/null 2>&1; then
-    jq -r '.model // empty' "$INSTALL_DIR/.claude/settings.json" 2>/dev/null
+  if [ -f "$INSTALL_DIR/.claude/settings.json" ]; then
+    # python3 fallback: jq is not guaranteed on the host (stock WSL/minimal
+    # Debian images ship without it). Behind a `command -v jq` guard alone the
+    # settings.json read silently resolves EMPTY on such a host: MODEL_FLAG is
+    # omitted, the main agent launches on the CLI's built-in default, and every
+    # status surface keeps naming the configured model -- a silent model drift
+    # with no error anywhere. python3 is already a hard dependency of the hooks,
+    # so it is always available as the fallback reader.
+    if command -v jq >/dev/null 2>&1; then
+      jq -r '.model // empty' "$INSTALL_DIR/.claude/settings.json" 2>/dev/null
+    else
+      python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("model") or "")' "$INSTALL_DIR/.claude/settings.json" 2>/dev/null
+    fi
   fi
 }
 


### PR DESCRIPTION
### What this changes

`resolve_main_model()` in `scripts/channels.sh` reads the tracked
`.claude/settings.json` behind a `command -v jq` guard alone. On a host
without `jq` -- stock WSL and minimal Debian images ship without it -- the
read silently resolves EMPTY whenever `.env` carries no `MAIN_AGENT_MODEL`:

- `MAIN_MODEL` is empty, so the `--model` flag is omitted entirely and the
  main agent launches on the CLI's built-in default model;
- every status surface (the tracked settings.json, the dashboard) keeps
  naming the configured model;
- no error is raised anywhere.

That is a silent model drift, in the exact code path 9aa26f4's shell<->TS
parity suite exists to protect. This PR adds a `python3` fallback reader for
the no-jq branch. `python3` is already a hard dependency of the hooks, so it
is always available.

### Why / evidence

Reproducible on any host without `jq` (`command -v jq` empty):

- Before: `main-model-resolution-parity.test.ts` fails 3 of its cases -- the
  shell side returns `''` where the TS side (`readConfiguredMainModel`, which
  reads settings.json unconditionally) returns the model. The suite itself is
  the detector: a maintainer running it on a jq-less machine sees the split.
- After: the full parity + precedence suites pass (18/18) on the same jq-less
  host, unchanged on hosts with jq (the jq branch is untouched).

Ten-second repro without the suite: unset any `MAIN_AGENT_MODEL` in `.env`,
put a model in `.claude/settings.json`, and run
`bash scripts/channels.sh --resolve-main-model` on a host without jq --
empty before, the configured model after.

### Changed files

- `scripts/channels.sh` (+13/-2)