### PR TITLE
fix: self-healing binary/credential resolution + disable in-place aut…

### DIFF
--- a/src/__tests__/channel-stability-contract.test.ts
+++ b/src/__tests__/channel-stability-contract.test.ts
@@ -79,6 +79,15 @@ describe('P1#3 — .bun/bin PATH on every claude (re)spawn path', () => {
   })
 })
 
+describe('P1#4 — DISABLE_AUTOUPDATER=1 on the sub-agent spawn path', () => {
+  // A spawned agent whose Claude Code auto-updater fires does an in-place global
+  // reinstall into the shared package prefix and can corrupt the one install
+  // every agent resolves through. The launch command must disable it.
+  it('agent-process.ts sub-agent launch disables the auto-updater', () => {
+    expect(read('src/web/agent-process.ts')).toMatch(/DISABLE_AUTOUPDATER=1/)
+  })
+})
+
 describe('P2#4 — independent systemd-timer watchdog', () => {
   const sh = read('scripts/channel-watchdog.sh')
   const timer = read('scripts/systemd/channel-watchdog.timer')

--- a/src/__tests__/platform-bin-resolve.test.ts
+++ b/src/__tests__/platform-bin-resolve.test.ts
@@ -91,12 +91,30 @@ describe('makeLazyBinResolver', () => {
     expect(mockExistsSync).not.toHaveBeenCalled()
   })
 
-  it('resolves on first call and memoises the result', () => {
+  it('resolves on first call and memoises while the cached path still exists', () => {
     mockExecSync.mockReturnValue('/opt/homebrew/bin/tmux\n')
+    mockExistsSync.mockImplementation((p: string) => p === '/opt/homebrew/bin/tmux')
     const tmuxBin = makeLazyBinResolver('tmux')
     expect(tmuxBin()).toBe('/opt/homebrew/bin/tmux')
     expect(tmuxBin()).toBe('/opt/homebrew/bin/tmux')
+    // Second call re-validates via existsSync but does NOT re-run `which`.
     expect(mockExecSync).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-resolves when the cached path disappears (binary moved / symlink repointed)', () => {
+    const stale = join(homedir(), '.local', 'bin', 'claude')
+    const fresh = '/opt/homebrew/bin/claude'
+    mockExecSync.mockReturnValue(stale + '\n')
+    mockExistsSync.mockImplementation((p: string) => p === stale)
+    const claudeBin = makeLazyBinResolver('claude')
+    expect(claudeBin()).toBe(stale)
+
+    // The cached path vanishes and `which` now resolves elsewhere: the next call
+    // must re-resolve instead of returning the dead path -- no restart needed.
+    mockExecSync.mockReturnValue(fresh + '\n')
+    mockExistsSync.mockImplementation((p: string) => p === fresh)
+    expect(claudeBin()).toBe(fresh)
+    expect(mockExecSync).toHaveBeenCalledTimes(2)
   })
 
   it('surfaces the not-found error on first use, not at import', () => {

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -81,7 +81,15 @@ function detectLinuxLibc(): 'glibc' | 'musl' | 'unknown' {
 
 let cachedClaudeCodeBin: string | undefined | null = null
 function resolveClaudeCodeBin(): string | undefined {
-  if (cachedClaudeCodeBin !== null) return cachedClaudeCodeBin
+  // Return the cache only while it still points at a real file. A bare
+  // `!== null` check memoised the resolution forever, so a node_modules
+  // reinstall/rebuild under a long-lived process could leave a stale path (the
+  // same staleness class makeLazyBinResolver guards against). Re-validate with
+  // existsSync each call; anything else re-resolves (also self-heals the "bin
+  // appeared later" case).
+  if (typeof cachedClaudeCodeBin === 'string' && existsSync(cachedClaudeCodeBin)) {
+    return cachedClaudeCodeBin
+  }
   if (process.env.CLAUDE_CODE_BIN) {
     cachedClaudeCodeBin = process.env.CLAUDE_CODE_BIN
     return cachedClaudeCodeBin

--- a/src/google-api.ts
+++ b/src/google-api.ts
@@ -49,7 +49,7 @@ interface CalendarListResponse {
 // process restart, because cachedTokens held the pre-re-auth (88-day-old,
 // already-revoked) refresh_token.
 let cachedTokens: { normal: TokenData; mtimeMs: number } | null = null
-let cachedClient: ClientCredentials | null = null
+let cachedClient: { value: ClientCredentials; mtimeMs: number } | null = null
 
 function loadTokens(): TokenData {
   let currentMtime = 0
@@ -72,10 +72,15 @@ function saveTokens(tokens: TokenData): void {
 }
 
 function loadClientCredentials(): ClientCredentials {
-  if (!cachedClient) {
-    cachedClient = JSON.parse(readFileSync(CLIENT_CREDS_PATH, 'utf-8'))
+  // mtime-invalidated like loadTokens above. Client credentials rotate rarely,
+  // but a bare `if (!cachedClient)` would hold a stale payload forever after an
+  // out-of-process credentials rewrite. Re-read whenever the file's mtime advances.
+  let currentMtime = 0
+  try { currentMtime = statSync(CLIENT_CREDS_PATH).mtimeMs } catch { /* missing -- fall through to readFileSync error */ }
+  if (!cachedClient || cachedClient.mtimeMs !== currentMtime) {
+    cachedClient = { value: JSON.parse(readFileSync(CLIENT_CREDS_PATH, 'utf-8')), mtimeMs: currentMtime }
   }
-  return cachedClient!
+  return cachedClient.value
 }
 
 function httpsRequest(

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -59,17 +59,25 @@ export function resolveFromPath(name: string): string {
   return resolved
 }
 
-// Lazy, memoised binary resolver. Unlike a module-level `resolveFromPath(...)`
-// const -- which throws at IMPORT time and takes the whole dashboard (and the
-// scheduler that lives in it) down if the binary is transiently unresolvable --
-// this defers resolution to first use. A boot that happens during a PATH gap
-// therefore succeeds; only the first actual use of the binary can throw, and
-// that call site can handle it. The resolved path is cached after the first
-// successful lookup.
+// Lazy, memoised, self-healing binary resolver. Unlike a module-level
+// `resolveFromPath(...)` const -- which throws at IMPORT time and takes the whole
+// dashboard (and the scheduler that lives in it) down if the binary is
+// transiently unresolvable -- this defers resolution to first use. A boot that
+// happens during a PATH gap therefore succeeds; only the first actual use of the
+// binary can throw, and that call site can handle it.
+//
+// The resolved path is cached, but RE-VALIDATED with existsSync on every call: a
+// cached absolute path can go stale when the binary is moved or its symlink is
+// repointed/broken out from under a long-lived process (e.g. an in-place package
+// update or a version-manager switch). existsSync follows symlinks, so a dangling
+// link or a link to a now-missing target fails the check and we re-resolve -- no
+// process restart needed. Still lazy: the FIRST resolve is deferred to first use,
+// so boot-time PATH-gap resilience is preserved.
 export function makeLazyBinResolver(name: string): () => string {
   let cached: string | null = null
   return () => {
-    if (cached === null) cached = resolveFromPath(name)
+    if (cached !== null && existsSync(cached)) return cached
+    cached = resolveFromPath(name)
     return cached
   }
 }

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -1310,11 +1310,18 @@ export function startAgentProcess(name: string, opts: { fresh?: boolean } = {}):
     // member. Killing the suggestion at the source removes the ghost the recovery
     // misreads. Env var verified present in claude.exe (CLAUDE_CODE_ENABLE_*).
     const promptSuggestionEnv = 'export CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false && '
+    // Disable Claude Code's in-place auto-updater for every spawned agent. A
+    // running agent whose updater fires does an in-place global reinstall into the
+    // shared package prefix; a half-completed update can leave a broken stub and
+    // drop the bin symlink, corrupting the one install every agent resolves
+    // through. Agents launch from a deliberately pinned install, so the updater
+    // must never move it out from under a live process.
+    const autoUpdaterEnv = 'export DISABLE_AUTOUPDATER=1 && '
     // shSingleQuote(model) (card b7fa5281): the model is POSIX single-quote ESCAPED, which both keeps
     // values like `claude-opus-4-8[1m]` (1M-context suffix) from being glob-expanded AND makes a `'`
     // in the value inert rather than a quote-break -> command injection. Same escape at the three
     // ANTHROPIC_MODEL env sites above.
-    const cmd = `export PATH="/opt/homebrew/bin:$HOME/.bun/bin:/usr/local/bin:/usr/bin:/bin:$PATH" && ${unsetTokens} && ${promptSuggestionEnv}${mcpEnv}${channelSetup}${apiKeyEnv}${claudeConfigEnv}${oauthTokenEnv}${ollamaEnv}${deepseekEnv}${openrouterEnv}cd "${dir}" && ${claudeBin()} ${continueFlag}${skipFlag}--model ${shSingleQuote(model)} ${channelFlag}`.trimEnd()
+    const cmd = `export PATH="/opt/homebrew/bin:$HOME/.bun/bin:/usr/local/bin:/usr/bin:/bin:$PATH" && ${unsetTokens} && ${autoUpdaterEnv}${promptSuggestionEnv}${mcpEnv}${channelSetup}${apiKeyEnv}${claudeConfigEnv}${oauthTokenEnv}${ollamaEnv}${deepseekEnv}${openrouterEnv}cd "${dir}" && ${claudeBin()} ${continueFlag}${skipFlag}--model ${shSingleQuote(model)} ${channelFlag}`.trimEnd()
     runTmux(null, ['new-session', '-d', '-s', session, cmd], { timeout: 10000 })
 
     logger.info({ name, session, channelDir: agentChannelDir }, 'Agent tmux session started')


### PR DESCRIPTION
…o-updater

Long-lived processes memoised resolved paths and parsed credentials forever, so a binary moved out from under them (an in-place package update, a version-manager switch) or an out-of-process credentials rewrite left a stale value until a manual restart. Separately, a spawned agent's Claude Code auto-updater could reinstall in place and corrupt the shared install every agent resolves through.

- platform.ts makeLazyBinResolver: re-validate the cached path with existsSync on every call and re-resolve when it disappears (still lazy on first use, so boot-time PATH-gap resilience is preserved).
- agent.ts resolveClaudeCodeBin: the same existsSync re-validation instead of a permanent `!== null` memo.
- google-api.ts loadClientCredentials: mtime-invalidate the client-credentials cache, matching the sibling token cache.
- agent-process.ts: export DISABLE_AUTOUPDATER=1 on every sub-agent launch so a spawned agent's updater can't reinstall the shared install out from under a live process.
- tests: cover re-resolve-on-disappear, and assert DISABLE_AUTOUPDATER on the spawn path.

<!--
  HU + EN. Töltsd ki minden szakaszt. / Fill in every section.
  A jelölőnégyzeteket így pipáld: [x]  /  Tick a box like this: [x]
-->

## A változtatás típusa / Type of change

- [ ] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

<!-- HU: Foglald össze, milyen problémát old meg a PR és milyen technikai megközelítést alkalmaztál.
     EN: Summarize what problem this PR solves and the technical approach you took. -->

## Kapcsolódó issue / Related issue

Closes #

## Ellenőrzőlista / Checklist

- [ ] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [ ] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
- [ ] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [ ] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).
