### PR TITLE
fix(respawn): every respawn path resolves the main model through the one three-layer resolver (RESPAWNMODEL807)

### DIFF
--- a/scripts/channel-watchdog.sh
+++ b/scripts/channel-watchdog.sh
@@ -166,10 +166,13 @@ if [ "$count" -ge "$MAX_CONSECUTIVE" ]; then
 fi
 
 # --- recover: respawn-pane ONLY the channels session, fresh claude ---
-MAIN_MODEL=""
-if [ -f "$INSTALL_DIR/.claude/settings.json" ] && command -v jq >/dev/null 2>&1; then
-  MAIN_MODEL="$(jq -r '.model // empty' "$INSTALL_DIR/.claude/settings.json" 2>/dev/null)"
-fi
+# RESPAWNMODEL807: this used to read ONLY .claude/settings.json with jq -- a
+# second copy of the model resolution that missed BOTH the .env override (the
+# documented per-install route) and the shipped distribution default. The day
+# the shipped settings.json stopped pinning a model (#924), this path started
+# building a flag-less respawn. One resolver exists and the launch path already
+# uses it; ask IT instead of maintaining another copy.
+MAIN_MODEL="$(bash "$INSTALL_DIR/scripts/channels.sh" --resolve-main-model 2>/dev/null | head -1)"
 MODEL_FLAG=""
 [ -n "$MAIN_MODEL" ] && MODEL_FLAG="--model '$MAIN_MODEL' "
 

