### PR TITLE
fix(model-suggest): the top-tier recommendation is the distribution default, never a 4.8 literal (MODELSUGGEST807)

### DIFF
--- a/src/__tests__/model-suggest.test.ts
+++ b/src/__tests__/model-suggest.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect } from 'vitest'
-import { classifyPersona, suggestForAgent } from '../web/model-suggest.js'
+import { classifyPersona, suggestForAgent , humanModelLabel } from '../web/model-suggest.js'
+import { DISTRIBUTION_DEFAULT_AGENT_MODEL } from '../config-registry.js'
 
 describe('classifyPersona', () => {
   it('suggests Opus for an architect persona', () => {
     const text = 'Te vagy a fleet IT rendszerarchitektje. Elosztott rendszerek, mikroszolgáltatás-architektúrák, komplex döntések.'
     const result = classifyPersona(text)
-    expect(result.suggestedModel).toBe('claude-opus-4-8[1m]')
+    expect(result.suggestedModel).toBe(DISTRIBUTION_DEFAULT_AGENT_MODEL)
   })
 
   it('suggests Haiku for a fitness coach persona', () => {
@@ -29,7 +30,7 @@ describe('classifyPersona', () => {
   it('overrides to Opus when contextTokens > 150k regardless of persona', () => {
     const text = 'Egyszerű feladatok, rövid válaszok, sport, edzés.'
     const result = classifyPersona(text, 160_000)
-    expect(result.suggestedModel).toBe('claude-opus-4-8[1m]')
+    expect(result.suggestedModel).toBe(DISTRIBUTION_DEFAULT_AGENT_MODEL)
     expect(result.reason).toMatch(/kontextus/)
   })
 
@@ -53,13 +54,22 @@ describe('suggestForAgent -- base (no signals)', () => {
     const text = 'IT architekt. Komplex elosztott rendszerterv, mikroszolgáltatás, stratégiai döntések.'
     const result = suggestForAgent('rick', 'claude-sonnet-5', text)
     expect(result.changeAdvised).toBe(true)
-    expect(result.suggestedModel).toBe('claude-opus-4-8[1m]')
+    expect(result.suggestedModel).toBe(DISTRIBUTION_DEFAULT_AGENT_MODEL)
   })
 
   it('normalises [1m] suffix for comparison', () => {
     const text = 'IT architekt. Komplex elosztott rendszerterv, mikroszolgáltatás, stratégiai döntések.'
-    const result = suggestForAgent('rick', 'claude-opus-4-8[1m]', text)
+    // Plain opus-5 vs the suggested opus-5[1m]: same family after normalize(),
+    // so no change is advised -- the suffix alone must not trigger churn.
+    const result = suggestForAgent('rick', 'claude-opus-5', text)
     expect(result.changeAdvised).toBe(false)
+  })
+
+  it('an agent still on Opus 4.8 IS advised to move to the distribution default (MODELSUGGEST807)', () => {
+    const text = 'IT architekt. Komplex elosztott rendszerterv, mikroszolgáltatás, stratégiai döntések.'
+    const result = suggestForAgent('rick', 'claude-opus-4-8[1m]', text)
+    expect(result.suggestedModel).toBe(DISTRIBUTION_DEFAULT_AGENT_MODEL)
+    expect(result.changeAdvised).toBe(true)
   })
 })
 
@@ -79,7 +89,7 @@ describe('suggestForAgent -- AgentSignals thresholds', () => {
       tokenAvgInputPerCall: 15_000,
       mcpServerCount: 5,
     })
-    expect(result.suggestedModel).toBe('claude-opus-4-8[1m]')
+    expect(result.suggestedModel).toBe(DISTRIBUTION_DEFAULT_AGENT_MODEL)
     expect(result.changeAdvised).toBe(true)
   })
 
@@ -88,7 +98,7 @@ describe('suggestForAgent -- AgentSignals thresholds', () => {
       mcpServerCount: 4,
       kanbanUrgentCount: 3,
     })
-    expect(result.suggestedModel).toBe('claude-opus-4-8[1m]')
+    expect(result.suggestedModel).toBe(DISTRIBUTION_DEFAULT_AGENT_MODEL)
   })
 
   it('scheduledFreqPerDay >= 10 alone adds 1 haiku signal point (not enough without persona)', () => {
@@ -115,7 +125,7 @@ describe('suggestForAgent -- AgentSignals thresholds', () => {
       kanbanUrgentCount: 2,       // +1 opus signal
     })
     // totalOpus=2 (signals) > 0, so Haiku condition fails; totalOpus>=2 -> Opus
-    expect(result.suggestedModel).toBe('claude-opus-4-8[1m]')
+    expect(result.suggestedModel).toBe(DISTRIBUTION_DEFAULT_AGENT_MODEL)
   })
 
   it('context override (>150K) wins over all signals', () => {
@@ -123,7 +133,7 @@ describe('suggestForAgent -- AgentSignals thresholds', () => {
       scheduledFreqPerDay: 200,
       kanbanOpenCount: 0,
     })
-    expect(result.suggestedModel).toBe('claude-opus-4-8[1m]')
+    expect(result.suggestedModel).toBe(DISTRIBUTION_DEFAULT_AGENT_MODEL)
     expect(result.changeAdvised).toBe(true)
   })
 
