### PR TITLE
fix(tests): the live-install refusal must not send people to /tmp (SUITERED807 follow-up)

### DIFF
--- a/src/__tests__/setup/assert-not-live-install.ts
+++ b/src/__tests__/setup/assert-not-live-install.ts
@@ -30,6 +30,13 @@ if (found.length > 0) {
   throw new Error(
     `REFUSING TO RUN TESTS: ${repoRoot} looks like a LIVE install (found: ${found.join(', ')}). ` +
       'The suite mutates files under the checkout it runs in (store/, .env, .claude/skills/). ' +
-      'Run it from a git worktree or CI checkout instead, e.g. `git worktree add /tmp/claw-test && cd /tmp/claw-test && npm test`.',
+      // SUITERED807: this line used to suggest `/tmp/claw-test` -- but the
+      // hook-path registration guard (isUnsafeHookCommand) rightly rejects any
+      // /tmp-prefixed PROJECT_ROOT, so from a /tmp checkout the four gate test
+      // files go falsely red. The tool must not send its user to the one place
+      // another of its own guards forbids.
+      'Run it from a git worktree or CI checkout UNDER YOUR HOME (not /tmp!), e.g. ' +
+      '`git worktree add ~/claw-test && cd ~/claw-test && npm test`. ' +
+      'Not /tmp: the hook-path guard rejects /tmp-prefixed roots, so the gate tests would go falsely red there.',
   )
 }


### PR DESCRIPTION
## Mit javit

Az assert-not-live-install elutasito uzenete `git worktree add /tmp/claw-test`-et javasolt -- pont azt a helyszint, ahol a termek masik guardja (isUnsafeHookCommand, /tmp-prefixu hook-utak tiltasa) miatt a negy gate-teszt fajl hamisan pirosra valt. Aki a szerszam sajat tanacsat koveti, a SUITERED807-et reprodukalja.

Az uzenet mostantol home-alatti worktree-t javasol (`~/claw-test`) es egy mondatban kimondja, miert nem /tmp.

## Kontextus

Ez a commit (575d3533) eredetileg a #927 masodik commitja volt, de a push keresztezte a squash-merge-et (a 9ee5de35 a b06500dd-t rogzitette), igy a fix LEMARADT a developrol -- itt megy ujra, kulon PR-kent, ahogy Marveen a 9207-ben kerte. Merve: az origin/develop 33. sora meg a /tmp-t javasolja.

tsc tiszta; tartalmi valtozas csak az uzeneteben es a kommentben.

🤖 Generated with [Claude Code](https://claude.com/claude-code)