### PR TITLE
fix(heartbeat): the hot-memory metric ships as a ready-made query, not prose (HBMEMBLIND807)

### DIFF
--- a/src/__tests__/heartbeat-agent-scaffold.test.ts
+++ b/src/__tests__/heartbeat-agent-scaffold.test.ts
@@ -207,3 +207,29 @@ describe('shouldBootHeartbeatAgent', () => {
     expect(shouldBootHeartbeatAgent({ respawnEnabled: false, agentEnabled: false })).toBe(false)
   })
 })
+
+// HBMEMBLIND807: the hot-memory metric must ship as a READY-MADE query, the
+// way task_runs does -- a prose-only bullet let the heartbeat agent compose
+// its own SQL and report 0 with three hot memories in the window. Lock the
+// contract: the exact query, the SECONDS cutoff (no ms multiplier -- that is
+// the task_runs unit, not this one), and the do-not-rewrite instruction.
+describe('hot-memory metric is a ready-made query (HBMEMBLIND807)', () => {
+  it('ships the exact scoped count query', () => {
+    const out = renderHeartbeatClaudeMd(ID)
+    expect(out).toContain("SELECT COUNT(*) FROM memories")
+    expect(out).toContain(`agent_id='${ID.mainAgentId}'`)
+    expect(out).toContain("category='hot'")
+    expect(out).toContain('created_at > unixepoch()-3600')
+  })
+
+  it('the memory cutoff carries NO millisecond multiplier', () => {
+    const out = renderHeartbeatClaudeMd(ID)
+    const memBullet = out.slice(out.indexOf('Memory + system'))
+    expect(memBullet.slice(0, 1200)).not.toContain("(unixepoch()-3600)*1000")
+  })
+
+  it('tells the agent to report the number, not to rewrite the query', () => {
+    const out = renderHeartbeatClaudeMd(ID)
+    expect(out).toContain('do not rewrite the query')
+  })
+})

--- a/src/web/heartbeat-agent-scaffold.ts
+++ b/src/web/heartbeat-agent-scaffold.ts
@@ -230,9 +230,23 @@ When you receive the heartbeat prompt:
      the whole table:
      \`sqlite3 ${id.storeDir}/claudeclaw.db "SELECT status, COUNT(*) FROM
      task_runs WHERE ts > (unixepoch()-3600)*1000 GROUP BY status"\`.
-   - **Memory + system** -- DB file size, any \`category='hot'\`
-     memories newer than 1 hour, plus presence of any
-     \`status='warning'\` entries in the memory log.
+   - **Memory + system** -- DB file size, new hot memories, warning
+     entries. HBMEMBLIND807: the hot-memory count is a READY-MADE query,
+     exactly like task_runs above -- when this bullet was prose only, the
+     heartbeat agent composed its own SQL and reported 0 while three hot
+     memories sat in the window (measured 2026-08-07 09:00, ids
+     2442-2444). A metric line that can silently read 0 is worse than no
+     line: real change looks identical to silence. NOTE the unit
+     difference from task_runs: \`memories.created_at\` is SECONDS, so
+     the cutoff is \`unixepoch()-3600\` with NO millisecond multiplier:
+
+     \`\`\`bash
+     sqlite3 ${id.storeDir}/claudeclaw.db "SELECT COUNT(*) FROM memories \\
+       WHERE agent_id='${id.mainAgentId}' AND category='hot' \\
+       AND created_at > unixepoch()-3600"
+     \`\`\`
+
+     Report the number this query returns -- do not rewrite the query.
 
 2. **Format** the result as a single inter-agent message:
 


### PR DESCRIPTION
## Mit javit

A scaffold a task_runs-hoz KESZ sqlite-parancsot ad (ms-cutoff buktatoval egyutt), a hot-memoria szamlalot viszont CSAK PROZABAN kerte -- a Haiku heartbeat-agens maga fogalmazta a lekerdezest es elrontotta: 'new hot memories (1h): 0' mikozben harom hot memoria ult az ablakban (elesben merve 09:00, id 2442-2444). A 10:00-as kor aztan VALODI 0-t jelentett -- pont ezert rosszabb egy nema-hibas metrika a semminel: a valodi valtozas ugyanugy nez ki, mint a csend.

## Valtozas

A bullet mostantol a PONTOS, scope-olt lekerdezest szallitja (agent_id + category='hot' + MASODPERCES cutoff -- kimondottan szembeallitva a szomszedos task_runs ms-egysegevel, hogy a minta at ne verodjon), es utasitja az agenst: a szamot jelentse, a lekerdezest ne irja at.

## Verify

Kontrakt-tesztek zaroljak a query-alakot, az egyseget es a ne-ird-at sort. 28/28, tsc tiszta, red-check 2 piros a scaffold-valtozas visszavonasara. **ELO bizonyitek a deploy utan** (a kartya repro-utmutatoja szerint): egy hot memoria seedelese az ablakban + a kovetkezo heartbeat-kor >=1-et kell jelentsen -- egy nulla-hot-memorias 'helyes' kor NEM cafolat.

## Terjedes

A scaffold a dashboard-boot ensureHeartbeatAgent lepeseben irodik ujra -- a host kovetkezo update+restart-ja utan el; a futo heartbeat-agens a friss CLAUDE.md-t a kovetkezo korében olvassa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)