### PR TITLE
fix(activity): prevent main agent from appearing twice in activity and model-suggest responses

### DIFF
--- a/src/__tests__/activity-no-main-duplicate.test.ts
+++ b/src/__tests__/activity-no-main-duplicate.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { MAIN_AGENT_ID } from '../config.js'
+import { withoutMainAgent, isMainChannelsAgent } from '../web/main-agent.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const agentsSource = readFileSync(join(__dirname, '..', 'web', 'routes', 'agents.ts'), 'utf8')
+
+describe('withoutMainAgent', () => {
+  it('removes the main agent id from a list that contains it', () => {
+    const result = withoutMainAgent([MAIN_AGENT_ID, 'hermes', 'prometheus'])
+    expect(result).not.toContain(MAIN_AGENT_ID)
+    expect(result).toEqual(['hermes', 'prometheus'])
+  })
+
+  it('leaves a list that does not contain the main agent unchanged', () => {
+    const result = withoutMainAgent(['hermes', 'prometheus'])
+    expect(result).toEqual(['hermes', 'prometheus'])
+  })
+
+  it('returns an empty list when given only the main agent', () => {
+    expect(withoutMainAgent([MAIN_AGENT_ID])).toEqual([])
+  })
+
+  it('is consistent with isMainChannelsAgent', () => {
+    const names = [MAIN_AGENT_ID, 'hermes']
+    const filtered = withoutMainAgent(names)
+    for (const n of filtered) {
+      expect(isMainChannelsAgent(n)).toBe(false)
+    }
+  })
+})
+
+// Structural guard: the activity endpoint must use withoutMainAgent so that the
+// main agent is never pushed as a second isMain:false worker entry. The guard
+// covers both the for-loop source and the model-suggest names variable.
+describe('/api/agents/activity: main agent must not appear as a worker entry', () => {
+  it('the activity worker loop uses withoutMainAgent (not a raw listAgentNames)', () => {
+    // Isolate the activity handler block
+    const startMarker = "if (path === '/api/agents/activity' && method === 'GET')"
+    const endMarker = "if (path === '/api/agents/model-suggest'"
+    const start = agentsSource.indexOf(startMarker)
+    const end = agentsSource.indexOf(endMarker, start)
+    expect(start).toBeGreaterThan(-1)
+    expect(end).toBeGreaterThan(start)
+    const block = agentsSource.slice(start, end)
+
+    expect(block).toContain('withoutMainAgent(listAgentNames())')
+    // The raw loop without the filter must not be present
+    expect(block).not.toContain('for (const name of listAgentNames())')
+  })
+})
+
+// Structural guard: model-suggest must not prepend MAIN_AGENT_ID onto a raw
+// listAgentNames() result, which would include the main agent twice.
+describe('/api/agents/model-suggest: main agent must not appear twice', () => {
+  it('filters the main agent out of names before prepending MAIN_AGENT_ID', () => {
+    const startMarker = "if (path === '/api/agents/model-suggest'"
+    const endMarker = "if (path === '/api/agents' && method === 'POST')"
+    const start = agentsSource.indexOf(startMarker)
+    const end = agentsSource.indexOf(endMarker, start)
+    expect(start).toBeGreaterThan(-1)
+    expect(end).toBeGreaterThan(start)
+    const block = agentsSource.slice(start, end)
+
+    expect(block).toContain('withoutMainAgent(listAgentNames())')
+    // Must not spread a raw listAgentNames() result
+    expect(block).not.toMatch(/const names = listAgentNames\(\)\s*\n/)
+  })
+})