@@ -197,5 +207,44 @@ describe('suggestForAgent -- reason structure (6 sections)', () => {
     })
     expect(result.suggestedModel).toBe('claude-haiku-4-5-20251001')
     expect(result.reason).toMatch(/olcsóbb/)
+  })
+})
+
+// MODELSUGGEST807: the migration missed this customer-facing surface -- the
+// suggester kept recommending claude-opus-4-8[1m] (measured on the live
+// endpoint: 6 of 10 agents advised to DOWNGRADE, 5 of them on Opus 5).
+describe('MODELSUGGEST807 -- top tier is the shipped distribution default', () => {
+  it('the constant this suite locks to is Opus 5 (1M) today', () => {
+    expect(DISTRIBUTION_DEFAULT_AGENT_MODEL).toBe('claude-opus-5[1m]')
+  })
+
+  it('an agent already ON the distribution default is never advised to change tier upward', () => {
+    const r = suggestForAgent('archie', DISTRIBUTION_DEFAULT_AGENT_MODEL,
+      'senior architect, komplex elosztott rendszerek koordinálása, multi-agent')
+    expect(r.suggestedModel).toBe(DISTRIBUTION_DEFAULT_AGENT_MODEL)
+    expect(r.changeAdvised).toBe(false)
+  })
+
+  it('the >150k context override recommends the distribution default, not a downgrade', () => {
+    const r = suggestForAgent('bigctx', DISTRIBUTION_DEFAULT_AGENT_MODEL, 'anything', 180_000)
+    expect(r.suggestedModel).toBe(DISTRIBUTION_DEFAULT_AGENT_MODEL)
+    expect(r.changeAdvised).toBe(false)
+  })
+
+  it('no reason text ever names Opus 4.8 as the recommendation', () => {
+    for (const [persona, ctx] of [
+      ['senior architect koordinál komplex multi-agent', 0],
+      ['anything', 200_000],
+      ['általános ágens', 0],
+    ] as Array<[string, number]>) {
+      const r = suggestForAgent('probe', 'claude-opus-5[1m]', persona, ctx)
+      expect(r.reason).not.toMatch(/Opus 4\.8 ajánlott/)
+      expect(r.suggestedModel).not.toContain('opus-4-8')
+    }
+  })
+
+  it('humanModelLabel derives the prose label from the model id', () => {
+    expect(humanModelLabel('claude-opus-5[1m]')).toBe('Opus 5 (1M)')
+    expect(humanModelLabel('claude-sonnet-5')).toBe('Sonnet 5')
   })
 })

