### PR TITLE
feat(channels): reject a busy Telegram bot token at save time with a human remedy (MCPTOKEN807)

### DIFF
--- a/src/__tests__/channel-provider.test.ts
+++ b/src/__tests__/channel-provider.test.ts
@@ -146,3 +146,75 @@ describe('splitMessage per provider', () => {
     }
   })
 })
+
+// MCPTOKEN807: busy-token probe -- a valid token that a webhook or another
+// running install already owns must be rejected at save time with a human
+// remedy, not die later as an opaque plugin -32000.
+import { checkTelegramTokenBusy } from '../channel-provider.js'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+function fakeFetch(routes: Record<string, { status?: number; body?: unknown }>): typeof fetch {
+  return (async (url: RequestInfo | URL) => {
+    const u = String(url)
+    const key = Object.keys(routes).find((k) => u.includes(k))
+    const r = key ? routes[key] : {}
+    return {
+      status: r.status ?? 200,
+      json: async () => r.body ?? {},
+    } as Response
+  }) as typeof fetch
+}
+
+describe('checkTelegramTokenBusy', () => {
+  const TOKEN = '123456:TESTSECRETVALUE'
+
+  it('reports webhook-bound tokens with the deleteWebhook remedy, without leaking the token', async () => {
+    const r = await checkTelegramTokenBusy(TOKEN, fakeFetch({
+      getWebhookInfo: { body: { ok: true, result: { url: 'https://old-install.example/hook' } } },
+    }))
+    expect(r.busy).toBe(true)
+    expect(r.reason).toBe('webhook')
+    expect(r.error).toContain('deleteWebhook')
+    expect(r.error).toContain('BotFather')
+    expect(r.error).not.toContain(TOKEN)
+    expect(r.error).not.toContain('TESTSECRETVALUE')
+  })
+
+  it('reports a competing poller on getUpdates 409 with the stop-or-new-bot remedy', async () => {
+    const r = await checkTelegramTokenBusy(TOKEN, fakeFetch({
+      getWebhookInfo: { body: { ok: true, result: { url: '' } } },
+      getUpdates: { status: 409 },
+    }))
+    expect(r.busy).toBe(true)
+    expect(r.reason).toBe('poller')
+    expect(r.error).toContain('409')
+    expect(r.error).toContain('BotFather')
+    expect(r.error).not.toContain(TOKEN)
+  })
+
+  it('passes a free token', async () => {
+    const r = await checkTelegramTokenBusy(TOKEN, fakeFetch({
+      getWebhookInfo: { body: { ok: true, result: { url: '' } } },
+      getUpdates: { status: 200, body: { ok: true, result: [] } },
+    }))
+    expect(r).toEqual({ busy: false })
+  })
+
+  it('is advisory: a probe network error lets the save through (getMe already proved connectivity)', async () => {
+    const failing = (async () => { throw new Error('network down') }) as unknown as typeof fetch
+    const r = await checkTelegramTokenBusy(TOKEN, failing)
+    expect(r.busy).toBe(false)
+  })
+
+  // The renderer-wiring lesson (INSTNODE806): the helper being correct proves
+  // nothing about the route actually calling it. Lock the wiring structurally:
+  // the setup handler must call the probe, and must skip it for a re-saved
+  // identical token (its own live poller reads as busy).
+  it('the channel setup route wires the busy probe in, gated on a token change', () => {
+    const src = readFileSync(join(__dirname, '..', 'web', 'routes', 'agents.ts'), 'utf-8')
+    expect(src).toMatch(/checkTelegramTokenBusy\(botToken\.trim\(\)\)/)
+    expect(src).toMatch(/botToken\.trim\(\) !== currentToken/)
+    expect(src.indexOf('checkTelegramTokenBusy(botToken')).toBeGreaterThan(src.indexOf('findBotTokenDuplicate'))
+  })
+})

--- a/src/channel-provider.ts
+++ b/src/channel-provider.ts
@@ -103,6 +103,50 @@ const telegramProvider: ChannelProvider = {
   splitMessage: (text) => splitMessage(text),
 }
 
