### PR TITLE
fix(guard): disk-space reaper silent no-op on macOS + repair two red shell tests (SHTEST807)

### DIFF
--- a/scripts/__tests__/disk-space-guard.test.sh
+++ b/scripts/__tests__/disk-space-guard.test.sh
@@ -18,6 +18,13 @@ assert_eq() { if [ "$2" = "$3" ]; then pass "$1"; else fail "$1 (expected '$2', 
 INSTALL_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
 GUARD="$INSTALL_DIR/scripts/disk-space-guard.sh"
 
+# SHTEST807: GNU `touch_aged` is not portable -- BSD (macOS) touch
+# rejects it, the fixture files were never created, and every "survives the
+# reap" assert read the missing file as "deleted" (3 false FAILs + 2 more).
+# `touch -t [[CC]YY]MMDDhhmm` is accepted by BSD and GNU alike.
+TS_2H_AGO="$(python3 -c 'import time; print(time.strftime("%Y%m%d%H%M", time.localtime(time.time()-7200)))')"
+touch_aged() { touch -t "$TS_2H_AGO" "$@"; }
+
 # Run the guard with an isolated scratch + state dir and a usage override.
 # Args: usage scratch_dir state_dir  -> prints stdout (logs + any ALERT_DRYRUN).
 run_guard() {
@@ -25,9 +32,14 @@ run_guard() {
     DISK_GUARD_ALERT_DRYRUN=1 bash "$GUARD" 2>&1
 }
 
+# SHTEST807: the scratch fixture must live under the REAL /tmp -- macOS mktemp
+# honours TMPDIR=/var/folders/..., which the guard's W3 location guard rightly
+# refuses, so every reap assert failed before it began. State can stay anywhere.
+SCRATCH_BASE="$(mktemp -d /tmp/dsg-test-XXXXXX)"
+trap 'rm -rf "$TMPDIR_BASE" "$SCRATCH_BASE"' EXIT
 fresh_case() { # -> echoes "scratch state" for a clean case dir
-  local d; d="$TMPDIR_BASE/case-$1"; mkdir -p "$d/scratch" "$d/state"
-  echo "$d/scratch $d/state"
+  local d s; d="$TMPDIR_BASE/case-$1"; s="$SCRATCH_BASE/case-$1"; mkdir -p "$s" "$d/state"
+  echo "$s $d/state"
 }
 
 echo "disk-space-guard tests"
@@ -39,7 +51,7 @@ echo "======================"
 echo ""
 echo "(a) Below threshold"
 read -r SCR ST <<<"$(fresh_case a)"
-touch -d '2 hours ago' "$SCR/health_old.bin"
+touch_aged "$SCR/health_old.bin"
 OUT="$(run_guard 50 "$SCR" "$ST")"
 assert_eq "below threshold: no reap log" "" "$OUT"
 [ -e "$SCR/health_old.bin" ] && pass "below threshold: scratch untouched" || fail "below threshold: scratch was reaped"
@@ -50,10 +62,10 @@ assert_eq "below threshold: no reap log" "" "$OUT"
 echo ""
 echo "(b) Reap threshold"
 read -r SCR ST <<<"$(fresh_case b)"
-touch -d '2 hours ago' "$SCR/health_old.xml"
-mkdir -p "$SCR/health_unpacked"; touch -d '2 hours ago' "$SCR/health_unpacked"
+touch_aged "$SCR/health_old.xml"
+mkdir -p "$SCR/health_unpacked"; touch_aged "$SCR/health_unpacked"
 touch "$SCR/health_fresh.xml"               # recent -> age guard protects it
-touch -d '2 hours ago' "$SCR/keepme.txt"    # not on allowlist -> protected
+touch_aged "$SCR/keepme.txt"    # not on allowlist -> protected
 OUT="$(run_guard 92 "$SCR" "$ST")"
 [ ! -e "$SCR/health_old.xml" ] && pass "reap: aged health_* file removed" || fail "reap: aged health file survived"
 [ ! -e "$SCR/health_unpacked" ] && pass "reap: aged health_* dir removed" || fail "reap: aged health dir survived"
@@ -85,7 +97,7 @@ if printf '%s' "$OUT2" | grep -q "ALERT_DRYRUN"; then fail "cooldown: re-alerted
 echo ""
 echo "(e) Malformed usage"
 read -r SCR ST <<<"$(fresh_case e)"
-touch -d '2 hours ago' "$SCR/health_old.bin"
+touch_aged "$SCR/health_old.bin"
 OUT="$(run_guard "garbage" "$SCR" "$ST")"
 if printf '%s' "$OUT" | grep -q "could not read disk usage"; then pass "malformed: logs a clean no-op"; else fail "malformed: unexpected output: $OUT"; fi
 [ -e "$SCR/health_old.bin" ] && pass "malformed: scratch untouched on bad usage" || fail "malformed: reaped on bad usage"
@@ -97,7 +109,7 @@ echo ""
 echo "(f) W3 location guard"
 OUTSIDE="$(TMPDIR="$HOME" mktemp -d 2>/dev/null || true)"
 if [ -n "$OUTSIDE" ]; then
-  touch -d '2 hours ago' "$OUTSIDE/health_outside.bin"
+  touch_aged "$OUTSIDE/health_outside.bin"
   run_guard 92 "$OUTSIDE" "$OUTSIDE" >/dev/null 2>&1
   [ -e "$OUTSIDE/health_outside.bin" ] && pass "W3: scratch outside /tmp is NOT reaped" || fail "W3: reaped scratch outside /tmp"
   rm -rf "$OUTSIDE"
@@ -106,7 +118,7 @@ else
 fi
 # A symlinked SCRATCH_DIR (even pointing into /tmp) is refused.
 read -r SCR ST <<<"$(fresh_case f)"
-touch -d '2 hours ago' "$SCR/health_real.bin"
+touch_aged "$SCR/health_real.bin"
 LINK="$TMPDIR_BASE/f-link"; ln -s "$SCR" "$LINK"
 run_guard 92 "$LINK" "$ST" >/dev/null 2>&1
 [ -e "$SCR/health_real.bin" ] && pass "W3: symlinked SCRATCH_DIR is NOT reaped" || fail "W3: reaped via symlinked SCRATCH_DIR"
@@ -117,12 +129,12 @@ run_guard 92 "$LINK" "$ST" >/dev/null 2>&1
 echo ""
 echo "(g) W2 reap-age validation"
 read -r SCR ST <<<"$(fresh_case g)"
-touch -d '2 hours ago' "$SCR/health_2h.bin"   # 120 min old; < the 1440 fallback
+touch_aged "$SCR/health_2h.bin"   # 120 min old; < the 1440 fallback
 DISK_GUARD_REAP_MIN_AGE_MIN="garbage" run_guard 92 "$SCR" "$ST" >/dev/null 2>&1
 [ -e "$SCR/health_2h.bin" ] && pass "W2: invalid reap-age -> conservative default, recent file kept" || fail "W2: invalid reap-age reaped a 2h-old file"
 # Sanity: a valid small age still reaps the same 2h-old file.
 read -r SCR2 ST2 <<<"$(fresh_case g2)"
-touch -d '2 hours ago' "$SCR2/health_2h.bin"
+touch_aged "$SCR2/health_2h.bin"
 DISK_GUARD_REAP_MIN_AGE_MIN="30" run_guard 92 "$SCR2" "$ST2" >/dev/null 2>&1
 [ ! -e "$SCR2/health_2h.bin" ] && pass "W2: valid reap-age still reaps an aged file" || fail "W2: valid reap-age failed to reap"
 
@@ -143,12 +155,12 @@ echo ""
 echo "(i) D directory-mtime guard"
 read -r SCR ST <<<"$(fresh_case i)"
 mkdir -p "$SCR/health_inprogress"; touch "$SCR/health_inprogress/part.xml"   # fresh file inside
-touch -d '2 hours ago' "$SCR/health_inprogress"                              # dir mtime looks old
+touch_aged "$SCR/health_inprogress"                              # dir mtime looks old
 DISK_GUARD_REAP_MIN_AGE_MIN="30" run_guard 92 "$SCR" "$ST" >/dev/null 2>&1
 [ -d "$SCR/health_inprogress" ] && pass "D: aged dir with a fresh file inside is NOT reaped" || fail "D: reaped an in-progress export dir"
 # Control: a dir whose files are ALL old IS reaped.
 read -r SCR2 ST2 <<<"$(fresh_case i2)"
-mkdir -p "$SCR2/health_done"; touch -d '2 hours ago' "$SCR2/health_done/done.xml" "$SCR2/health_done"
+mkdir -p "$SCR2/health_done"; touch_aged "$SCR2/health_done/done.xml" "$SCR2/health_done"
 DISK_GUARD_REAP_MIN_AGE_MIN="30" run_guard 92 "$SCR2" "$ST2" >/dev/null 2>&1
 [ ! -d "$SCR2/health_done" ] && pass "D: fully-old dir is still reaped" || fail "D: fully-old dir not reaped"
 

--- a/scripts/__tests__/seed-skills.test.sh
+++ b/scripts/__tests__/seed-skills.test.sh
@@ -132,10 +132,19 @@ else
   fail "MAIN_AGENT_ID NOT substituted in task-config.json"
 fi
 
-if grep -q '/opt/testbot/store/claudeclaw.db' "$SCHED_TARGET/kanban-audit/SKILL.md"; then
+# SHTEST807: this assert used to grep for '/opt/testbot/store/claudeclaw.db',
+# a recipe-content string that #870 rewrote away (sqlite3 paths -> HTTP API), so
+# it failed on every current tree. Assert the substitution MECHANISM, not the
+# recipe text, so the next recipe rewrite cannot break it again.
+if grep -q '/opt/testbot/' "$SCHED_TARGET/kanban-audit/SKILL.md"; then
   pass "INSTALL_DIR substituted in SKILL.md"
 else
   fail "INSTALL_DIR NOT substituted in SKILL.md"
+fi
+if ! grep -rq '{{' "$SCHED_TARGET"; then
+  pass "no unsubstituted {{placeholder}} left anywhere in seeded output"
+else
+  fail "unsubstituted {{placeholder}} left in seeded output: $(grep -rl '{{' "$SCHED_TARGET" | head -2 | tr '\n' ' ')"
 fi
 
 if grep -q "skip ha assignee='testbot'" "$SCHED_TARGET/kanban-audit/SKILL.md"; then

--- a/scripts/disk-space-guard.sh
+++ b/scripts/disk-space-guard.sh
@@ -84,6 +84,11 @@ reap_scratch() {
   [ -z "$real" ] && { echo 0; return; }
   case "$real/" in
     /tmp/*) : ;;
+    # SHTEST807: on macOS /tmp is a symlink to /private/tmp, so every resolved
+    # scratch path starts with /private/tmp and the /tmp/* arm never matches --
+    # the reaper was a silent no-op on every macOS install. /private/tmp does
+    # not exist on Linux, so this arm is inert there.
+    /private/tmp/*) : ;;
     "${XDG_RUNTIME_DIR:-/nonexistent-xdg}"/*) : ;;
     *) echo 0; return ;;
   esac


### PR DESCRIPTION
## Diagnozis (Marveen 9196 kerese szerint: elobb meres, aztan dontes)

A tiszta develop HEAD-en (618f5e4d) buko ket shell-teszt gyokere HAROM kulon hiba:

1. **TERMEK-HIBA (uj lelet)**: a reaper W3 location-kapuja a feloldott utat `/tmp/*`-ra illeszti, de macOS-en a /tmp symlink /private/tmp-re -- a resolved ut SOSEM illeszkedik, a reap_scratch minden macOS-installon NEMAN 0-t ad vissza. A guard fail-closed iranyba hibazott (nem torolt semmit), de a funkcio macOS-en soha nem futott. Fix: `/private/tmp/*` ag is (Linuxon inert).
2. **Teszt-hordozhatosag**: GNU `touch -d '2 hours ago'` -- a BSD touch elutasitja, a fixture-ok letre sem jottek, 5 assert a hianyzo fajlt 'torolve'-nek olvasta. Portable `touch -t` helper + a scratch-fixture a valodi /tmp ala (a macOS mktemp TMPDIR=/var/folders-t hasznal, amit a location-kapu jogosan utasit el).
3. **Elavult assert**: a seed-skills teszt a #870-ben atirt recept regi tartalom-stringjet (claudeclaw.db) grepelte. Most a szubsztitucios MECHANIZMUST asserteli + no-placeholder-left sweep.

## Vevo-erintettseg

- A seed-ut a VALODI utvonalon merve TISZTA (0 maradek placeholder) -- a szallitott seedek sosem voltak vevo-erintok, az (a) eset.
- A reaper-hiba vevo-erinto abban az ertelemben, hogy macOS-en a scratch-takaritas sosem futott (korlatlan novekedes lehetseges), de adatvesztes-irany NINCS (fail-closed).

## Verify

22/22 (disk-space-guard) + 20/20 (seed-skills) a javitott fan. RED-CHECK: a guard-fix visszavonasa 4 tesztet pirosit (a fixture-javitas onmagaban NEM teszi zoldre -- a termek-fix load-bearing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)