--- a/src/web/model-suggest.ts
+++ b/src/web/model-suggest.ts
@@ -1,10 +1,34 @@
 // Pure, side-effect-free persona→model classifier. Imported by the route and
 // by unit tests. No fs, no network, no db -- all I/O happens in the caller.
 
+// MODELSUGGEST807: the top-tier suggestion is the SHIPPED distribution default,
+// never a literal. This module used to hardcode claude-opus-4-8[1m] on every
+// opus branch, so after the Opus 5 migration the dashboard advised DOWNGRADING
+// Opus 5 agents to 4.8 (measured on the live endpoint: 6 of 10 agents, 5 of
+// them running Opus 5) -- a customer-facing surface the migration missed.
+// [1m] everywhere, not a split: a second plain-opus literal would be the next
+// forgotten drift seed, a context-threshold split would make suggestions flap
+// around the boundary, and this module's own cost table prices the variants
+// identically.
+import { DISTRIBUTION_DEFAULT_AGENT_MODEL } from '../config-registry.js'
+
+// Human label for the reason texts, derived from the constant so a future
+// model bump rewrites the prose too: 'claude-opus-5[1m]' -> 'Opus 5 (1M)'.
+export function humanModelLabel(model: string): string {
+  const oneM = /\[1m\]$/i.test(model)
+  const base = model.replace(/\[.*\]$/, '').replace(/^claude-/, '')
+  const words = base.split('-').map(w => (/^\d/.test(w) ? w.replace(/-/g, '.') : w.charAt(0).toUpperCase() + w.slice(1)))
+  const label = words.join(' ').replace(/(\d) (\d)/g, '$1.$2')
+  return oneM ? `${label} (1M)` : label
+}
+
+const TOP_TIER_MODEL = DISTRIBUTION_DEFAULT_AGENT_MODEL
+const TOP_TIER_LABEL = humanModelLabel(TOP_TIER_MODEL)
+
 export type ModelId =
   | 'claude-haiku-4-5-20251001'
   | 'claude-sonnet-5'
-  | 'claude-opus-4-8[1m]'
+  | 'claude-opus-5[1m]'
   | 'claude-opus-5'
   | 'claude-fable-5'
   | string
