### PR TITLE
feat(install): probe the entered Telegram bot token and speak the findings (INSTTOKEN807)

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -846,6 +846,43 @@ else
 fi
 ok "Csatorna: $CHANNEL_PROVIDER"
 
+# INSTTOKEN807: probe the freshly entered bot token BEFORE anything is written.
+# Warn-only (advisory), for two hard reasons: a network hiccup must not block
+# the install, and the headless derive contract (Bridge payload) forbids new
+# interactive reads here -- so we say it loudly and let the install continue.
+# The dashboard save path hard-rejects the same states (#926); this is the
+# installer-side voice for the same three findings, each with its remedy.
+# set -e safe: every path ends in return 0; curl failures are guarded.
+# The token value itself is NEVER printed.
+probe_telegram_token() {
+  _ptt_t="$1"
+  [ -n "$_ptt_t" ] || return 0
+  _ptt_me="$(curl -s --max-time 8 "https://api.telegram.org/bot${_ptt_t}/getMe" 2>/dev/null)" || return 0
+  case "$_ptt_me" in
+    *'"ok":true'*) : ;;
+    *'"ok":false'*)
+      warn "A megadott bot token ERVENYTELEN (a Telegram getMe elutasitotta)."
+      echo -e "    ${DIM}Ellenorizd a @BotFather-tol kapott tokent. A telepites folytatodik, de a bot ezzel a tokennel nem fog valaszolni.${NC}"
+      return 0 ;;
+    *) return 0 ;;
+  esac
+  _ptt_wh="$(curl -s --max-time 8 "https://api.telegram.org/bot${_ptt_t}/getWebhookInfo" 2>/dev/null)" || return 0
+  case "$_ptt_wh" in
+    *'"url":"http'*)
+      warn "A bot token ervenyes, de a bot WEBHOOKRA van kotve -- a Marveen poller igy nem tud ra csatlakozni."
+      echo -e "    ${DIM}Teendo: nyisd meg bongeszoben: https://api.telegram.org/bot<A-TOKENED>/deleteWebhook${NC}"
+      echo -e "    ${DIM}vagy keszits uj botot a @BotFather-nel, es futtasd ujra a telepitot azzal.${NC}"
+      return 0 ;;
+  esac
+  _ptt_up="$(curl -s -o /dev/null -w '%{http_code}' --max-time 8 "https://api.telegram.org/bot${_ptt_t}/getUpdates?timeout=0&limit=1" 2>/dev/null)" || return 0
+  if [ "$_ptt_up" = "409" ]; then
+    warn "A bot token ervenyes, de egy MASIK futo rendszer mar hasznalja (Telegram 409 Conflict)."
+    echo -e "    ${DIM}Egy tokent egyszerre csak egy telepites hasznalhat. Teendo: allitsd le a korabbi telepitest,${NC}"
+    echo -e "    ${DIM}vagy keszits uj botot a @BotFather-nel, es futtasd ujra a telepitot az uj tokennel.${NC}"
+  fi
+  return 0
+}
+
 BOT_TOKEN=""
 SLACK_BOT_TOKEN=""
 SLACK_APP_TOKEN=""
@@ -862,6 +899,7 @@ if [ "$CHANNEL_PROVIDER" = "telegram" ]; then
   echo -e "${DIM}  4. Masold ide a kapott tokent:${NC}"
   echo ""
   read -rp "$(_t prompt_telegram_token)" BOT_TOKEN
+  probe_telegram_token "$BOT_TOKEN"
 elif [ "$CHANNEL_PROVIDER" = "discord" ]; then
   echo ""
   echo -e "${DIM}  Az AI asszisztensed Discordon kommunikal veled.${NC}"

--- a/install-macos.sh
+++ b/install-macos.sh
@@ -407,6 +407,43 @@ else
 fi
 echo -e "  ${GREEN}✓${NC} Csatorna: $CHANNEL_PROVIDER"
 
