### PR TITLE
fix(install): ship a main-agent model default so a fresh install runs Opus 5, not the CLI fallback (MAINMODEL806)

### DIFF
--- a/scripts/__tests__/channels-main-model.test.sh
+++ b/scripts/__tests__/channels-main-model.test.sh
@@ -69,6 +69,33 @@ expect_model "a similarly named key does not leak in" \
   'NOT_MAIN_AGENT_MODEL=wrong-model
 MAIN_AGENT_MODEL=claude-haiku-4-5' '' 'claude-haiku-4-5'
 
+# THE SHIPPED-DEFAULT CONTRACT (2026-08-06): a fresh install ships
+# templates/settings.json.template as .claude/settings.json and writes no
+# MAIN_AGENT_MODEL to .env, so resolve_main_model reads the template's model.
+# The 2026-08-06 bug was that the template had NO model field -> empty ->
+# the main agent came up on claude-code's built-in default (4.8), silently.
+# This locks the template to a non-empty model, driven through the REAL
+# resolver over the REAL shipped template.
+TEMPLATE="$INSTALL_DIR/templates/settings.json.template"
+template_model="$(bash -c '
+  root="$(mktemp -d)"; mkdir -p "$root/scripts" "$root/.claude"
+  cp "'"$SRC"'" "$root/scripts/channels.sh"
+  cp "'"$TEMPLATE"'" "$root/.claude/settings.json"
+  bash "$root/scripts/channels.sh" --resolve-main-model 2>/dev/null | head -1
+  rm -rf "$root"
+')"
+if [ -n "$template_model" ]; then
+  pass "shipped template resolves to a NON-EMPTY main model ($template_model)"
+else
+  fail "shipped template resolves to a non-empty main model" "non-empty" "(empty)"
+fi
+# And it is the intended Opus 5 (1M) default, matching the fleet host.
+if [ "$template_model" = "claude-opus-5[1m]" ]; then
+  pass "shipped template main model is claude-opus-5[1m]"
+else
+  fail "shipped template main model" "claude-opus-5[1m]" "$template_model"
+fi
+
 echo
 echo "  $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/templates/settings.json.template
+++ b/templates/settings.json.template
@@ -1,4 +1,5 @@
 {
+  "model": "claude-opus-5[1m]",
   "enabledPlugins": {
     "telegram@claude-plugins-official": true
   },


### PR DESCRIPTION
## Summary
Szabi noticed the MAIN agent on Opus 4.8 after Adam's install, and said it was likely the base install, not the Marveen-installer -- correct, and here is the measured chain.

`resolve_main_model` (scripts/channels.sh) reads `MAIN_AGENT_MODEL` from .env, else `.model` from .claude/settings.json. Measured:
1. The installers write NO `MAIN_AGENT_MODEL` (grep: 0 hits in install-macos.sh / install-linux.sh).
2. The shipped `templates/settings.json.template` had NO `model` field (`jq .model` → null).

So a fresh install resolved to **empty**, and the main agent came up on claude-code's built-in default (4.8) -- silently. Our own fleet host has `claude-opus-5[1m]` in .claude/settings.json, which is why it never showed here: the classic ship-default vs own-machine gap.

## Fix
The template now ships `"model": "claude-opus-5[1m]"`. The value is `claude-opus-5[1m]` because **(a)** it is what the fleet host runs (verified live), and **(b)** channels.sh already single-quotes the id specifically so a bracketed `[1m]` survives the tmux round-trip without glob-expanding (existing comment + test) -- so the 1M suffix is supported on this path by measurement, not assumption.

## Test
The shipped template, driven through the REAL resolver, must resolve to a NON-EMPTY main model (exactly what was missing today) and to `claude-opus-5[1m]`. **Adversarially verified**: removing the model field → red; restore → green. 9/9 in channels-main-model.test.sh.

## Scope — read before merging
- **NEW installs only.** The template is copied at install time.
- **Existing installs are unaffected** and would need a SEPARATE one-time migration -- writing `MAIN_AGENT_MODEL=claude-opus-5[1m]` to their .env (per-install, gitignored, does not block the update preflight; the .model-in-settings route would). NOT smuggled in here -- flagged for a separate decision.
- **NOT touched:** `DISTRIBUTION_DEFAULT_AGENT_MODEL` (config-registry.ts) -- that is the OTHER agents / background workers default, not the main agent. Whether it also moves to Opus 5 is a separate call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)