@@ -241,16 +265,16 @@ export function classifyPersona(
   // Context-window override: very large sessions always need Opus
   if (contextTokens > 150_000) {
     return {
-      suggestedModel: 'claude-opus-4-8[1m]',
-      reason: `Nagy session-kontextus (${Math.round(contextTokens / 1000)}K token) -- Opus 4.8 ajánlott a hosszú memóriakezeléshez.`,
+      suggestedModel: TOP_TIER_MODEL,
+      reason: `Nagy session-kontextus (${Math.round(contextTokens / 1000)}K token) -- ${TOP_TIER_LABEL} ajánlott a hosszú memóriakezeléshez.`,
       changeAdvised: true,
     }
   }
 
   if (opusHits >= 2) {
     return {
-      suggestedModel: 'claude-opus-4-8[1m]',
-      reason: `A persona architektúra/koordináció/komplex feladatokra utal (${opusHits} egyező jelző) -- Opus 4.8 ajánlott.`,
+      suggestedModel: TOP_TIER_MODEL,
+      reason: `A persona architektúra/koordináció/komplex feladatokra utal (${opusHits} egyező jelző) -- ${TOP_TIER_LABEL} ajánlott.`,
       changeAdvised: true,
     }
   }
@@ -288,7 +312,7 @@ export function suggestForAgent(
   // Context-window override takes priority over everything
   const contextOverride = contextTokens > 150_000
   if (contextOverride) {
-    const suggestedModel = 'claude-opus-4-8[1m]'
+    const suggestedModel = TOP_TIER_MODEL
     const changeAdvised = normalize(suggestedModel) !== normalize(currentModel)
     return {
       agent: agentName,
@@ -315,7 +339,7 @@ export function suggestForAgent(
   const totalHaiku = haikuKeyHits + haikuSignalHits
 
   let suggestedModel: ModelId
-  if (totalOpus >= 2) suggestedModel = 'claude-opus-4-8[1m]'
+  if (totalOpus >= 2) suggestedModel = TOP_TIER_MODEL
   else if (totalHaiku >= 2 && totalOpus === 0) suggestedModel = 'claude-haiku-4-5-20251001'
   else suggestedModel = 'claude-sonnet-5'
 

--- a/src/web/model-suggest.ts
+++ b/src/web/model-suggest.ts
@@ -14,6 +14,10 @@ import { DISTRIBUTION_DEFAULT_AGENT_MODEL } from '../config-registry.js'
 
 // Human label for the reason texts, derived from the constant so a future
 // model bump rewrites the prose too: 'claude-opus-5[1m]' -> 'Opus 5 (1M)'.
+// CAVEAT: only sane for family-major ids (opus/sonnet/fable tiers). A dated id
+// like 'claude-haiku-4-5-20251001' would yield a nonsense label -- today this
+// is only ever called with TOP_TIER_MODEL; extend the parser before any
+// general-purpose use.
 export function humanModelLabel(model: string): string {
   const oneM = /\[1m\]$/i.test(model)
   const base = model.replace(/\[.*\]$/, '').replace(/^claude-/, '')


### PR DESCRIPTION
## Mit javit (HIGH, vevo-fele latszo)

A dashboard modell-javasloja minden opus-agon `claude-opus-4-8[1m]`-et hardcode-olt, igy a migracio utan Opus 5 agenseknek javasolt VISSZALEPEST 4.8-ra. ELO vegpont-meres (teljes populacio, 10 agens, ELOTTE-snapshot 08:29): 6 agens kapott 4.8-javaslatot changeAdvised=true-val, kozuluk 5 MOST Opus 5-on fut; a magyar indoklas szo szerint 'Opus 4.8 ajanlott'. A legdurvabb a >150k kontextus-override volt: pont a legnagyobb kontextusu agensnek javasolt visszalepest.

## Dontes (Marveen kerdesere): [1m] MINDENHOVA, a konstansbol

Nem kontextus-fuggo split, hanem `DISTRIBUTION_DEFAULT_AGENT_MODEL` minden felso-tier agra, mert:
1. **Egy forras**: egy masodik sima-opus-5 literal a kovetkezo elfelejtett drift-mag lenne (pont a MODELDRIFT807 osztaly); a konstans ugyanaz, amit a resolver-lanc hasznal a #924 ota.
2. **Nincs flapping**: kuszob-fuggo split a 150k hatar korul ide-oda valtogatna a javaslatot.
3. **Koltseg-azonos**: e modul sajat ar-tablaja a ket opus-varianst azonosan arazza.

## Valtozasok

- Mind a 4 javaslati ag a konstansbol derival; az indoklo prozat a `humanModelLabel()` irja ('Opus 5 (1M)') -- a kovetkezo bump a szoveget is atirja.
- Uj viselkedes: a MEG 4.8-on ulo agens UPGRADE-javaslatot kap (ez a kivant irany; a jumanji config-kerdese kulon szal Szabinal).
- `MODEL_COST_PER_M` opus-4-8 sora MARAD: az a jelenlegi 4.8-as agensek arazasa, nem javaslat.

## Verify

29/29 (a regi elvarasokat a konstansra zaroltam + 1 literal-lock hogy MA claude-opus-5[1m]; kontextus-override-nem-downgrade; nincs 'Opus 4.8 ajanlott' szoveg; 4.8-rol upgrade-advised). tsc tiszta. RED-CHECK: a modul-fix visszavonasa 13 tesztet pirosit. **Az UTANA elo-vegpont bizonyitek a host-deployjal jon** (a merge utan felhuzom a hostot a ma delelotti recepttel es ujra lehivom a teljes populaciot -- az ELOTTE-snapshot mentve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)