+# INSTTOKEN807: probe the freshly entered bot token BEFORE anything is written.
+# Warn-only (advisory), for two hard reasons: a network hiccup must not block
+# the install, and the headless derive contract (Bridge payload) forbids new
+# interactive reads here -- so we say it loudly and let the install continue.
+# The dashboard save path hard-rejects the same states (#926); this is the
+# installer-side voice for the same three findings, each with its remedy.
+# set -e safe: every path ends in return 0; curl failures are guarded.
+# The token value itself is NEVER printed.
+probe_telegram_token() {
+  _ptt_t="$1"
+  [ -n "$_ptt_t" ] || return 0
+  _ptt_me="$(curl -s --max-time 8 "https://api.telegram.org/bot${_ptt_t}/getMe" 2>/dev/null)" || return 0
+  case "$_ptt_me" in
+    *'"ok":true'*) : ;;
+    *'"ok":false'*)
+      warn "A megadott bot token ERVENYTELEN (a Telegram getMe elutasitotta)."
+      echo -e "    ${DIM}Ellenorizd a @BotFather-tol kapott tokent. A telepites folytatodik, de a bot ezzel a tokennel nem fog valaszolni.${NC}"
+      return 0 ;;
+    *) return 0 ;;
+  esac
+  _ptt_wh="$(curl -s --max-time 8 "https://api.telegram.org/bot${_ptt_t}/getWebhookInfo" 2>/dev/null)" || return 0
+  case "$_ptt_wh" in
+    *'"url":"http'*)
+      warn "A bot token ervenyes, de a bot WEBHOOKRA van kotve -- a Marveen poller igy nem tud ra csatlakozni."
+      echo -e "    ${DIM}Teendo: nyisd meg bongeszoben: https://api.telegram.org/bot<A-TOKENED>/deleteWebhook${NC}"
+      echo -e "    ${DIM}vagy keszits uj botot a @BotFather-nel, es futtasd ujra a telepitot azzal.${NC}"
+      return 0 ;;
+  esac
+  _ptt_up="$(curl -s -o /dev/null -w '%{http_code}' --max-time 8 "https://api.telegram.org/bot${_ptt_t}/getUpdates?timeout=0&limit=1" 2>/dev/null)" || return 0
+  if [ "$_ptt_up" = "409" ]; then
+    warn "A bot token ervenyes, de egy MASIK futo rendszer mar hasznalja (Telegram 409 Conflict)."
+    echo -e "    ${DIM}Egy tokent egyszerre csak egy telepites hasznalhat. Teendo: allitsd le a korabbi telepitest,${NC}"
+    echo -e "    ${DIM}vagy keszits uj botot a @BotFather-nel, es futtasd ujra a telepitot az uj tokennel.${NC}"
+  fi
+  return 0
+}
+
 BOT_TOKEN=""
 SLACK_BOT_TOKEN=""
 SLACK_APP_TOKEN=""
@@ -420,6 +457,7 @@ if [ "$CHANNEL_PROVIDER" = "telegram" ]; then
   echo -e "${DIM}  4. Masold ide a kapott tokent:${NC}"
   echo ""
   read -rp "$(_t prompt_telegram_token)" BOT_TOKEN
+  probe_telegram_token "$BOT_TOKEN"
 else
   echo ""
   echo -e "${DIM}  Az AI asszisztensed Slack-en kommunikal veled.${NC}"

