### PR TITLE
fix(model): inherited distribution-default fallback + opus alias to Opus 5 (MODELMIGRATE806)

### DIFF
--- a/scripts/__tests__/channels-main-model.test.sh
+++ b/scripts/__tests__/channels-main-model.test.sh
@@ -69,6 +69,28 @@ expect_model "a similarly named key does not leak in" \
   'NOT_MAIN_AGENT_MODEL=wrong-model
 MAIN_AGENT_MODEL=claude-haiku-4-5' '' 'claude-haiku-4-5'
 
+# MODELMIGRATE806: with NO .env override and NO model in settings.json, the
+# resolver falls back to the SHIPPED DISTRIBUTION_DEFAULT_AGENT_MODEL, read from
+# dist/config-registry.js via node. This is what reaches existing model-less
+# installs on a plain code update -- no per-install .env write. Drive it through
+# the real resolver with a fixture dist that exports a known constant.
+migr_fallback() {
+  local want="$1" root
+  root="$(mktemp -d)"
+  mkdir -p "$root/scripts" "$root/dist"
+  cp "$SRC" "$root/scripts/channels.sh"
+  printf 'exports.DISTRIBUTION_DEFAULT_AGENT_MODEL = %s;\n' "\"$want\"" > "$root/dist/config-registry.js"
+  local got
+  got="$(bash "$root/scripts/channels.sh" --resolve-main-model 2>/dev/null | head -1)"
+  rm -rf "$root"
+  if [ "$got" = "$want" ]; then pass "no .env + no settings model -> shipped distribution default ($want)"; else fail "distribution-default fallback" "$want" "$got"; fi
+}
+migr_fallback "claude-opus-5[1m]"
+
+# The .env override still wins over the distribution-default fallback.
+expect_model ".env override beats the distribution-default fallback" \
+  'MAIN_AGENT_MODEL=claude-sonnet-5' '' 'claude-sonnet-5'
+
 # THE SHIPPED-DEFAULT CONTRACT (2026-08-06): a fresh install ships
 # templates/settings.json.template as .claude/settings.json and writes no
 # MAIN_AGENT_MODEL to .env, so resolve_main_model reads the template's model.

--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -125,6 +125,7 @@ resolve_main_model() {
     printf '%s' "$MAIN_AGENT_MODEL"
     return 0
   fi
+  local _m=""
   if [ -f "$INSTALL_DIR/.claude/settings.json" ]; then
     # python3 fallback: jq is not guaranteed on the host (stock WSL/minimal
     # Debian images ship without it). Behind a `command -v jq` guard alone the
@@ -134,10 +135,27 @@ resolve_main_model() {
     # with no error anywhere. python3 is already a hard dependency of the hooks,
     # so it is always available as the fallback reader.
     if command -v jq >/dev/null 2>&1; then
-      jq -r '.model // empty' "$INSTALL_DIR/.claude/settings.json" 2>/dev/null
+      _m="$(jq -r '.model // empty' "$INSTALL_DIR/.claude/settings.json" 2>/dev/null)"
     else
-      python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("model") or "")' "$INSTALL_DIR/.claude/settings.json" 2>/dev/null
+      _m="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("model") or "")' "$INSTALL_DIR/.claude/settings.json" 2>/dev/null)"
     fi
+  fi
+  if [ -n "$_m" ]; then
+    printf '%s' "$_m"
+    return 0
+  fi
+  # MODELMIGRATE806: settings.json has no model -> fall back to the SHIPPED
+  # distribution default (DISTRIBUTION_DEFAULT_AGENT_MODEL). This is what lets a
+  # model bump reach EXISTING installs through a plain code update: their
+  # settings.json (shipped before the model field existed) stays model-less, and
+  # WITHOUT this fallback they would silently keep the CLI default forever. We do
+  # NOT write the value into a per-install file -- that would pin an inherited
+  # default and cut those machines off from the NEXT bump. The shipped TS
+  # constant stays the single source of truth; node reads it (node is already a
+  # hard dependency on this launch path, and the read is ~one-time per restart).
+  # The .env override above still wins, so a hand-set model is untouched.
+  if command -v node >/dev/null 2>&1 && [ -f "$INSTALL_DIR/dist/config-registry.js" ]; then
+    node -e 'try { process.stdout.write(String(require(process.argv[1]).DISTRIBUTION_DEFAULT_AGENT_MODEL || "")) } catch (e) {}' "$INSTALL_DIR/dist/config-registry.js" 2>/dev/null
   fi
 }
 

--- a/src/__tests__/default-agent-model.test.ts
+++ b/src/__tests__/default-agent-model.test.ts
@@ -64,11 +64,15 @@ describe('agent-config default wiring', () => {
     expect(resolveModelId('inherit')).toBe(DEFAULT_AGENT_MODEL)
   })
 
-  it("leaves the bare 'opus' alias pinned to 4.8", () => {
-    // Deliberate upstream decision (v1.23.2): raising the install default must
-    // not silently reconfigure agents whose config says the generic 'opus'.
-    expect(MODEL_ALIASES['opus']).toBe('claude-opus-4-8[1m]')
-    expect(resolveModelId('opus')).toBe('claude-opus-4-8[1m]')
+  it("resolves the bare 'opus' alias to Opus 5 (MODELMIGRATE806)", () => {
+    // Szabi's "everything on Opus 5" applies here too. Measured before the
+    // change: ZERO live callers use the bare 'opus' alias -- all 10 fleet
+    // agent-configs carry a full model id, and the UI picks from the valueSet
+    // (full ids), never an alias. So the change is zero-risk, and a dead alias
+    // still pointing at the OLD model is exactly the silent trap we spent a day
+    // on: whoever writes 'opus' gets 4.8 with nothing warning them.
+    expect(MODEL_ALIASES['opus']).toBe('claude-opus-5[1m]')
+    expect(resolveModelId('opus')).toBe('claude-opus-5[1m]')
   })
 })
 

