### PR TITLE
fix(agents): move the distribution default agent model to Opus 5 too (MAINMODEL806 follow-up)

### DIFF
--- a/src/config-registry.ts
+++ b/src/config-registry.ts
@@ -13,7 +13,16 @@
 // (a zero-import module) so the registry default and the boot-time constant in
 // config.ts cannot drift apart -- bumping the distribution default is a
 // one-line change in exactly one place.
-export const DISTRIBUTION_DEFAULT_AGENT_MODEL = 'claude-opus-4-8[1m]'
+// MAINMODEL806 (Szabi: "everything on Opus 5"): the default for the OTHER
+// agents and the background-worker sessions. The [1m] suffix is DELIBERATE and
+// matches the main agent's template default (claude-opus-5[1m]): the prior
+// worker default was already [1m] (claude-opus-4-8[1m]), so this preserves the
+// 1M-context behaviour and only lifts the version -- it does NOT quietly diverge
+// from the main-agent value. resolveModelId passes the [1m] id through
+// unchanged (measured), exactly as the CLI already handles the 4.8[1m] default.
+// The valueSet below carries BOTH claude-opus-5 and claude-opus-5[1m] so an
+// operator can still pick the non-1M form.
+export const DISTRIBUTION_DEFAULT_AGENT_MODEL = 'claude-opus-5[1m]'
 
 export type SettingType = 'int' | 'string' | 'color' | 'boolean'
 
@@ -421,6 +430,7 @@ export const SETTINGS_REGISTRY: SettingDefinition[] = [
     requiresRestart: true,
     valueSet: [
       'claude-opus-5',
+      'claude-opus-5[1m]',
       'claude-sonnet-5',
       'claude-fable-5',
       'claude-opus-4-8[1m]',


### PR DESCRIPTION
## Summary
Follow-up to #916 (which shipped the MAIN agent's Opus 5 template default). Szabi extended the ask to **everything on Opus 5**, so this brings the OTHER agents and the background-worker sessions along: `DISTRIBUTION_DEFAULT_AGENT_MODEL` (config-registry.ts) goes `claude-opus-4-8[1m]` → `claude-opus-5[1m]`.

(#916 had already merged when Szabi extended the scope, so this is a clean cherry-pick onto develop — the template fix is not re-included.)

## The value decision, measured (Marveen's review point: don't let the two sites diverge silently)
`claude-opus-5[1m]`, NOT bare `claude-opus-5`, deliberately:
- The prior worker default was already `claude-opus-4-8[1m]` — keeping `[1m]` preserves the 1M-context behaviour and only lifts the version.
- It matches the main-agent template value, so the two do not diverge. A code comment states why, so the next reader does not "unify" it as a typo.
- `resolveModelId` passes a `[1m]` id through unchanged (measured: `MODEL_ALIASES[raw] || raw`), exactly as it already does for the 4.8[1m] default — the worker path handles the suffix.

The valueSet gains `claude-opus-5[1m]` so the distribution default is a selectable value (the default-agent-model contract requires it), while keeping bare `claude-opus-5` so an operator can pick the non-1M form.

## Test
29/29 model tests pass; the registry-default-in-valueSet contract holds. **Adversarially verified**: removing `claude-opus-5[1m]` from the valueSet → red.

## Separate, NOT touched
- The `opus` MODEL_ALIAS still maps to `claude-opus-4-8[1m]` — a shorthand, not the distribution default; its move is a separate call.
- **Already-installed machines**: this changes NEW installs / the shipped default only. Existing installs keep their configured value. A migration for those is a separate item (below) — Szabi said "everything", so it is needed, but not smuggled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)