### PR TITLE
fix(install): the not-started remedy now works on an unregistered launchd unit (REMEDYCMD807)

### DIFF
--- a/install-macos.sh
+++ b/install-macos.sh
@@ -1293,8 +1293,15 @@ else
   # nobody measured -- the same defect as the banner above it.
   echo -e "    ${DIM}A unit-fajlok a helyukon vannak, de futo folyamatot nem talaltunk.${NC}"
   echo -e "    ${BOLD}Javitas most:${NC}"
-  echo -e "    ${BLUE}launchctl kickstart -p gui/$(id -u)/${DASHBOARD_PLIST}${NC}"
-  echo -e "    ${BLUE}launchctl kickstart -p gui/$(id -u)/${CHANNELS_PLIST}${NC}"
+  # REMEDYCMD807: kickstart alone cannot start a unit that was never REGISTERED
+  # in the gui domain -- and that is exactly the state this branch fires in most
+  # often (an SSH-driven install cannot bootstrap into gui/$UID; measured live,
+  # rc=5 EIO). The remedy the user runs from a GUI terminal must be
+  # state-agnostic: bootstrap first (registers + RunAtLoad-starts; errors
+  # harmlessly if already registered), then kickstart (covers the
+  # registered-but-dead state).
+  echo -e "    ${BLUE}launchctl bootstrap gui/$(id -u) \"\$HOME/Library/LaunchAgents/${DASHBOARD_PLIST}.plist\" 2>/dev/null; launchctl kickstart -p gui/$(id -u)/${DASHBOARD_PLIST}${NC}"
+  echo -e "    ${BLUE}launchctl bootstrap gui/$(id -u) \"\$HOME/Library/LaunchAgents/${CHANNELS_PLIST}.plist\" 2>/dev/null; launchctl kickstart -p gui/$(id -u)/${CHANNELS_PLIST}${NC}"
   echo -e "    ${DIM}Ellenorzes: launchctl print gui/$(id -u)/${CHANNELS_PLIST} | grep -E 'state|pid'${NC}"
 fi
 

--- a/src/__tests__/installer-start-and-fallback.test.ts
+++ b/src/__tests__/installer-start-and-fallback.test.ts
@@ -308,3 +308,32 @@ describe('every touched shell entry point stays parseable', () => {
     },
   )
 })
+
+describe('install-macos.sh -- the not-started remedy must work on an UNREGISTERED unit (REMEDYCMD807)', () => {
+  // The remedy screen fires precisely when start_launchd_unit could not bring
+  // the units up -- on an SSH-driven install because gui/$UID bootstrap fails
+  // there (measured live: rc=5 EIO), so the unit is usually NOT REGISTERED at
+  // all. `launchctl kickstart` cannot start an unregistered unit, so a
+  // kickstart-only remedy is guaranteed dead advice in the most common state.
+  // The printed remedy must be state-agnostic: bootstrap the plist first, then
+  // kickstart the label.
+  const remedy = MACOS.slice(MACOS.indexOf('Javitas most'))
+
+  it('bootstraps the plist before kickstarting, for both units', () => {
+    for (const unit of ['DASHBOARD_PLIST', 'CHANNELS_PLIST']) {
+      const line = remedy.split('\n').find((l) => l.includes('bootstrap') && l.includes(unit))
+      expect(line, `bootstrap remedy line for ${unit}`).toBeTruthy()
+      expect(line).toMatch(/launchctl bootstrap gui\//)
+      expect(line).toMatch(/\.plist/)
+      // kickstart follows ON THE SAME LINE so a copy-paste of one line works
+      // regardless of whether the unit was registered.
+      expect(line!.indexOf('bootstrap')).toBeLessThan(line!.indexOf('kickstart'))
+    }
+  })
+
+  it('never offers kickstart WITHOUT a preceding bootstrap on the same line', () => {
+    const kickLines = remedy.split('\n').filter((l) => l.includes('kickstart') && l.includes('BLUE'))
+    expect(kickLines.length).toBeGreaterThan(0)
+    for (const l of kickLines) expect(l).toContain('bootstrap')
+  })
+})


### PR DESCRIPTION
## Mit javit

A 'SZOLGALTATASOK INDULASA NEM IGAZOLT' kepernyo javitasi javaslata eddig kickstart-only volt -- ami NEM REGISZTRALT uniton nem mukodhet. Marpedig pont ez a leggyakoribb allapot, amikor ez az ag tuzel: SSH-vezerelt telepitesnel a gui/$UID bootstrap az SSH security-sessionbol bukik (elesben merve a marveen2-n: rc=5 EIO), tehat a unit sehova sincs regisztralva. A vevo a kepernyorol masolt paranccsal nem tudott tovabbjutni.

## Valtozas

A remedy-sorok allapot-agnosztikus egysorosok lettek: eloszor bootstrap a plist-re (regisztral + RunAtLoad-dal indit; mar-regisztralt allapotban artalmatlanul hibazik), utana kickstart a labelre (a regisztralt-de-halott allapotot fedi). Egyetlen copy-paste mukodik a GUI terminalbol, barmelyik allapotban van a unit.

## Verify

- Strukturalis tesztek zaroljak az alakot: bootstrap a kickstart ELOTT ugyanazon a soron mindket unitra; BLUE remedy-sor nem ajanlhat kickstartot bootstrap nelkul.
- 26/26 PASS (installer-start-and-fallback), bash -n OK.
- RED-CHECK: az install-macos.sh valtozas visszavonasa 2 tesztet pirosit.
- A teszt-futtatas workspace-checkoutbol tortent (SUITERED807 tanulsag: /tmp-checkouton a gate-tesztek hamisan pirosak).

## Kapcsolodo

Az install-linux.sh systemd-agat nem erinti (ott systemctl --user restart a remedy, az mukodik unregistered allapot hianyaban). A Bridge 0.3.13+ a re-vendor lancon kapja meg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)