### PR TITLE
fix(install): report zstd version in the dependency check summary

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -357,7 +357,7 @@ if command -v free &>/dev/null; then
 fi
 
 MISSING_PKGS=""
-for pkg in ffmpeg git tmux lsof curl python3 pipx unzip; do
+for pkg in ffmpeg git tmux lsof curl python3 pipx unzip zstd; do
   if ! command -v "$pkg" &>/dev/null; then
     MISSING_PKGS="$MISSING_PKGS $pkg"
   fi
@@ -427,7 +427,7 @@ if [ -n "$MISSING_PKGS" ]; then
     # dnf/yum (Fedora/Nobara/RHEL). A disztro nodejs csomagja v20+ az aktualis
     # kiadasokon, es az npm-et is tartalmazza -- nincs szukseg kulso repora.
     # Csomagnevek megegyeznek a Debian-belivel (ffmpeg/git/tmux/lsof/curl/
-    # python3/pipx/unzip/nodejs). Az ffmpeg-hez Fedoran az RPM Fusion repo
+    # python3/pipx/unzip/zstd/nodejs). Az ffmpeg-hez Fedoran az RPM Fusion repo
     # kellhet; ha mar engedelyezve van, a csomag elerheto.
     # shellcheck disable=SC2086
     pkg_install_noninteractive $MISSING_PKGS
@@ -457,6 +457,7 @@ ok "pipx" $(pipx --version)
 ok "python3 $(python3 --version | awk '{print $2}')"
 ok "tmux $(tmux -V | awk '{print $2}')"
 ok "unzip" $(unzip -v | awk 'NR==1 {print $2}')
+ok "zstd $(zstd --version | awk '{gsub(",","",$5); print $5}')"
 
 # ─────────────────────────────────────────────
 # Repo bootstrap
@@ -602,6 +603,11 @@ export PATH="$BUN_INSTALL/bin:$PATH"
 if command -v bun &>/dev/null; then
   ok "bun mar telepitve: $(bun --version)"
 else
+  # unzip -- a Bun hivatalos telepitoje ezzel csomagolja ki a binarist; nincs alapertelmezetten telepitve friss Ubuntu
+  # WSL kepen, nelkule "error: unzip is required to install bun"-nal elhasal.
+  if ! command -v unzip &>/dev/null; then
+    sudo apt-get install -y unzip 2>/dev/null || true
+  fi
   echo -e "  Bun telepitese (Telegram plugin fuggoseg)..."
   curl -fsSL https://bun.sh/install | bash 2>/dev/null
   if ! command -v bun &>/dev/null; then
@@ -1416,6 +1422,11 @@ else
   # Az ollama telepitoje sudo-val ir a /usr/local/bin-be es allit be systemd service-t.
   # Elore gyorsitotarazzuk a sudo hitelesitest, hogy a gyermek-script sudo prompt-ja ne bukjon el.
   sudo -v 2>/dev/null || true
+  # zstd -- az ollama telepitoje ezzel csomagolja ki a binarist; nincs alapertelmezetten telepitve friss Ubuntu
+  # WSL kepen, nelkule "ERROR: This version requires zstd for extraction" hibaval elhasal.
+  if ! command -v zstd &>/dev/null; then
+    sudo apt-get install -y zstd 2>/dev/null || true
+  fi
   # NEM fatalis: ha az ollama telepitoje hibara fut (pl. sudo, halozat, WSL),
   # csak figyelmeztetunk es kihagyjuk a szemantikus memoria lepest -- a telepito megy tovabb.
   if curl -fsSL https://ollama.com/install.sh | sh; then

--- a/install-linux.sh
+++ b/install-linux.sh
@@ -457,7 +457,7 @@ ok "pipx" $(pipx --version)
 ok "python3 $(python3 --version | awk '{print $2}')"
 ok "tmux $(tmux -V | awk '{print $2}')"
 ok "unzip" $(unzip -v | awk 'NR==1 {print $2}')
-ok "zstd $(zstd --version | awk '{gsub(",","",$5); print $5}')"
+ok "zstd $(zstd --version | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
 
 # ─────────────────────────────────────────────
 # Repo bootstrap
@@ -603,11 +603,9 @@ export PATH="$BUN_INSTALL/bin:$PATH"
 if command -v bun &>/dev/null; then
   ok "bun mar telepitve: $(bun --version)"
 else
