### PR TITLE
docs(model-suggest): correct the measured before-figures (MODELSUGGEST807)

### DIFF
--- a/src/__tests__/model-suggest.test.ts
+++ b/src/__tests__/model-suggest.test.ts
@@ -212,7 +212,8 @@ describe('suggestForAgent -- reason structure (6 sections)', () => {
 
 // MODELSUGGEST807: the migration missed this customer-facing surface -- the
 // suggester kept recommending claude-opus-4-8[1m] (measured on the live
-// endpoint: 6 of 10 agents advised to DOWNGRADE, 5 of them on Opus 5).
+// endpoint before the fix: 8 of 10 agents were suggested 4.8, 7 of them with
+// changeAdvised, 5 of those running Opus 5; after: 0 of 10).
 describe('MODELSUGGEST807 -- top tier is the shipped distribution default', () => {
   it('the constant this suite locks to is Opus 5 (1M) today', () => {
     expect(DISTRIBUTION_DEFAULT_AGENT_MODEL).toBe('claude-opus-5[1m]')

--- a/src/web/model-suggest.ts
+++ b/src/web/model-suggest.ts
@@ -4,8 +4,9 @@
 // MODELSUGGEST807: the top-tier suggestion is the SHIPPED distribution default,
 // never a literal. This module used to hardcode claude-opus-4-8[1m] on every
 // opus branch, so after the Opus 5 migration the dashboard advised DOWNGRADING
-// Opus 5 agents to 4.8 (measured on the live endpoint: 6 of 10 agents, 5 of
-// them running Opus 5) -- a customer-facing surface the migration missed.
+// Opus 5 agents to 4.8 (measured on the live endpoint before the fix: 8 of 10
+// agents were suggested 4.8, 7 of them with changeAdvised, 5 of those running
+// Opus 5; after: 0 of 10) -- a customer-facing surface the migration missed.
 // [1m] everywhere, not a split: a second plain-opus literal would be the next
 // forgotten drift seed, a context-threshold split would make suggestions flap
 // around the boundary, and this module's own cost table prices the variants


### PR DESCRIPTION
A shippelt kommentek '6 of 10'-et allitottak -- kezi osszeadasi hiba, amit mindketten tovabbvittunk (Marveen 9232 korrekcioja). A MERT szamok (a mentett 08:29-es ELOTTE-snapshot ES Marveen fuggetlen pre-pull futasa alapjan, egyezoen): **8/10 agens kapott 4.8-javaslatot, 7 changeAdvised-del, kozuluk 5 futott Opus 5-on; a fix utan: 0/10.** Csak komment-szoveg valtozik, kod nem. 29/29 zold.

VEGLEGES FEJ (erre tobbet nem tolok): a commit SHA-t az inter-agent uzenetben deklaralom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)