--- a/src/__tests__/installer-token-probe.test.ts
+++ b/src/__tests__/installer-token-probe.test.ts
@@ -1,0 +1,135 @@
+// INSTTOKEN807: the installer's token prompt must probe the freshly entered
+// Telegram bot token and SAY IT in human language when the token is invalid,
+// webhook-bound, or owned by another running install -- instead of the
+// customer meeting an opaque plugin "-32000" at first contact (measured live,
+// Szabolcs's 2026-08-07 install with a reused test-bot token). Warn-only by
+// design: the headless derive contract forbids new interactive reads, and a
+// transient network error must not block an install.
+import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync, chmodSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+const ROOT = resolve(__dirname, '..', '..')
+const MACOS = readFileSync(join(ROOT, 'install-macos.sh'), 'utf-8')
+const LINUX = readFileSync(join(ROOT, 'install-linux.sh'), 'utf-8')
+
+function sliceProbeFn(src: string): string {
+  const start = src.indexOf('probe_telegram_token() {')
+  expect(start).toBeGreaterThan(-1)
+  const end = src.indexOf('\n}', start)
+  return src.slice(start, end + 2)
+}
+
+/**
+ * Run the real probe function against a stubbed `curl`. The stub answers per
+ * Telegram method from files the case writes, so each scenario drives the real
+ * parsing, not a re-implementation of it.
+ */
+function runProbe(opts: { getMe: string; webhook?: string; updatesStatus?: string; curlFails?: boolean }): string {
+  const dir = mkdtempSync(join(tmpdir(), 'tokenprobe-'))
+  try {
+    const stub = join(dir, 'curl')
+    writeFileSync(
+      stub,
+      [
+        '#!/bin/bash',
+        opts.curlFails ? 'exit 7' : '',
+        'url="${@: -1}"',
+        'case "$url" in',
+        `  *getMe*) printf '%s' '${opts.getMe}' ;;`,
+        `  *getWebhookInfo*) printf '%s' '${opts.webhook ?? '{"ok":true,"result":{"url":""}}'}' ;;`,
+        // -w %{http_code} form: emit the status code like curl would
+        `  *getUpdates*) printf '%s' '${opts.updatesStatus ?? '200'}' ;;`,
+        'esac',
+        'exit 0',
+      ].join('\n'),
+    )
+    chmodSync(stub, 0o755)
+    const script = join(dir, 'probe.sh')
+    writeFileSync(
+      script,
+      [
+        '#!/bin/bash',
+        'set -e',                                  // the installer runs under set -e
+        'ORANGE=""; NC=""; DIM=""',
+        'warn() { echo "WARN: $*"; }',
+        sliceProbeFn(MACOS),
+        'probe_telegram_token "123456:SECRETTOKENVALUE"',
+        'echo "PROBE_DONE rc=$?"',
+      ].join('\n'),
+    )
+    return execFileSync('bash', [script], { env: { ...process.env, PATH: `${dir}:${process.env.PATH}` }, encoding: 'utf-8' })
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+describe('probe_telegram_token -- functional, through the real shell function', () => {
+  it('says INVALID in human language when getMe rejects, and still completes', () => {
+    const out = runProbe({ getMe: '{"ok":false,"error_code":401}' })
+    expect(out).toContain('WARN:')
+    expect(out).toContain('ERVENYTELEN')
+    expect(out).toContain('BotFather')
+    expect(out).toContain('PROBE_DONE rc=0')
+    expect(out).not.toContain('SECRETTOKENVALUE')
+  })
+
+  it('names the webhook state with the deleteWebhook remedy', () => {
+    const out = runProbe({
+      getMe: '{"ok":true,"result":{"username":"x_bot"}}',
+      webhook: '{"ok":true,"result":{"url":"https://old.example/hook"}}',
+    })
+    expect(out).toContain('WEBHOOK')
+    expect(out).toContain('deleteWebhook')
+    expect(out).toContain('PROBE_DONE rc=0')
+    expect(out).not.toContain('SECRETTOKENVALUE')
+  })
+
+  it('names the competing-poller state on getUpdates 409 with the stop-or-new-bot remedy', () => {
+    const out = runProbe({ getMe: '{"ok":true,"result":{"username":"x_bot"}}', updatesStatus: '409' })
+    expect(out).toContain('409')
+    expect(out).toContain('BotFather')
+    expect(out).toContain('PROBE_DONE rc=0')
+  })
+
+  it('stays SILENT on a free token', () => {
+    const out = runProbe({ getMe: '{"ok":true,"result":{"username":"x_bot"}}' })
+    expect(out).not.toContain('WARN:')
+    expect(out).toContain('PROBE_DONE rc=0')
+  })
+
+  it('is advisory: a failing curl neither warns nor aborts the set -e installer', () => {
+    const out = runProbe({ getMe: '', curlFails: true })
+    expect(out).not.toContain('WARN:')
+    expect(out).toContain('PROBE_DONE rc=0')
+  })
+})
+
+describe('both installers wire the probe after the telegram token prompt', () => {
+  it.each([
+    ['install-macos.sh', MACOS],
+    ['install-linux.sh', LINUX],
+  ])('%s defines the probe and calls it right after the prompt', (_name, src) => {
+    expect(src).toContain('probe_telegram_token() {')
+    const promptIdx = src.indexOf('prompt_telegram_token)" BOT_TOKEN')
+    expect(promptIdx).toBeGreaterThan(-1)
+    const after = src.slice(promptIdx, promptIdx + 200)
+    expect(after).toContain('probe_telegram_token "$BOT_TOKEN"')
+  })
+
+  it.each([
+    ['install-macos.sh', MACOS],
+    ['install-linux.sh', LINUX],
+  ])('%s never prints the token value in the probe messages', (_name, src) => {
+    const fn = sliceProbeFn(src)
+    // No echo/printf line inside the probe may interpolate the token variable.
+    for (const line of fn.split('\n')) {
+      if (/echo|printf/.test(line) && !/curl/.test(line)) {
+        expect(line).not.toContain('$_ptt_t')
+        expect(line).not.toContain('${_ptt_t}')
+      }
+    }
+  })
+})


### PR DESCRIPTION
## Mit javit

A telepito eddig BARMILYEN stringet elfogadott bot tokenkent -- elutott token, webhookra kotott bot, vagy egy masik futo telepites altal hasznalt token mind 'kesz' telepitest adott, amiben a plugin aztan a semmitmondo -32000-rel halt el (elesben merve Szabi ma reggeli telepitesen). A dashboard-oldali mentes mar kemenyen elutasit (#926) -- ez az installer-oldali hang ugyanarra a harom leletre.

## Valtozasok

`probe_telegram_token`, kozvetlenul a token-prompt utan MINDKET installerben (macos+linux):
- getMe elutasit -> ERVENYTELEN token figyelmeztetes
- getWebhookInfo url -> WEBHOOK-kotes + deleteWebhook teendo
- getUpdates 409 -> masik poller birtokolja + leallitas-vagy-uj-bot teendo

**WARN-ONLY, szandekosan**: (1) a headless derive-kontrakt (Bridge payload) nem enged uj interaktiv read-et -- a `read -rp` szam marad 13; (2) tranziens halozati hiba nem blokkolhat telepitest -- minden ag return 0 a set -e alatt. A token erteke SOHA nem irodik ki.

## Verify

- A tesztek a VALODI shell-fuggvenyt hajtjak stub curl-lel (invalid / webhook / 409 / szabad / curl-hiba) + strukturalis wiring-assertek mindket installerre + token-nem-szivarog sweep.
- 9/9 PASS; RED-CHECK: az installer-beszuras visszavonasa mind a 9-et pirositja. bash -n OK mindketto.
- Workspace-checkoutbol futtatva (nem /tmp).

## Scope-megjegyzes

Ha az invalid-token agra ujra-prompt hurkot akarunk (ne csak hangot), az a Bridge derive-kontrakt modositasat is igenyli -- kulon kor, ha kell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)