-  # unzip -- a Bun hivatalos telepitoje ezzel csomagolja ki a binarist; nincs alapertelmezetten telepitve friss Ubuntu
-  # WSL kepen, nelkule "error: unzip is required to install bun"-nal elhasal.
-  if ! command -v unzip &>/dev/null; then
-    sudo apt-get install -y unzip 2>/dev/null || true
-  fi
+  # unzip -- a Bun hivatalos telepitoje ezzel csomagolja ki a binarist; nincs alapertelmezetten telepitve friss WSL distrokon,
+  # nelkule "error: unzip is required to install bun"-nal elhasal.
+  command -v unzip &>/dev/null || pkg_install_noninteractive unzip || true
   echo -e "  Bun telepitese (Telegram plugin fuggoseg)..."
   curl -fsSL https://bun.sh/install | bash 2>/dev/null
   if ! command -v bun &>/dev/null; then
@@ -1422,11 +1420,9 @@ else
   # Az ollama telepitoje sudo-val ir a /usr/local/bin-be es allit be systemd service-t.
   # Elore gyorsitotarazzuk a sudo hitelesitest, hogy a gyermek-script sudo prompt-ja ne bukjon el.
   sudo -v 2>/dev/null || true
-  # zstd -- az ollama telepitoje ezzel csomagolja ki a binarist; nincs alapertelmezetten telepitve friss Ubuntu
-  # WSL kepen, nelkule "ERROR: This version requires zstd for extraction" hibaval elhasal.
-  if ! command -v zstd &>/dev/null; then
-    sudo apt-get install -y zstd 2>/dev/null || true
-  fi
+  # zstd -- az ollama telepitoje ezzel csomagolja ki a binarist; nincs alapertelmezetten telepitve friss WSL distron,
+  # nelkule "ERROR: This version requires zstd for extraction" hibaval elhasal.
+  command -v zstd &>/dev/null || pkg_install_noninteractive zstd || true
   # NEM fatalis: ha az ollama telepitoje hibara fut (pl. sudo, halozat, WSL),
   # csak figyelmeztetunk es kihagyjuk a szemantikus memoria lepest -- a telepito megy tovabb.
   if curl -fsSL https://ollama.com/install.sh | sh; then


### PR DESCRIPTION
zstd is installed as part of the missing-package loop but was never echoed back with the rest of the dependency versions.

<!--
  HU + EN. Töltsd ki minden szakaszt. / Fill in every section.
  A jelölőnégyzeteket így pipáld: [x]  /  Tick a box like this: [x]
-->

## A változtatás típusa / Type of change

- [x ] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

     HU: 

Hiányzó zstd és unzip csomagok pótlása a Linux telepítőben

Friss Ubuntu/WSL image-eken sem az unzip, sem a zstd nincs alapból telepítve. Emiatt a telepítés két ponton is elszállt:
- a Bun hivatalos telepítője unzip-pel csomagolja ki a binárist → error: unzip is required to install bun
- az Ollama telepítője zstd-vel csomagolja ki a binárist → ERROR: This version requires zstd for extraction

A javítás mindkét csomagot felveszi a kezdeti függőség-ellenőrző listába, és emellett közvetlenül a Bun-, illetve Ollama-telepítés előtt is biztosítja a jelenlétüket (apt-get install, hibatűrő módon) — így akkor is működik, ha valaki a csomaglistát megkerülve, önállóan futtatja azt a szakaszt. A függőség-összegzőbe is bekerült a zstd verziószáma, konzisztensen a többi csomaggal.

     EN: 

Add missing zstd and unzip packages to the Linux installer

Neither unzip nor zstd ship by default on a fresh Ubuntu/WSL image, which broke the install at two separate points:
- Bun's official installer unpacks its binary with unzip → error: unzip is required to install bun
- Ollama's installer unpacks its binary with zstd → ERROR: This version requires zstd for extraction

The fix adds both packages to the upfront dependency check, and also ensures their presence right before the Bun and Ollama install steps respectively (apt-get install, fault-tolerant) — so it still works even if that section runs independently of the package-list check. zstd's version is now also echoed in the dependency summary, consistent with the other packages.

## Kapcsolódó issue / Related issue

Closes #

## Ellenőrzőlista / Checklist

- [ x] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [ ] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
- [x ] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [x ] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).

## Tesztelés

- hianyzo zstd miatt kiakad WSL friss Ubuntu alatt

<img width="647" height="222" alt="linux_install_missing_zstd_in_WSL" src="https://github.com/user-attachments/assets/6ce95097-94a2-4b2a-87c9-ba76dc12016a" />

- javitott verzio

<img width="437" height="275" alt="linux_install_fixed_zstd_in_WSL_01" src="https://github.com/user-attachments/assets/0dc7b627-eb54-453c-a6cc-152ce11e029a" />
<img width="697" height="164" alt="linux_install_fixed_zstd_in_WSL_02" src="https://github.com/user-attachments/assets/e15e2cda-f587-43df-b1b0-2c21859c2463" />