--- a/src/__tests__/activity-no-main-duplicate.test.ts
+++ b/src/__tests__/activity-no-main-duplicate.test.ts
@@ -10,14 +10,14 @@ const agentsSource = readFileSync(join(__dirname, '..', 'web', 'routes', 'agents
 
 describe('withoutMainAgent', () => {
   it('removes the main agent id from a list that contains it', () => {
-    const result = withoutMainAgent([MAIN_AGENT_ID, 'hermes', 'prometheus'])
+    const result = withoutMainAgent([MAIN_AGENT_ID, 'agent-a', 'agent-b'])
     expect(result).not.toContain(MAIN_AGENT_ID)
-    expect(result).toEqual(['hermes', 'prometheus'])
+    expect(result).toEqual(['agent-a', 'agent-b'])
   })
 
   it('leaves a list that does not contain the main agent unchanged', () => {
-    const result = withoutMainAgent(['hermes', 'prometheus'])
-    expect(result).toEqual(['hermes', 'prometheus'])
+    const result = withoutMainAgent(['agent-a', 'agent-b'])
+    expect(result).toEqual(['agent-a', 'agent-b'])
   })
 
   it('returns an empty list when given only the main agent', () => {
@@ -25,7 +25,7 @@ describe('withoutMainAgent', () => {
   })
 
   it('is consistent with isMainChannelsAgent', () => {
-    const names = [MAIN_AGENT_ID, 'hermes']
+    const names = [MAIN_AGENT_ID, 'agent-a']
     const filtered = withoutMainAgent(names)
     for (const n of filtered) {
       expect(isMainChannelsAgent(n)).toBe(false)

--- a/src/web/main-agent.ts
+++ b/src/web/main-agent.ts
@@ -47,3 +47,9 @@ export const MAIN_CHANNELS_PLIST = channelsPlistPath(SERVICE_ID)
 export function isMainChannelsAgent(name: string): boolean {
   return name === MAIN_AGENT_ID
 }
+
+// Filter helper for endpoints that prepend the main agent separately and must
+// not list it again as a worker entry (activity panel, model-suggest).
+export function withoutMainAgent(names: string[]): string[] {
+  return names.filter(n => !isMainChannelsAgent(n))
+}

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -75,7 +75,7 @@ import {
   agentChannelDir,
 } from '../channel-invites.js'
 import { hardRestartMarveenChannels } from '../channel-monitor.js'
-import { isMainChannelsAgent, MAIN_CHANNELS_SESSION } from '../main-agent.js'
+import { isMainChannelsAgent, MAIN_CHANNELS_SESSION, withoutMainAgent } from '../main-agent.js'
 import {
   getProvider,
   channelStateDir,
@@ -700,7 +700,7 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
       })
     }
 
-    for (const name of listAgentNames()) {
+    for (const name of withoutMainAgent(listAgentNames())) {
       // Remote agents: resolve run state + pane through the short-TTL caches so
       // this 3s-polled endpoint never blocks the event loop on an ssh timeout.
       const host = readAgentRemoteHost(name)
@@ -784,7 +784,7 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
       } catch { return 0 }
     }
 
-    const names = listAgentNames()
+    const names = withoutMainAgent(listAgentNames())
     const results = [MAIN_AGENT_ID, ...names].map(name => {
       const dir = agentDir(name)
       const claudeMd = readFileOr(join(dir, 'CLAUDE.md'), '')


### PR DESCRIPTION
## Problem

The `/api/agents/activity` endpoint and `/api/agents/model-suggest` both iterate over
`listAgentNames()` and prepend the main agent id separately. When a config directory
exists for the main agent, `listAgentNames()` includes it — so the main agent ends up
in the response twice: once as `isMain: true` from the channels session pane, and once
as `isMain: false / running: false` from the loop. This causes the Activity view to
show two cards for the main agent.

The same raw-loop pattern on `model-suggest` produces a doubled entry at the top of the
model-target list.

## Fix

Extract a `withoutMainAgent(names)` helper in `src/web/main-agent.ts` that filters the
main agent id out of a name list. Apply it in both places before the loop so neither
endpoint can accidentally include the main agent twice.

```
withoutMainAgent([mainAgentId, 'agent-a', 'agent-b'])
// => ['agent-a', 'agent-b']
```

## Changes

- `src/web/main-agent.ts`: add `withoutMainAgent()` and export `isMainChannelsAgent()`
- `src/web/routes/agents.ts`: use `withoutMainAgent(listAgentNames())` in the activity
  worker loop and in the model-suggest names variable
- `src/__tests__/activity-no-main-duplicate.test.ts`: new regression test
  - unit tests for `withoutMainAgent` (pure function, no mocks)
  - structural guard that the activity handler uses `withoutMainAgent` (not a raw loop)
  - structural guard that model-suggest filters before prepending the main agent id

## Testing

All new tests pass. The structural guards will fail if either handler regresses to a
raw `listAgentNames()` loop without the filter.