+// MCPTOKEN807: a syntactically valid token (getMe ok) can still be UNUSABLE by
+// our poller. Two live-measured cases (Szabolcs, 2026-08-07 fresh install with
+// a reused test-bot token): a webhook bound to the bot, or another running
+// install already long-polling getUpdates -- either way the plugin dies with an
+// opaque "-32000" at runtime. Probe BOTH at save time and answer in human
+// language with the remedy. The probe is advisory: if the probe request itself
+// fails (network hiccup -- getMe already proved connectivity moments ago), we
+// let the save through rather than block setup on a transient error.
+// NOT part of validateToken: the /test endpoint validates the agent's CURRENT
+// token, whose own running poller would 409 against this probe (false busy).
+// Call it only when saving a token that differs from the one already stored.
+export async function checkTelegramTokenBusy(
+  token: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<{ busy: boolean; reason?: 'webhook' | 'poller'; error?: string }> {
+  try {
+    const wh = await fetchImpl(`https://api.telegram.org/bot${token}/getWebhookInfo`)
+    const whData = await wh.json() as { ok: boolean; result?: { url?: string } }
+    if (whData.ok && whData.result?.url) {
+      return {
+        busy: true,
+        reason: 'webhook',
+        // The token itself must never appear in this user-facing message.
+        error: 'A bot token érvényes, de a bot jelenleg webhookra van kötve, így a Marveen nem tud rá csatlakozni. '
+          + `Teendő: szüntesd meg a webhookot (nyisd meg böngészőben: https://api.telegram.org/bot<A-TOKENED>/deleteWebhook), `
+          + 'vagy készíts új botot a @BotFather-nél, és annak a tokenjét add meg itt.',
+      }
+    }
+    const up = await fetchImpl(`https://api.telegram.org/bot${token}/getUpdates?timeout=0&limit=1`)
+    if (up.status === 409) {
+      return {
+        busy: true,
+        reason: 'poller',
+        error: 'A bot token érvényes, de egy másik futó rendszer már használja (a Telegram 409 Conflict választ adott). '
+          + 'Egy bot tokent egyszerre csak egy telepítés használhat. Teendő: állítsd le a korábbi telepítést, '
+          + 'amelyik még ezzel a tokennel fut, vagy készíts új botot a @BotFather-nél, és annak a tokenjét add meg itt.',
+      }
+    }
+    return { busy: false }
+  } catch {
+    return { busy: false }
+  }
+}
+
 // -- Slack implementation (stub) --
 // The actual Slack channel plugin (jeremylongshore/claude-code-slack-channel)
 // handles message delivery via its own MCP tools. This stub provides the

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -80,6 +80,7 @@ import {
   getProvider,
   channelStateDir,
   readChannelToken,
+  checkTelegramTokenBusy,
   generateSlackAppManifest,
   getSlackAppSetupInstructions,
   type ChannelProviderType,
@@ -1126,6 +1127,20 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     if (dupeOwner) {
       json(res, { error: `This bot token is already used by agent "${dupeOwner}". Each agent needs its own bot token to avoid getUpdates conflicts.` }, 409)
       return true
+    }
+
+    // MCPTOKEN807: a token reused from a PREVIOUS install (webhook bound, or a
+    // poller still running elsewhere) passes getMe and the local dupe check,
+    // then kills the plugin at runtime with an opaque -32000. Probe at save
+    // time and answer with the remedy. Skipped when re-saving the token this
+    // agent already runs with -- its OWN live poller would read as busy.
+    if (provider === 'telegram') {
+      const preEnvPath = join(isMain ? channelStateDir(provider) : channelStateDir(provider, agentDir(name)), '.env')
+      const currentToken = readChannelToken(provider, preEnvPath)
+      if (botToken.trim() !== currentToken) {
+        const busyCheck = await checkTelegramTokenBusy(botToken.trim())
+        if (busyCheck.busy) { json(res, { error: busyCheck.error }, 409); return true }
+      }
     }
 
     if (provider === 'slack' && !isManagedSettingsReady()) {


### PR DESCRIPTION
## Mit javit

Szabi ma reggeli friss telepitesen egy KORABBI teszt-installnal mar hasznalt bot tokent adott meg: a getMe atengedte, a lokalis dupe-check atengedte, a plugin pedig futasidoben halt el a semmitmondo `Failed to reconnect ... -32000`-rel. Egy bot tokenhez egyszerre EGY fogyaszto tartozhat: kotott webhook VAGY masik futo install pollere = a token itt hasznalhatatlan.

## Valtozasok

1. **`checkTelegramTokenBusy()`** (channel-provider.ts): getWebhookInfo proba (webhook kotve -> emberi uzenet a deleteWebhook teendovel) + getUpdates proba (409 -> masik poller birtokolja; teendo: a regi telepites leallitasa vagy uj bot a @BotFather-nel). ADVISORY: ha maga a proba halozati hibara fut, a mentes atmegy -- a getMe percen belul bizonyitotta a kapcsolatot, tranziens hibara setup-blokkolas rosszabb lenne. A hibauzenetek a tokent SOSEM tartalmazzak.
2. **Setup route wiring** (agents.ts): a lokalis dupe-check UTAN, es CSAK ha a token tenylegesen valtozik -- a sajat, mar futo poller ellen probazni hamis 'foglalt'-ot adna ugyanazon token ujramentesekor.
3. **Tesztek**: webhook / poller / szabad / advisory-hiba esetek + token-nem-szivarog assert mindket uzenetre + STRUKTURALIS wiring-assert a route-ra (a helper helyessege semmit nem bizonyit arrol, hogy a route hivja is -- INSTNODE806 renderer-tanulsag).

## Verify

27/27 channel-provider teszt, tsc tiszta. RED-CHECK: a wiring visszavonasa pirositja a strukturalis assertet. Teljes vitest: UGYANAZ a 4 fajl / 19 bukas, mint a tiszta develop HEAD-en (email-send-gate, governance-gates, hook-command-quoting, hook-path-guard -- pre-existing, host-fuggo, ettol a PR-tol fuggetlen; ha kell, kulon kartyazom).

## Hatokor

A dashboard/wizard setup-utjat fedi (ez volt Szabi utja). A telepito-script sajat token-prompt aga kulon feluleten fut -- ha oda is kell a proba, az kulon kor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)