### PR TITLE
fix(scheduler): both resubmit dead ends enqueue the never-abandon pending retry

### DIFF
--- a/src/__tests__/schedule-runner-resubmit-escalation.test.ts
+++ b/src/__tests__/schedule-runner-resubmit-escalation.test.ts
@@ -89,3 +89,26 @@ describe('schedule-runner: resubmit probe+act is a recover-mode critical section
     expect(captureIdx).toBeGreaterThan(lockIdx)
   })
 })
+
+describe('schedule-runner: resubmit dead ends are compensated, never silent', () => {
+  const SRC = readFileSync(join(__dirname, '../web/schedule-runner.ts'), 'utf-8')
+
+  it("the 'giveup' exit enqueues a pending retry (the run-log already says 'fired')", () => {
+    // attemptFireTask records 'fired' + stamps scheduleLastRun BEFORE the
+    // detached resubmit chain runs; a giveup without compensation is a run-log
+    // row that says 'fired' for a task that never ran.
+    const giveupIdx = SRC.indexOf('still stuck after Enter + re-inject retries -- giving up')
+    expect(giveupIdx).toBeGreaterThan(-1)
+    const after = SRC.slice(giveupIdx, giveupIdx + 1200)
+    expect(after).toMatch(/insertPendingTaskRetryIfNew\(task\.name, agentName, now, 'giveup'\)/)
+  })
+
+  it('the lane-busy-exhausted exit enqueues a pending retry too', () => {
+    // Exhausting the skip budget exits with NO measurement ever taken -- the
+    // prompt may be parked and nothing would ever look again.
+    const busyIdx = SRC.indexOf('lane stayed busy past the skip budget')
+    expect(busyIdx).toBeGreaterThan(-1)
+    const after = SRC.slice(busyIdx, busyIdx + 800)
+    expect(after).toMatch(/insertPendingTaskRetryIfNew\(task\.name, agentName, now, 'lane-busy'\)/)
+  })
+})

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -738,6 +738,17 @@ async function attemptFireTask(
           if (action === 'none') return 'done'
           if (action === 'giveup') {
             logger.warn({ task: task.name, session }, 'Scheduled prompt still stuck after Enter + re-inject retries -- giving up')
+            // The prompt is parked (never submitted), yet attemptFireTask
+            // already recorded the task 'fired' + stamped scheduleLastRun
+            // BEFORE this detached resubmit chain ran -- do NOT move that
+            // write, it guards the CRON path against a double-fire while the
+            // first injection is still resubmitting. Compensate instead: a
+            // pending retry re-fires the task once the session frees
+            // (isSessionReadyForPrompt gates it, so it never re-injects on
+            // top of the still-parked prompt), and the age-threshold alert
+            // names a long-stuck one. Without this a swallowed-Enter giveup
+            // is a run-log row that says 'fired' for a task that never ran.
+            insertPendingTaskRetryIfNew(task.name, agentName, now, 'giveup')
             return 'done'
           }
           if (action === 'reinject') {
@@ -767,6 +778,11 @@ async function attemptFireTask(
           // frees up; bounded so a wedged holder cannot chain timers forever.
           if (laneBusySkips >= RESUBMIT_LANE_BUSY_MAX_SKIPS) {
             logger.warn({ task: task.name, session, attempt }, 'Post-send resubmit gave up: pane send lane stayed busy past the skip budget')
+            // Exiting here means NO measurement was ever taken: the prompt may
+            // be parked and this chain will never look again. Same shape as
+            // the 'giveup' action above, so it gets the same compensation --
+            // otherwise the skip budget is a second silent-lost-task exit.
+            insertPendingTaskRetryIfNew(task.name, agentName, now, 'lane-busy')
             return
           }
           logger.info({ task: task.name, session, attempt, laneBusySkips }, 'Post-send resubmit skipped: a delivery is in flight into this pane (fail-closed)')


### PR DESCRIPTION
### What this changes

The post-send resubmit chain has two exits that end with nothing ever looking
at the task again:

1. the escalation-ladder `'giveup'` -- bare Enters and the clear + re-inject
   all failed, the prompt is still parked;
2. the lane-busy skip budget (`RESUBMIT_LANE_BUSY_MAX_SKIPS`, TASKTAIL805)
   running out -- the chain exits having taken NO measurement at all.

Both are reached AFTER `attemptFireTask` recorded the task `'fired'` and
stamped `scheduleLastRun` (deliberately -- that stamp guards the CRON path
against a double-fire while the injection is still resubmitting, and must not
move). So on both paths the run history says the task ran while its prompt
may still be sitting, unsubmitted, in the input box.

This PR enqueues `insertPendingTaskRetryIfNew` on both exits (`'giveup'` /
`'lane-busy'`). The existing machinery does the rest: the retry loop's
`isSessionReadyForPrompt` gate means it never re-injects on top of a
still-parked prompt (the pane is not idle-ready while text is parked), and
the age-threshold alert names a long-stuck task to the operator instead of
losing it.

### Why

The pending-retry queue's own contract, quoted from the code: *"We NEVER
abandon -- the operator can cancel from the UI if a retry has become
obsolete."* These two exits are silent exceptions to it -- and the worse kind,
because the run log actively says `'fired'`. The lane-busy exit is new with
TASKTAIL805; the fail-closed lane discipline is correct (nothing must type
into someone else's delivery), which is exactly why the not-typed task needs a
compensating retry rather than a warn line only.

### Evidence / verification

- Two new contract tests in `schedule-runner-resubmit-escalation.test.ts`
  (the file that already pins the TASKTAIL805 lane discipline), asserting each
  exit enqueues its retry; 14/14 green, `tsc` clean.
- The compensation mirrors the pattern the retry loop already uses for
  `'starting'` / `'mcp-missing'` outcomes -- no new machinery.

### Changed files

- `src/web/schedule-runner.ts` (+16)
- `src/__tests__/schedule-runner-resubmit-escalation.test.ts` (+23)