### PR TITLE
fix(heartbeat): remove the unfalsifiable warnings metric (HBWARN807)

### DIFF
--- a/src/__tests__/heartbeat-agent-scaffold.test.ts
+++ b/src/__tests__/heartbeat-agent-scaffold.test.ts
@@ -233,3 +233,41 @@ describe('hot-memory metric is a ready-made query (HBMEMBLIND807)', () => {
     expect(out).toContain('do not rewrite the query')
   })
 })
+
+// HBWARN807: the warnings metric was unfalsifiable -- it pointed at a source
+// that does not exist (no status column on memories, no such log table), so
+// it could only ever render 'none'. It was removed. This contract stops it
+// from creeping back WITHOUT a real, ready-made query behind it.
+describe('no unfalsifiable warnings metric (HBWARN807)', () => {
+  it('the report format has no bare "warnings:" output line', () => {
+    const out = renderHeartbeatClaudeMd(ID)
+    // The removed line was `- warnings: <none | comma-separated>`. Any warnings
+    // OUTPUT line must be backed by a query; a bare template line is the defect.
+    expect(out).not.toMatch(/^\s*-\s*warnings:/m)
+  })
+
+  it('mentions status=warning only inside the guard comment, never in a query block', () => {
+    const out = renderHeartbeatClaudeMd(ID)
+    // The string may appear once, in the HBWARN807 explanation naming the dead
+    // source. It must NOT appear inside a ```-fenced block (i.e. as a query the
+    // agent is told to run).
+    const fences = out.split('```')
+    for (let i = 1; i < fences.length; i += 2) {
+      expect(fences[i]).not.toContain("status='warning'")
+    }
+    // And it never appears as an actual sqlite invocation anywhere.
+    expect(out).not.toMatch(/sqlite3[^\n]*status='warning'/)
+  })
+
+  it('if warnings is mentioned at all, it is only the guard comment demanding a real query', () => {
+    const out = renderHeartbeatClaudeMd(ID)
+    // Every surviving "warning" mention must sit in the HBWARN807 explanation,
+    // never as a metric the agent is told to emit. Proxy: no "warning" line
+    // appears inside a ```-fenced report template block.
+    const fences = out.split('```')
+    // odd indices are inside fenced blocks
+    for (let i = 1; i < fences.length; i += 2) {
+      expect(fences[i].toLowerCase()).not.toContain('warning')
+    }
+  })
+})

--- a/src/web/heartbeat-agent-scaffold.ts
+++ b/src/web/heartbeat-agent-scaffold.ts
@@ -230,8 +230,16 @@ When you receive the heartbeat prompt:
      the whole table:
      \`sqlite3 ${id.storeDir}/claudeclaw.db "SELECT status, COUNT(*) FROM
      task_runs WHERE ts > (unixepoch()-3600)*1000 GROUP BY status"\`.
-   - **Memory + system** -- DB file size, new hot memories, warning
-     entries. HBMEMBLIND807: the hot-memory count is a READY-MADE query,
+   - **Memory + system** -- DB file size and new hot memories.
+     HBWARN807: there is NO warnings metric here on purpose. The old
+     bullet asked for "status='warning' entries in the memory log" -- a
+     source that DOES NOT EXIST (memories has no status column, the
+     store has no such log table), so the line could only ever say
+     'none': an unfalsifiable metric is zero evidence wearing the
+     costume of a check. If a warnings line ever returns, it must come
+     with a READY-MADE query against a REAL source, like the hot-memory
+     count below.
+     HBMEMBLIND807: the hot-memory count is a READY-MADE query,
      exactly like task_runs above -- when this bullet was prose only, the
      heartbeat agent composed its own SQL and reported 0 while three hot
      memories sat in the window (measured 2026-08-07 09:00, ids
@@ -271,18 +279,14 @@ When you receive the heartbeat prompt:
    ### Memory / system
    - DB size: <X> MB
    - new hot memories (1h): <N>
-   - warnings: <none | comma-separated>
    \`\`\`
 
    Every line above is a MEASUREMENT of this round, never a memory of
    an earlier one. Run the queries again and report what they return
    now, even when you are sure nothing changed -- especially then.
-   A warning belongs on that last line only if THIS round's query
-   still returns it: a card that has since become \`done\` or archived
-   drops off, and so does a deadline that has been closed. Carrying
-   one over makes the line constant, and a line that always says the
-   same thing stops being read -- at which point a real warning looks
-   exactly like the two dead ones next to it.
+   A value carried over from an earlier round makes its line constant,
+   and a line that always says the same thing stops being read -- at
+   which point a real change looks exactly like the noise around it.
 
 3. **Send** that string to the main agent via the dashboard API:
 
@@ -313,11 +317,11 @@ When you receive the heartbeat prompt:
   not.
 - **NEVER** copy a value from an earlier round's report, and never
   fill a field from what you remember saying last time. Every number,
-  title, timestamp and warning comes from a query you ran in THIS
+  title and timestamp comes from a query you ran in THIS
   round. If a query fails, say it failed -- do not substitute the
   previous answer, because a stale value is indistinguishable from a
   fresh one once it is in the message.
-  This applies to the whole report, not only to \`warnings\`: the
+  This applies to the whole report: the
   urgent titles, the task counts, \`next:\`, the DB size and the
   one-hour hot-memory count are all measurements with a timestamp,
   and every one of them is wrong the moment it is reused.


### PR DESCRIPTION
## Mit javit (Marveen dontese, 9366)

A 'warnings: none' sor NEM LETEZO forrasra mutatott: status='warning' bejegyzeseket kert egy 'memory log'-bol, de a memories tablanak nincs status oszlopa es a store-ban nincs ilyen tabla (merve: pragma + a *_log tablak vegignezese). A sor igy STRUKTURALISAN csak 'none'-t tudott mondani -- nulla bizonyitek egy ellenorzes jelmezeben, ami elfoglalja az olvaso figyelmet azzal a hamis igerettel, hogy valaki figyeli a warningokat. Rosszabb, mint ha ott sem lenne.

## Valtozas

A sor torolve a format-sablonbol, az intro-bulletbol es a frissessegi bekezdesbol (annak tanulsaga -- sose vigyél at erteket korok kozott -- megmarad, csak mar nem a warnings-peldan log). Egy guard-komment megnevezi a halott forrast, hogy egy kesobbi szerkesztes ne tudja visszatenni a sort VALODI, kesz lekerdezes nelkul -- ugyanugy, ahogy a hot-szamlalonak most van.

Valos warning-jelzes kesobb (credentials-guard log, dashboard.error.log) UJ feature, sajat szandekkal es sajat kesz lekerdezessel -- nem feltamasztott proza-bullet.

## Verify

Kontrakt-tesztek: nincs csupasz 'warnings:' kimeneti sor; status='warning' soha fenced/query-blokkban; egyetlen report-sablon-fence sem tartalmaz 'warning'-ot. 31/31, tsc tiszta, red-check 2 piros a scaffold visszavonasara. Workspace-checkoutbol futtatva.

## Terjedes

A scaffold a dashboard-boot ensureHeartbeatAgent lepeseben irodik ujra -- a HBMEMBLIND807 (#933) live-proofjaval EGY host-restartban ellenorizheto vissza mindketto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)