--- a/src/config-registry.ts
+++ b/src/config-registry.ts
@@ -14,14 +14,20 @@
 // config.ts cannot drift apart -- bumping the distribution default is a
 // one-line change in exactly one place.
 // MAINMODEL806 (Szabi: "everything on Opus 5"): the default for the OTHER
-// agents and the background-worker sessions. The [1m] suffix is DELIBERATE and
-// matches the main agent's template default (claude-opus-5[1m]): the prior
-// worker default was already [1m] (claude-opus-4-8[1m]), so this preserves the
-// 1M-context behaviour and only lifts the version -- it does NOT quietly diverge
-// from the main-agent value. resolveModelId passes the [1m] id through
-// unchanged (measured), exactly as the CLI already handles the 4.8[1m] default.
-// The valueSet below carries BOTH claude-opus-5 and claude-opus-5[1m] so an
-// operator can still pick the non-1M form.
+// agents and the background-worker sessions -- AND, via resolve_main_model's
+// fallback (channels.sh), the effective default for the MAIN agent on any
+// install whose settings.json has no model. So this value is INHERITED by NEW
+// agents and by existing model-less installs; it is not a mere worker knob.
+// The [1m] suffix is DELIBERATE, and the real reason is that inheritance, not
+// continuity: a new agent is as long-lived as the current fleet (all of whom
+// run explicit [1m]), and a narrower window would reproduce the context-guard
+// restarts we measured. (The prior worker default happening to be [1m] only
+// proves precedent, not need -- do not read it as "it was always this".) It
+// matches the main agent's template value, so the two do not quietly diverge.
+// resolveModelId passes the [1m] id through unchanged (measured), exactly as
+// the CLI already handles the 4.8[1m] default. The valueSet below carries BOTH
+// claude-opus-5 and claude-opus-5[1m] so an operator can still pick the
+// non-1M form.
 export const DISTRIBUTION_DEFAULT_AGENT_MODEL = 'claude-opus-5[1m]'
 
 export type SettingType = 'int' | 'string' | 'color' | 'boolean'

--- a/src/web/agent-config.ts
+++ b/src/web/agent-config.ts
@@ -22,7 +22,7 @@ export const DEFAULT_MODEL = DEFAULT_AGENT_MODEL
 
 // Map short model names to full Claude model IDs (backwards compat with old configs)
 export const MODEL_ALIASES: Record<string, string> = {
-  'opus': 'claude-opus-4-8[1m]',
+  'opus': 'claude-opus-5[1m]',
   'sonnet': 'claude-sonnet-5',
   'sonnet-5': 'claude-sonnet-5',
   'sonnet5': 'claude-sonnet-5',


### PR DESCRIPTION
## Summary
So Szabi's "everything on Opus 5" reaches the **28 EXISTING installs**, not just new ones. Builds on #910 (jq→python3 fallback) -- same function, one round, as Marveen asked.

### 1. resolve_main_model inherited fallback (the measured-better migration path)
Chain is now: `MAIN_AGENT_MODEL` (.env, hand override) → `settings.json .model` → **node reads `DISTRIBUTION_DEFAULT_AGENT_MODEL` from `dist/config-registry.js`**.

Why this over writing MAIN_AGENT_MODEL into each customer .env (my first idea, which Marveen correctly rejected):
- reaches the 28 existing model-less installs on a **plain code update** -- no per-install file write, nothing outward-facing on their machines;
- stays **inherited**, so the NEXT bump (Opus 6 / a rollback) also reaches them, instead of pinning today's value;
- the hand .env override still wins.

**Measured** (Marveen's condition, before coding): the shell can read the TS constant cheaply -- channels.sh already uses node on this path, dist/config-registry.js exports it, the read is ~38 ms once per restart. So **no constant duplication** and no two-place sync test -- the TS value stays the single source of truth. Works on a **jq-free PATH** too (node, not jq).

### 2. bare `opus` alias → claude-opus-5[1m]
**Measured**: ZERO live callers use the bare alias (all 10 fleet agent-configs carry a full id; the UI picks full ids from the valueSet). Zero-risk, and a dead alias pointing at the OLD model is the silent trap we spent the day on.

### 3. comment fix (Marveen review follow-up)
The DISTRIBUTION_DEFAULT comment now states the REAL reason for [1m] -- inheritance by new agents and model-less installs -- not the weak "it was always this".

## Test plan
- [x] channels-main-model.test.sh: fallback case (no .env + no settings model → the fixture dist constant) + .env-beats-fallback; **11/11, incl. a jq-free PATH run**.
- [x] 21/21 TS model tests; the opus assertion updated to Opus 5.
- [x] **Adversarially verified**: removing the fallback block → red; reverting the alias to 4.8 → red; restore → green, clean tree.

## Scope note
Merged/live gap: this is on develop; existing installs get it on their next code update (that is the whole point of the inherited path). Not touched: the DEFAULT_AGENT_MODEL dashboard setting for workers on existing installs stays opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)