--- a/scripts/stuck-modal-guard.sh
+++ b/scripts/stuck-modal-guard.sh
@@ -238,9 +238,11 @@ run_guard() {
   fi
 
   local MAIN_MODEL="" MODEL_FLAG="" CLAUDE_Q
-  if [ -f "$INSTALL_DIR/.claude/settings.json" ] && command -v jq >/dev/null 2>&1; then
-    MAIN_MODEL="$(jq -r '.model // empty' "$INSTALL_DIR/.claude/settings.json" 2>/dev/null)"
-  fi
+  # RESPAWNMODEL807: ask the ONE resolver (all three layers: .env override >
+  # settings.json > shipped distribution default) instead of keeping a fourth
+  # jq-only copy that missed two of them and went flag-less the day the shipped
+  # settings.json stopped pinning a model (#924).
+  MAIN_MODEL="$(bash "$INSTALL_DIR/scripts/channels.sh" --resolve-main-model 2>/dev/null | head -1)"
   # W1: sanitize the model id before interpolating it into the respawn shell
   # string (defense in depth -- settings.json is local config). Preserves the
   # "[1m]" context suffix while stripping shell metacharacters.

--- a/src/__tests__/main-model-env-precedence.test.ts
+++ b/src/__tests__/main-model-env-precedence.test.ts
@@ -26,6 +26,7 @@ import { tmpdir } from 'node:os'
 import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
 import { readConfiguredMainModel, readExtraChannelPluginIds } from '../web/channel-monitor.js'
+import { DISTRIBUTION_DEFAULT_AGENT_MODEL } from '../config-registry.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
@@ -76,10 +77,15 @@ describe('readConfiguredMainModel', () => {
     expect(readConfiguredMainModel(root)).toBe('claude-opus-5')
   })
 
-  it('returns empty string when neither source names a model', () => {
+  it('falls back to the shipped distribution default when neither source names a model (RESPAWNMODEL807)', () => {
+    // The old contract here was '' -- and '' meant every respawn call site
+    // silently dropped --model the day the shipped settings.json stopped
+    // pinning one (#924). Measured live on hermes: bare `claude`, actual
+    // model claude-sonnet-4-6. The resolver now lands on the same third
+    // layer as the launch path.
     writeEnv('MAIN_AGENT_MODEL_SOMETHINGELSE=x\n')
     writeSettings({ enabledPlugins: {} })
-    expect(readConfiguredMainModel(root)).toBe('')
+    expect(readConfiguredMainModel(root)).toBe(DISTRIBUTION_DEFAULT_AGENT_MODEL)
   })
 
   it('survives an unparseable settings.json', () => {

--- a/src/__tests__/main-model-resolution-parity.test.ts
+++ b/src/__tests__/main-model-resolution-parity.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from 'node:os'
 import { fileURLToPath } from 'node:url'
 
 import { readConfiguredMainModel } from '../web/channel-monitor.js'
+import { DISTRIBUTION_DEFAULT_AGENT_MODEL } from '../config-registry.js'
 
 // The main agent's model is resolved by TWO independent implementations:
 //
@@ -47,6 +48,13 @@ function fixture(envBody: string | null, settingsBody: string | null): string {
   mkdirSync(join(root, 'scripts'), { recursive: true })
   mkdirSync(join(root, '.claude'), { recursive: true })
   copyFileSync(CHANNELS_SH, join(root, 'scripts', 'channels.sh'))
+  // RESPAWNMODEL807: a real install always has a BUILT dist/config-registry.js
+  // (the launch path's third layer reads it with node). The fixture ships the
+  // SAME constant the TS side compiled in, so parity is measured over all
+  // three layers, exactly like production.
+  mkdirSync(join(root, 'dist'), { recursive: true })
+  writeFileSync(join(root, 'dist', 'config-registry.js'),
+    `exports.DISTRIBUTION_DEFAULT_AGENT_MODEL = ${JSON.stringify(DISTRIBUTION_DEFAULT_AGENT_MODEL)};\n`)
   if (envBody !== null) writeFileSync(join(root, '.env'), envBody + '\n')
   if (settingsBody !== null) writeFileSync(join(root, '.claude', 'settings.json'), settingsBody + '\n')
   return root
@@ -68,13 +76,17 @@ const CASES: Array<[string, string | null, string | null, string]> = [
   // drift was found: .env said opus-5, the tracked file said opus-4-8[1m].
   ['.env wins over settings.json (the whole point)', 'MAIN_AGENT_MODEL=claude-opus-5', '{"model":"claude-opus-4-8[1m]"}', 'claude-opus-5'],
   ['.env alone works with no settings.json', 'MAIN_AGENT_MODEL=claude-sonnet-5', null, 'claude-sonnet-5'],
-  ['neither present -> empty, so the launcher omits --model', null, null, ''],
+  // RESPAWNMODEL807: 'neither present' no longer means flag-less -- BOTH paths
+  // land on the shipped distribution default (the third layer). The '' era is
+  // exactly what let a respawn drop --model the day the shipped settings.json
+  // stopped pinning a model.
+  ['neither present -> the shipped distribution default', null, null, DISTRIBUTION_DEFAULT_AGENT_MODEL],
   ['an EMPTY MAIN_AGENT_MODEL does not shadow settings.json', 'MAIN_AGENT_MODEL=', '{"model":"claude-opus-5"}', 'claude-opus-5'],
   // `[1m]` must survive intact: it is a glob in shell and would silently vanish
   // if either side let a bare word through an unquoted expansion.
   ['a bracketed 1M suffix survives the .env route', 'MAIN_AGENT_MODEL=claude-opus-4-8[1m]', null, 'claude-opus-4-8[1m]'],
   ['a similarly named key does not leak in', 'NOT_MAIN_AGENT_MODEL=wrong-model', '{"model":"claude-opus-5"}', 'claude-opus-5'],
-  ['settings.json without a model key falls back to empty', null, '{"enabledPlugins":{}}', ''],
+  ['settings.json without a model key falls back to the distribution default', null, '{"enabledPlugins":{}}', DISTRIBUTION_DEFAULT_AGENT_MODEL],
 ]
 
 describe('main-agent model resolution: launch and respawn agree', () => {
@@ -105,5 +117,46 @@ describe('the respawn path reads .env at all (guards the 2026-08-03 defect direc
     const root = fixture(null, '{"model":"claude-opus-5"}')
     mkdirSync(join(root, '.env')) // a directory where a file is expected
     expect(readConfiguredMainModel(root)).toBe('claude-opus-5')
+  })
+})
+
+
+// RESPAWNMODEL807 structural locks: four copies of the model resolution
+// existed and three went stale. Lock every respawn path onto the ONE resolver
+// so a fifth copy (or a revived jq-only read) fails loudly here.
+import { readFileSync as _rf } from 'node:fs'
+describe('every respawn path asks the one resolver (RESPAWNMODEL807)', () => {
+  it('channel-watchdog.sh calls --resolve-main-model and carries no jq-only model read', () => {
+    const src = _rf(join(REPO_ROOT, 'scripts', 'channel-watchdog.sh'), 'utf-8')
+    expect(src).toContain('--resolve-main-model')
+    expect(src).not.toMatch(/jq -r '\.model/)
+  })
+
+  it('stuck-modal-guard.sh calls --resolve-main-model and carries no jq-only model read', () => {
+    const src = _rf(join(REPO_ROOT, 'scripts', 'stuck-modal-guard.sh'), 'utf-8')
+    expect(src).toContain('--resolve-main-model')
+    expect(src).not.toMatch(/jq -r '\.model/)
+  })
+
+  it('every buildMainSessionRespawnCmd call site passes model: readConfiguredMainModel()', () => {
+    const src = _rf(join(REPO_ROOT, 'src', 'web', 'channel-monitor.ts'), 'utf-8')
+    // CALL sites only: `= buildMainSessionRespawnCmd({` -- the bare-substring
+    // count also caught the definition and a comment mention (measured: 4 vs
+    // 3 real calls at 714/784/997) and would drift with prose edits.
+    const sites = src.split('= buildMainSessionRespawnCmd({').length - 1
+    const wired = src.split('model: readConfiguredMainModel()').length - 1
+    expect(sites).toBeGreaterThanOrEqual(3)
+    expect(wired).toBe(sites)
+  })
+
+  it('readConfiguredMainModel never returns empty while a distribution default exists', () => {
+    const root = fixture(null, null)
+    expect(readConfiguredMainModel(root)).toBe(DISTRIBUTION_DEFAULT_AGENT_MODEL)
+  })
+
+  it('NEGATIVE CONTROL: a per-install .env choice beats the distribution default on the respawn path', () => {
+    const root = fixture('MAIN_AGENT_MODEL=claude-sonnet-5', null)
+    expect(readConfiguredMainModel(root)).toBe('claude-sonnet-5')
+    expect(readConfiguredMainModel(root)).not.toBe(DISTRIBUTION_DEFAULT_AGENT_MODEL)
   })
 })

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -6,6 +6,7 @@ import { resolveFromPath } from '../platform.js'
 import { WEB_PORT } from '../config.js'
 import { logger } from '../logger.js'
 import { MAIN_AGENT_ID, SERVICE_ID, BOT_NAME, CHANNEL_PROVIDER, PROJECT_ROOT, RESPAWN_ENABLED } from '../config.js'
+import { DISTRIBUTION_DEFAULT_AGENT_MODEL } from '../config-registry.js'
 import { agentDir, listAgentNames, readAgentChannelProvider } from './agent-config.js'
 import {
   agentHasChannel,
@@ -565,18 +566,33 @@ function readEnvValue(projectRoot: string, key: string): string {
 // than the one it launched with -- below the operator's required floor, with no
 // dialog, no error and no log line. The launch path would keep saying the right
 // thing, which is exactly what makes it hard to see.
+//
+// RESPAWNMODEL807 (2026-08-07): the parity claim above went stale the day
+// MODELDRIFT807 removed the pinned model from the shipped settings.json. The
+// launch path had a THIRD layer (the shipped DISTRIBUTION_DEFAULT_AGENT_MODEL,
+// #918) -- this function did not, so on a clean install it started returning
+// '' and every respawn call site dropped the --model flag entirely. Measured
+// live on the hermes soak box: the respawned main session ran a bare `claude`
+// and the transcript showed claude-sonnet-4-6 -- neither the fleet default nor
+// any configured value, just the CLI's account-tier default. The fix mirrors
+// the launch path's final layer from the SAME single source (a TS import of
+// the constant the shell path reads out of dist/config-registry.js), so this
+// resolver can no longer return empty while a distribution default exists.
 export function readConfiguredMainModel(projectRoot: string = PROJECT_ROOT): string {
   const fromEnv = readEnvValue(projectRoot, 'MAIN_AGENT_MODEL')
   if (fromEnv) return fromEnv
   try {
     const settingsPath = join(projectRoot, '.claude', 'settings.json')
-    if (!existsSync(settingsPath)) return ''
-    const parsed = JSON.parse(readFileSync(settingsPath, 'utf-8'))
-    const model = parsed?.model
-    return typeof model === 'string' ? model.trim() : ''
+    if (existsSync(settingsPath)) {
+      const parsed = JSON.parse(readFileSync(settingsPath, 'utf-8'))
+      const model = parsed?.model
+      if (typeof model === 'string' && model.trim()) return model.trim()
+    }
   } catch {
-    return ''
+    // fall through to the distribution default -- an unreadable settings file
+    // must degrade the same way as a model-less one, never to a flag-less spawn
   }
+  return DISTRIBUTION_DEFAULT_AGENT_MODEL
 }
 
 // Secondary channel plugins the main session co-listens on, read from .env


### PR DESCRIPTION
## Mit javit (URGENT, a mai kiadas aktivalta + egy regebbi res)

NEGY masolata letezett a fo-agens modell-feloldasnak, es harom elavult aznap, amikor a #924 kivette a pinnelt modellt a szallitott settings.json-bol: a launch-ut (channels.sh) harmadik retege (DISTRIBUTION_DEFAULT_AGENT_MODEL) megvolt, a readConfiguredMainModel() (3 respawn-hivohely), a channel-watchdog.sh es a stuck-modal-guard.sh viszont ''-t adott -> FLAG NELKULI respawn. ELESBEN MERVE a hermesen: puszta `claude`, tenyleges modell claude-sonnet-4-6. A ket shell-ut raadasul a dokumentalt .env MAIN_AGENT_MODEL override-ot SEM olvasta (pre-existing, sulyosabb res).

## Valtozasok (Marveen 9266 (a) kikotese szerint: EGY forras, nem negyedik masolat)

1. **readConfiguredMainModel()**: harmadik reteg ugyanabbol az EGY forrasbol (TS-import a config-registry konstansra -- ugyanaz, amit a shell-ut a dist-bol olvas). Tobbe nem adhat ''-t; olvashatatlan settings.json is a defaultra degradal, sosem flag-nelkulire.
2. **watchdog + stuck-modal-guard**: a jq-only masolatok TOROLVE -- mindketto a `channels.sh --resolve-main-model` seamet hivja (a seam a .env-parse UTAN fut, forrasbol igazolva, tehat mindharom reteg el). A sanitize+%q hardening marad.
3. **Parity-fixture**: buildelt dist/config-registry.js-t szallit a valodi konstanssal -- a paritas mindharom retegen mert, mint elesben.
4. **Strukturalis lockok (9266 (c))**: a ket shell-script KOTELEZOEN tartalmazza a resolver-hivast es TILTOTTAN a jq-only olvasast; MINDEN buildMainSessionRespawnCmd hivohely model: readConfiguredMainModel()-t kot be; no-model fixture = default; NEGATIV kontroll: .env-valasztas veri a defaultot. (A hivohely-szamlalo elso mintaja a definiciot+kommentet is fogta -- 4 vs 3 valodi hivas -- pontositva.)

## Verify

3436/3436 teljes vitest (home-worktree), tsc tiszta, bash -n mindket scriptre. RED-CHECK ketiranyu: a TS-resolver visszavonasa 3, a ket shell-script visszavonasa 2 tesztet pirosit.

## Elo bizonyitek (9266 (b)) -- a merge UTAN esedekes

A hermes szandekosan a torott allapoton all (bare claude / sonnet-4-6) mint ELOTTE-oldal. A merge + soak-deploy utan ugyanott merem: respawn elott/utan ps-cmdline + transcript-JSONL modell, PLUSZ negativ kontroll (.env MAIN_AGENT_MODEL atmeneti beallitasaval, deklaralt vegallapottal). Az eredmeny kulon jelentesben.

🤖 Generated with [Claude Code](https://claude.com/claude-code)