### PR TITLE
fix(install): surface the managed-settings channel-gate outcome in the final summary (ORGGATESILENT806)

### DIFF
--- a/install-macos.sh
+++ b/install-macos.sh
@@ -492,9 +492,20 @@ fi
 # >= 2.1.205 silently drops channel-plugin INBOUND notifications on a team/
 # enterprise org unless managed-settings has channelsEnabled:true (harmless /
 # no-op on a personal org). Idempotent + preserves existing managed keys.
+CHANNELS_GATE_STATE="manual"
 if [ -f "$INSTALL_DIR/scripts/ensure-managed-channels-enabled.sh" ]; then
   echo -e "  Managed-settings channel-kapu ellenorzese..."
-  bash "$INSTALL_DIR/scripts/ensure-managed-channels-enabled.sh" || true
+  # ORGGATESILENT806: the gate script must never fail the install (exit 0 on
+  # every path -- a personal org is a legitimate no-op), but its OUTCOME must
+  # not vanish either: it prints a MARVEEN_CHANNELS_GATE=ok|manual verdict
+  # line, and the final summary below repeats it -- with the exact root
+  # command when manual. Silent skipping was the bug, not skipping.
+  CHANNELS_GATE_OUT="$(bash "$INSTALL_DIR/scripts/ensure-managed-channels-enabled.sh" 2>&1 || true)"
+  echo "$CHANNELS_GATE_OUT"
+  case "$CHANNELS_GATE_OUT" in
+    *MARVEEN_CHANNELS_GATE=ok*) CHANNELS_GATE_STATE="ok" ;;
+    *) CHANNELS_GATE_STATE="manual" ;;
+  esac
 fi
 
 read -rp "$(_t prompt_bot_name)" BOT_NAME
@@ -1411,6 +1422,12 @@ else
   echo -e "  ${DIM}$(_t dash.no_token_hint)${NC}"
 fi
 echo -e "  ${BOLD}Telegram:${NC} $(_t telegram.write_hint)"
+if [ "${CHANNELS_GATE_STATE:-manual}" = "ok" ]; then
+  echo -e "  ${GREEN}✓${NC} Org-szintu channel-kapu: channelsEnabled=true a managed-settings-ben"
+else
+  echo -e "  ${ORANGE}!${NC} Org-szintu channel-kapu NINCS beallitva (team/enterprise orgnal a bejovo uzenetek elakadnak)."
+  echo -e "    Kezi root-lepes: ${BOLD}sudo bash \"$INSTALL_DIR/scripts/ensure-managed-channels-enabled.sh\"${NC}"
+fi
 echo ""
 echo -e "  ${DIM}$(_t next_steps.title)${NC}"
 echo -e "  ${DIM}$(_t next_steps.1)${NC}"

--- a/install-macos.sh
+++ b/install-macos.sh
@@ -501,7 +501,8 @@ if [ -f "$INSTALL_DIR/scripts/ensure-managed-channels-enabled.sh" ]; then
   # line, and the final summary below repeats it -- with the exact root
   # command when manual. Silent skipping was the bug, not skipping.
   CHANNELS_GATE_OUT="$(bash "$INSTALL_DIR/scripts/ensure-managed-channels-enabled.sh" 2>&1 || true)"
-  echo "$CHANNELS_GATE_OUT"
+  # The verdict line is machine-facing; the customer sees only the human lines.
+  echo "$CHANNELS_GATE_OUT" | grep -v "MARVEEN_CHANNELS_GATE=" || true
   case "$CHANNELS_GATE_OUT" in
     *MARVEEN_CHANNELS_GATE=ok*) CHANNELS_GATE_STATE="ok" ;;
     *) CHANNELS_GATE_STATE="manual" ;;

--- a/scripts/ensure-managed-channels-enabled.sh
+++ b/scripts/ensure-managed-channels-enabled.sh
@@ -25,7 +25,7 @@ set -u
 case "$(uname -s)" in
   Darwin) MANAGED_FILE="/Library/Application Support/ClaudeCode/managed-settings.json" ;;
   Linux)  MANAGED_FILE="/etc/claude-code/managed-settings.json" ;;
-  *) echo "  channelsEnabled: nem tamogatott OS ($(uname -s)); kihagyva."; exit 0 ;;
+  *) echo "  channelsEnabled: nem tamogatott OS ($(uname -s)); kihagyva."; echo "MARVEEN_CHANNELS_GATE=ok"; exit 0 ;;
 esac
 
 # Root-aware privilege prefix. The managed dir is root-owned on both platforms.
@@ -35,7 +35,9 @@ if [ "$(id -u)" -ne 0 ]; then
     SUDO="sudo"
   else
     echo "  ! channelsEnabled: nem root es nincs sudo -- kihagyva."
-    echo "    Kezi lepes (root): tedd be a(z) {\"channelsEnabled\": true}-t ide: $MANAGED_FILE"
+    echo "    Kezi lepes (rootkent futtatva biztonsagos, meglevo kulcsokat megorzi):"
+    echo "      sudo bash $0"
+    echo "MARVEEN_CHANNELS_GATE=manual"
     exit 0
   fi
 fi
@@ -50,11 +52,14 @@ except Exception:
 PY
 then
   echo "  channelsEnabled: mar be van kapcsolva ($MANAGED_FILE)"
+  echo "MARVEEN_CHANNELS_GATE=ok"
   exit 0
 fi
 
 if ! $SUDO mkdir -p "$(dirname "$MANAGED_FILE")" 2>/dev/null; then
-  echo "  ! channelsEnabled: nem sikerult letrehozni $(dirname "$MANAGED_FILE") -- kezi root-lepes szukseges."
+  echo "  ! channelsEnabled: nem sikerult letrehozni $(dirname "$MANAGED_FILE") -- kezi root-lepes szukseges:"
+  echo "      sudo bash $0"
+  echo "MARVEEN_CHANNELS_GATE=manual"
   exit 0
 fi
 
@@ -77,8 +82,11 @@ PY
 then
   echo "  channelsEnabled=true beallitva a managed-settings-ben ($MANAGED_FILE)"
   echo "    (a bejovo channel-uzenetek team/enterprise orgnal is celba ernek; restart utan lep eletbe.)"
+  echo "MARVEEN_CHANNELS_GATE=ok"
 else
   echo "  ! channelsEnabled: a managed-settings frissitese sikertelen."
-  echo "    Kezi lepes (root): tedd be a(z) {\"channelsEnabled\": true}-t ide: $MANAGED_FILE"
+  echo "    Kezi lepes (rootkent futtatva biztonsagos, meglevo kulcsokat megorzi):"
+  echo "      sudo bash $0"
+  echo "MARVEEN_CHANNELS_GATE=manual"
 fi
 exit 0


### PR DESCRIPTION
## Summary
The channel gate was doubly fail-open (script exit 0 on every error + `|| true` at the call site), so the installer claimed success while the org-policy gate silently never got created -- measured on two live macOS installs (08-05, 08-06), both fixed by hand.

Per the card's requirement: the script still never fails the install (personal org = legitimate no-op), but every path now ends with a `MARVEEN_CHANNELS_GATE=ok|manual` verdict line; the manual paths print the EXACT root command (`sudo bash <script>` -- safe idempotent JSON merge, preserves existing managed keys, unlike a tee overwrite); and the final install summary repeats the verdict: green check when set, orange warning + exact command when manual.

## Test plan
- [x] Behavioral: stubbed sudo (every privileged call failing) -> manual sentinel + exact command, exit 0 (install never fails).
- [x] 3 ok-paths + 3 manual-paths each carry the sentinel (counted).
- [x] `bash -n` clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)