### PR TITLE
fix(enroll): fail hard when a dashboard token was wanted but is missing (INSTNODE806 b)

### DIFF
--- a/scripts/remote-access-enroll.ts
+++ b/scripts/remote-access-enroll.ts
@@ -34,6 +34,7 @@ import {
   buildRestrictedLine,
   buildBundle,
   checkEnrollHost,
+  dashboardTokenDecision,
   encodeBundle,
   resolveHostKey,
   HOST_KEY_PUB_CANDIDATES,
@@ -227,21 +228,22 @@ async function main(): Promise<void> {
     webPort: args.webPort,
   }
 
-  if (args.includeDashboardToken) {
-    const dashboardToken = readDashboardToken()
-    if (dashboardToken === null) {
-      process.stderr.write(
-        'warning: no dashboard token found (DASHBOARD_TOKEN env or store/.dashboard-token); ' +
-          'emitting a token-free bundle. The device will need the dashboard access URL out of band.\n',
-      )
-    } else {
-      bundleInput.dashboardToken = dashboardToken
-      process.stderr.write(
-        'NOTE: this bundle contains the dashboard access token. Treat it as a secret: ' +
-          'hand it over on a private channel, never by email or shared chat. ' +
-          'Use --no-dashboard-token to emit a token-free bundle.\n',
-      )
-    }
+  // Token-bundle decision (INSTNODE806): a token was requested by default, so a
+  // MISSING token is a hard failure (the dashboard has not written one -- it is
+  // not running), not a silent degrade to an unusable token-free bundle. This is
+  // the same "unusable -- fail hard instead of emitting it silently" rule the
+  // host-key check above already applies. `--no-dashboard-token` still emits a
+  // deliberate token-free bundle.
+  const tokenDecision = dashboardTokenDecision(args.includeDashboardToken, readDashboardToken())
+  if ('ok' in tokenDecision) {
+    fail(tokenDecision.reason)
+  } else if (tokenDecision.include) {
+    bundleInput.dashboardToken = tokenDecision.token
+    process.stderr.write(
+      'NOTE: this bundle contains the dashboard access token. Treat it as a secret: ' +
+        'hand it over on a private channel, never by email or shared chat. ' +
+        'Use --no-dashboard-token to emit a token-free bundle.\n',
+    )
   }
 
   const encoded = encodeBundle(buildBundle(bundleInput))

--- a/src/__tests__/remote-enroll-core.test.ts
+++ b/src/__tests__/remote-enroll-core.test.ts
@@ -13,6 +13,7 @@ import {
   parseKeyscanEd25519,
   resolveHostKey,
   HOST_KEY_PUB_CANDIDATES,
+  dashboardTokenDecision,
   type ParsedKey,
 } from '../remote-enroll-core.js'
 
@@ -401,5 +402,37 @@ describe('resolveHostKey', () => {
   it('ships macOS locations among the default candidates', () => {
     expect(HOST_KEY_PUB_CANDIDATES).toContain('/etc/ssh/ssh_host_ed25519_key.pub')
     expect(HOST_KEY_PUB_CANDIDATES).toContain('/private/etc/ssh/ssh_host_ed25519_key.pub')
+  })
+})
+
+describe('dashboardTokenDecision (INSTNODE806)', () => {
+  it('includes the token when requested and present', () => {
+    expect(dashboardTokenDecision(true, 'tok_abc')).toEqual({ include: true, token: 'tok_abc' })
+  })
+
+  it('deliberate token-free bundle: --no-dashboard-token skips the token, no failure', () => {
+    expect(dashboardTokenDecision(false, null)).toEqual({ include: false })
+    // Even if a token exists, opting out must NOT include it.
+    expect(dashboardTokenDecision(false, 'tok_abc')).toEqual({ include: false })
+  })
+
+  it('FAILS HARD when a token was requested but is missing -- no silent token-free bundle', () => {
+    const d = dashboardTokenDecision(true, null)
+    // It MUST be the failure shape -- not a degrade to include:false (a silent
+    // token-free bundle) and not an include:true with a null token. Asserting
+    // `'ok' in d` (not just a falsy d.ok) is what catches those regressions.
+    expect('ok' in d).toBe(true)
+    expect((d as { ok: boolean }).ok).toBe(false)
+    const reason = (d as { reason: string }).reason
+    // The message must name the real cause (dashboard not running / no token)
+    // and the deliberate escape hatch, not a generic error.
+    expect(reason).toMatch(/dashboard/i)
+    expect(reason).toMatch(/--no-dashboard-token/)
+  })
+
+  it('treats an empty-string token as missing (fails hard, never ships an empty token)', () => {
+    const d = dashboardTokenDecision(true, '')
+    expect('ok' in d).toBe(true)
+    expect((d as { ok: boolean }).ok).toBe(false)
   })
 })

--- a/src/remote-enroll-core.ts
+++ b/src/remote-enroll-core.ts
@@ -43,6 +43,47 @@ const HOSTNAME_RE = new RegExp(`^${HOSTNAME_LABEL}(?:\\.${HOSTNAME_LABEL})*\\.?$
 
 export type HostCheck = { ok: true; host: string } | { ok: false; reason: string }
 
+export type DashboardTokenDecision =
+  | { include: false }
+  | { include: true; token: string }
+  | { ok: false; reason: string }
+
+/**
+ * Decide what a connection bundle should carry for the dashboard token.
+ *
+ * The caller asks for a token bundle by DEFAULT; `--no-dashboard-token` opts
+ * out. So `includeToken=false` is a deliberate token-free bundle (the device
+ * gets the dashboard URL out of band) -- fine.
+ *
+ * But `includeToken=true` with NO token present is NOT fine: it means the
+ * dashboard has not written store/.dashboard-token, which in practice means the
+ * dashboard service is not running. A token-free bundle emitted here is unusable
+ * -- the device cannot reach the dashboard -- so this FAILS HARD rather than
+ * degrading silently. This mirrors the host-key check, which already fails hard
+ * for the same "unusable, don't emit it silently" reason; the token is simply
+ * the second field that same rule must cover. (INSTNODE806: a broken install
+ * whose dashboard never started shipped a token-free bundle on only a warning,
+ * and it surfaced downstream as the Bridge's opaque "Nothing to verify".)
+ */
+export function dashboardTokenDecision(
+  includeToken: boolean,
+  token: string | null,
+): DashboardTokenDecision {
+  if (!includeToken) return { include: false }
+  if (token === null || token === '') {
+    return {
+      ok: false,
+      reason:
+        'no dashboard access token found (store/.dashboard-token is missing, and DASHBOARD_TOKEN is unset). ' +
+        'The dashboard service has not written one, which usually means it is not running yet, so a usable ' +
+        'bundle cannot be built. Start the service and confirm the dashboard answers on its web port, then ' +
+        're-run. To deliberately emit a token-free bundle (the device gets the dashboard URL out of band), ' +
+        'pass --no-dashboard-token.',
+    }
+  }
+  return { include: true, token }
+}
+
 /**
  * Validate a user-supplied target address. `isIP` covers IPv4 and IPv6
  * literals; anything else must look like a hostname.


### PR DESCRIPTION
## INSTNODE806 (b): a token-free connection bundle must fail hard, not degrade silently

A connection bundle includes the dashboard token by default; `--no-dashboard-token` opts out. When the token was wanted but `store/.dashboard-token` is absent, the enroll script only **warned** and shipped a token-free bundle -- which is unusable, the device cannot reach the dashboard. That is exactly what a broken install (the dashboard never came up) produced, and it surfaced downstream only as the Bridge's opaque "Nothing to verify".

This applies the rule the **host-key** check already uses -- its comment literally says *"unusable -- fail hard instead of emitting it silently"* -- to the second field that needs it. Not a new rule; the consistent application of our own.

### Change
- New pure `dashboardTokenDecision(includeToken, token)` in `remote-enroll-core.ts`: `include:false` for a deliberate `--no-dashboard-token` bundle, `include:true` when present, and a hard failure (`ok:false` + a cause-naming message) when the token was wanted but is missing or empty. `main()` fails via `fail()` on that result.
- The failure message names the real cause (the dashboard is not running yet, so no token was written) and the deliberate escape hatch (`--no-dashboard-token`), not a generic error.

### Behaviour change, in the fail direction (intended)
On a machine where the dashboard has not come up, enrollment now **stops loudly** where it used to ship a half-usable bundle silently. Better -- but louder: anyone reading the log should expect the hard stop rather than a warning.

### Shipping path (two separate paths -- neither release alone delivers both)
This fix is in the **marveen repo** (`scripts/remote-access-enroll.ts`), so it reaches customers via the **normal release (develop -> main promote)**, NOT via the Bridge DMG. Its sibling INSTNODE806 fix -- node resolution in the setup-token fallback -- lives in the **marveen-bridge-installer repo** and ships only via a **new signed DMG (0.3.11)**.

### Test plan
`dashboardTokenDecision` cases: token present, deliberate token-free, wanted-but-missing -> hard fail, empty-string -> hard fail. The assertions check the failure **shape** (`'ok' in d`), so a degrade-to-token-free regression is caught (a weaker `d.ok`-falsy check would pass both the correct fail and the regression). Full suite **3407/3407**, `tsc` clean. Adversarial red-check: weakening the guard turns the two fail-hard tests red.

Generated with Claude Code
