### PR TITLE
fix(model): drop the pinned model from shipped settings -- distribution default becomes the single source (MODELDRIFT807)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,4 @@
 {
-  "model": "claude-opus-4-8[1m]",
   "enabledPlugins": {
     "slack-channel@marveen-marketplace": false,
     "telegram@claude-plugins-official": true

--- a/.env.example
+++ b/.env.example
@@ -42,7 +42,7 @@ HEARTBEAT_CALENDAR_ID=your_calendar_id_or_email
 # WEB_PORT=3420
 # Az új ügynökök alapértelmezett modellje + a háttér-worker sessionök modellje.
 # Meglévő ügynökök NEM változnak tőle (az agent-config.json-jukban lévő konkrét
-# modell marad). Újraindítás után lép életbe. Alapérték: claude-opus-4-8[1m]
+# modell marad). Újraindítás után lép életbe. Alapérték: claude-opus-5[1m]
 # DEFAULT_AGENT_MODEL=claude-opus-5
 # WEB_HOST=127.0.0.1       # FONTOS: 0.0.0.0-val a dashboard elérhető a hálózatról. Használj DASHBOARD_TOKEN-t!
 # OLLAMA_URL=http://localhost:11434

--- a/scripts/__tests__/channels-main-model.test.sh
+++ b/scripts/__tests__/channels-main-model.test.sh
@@ -91,31 +91,59 @@ migr_fallback "claude-opus-5[1m]"
 expect_model ".env override beats the distribution-default fallback" \
   'MAIN_AGENT_MODEL=claude-sonnet-5' '' 'claude-sonnet-5'
 
-# THE SHIPPED-DEFAULT CONTRACT (2026-08-06): a fresh install ships
-# templates/settings.json.template as .claude/settings.json and writes no
-# MAIN_AGENT_MODEL to .env, so resolve_main_model reads the template's model.
-# The 2026-08-06 bug was that the template had NO model field -> empty ->
-# the main agent came up on claude-code's built-in default (4.8), silently.
-# This locks the template to a non-empty model, driven through the REAL
-# resolver over the REAL shipped template.
-TEMPLATE="$INSTALL_DIR/templates/settings.json.template"
-template_model="$(bash -c '
-  root="$(mktemp -d)"; mkdir -p "$root/scripts" "$root/.claude"
+# THE SHIPPED-DEFAULT CONTRACT (MODELDRIFT807, 2026-08-07): a fresh install
+# CLONES the repo, so the .claude/settings.json a customer gets is the TRACKED
+# file itself -- NO installer copies the template (or anything else) over it
+# (measured: install-macos.sh / install-linux.sh never write
+# $INSTALL_DIR/.claude/settings.json). The predecessor of this block copied the
+# TEMPLATE into the fixture and asserted on that -- a contract no installer
+# implements, so it stayed green while every real fresh install resolved the
+# tracked file's pinned claude-opus-4-8[1m] and the distribution default never
+# ran. These contracts drive the REAL shipped files instead.
+SHIPPED_SETTINGS="$INSTALL_DIR/.claude/settings.json"
+
+# (1) The tracked settings file pins NO model. A hand-set model on a live
+# install still wins (covered above) -- this is about what we SHIP.
+shipped_model="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("model") or "")' "$SHIPPED_SETTINGS")"
+if [ -z "$shipped_model" ]; then
+  pass "shipped .claude/settings.json pins no model (distribution default stays live)"
+else
+  fail "shipped .claude/settings.json pins no model" "(empty)" "$shipped_model"
+fi
+
+# (2) The resolver over the REAL shipped settings file falls through to the
+# distribution default. The sentinel value can only surface via the registry
+# read, so a pinned model in the shipped file turns this red.
+real_settings_model="$(bash -c '
+  root="$(mktemp -d)"; mkdir -p "$root/scripts" "$root/.claude" "$root/dist"
   cp "'"$SRC"'" "$root/scripts/channels.sh"
-  cp "'"$TEMPLATE"'" "$root/.claude/settings.json"
+  cp "'"$SHIPPED_SETTINGS"'" "$root/.claude/settings.json"
+  printf "exports.DISTRIBUTION_DEFAULT_AGENT_MODEL = \"SENTINEL-FROM-REGISTRY\";\n" > "$root/dist/config-registry.js"
   bash "$root/scripts/channels.sh" --resolve-main-model 2>/dev/null | head -1
   rm -rf "$root"
 ')"
-if [ -n "$template_model" ]; then
-  pass "shipped template resolves to a NON-EMPTY main model ($template_model)"
+if [ "$real_settings_model" = "SENTINEL-FROM-REGISTRY" ]; then
+  pass "resolver over the REAL shipped settings falls through to the distribution default"
 else
-  fail "shipped template resolves to a non-empty main model" "non-empty" "(empty)"
+  fail "resolver over the REAL shipped settings falls through to the distribution default" "SENTINEL-FROM-REGISTRY" "$real_settings_model"
 fi
-# And it is the intended Opus 5 (1M) default, matching the fleet host.
-if [ "$template_model" = "claude-opus-5[1m]" ]; then
-  pass "shipped template main model is claude-opus-5[1m]"
+
+# (3) The real shipped constant (the single source of truth) is Opus 5 (1M).
+registry_default="$(grep -oE "DISTRIBUTION_DEFAULT_AGENT_MODEL = '[^']+'" "$INSTALL_DIR/src/config-registry.ts" | head -1 | sed "s/.*'\(.*\)'/\1/")"
+if [ "$registry_default" = "claude-opus-5[1m]" ]; then
+  pass "DISTRIBUTION_DEFAULT_AGENT_MODEL is claude-opus-5[1m] (real src constant)"
 else
-  fail "shipped template main model" "claude-opus-5[1m]" "$template_model"
+  fail "DISTRIBUTION_DEFAULT_AGENT_MODEL is claude-opus-5[1m]" "claude-opus-5[1m]" "$registry_default"
+fi
+
+# (4) The template must not resurrect a second model source: no installer ships
+# it as .claude/settings.json, so a model field in it is dead code that a future
+# test could again mistake for the live contract.
+template_model="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("model") or "")' "$INSTALL_DIR/templates/settings.json.template")"
+if [ -z "$template_model" ]; then
+  pass "settings template pins no model (single source: config-registry)"
+else
+  fail "settings template pins no model" "(empty)" "$template_model"
 fi
 
 echo

--- a/templates/settings.json.template
+++ b/templates/settings.json.template
@@ -1,5 +1,4 @@
 {
-  "model": "claude-opus-5[1m]",
   "enabledPlugins": {
     "telegram@claude-plugins-official": true
   },


### PR DESCRIPTION
## Mit javit

A friss telepites a repot klonozza, igy a trackelt `.claude/settings.json` MAGA a vevo settings-fajlja -- es `claude-opus-4-8[1m]`-et pinnelt, ezert a `resolve_main_model` azt adta vissza, a #918-as `DISTRIBUTION_DEFAULT_AGENT_MODEL` (`claude-opus-5[1m]`) fallback pedig SOSEM futott friss installon. Elesben merve Szabolcs ma reggeli 0.3.12 telepitesen (Marveen msg 9187, MODELDRIFT807 kartya).

## Valtozasok

1. **`.claude/settings.json`**: model mezo torolve -- a #918 fallback mostantol a friss installokat (es update utan az erintetlen klonokat) a shippelt defaultra oldja.
2. **`templates/settings.json.template`**: model mezo torolve. Egyik installer sem masolja a template-et `.claude/settings.json`-ne -- a benne levo model halott kod volt, ami csak hamis teszt-zoldet taplalt.
3. **`channels-main-model.test.sh`**: a shipped-default kontrakt blokk korabban a TEMPLATE-et masolta a sajat fixture-jebe es azon assertelt (a stub adta a valaszt). Most a VALODI trackelt settings-fajlt hajtja (no-model kontrakt + sentinel fall-through), a VALODI src konstanst mero asserttel, es a template-et is model-mentesen zarolja.
4. **`.env.example`**: elavult default-doksi (4.8 -> 5).

## Amit NEM valtoztat

Explicit model (`.env` `MAIN_AGENT_MODEL`, vagy kezzel irt settings.json model) tovabbra is NYER -- a meglevo precedencia-tesztek valtozatlanul zoldek.

## Verify

- 13/13 PASS (channels-main-model.test.sh), tsc tiszta, parity-teszt 10/10, template-fuggo guard-tesztek 63/63.
- RED-CHECK: a settings-fix visszavonasa 2 tesztet, a template-fix visszavonasa 1 tesztet pirosit.
- `disk-space-guard` es `seed-skills` shell-tesztek a TISZTA develop HEAD-en (6cd0b54) is buknak -- pre-existing, ettol a PR-tol fuggetlen.

## Megjegyzes

NE mergeld kulon: Marveen egyben viszi a #919 + token-fail-hard (b) + ezen harmas kiadast, o meri vissza mindharmat (msg 9189).

🤖 Generated with [Claude Code](https://claude.com/claude-code)