### PR TITLE
fix(stuck-modal-guard): add 'limited' state for session quota exhaustion

### DIFF
--- a/scripts/__tests__/stuck-modal-guard.test.sh
+++ b/scripts/__tests__/stuck-modal-guard.test.sh
@@ -140,10 +140,10 @@ Some scrollback text here.
 assert_eq "B3 regression: limit text + idle footer -> idle (not limited)" "idle" "$(classify "$LIMIT_WITH_IDLE")"
 
 # ---------------------------------------------------------------------------
-# (h) parse-reset-epoch: extracts reset time from pane text
+# (h) parse-reset-epoch and is-overdue (B5: midnight-rollover guard)
 # ---------------------------------------------------------------------------
 echo ""
-echo "(h) parse-reset-epoch"
+echo "(h) parse-reset-epoch / is-overdue (midnight-rollover guard)"
 
 # Parseable format ("resets 5:50pm") -> non-empty epoch
 PR_RESULT="$(bash "$GUARD" parse-reset-epoch "You hit your session limit · resets 5:50pm")"
@@ -158,6 +158,29 @@ assert_eq "parse-reset-epoch: no reset time -> empty" "" "$PR_EMPTY"
 
 PR_JUNK="$(bash "$GUARD" parse-reset-epoch "junk pane with no time")"
 assert_eq "parse-reset-epoch: junk pane -> empty" "" "$PR_JUNK"
+
+# B5 regression: "resets 1am" observed at 19:00 must NOT be overdue.
+# date -d "1am" always returns today's 01:00, which is 18h in the past.
+# Without the rollover fix this would produce overdue=1 (false escalation).
+RESET_EP_1AM="$(bash "$GUARD" parse-reset-epoch "You hit your session limit · resets 1am")"
+ANCHOR_1900="$(date -d "19:00 today" +%s 2>/dev/null || date -d "today 19:00" +%s)"
+NOW_1929="$(date -d "19:29 today" +%s 2>/dev/null || date -d "today 19:29" +%s)"
+assert_eq "B5: 'resets 1am' at 19:29 with 19:00 anchor -> NOT overdue (rollover guard)" \
+  "0" "$(bash "$GUARD" is-overdue "$RESET_EP_1AM" "$ANCHOR_1900" "$NOW_1929")"
+
+# Normal overdue: "resets 5:50pm", first detection 16:00, now 19:00 -> overdue.
+RESET_EP_550="$(bash "$GUARD" parse-reset-epoch "You hit your session limit · resets 5:50pm")"
+ANCHOR_1600="$(date -d "16:00 today" +%s 2>/dev/null || date -d "today 16:00" +%s)"
+NOW_1900="$(date -d "19:00 today" +%s 2>/dev/null || date -d "today 19:00" +%s)"
+assert_eq "B5: 'resets 5:50pm' at 19:00 with 16:00 anchor -> overdue" \
+  "1" "$(bash "$GUARD" is-overdue "$RESET_EP_550" "$ANCHOR_1600" "$NOW_1900")"
+
+# Not yet overdue: reset is in the future.
+RESET_EP_550_FUTURE="$(bash "$GUARD" parse-reset-epoch "resets 5:50pm")"
+ANCHOR_1530="$(date -d "15:30 today" +%s 2>/dev/null || date -d "today 15:30" +%s)"
+NOW_1540="$(date -d "15:40 today" +%s 2>/dev/null || date -d "today 15:40" +%s)"
+assert_eq "B5: 'resets 5:50pm' at 15:40 -> not yet overdue" \
+  "0" "$(bash "$GUARD" is-overdue "$RESET_EP_550_FUTURE" "$ANCHOR_1530" "$NOW_1540")"
 
 # ---------------------------------------------------------------------------
 # (f) F1 — a missing state dir is created (no flock defer-forever, cold install)

--- a/scripts/__tests__/stuck-modal-guard.test.sh
+++ b/scripts/__tests__/stuck-modal-guard.test.sh
@@ -182,6 +182,20 @@ NOW_1540="$(date -d "15:40 today" +%s 2>/dev/null || date -d "today 15:40" +%s)"
 assert_eq "B5: 'resets 5:50pm' at 15:40 -> not yet overdue" \
   "0" "$(bash "$GUARD" is-overdue "$RESET_EP_550_FUTURE" "$ANCHOR_1530" "$NOW_1540")"
 
+# B6 regression: leading-zero minutes and hours must not trigger octal parse error.
+# bash treats 08/09 as invalid octal in $(( )) without explicit 10# prefix.
+PR_908PM="$(bash "$GUARD" parse-reset-epoch "resets 9:08pm")"
+case "$PR_908PM" in
+  ''|*[!0-9]*) fail "B6: 'resets 9:08pm' (leading-zero minute) returned empty/non-numeric: '$PR_908PM'" ;;
+  *) pass "B6: 'resets 9:08pm' leading-zero minute -> numeric epoch '$PR_908PM'" ;;
+esac
+
+PR_0830PM="$(bash "$GUARD" parse-reset-epoch "resets 08:30pm")"
+case "$PR_0830PM" in
+  ''|*[!0-9]*) fail "B6: 'resets 08:30pm' (leading-zero hour) returned empty/non-numeric: '$PR_0830PM'" ;;
+  *) pass "B6: 'resets 08:30pm' leading-zero hour -> numeric epoch '$PR_0830PM'" ;;
+esac
+
 # ---------------------------------------------------------------------------
 # (i) Portability: BSD fallback paths for parse-reset-epoch and stat-mtime
 # ---------------------------------------------------------------------------

--- a/scripts/__tests__/stuck-modal-guard.test.sh
+++ b/scripts/__tests__/stuck-modal-guard.test.sh
@@ -183,6 +183,62 @@ assert_eq "B5: 'resets 5:50pm' at 15:40 -> not yet overdue" \
   "0" "$(bash "$GUARD" is-overdue "$RESET_EP_550_FUTURE" "$ANCHOR_1530" "$NOW_1540")"
 
 # ---------------------------------------------------------------------------
+# (i) Portability: BSD fallback paths for parse-reset-epoch and stat-mtime
+# ---------------------------------------------------------------------------
+echo ""
+echo "(i) Portability: BSD fallback paths"
+
+FAKE_BIN="$(mktemp -d)"
+cleanup_fake_bin() { rm -rf "$FAKE_BIN"; }
+trap cleanup_fake_bin EXIT
+
+# parse-reset-epoch must NOT use 'date -d' at all after the portability fix.
+# Verify by placing a fake 'date' that fails on any -d invocation.
+cat > "$FAKE_BIN/date" << 'FAKE_DATE'
+#!/bin/sh
+# Mock BSD date: rejects any -d flag (GNU-only option)
+for arg; do
+  case "$arg" in -d) echo "date: illegal option -- d" >&2; exit 1 ;; esac
+done
+exec /usr/bin/date "$@"
+FAKE_DATE
+chmod +x "$FAKE_BIN/date"
+
+PR_BSD="$(PATH="$FAKE_BIN:$PATH" bash "$GUARD" parse-reset-epoch "resets 5:50pm")"
+case "$PR_BSD" in
+  ''|*[!0-9]*) fail "parse-reset-epoch: BSD (no date -d) returned empty/non-numeric: '$PR_BSD'" ;;
+  *) pass "parse-reset-epoch: works without GNU 'date -d' (BSD path)" ;;
+esac
+
+PR_BSD_EMPTY="$(PATH="$FAKE_BIN:$PATH" bash "$GUARD" parse-reset-epoch "no reset string")"
+assert_eq "parse-reset-epoch: BSD path, no reset string -> empty" "" "$PR_BSD_EMPTY"
+
+# stat-mtime: primary path (native stat, whichever dialect the host has)
+TMPFILE_I="$(mktemp)"
+MTIME_NATIVE="$(stat -c %Y "$TMPFILE_I" 2>/dev/null || stat -f %m "$TMPFILE_I" 2>/dev/null)"
+MTIME_GUARD="$(bash "$GUARD" stat-mtime "$TMPFILE_I")"
+assert_eq "stat-mtime: native dialect returns correct mtime" "$MTIME_NATIVE" "$MTIME_GUARD"
+
+# stat-mtime: python3 fallback when both GNU and BSD stat fail.
+# On Linux 'stat -f' means filesystem info (not BSD format), so we cannot
+# mock the BSD dialect by forwarding -- instead block ALL stat and let the
+# python3 fallback handle it.
+cat > "$FAKE_BIN/stat" << 'FAKE_STAT'
+#!/bin/sh
+# Mock: both GNU (-c) and BSD (-f %m) unavailable; python3 fallback must fire
+echo "stat: not available in this environment" >&2
+exit 1
+FAKE_STAT
+chmod +x "$FAKE_BIN/stat"
+
+MTIME_PY="$(PATH="$FAKE_BIN:$PATH" bash "$GUARD" stat-mtime "$TMPFILE_I")"
+assert_eq "stat-mtime: python3 fallback when both stat dialects fail" "$MTIME_NATIVE" "$MTIME_PY"
+rm -f "$TMPFILE_I"
+
+trap - EXIT
+rm -rf "$FAKE_BIN"
+
+# ---------------------------------------------------------------------------
 # (f) F1 — a missing state dir is created (no flock defer-forever, cold install)
 # ---------------------------------------------------------------------------
 echo ""

--- a/scripts/__tests__/stuck-modal-guard.test.sh
+++ b/scripts/__tests__/stuck-modal-guard.test.sh
@@ -132,6 +132,33 @@ assert_eq "limited: '5-hour limit reached' banner" "limited" "$(classify "$LIMIT
 assert_eq "decide: limited -> hold (no Escape, no respawn)" "hold" "$(decide limited 0 1000)"
 assert_eq "decide: limited -> hold even when firstseen is set" "hold" "$(decide limited 800 1000)"
 
+# B3 regression: limit text in scrollback but idle footer also present -> idle wins.
+# The guard must NEVER send Escape/respawn against a live session.
+LIMIT_WITH_IDLE='You hit your session limit · resets 5:50pm
+Some scrollback text here.
+                                                      ⏵⏵ bypass permissions on (shift+tab to cycle)'
+assert_eq "B3 regression: limit text + idle footer -> idle (not limited)" "idle" "$(classify "$LIMIT_WITH_IDLE")"
+
+# ---------------------------------------------------------------------------
+# (h) parse-reset-epoch: extracts reset time from pane text
+# ---------------------------------------------------------------------------
+echo ""
+echo "(h) parse-reset-epoch"
+
+# Parseable format ("resets 5:50pm") -> non-empty epoch
+PR_RESULT="$(bash "$GUARD" parse-reset-epoch "You hit your session limit · resets 5:50pm")"
+case "$PR_RESULT" in
+  ''|*[!0-9]*) fail "parse-reset-epoch: parseable input returned empty or non-numeric: '$PR_RESULT'" ;;
+  *) pass "parse-reset-epoch: parseable 'resets 5:50pm' -> epoch '$PR_RESULT'" ;;
+esac
+
+# Unparseable / no reset string -> empty
+PR_EMPTY="$(bash "$GUARD" parse-reset-epoch "You hit your session limit")"
+assert_eq "parse-reset-epoch: no reset time -> empty" "" "$PR_EMPTY"
+
+PR_JUNK="$(bash "$GUARD" parse-reset-epoch "junk pane with no time")"
+assert_eq "parse-reset-epoch: junk pane -> empty" "" "$PR_JUNK"
+
 # ---------------------------------------------------------------------------
 # (f) F1 — a missing state dir is created (no flock defer-forever, cold install)
 # ---------------------------------------------------------------------------

--- a/scripts/__tests__/stuck-modal-guard.test.sh
+++ b/scripts/__tests__/stuck-modal-guard.test.sh
@@ -113,6 +113,26 @@ case "$SAN" in
 esac
 
 # ---------------------------------------------------------------------------
+# (g) Classifier: session usage-limit banner -> limited (NOT stuck/idle)
+# ---------------------------------------------------------------------------
+echo ""
+echo "(g) Session usage-limit pane is 'limited' (not stuck, never Escape/respawn)"
+
+# Exact text observed by bigme on 2026-08-08.
+LIMIT_OBSERVED='You hit your session limit · resets 5:50pm
+
+> Start new session'
+assert_eq "limited: observed 'hit your session limit' banner" "limited" "$(classify "$LIMIT_OBSERVED")"
+
+# Canonical 5-hour variant from src/model-fallback.ts USAGE_LIMIT_RX.
+LIMIT_5H='5-hour limit reached ∙ resets 3pm'
+assert_eq "limited: '5-hour limit reached' banner" "limited" "$(classify "$LIMIT_5H")"
+
+# decide: limited -> hold (NEVER start-confirm/act; Escape and respawn must not fire)
+assert_eq "decide: limited -> hold (no Escape, no respawn)" "hold" "$(decide limited 0 1000)"
+assert_eq "decide: limited -> hold even when firstseen is set" "hold" "$(decide limited 800 1000)"
+
+# ---------------------------------------------------------------------------
 # (f) F1 — a missing state dir is created (no flock defer-forever, cold install)
 # ---------------------------------------------------------------------------
 echo ""

--- a/scripts/stuck-modal-guard.sh
+++ b/scripts/stuck-modal-guard.sh
@@ -185,8 +185,8 @@ parse_reset_epoch() {
     hour="$digits"; min=0
   fi
   case "$ampm" in
-    pm) [ "$hour" -ne 12 ] 2>/dev/null && hour=$(( hour + 12 )) ;;
-    am) [ "$hour" -eq 12 ] 2>/dev/null && hour=0 ;;
+    pm) [ $(( 10#$hour )) -ne 12 ] 2>/dev/null && hour=$(( 10#$hour + 12 )) ;;
+    am) [ $(( 10#$hour )) -eq 12 ] 2>/dev/null && hour=0 ;;
   esac
   if ! [ "${hour:-x}" -ge 0 ] 2>/dev/null || ! [ "$hour" -le 23 ] 2>/dev/null \
      || ! [ "${min:-x}" -ge 0 ] 2>/dev/null || ! [ "$min"  -le 59 ] 2>/dev/null; then
@@ -198,7 +198,7 @@ parse_reset_epoch() {
   now="$(date +%s)"
   cur_h="$(date +%H)"; cur_m="$(date +%M)"; cur_s="$(date +%S)"
   midnight_ep=$(( now - 10#$cur_h * 3600 - 10#$cur_m * 60 - 10#$cur_s ))
-  echo $(( midnight_ep + hour * 3600 + min * 60 ))
+  echo $(( midnight_ep + 10#$hour * 3600 + 10#$min * 60 ))
 }
 
 # --- overdue check (pure, testable) -------------------------------------------
@@ -316,7 +316,7 @@ run_guard() {
     # Anchor: time of first limit detection (stamp mtime), or now on first tick.
     anchor="$now"
     [ -f "$LIMIT_ALERTED_STAMP" ] && {
-      local fs; fs="$(stat -c %Y "$LIMIT_ALERTED_STAMP" 2>/dev/null || echo 0)"
+      local fs; fs="$(stat_mtime "$LIMIT_ALERTED_STAMP")"
       [ "$fs" -gt 0 ] && anchor="$fs"
     }
     if [ -n "$reset_ep" ]; then

--- a/scripts/stuck-modal-guard.sh
+++ b/scripts/stuck-modal-guard.sh
@@ -52,6 +52,9 @@ RESPAWN_STAMP="$STORE/.channel-last-respawn"           # SHARED with channel-wat
 RESPAWN_COUNT_FILE="$STORE/.stuck-modal-respawns"
 BACKOFF_STAMP="$STORE/.stuck-modal-backoff-alerted"
 LIMIT_ALERTED_STAMP="$STORE/.stuck-modal-limit-alerted"
+LIMIT_OVERDUE_STAMP="$STORE/.stuck-modal-limit-overdue-alerted"
+LIMIT_OVERDUE_GRACE=600          # seconds past reset time before escalating
+LIMIT_FALLBACK_SECONDS=21600     # 6 hours: cap when reset time is not parseable
 TG_ENV="$HOME/.claude/channels/telegram/.env"
 LOG_TAG="stuck-modal-guard"
 
@@ -88,20 +91,23 @@ classify_pane() {
   if printf '%s' "$pane" | grep -qE 'esc to interrupt|\([0-9]+s (·|\.)'; then
     echo busy; return
   fi
-  # 3. session/usage limit banner -> limited (quota exhausted, NOT a modal).
-  #    Observed text (bigme 2026-08-08): "You hit your session limit · resets 5:50pm".
-  #    Additional canonical variants from src/model-fallback.ts USAGE_LIMIT_RX.
-  #    Must be checked BEFORE the idle-footer test: the banner replaces the footer.
-  if printf '%s' "$pane" | grep -qiE \
-      'hit (your|the) (session|usage) limit|usage limit reached|[0-9]+-hour limit reached|limit will reset at|upgrade to increase your usage limit'; then
-    echo limited; return
-  fi
-  # 4. idle footer present -> idle (healthy prompt)
+  # 3. idle footer present -> idle (healthy prompt).
+  #    Checked BEFORE the limit banner: if somehow both are visible (e.g. the
+  #    limit text is in scrollback while the footer is live), the healthy state
+  #    wins and the guard never sends Escape/respawn against a live session.
   if printf '%s' "$pane" | grep -qaF 'bypass permissions on' \
      || printf '%s' "$pane" | grep -qaF '? for shortcuts'; then
     echo idle; return
   fi
-  # 4. neither -> the idle footer is hidden by a modal overlay and no live turn
+  # 4. session/usage limit banner -> limited (quota exhausted, NOT a modal).
+  #    Observed text (bigme 2026-08-08): "You hit your session limit · resets 5:50pm".
+  #    Additional canonical variants from src/model-fallback.ts USAGE_LIMIT_RX.
+  #    The banner replaces the idle footer, so reaching here means no footer.
+  if printf '%s' "$pane" | grep -qiE \
+      'hit (your|the) (session|usage) limit|usage limit reached|[0-9]+-hour limit reached|limit will reset at|upgrade to increase your usage limit'; then
+    echo limited; return
+  fi
+  # 5. neither -> the idle footer is hidden by a modal overlay and no live turn
   echo stuck
 }
 
@@ -135,6 +141,22 @@ sanitize_model() {
   printf '%s' "${1:-}" | tr -cd 'A-Za-z0-9._:[]-'
 }
 
+# --- parse reset epoch from pane text (pure, testable) -------------------------
+# Reads pane text on stdin. Outputs the Unix epoch of the reset time printed on
+# the pane (e.g. "resets 5:50pm" -> today's epoch at 17:50), or empty string if
+# the reset time is absent or unparseable. Used to detect when the quota has
+# already reset but the session is still showing the limit screen.
+parse_reset_epoch() {
+  local pane time_str ep
+  pane="$(cat)"
+  time_str="$(printf '%s' "$pane" \
+    | grep -oiE 'resets? +[0-9]+(:[0-9]+)? *(am|pm)' | head -1 \
+    | grep -oiE '[0-9]+(:[0-9]+)? *(am|pm)')"
+  [ -z "$time_str" ] && { echo ""; return; }
+  ep="$(date -d "$time_str" +%s 2>/dev/null)" || { echo ""; return; }
+  echo "$ep"
+}
+
 # --- session usage-limit notification (rate-limited to once/hour) --------------
 alert_limited() {
   local pane_text="$1" now="$2"
@@ -148,6 +170,24 @@ alert_limited() {
   log "session usage limit hit${reset_info} -- holding (no Escape/respawn)"
   alert_owner "⏳ The ${SESSION} session hit its usage limit${reset_info}. This is NOT a /mcp modal -- auto-respawn would not help. The session will resume automatically when the quota resets. Messages sent during this window may be queued."
   date +%s > "$LIMIT_ALERTED_STAMP" 2>/dev/null || true
+}
+
+# --- overdue-limit alert: reset passed but session still frozen ----------------
+# Rate-limited to once/hour. Called when parse_reset_epoch shows the reset time
+# has already passed (+ LIMIT_OVERDUE_GRACE), or when the fallback 6-hour cap
+# fires. After this, run_guard treats the state as 'stuck' so the normal
+# Escape -> respawn path can actually recover the session.
+alert_overdue_limit() {
+  local pane_text="$1" now="$2"
+  local bstamp=0
+  [ -f "$LIMIT_OVERDUE_STAMP" ] && bstamp="$(stat -c %Y "$LIMIT_OVERDUE_STAMP" 2>/dev/null || echo 0)"
+  [ $(( now - bstamp )) -lt 3600 ] && return 0
+  local reset_str reset_info=""
+  reset_str="$(printf '%s' "$pane_text" | grep -oiE 'resets? +[0-9]+(:[0-9]+)? *(am|pm)?' | head -1)"
+  [ -n "$reset_str" ] && reset_info=" ($reset_str)"
+  log "session limit reset time passed${reset_info} but banner still visible -- escalating to stuck path"
+  alert_owner "🔴 The ${SESSION} session's usage limit reset time has passed${reset_info} but the pane still shows the limit banner. The session did not auto-resume -- triggering recovery (Escape / respawn). If you messaged during the outage and got no reply, please resend."
+  date +%s > "$LIMIT_OVERDUE_STAMP" 2>/dev/null || true
 }
 
 # --- direct Bot API alert (mirrors channel-watchdog.sh alert_owner) -------------
@@ -205,16 +245,36 @@ run_guard() {
   firstseen=0; [ -f "$FIRSTSEEN_STAMP" ] && firstseen="$(cat "$FIRSTSEEN_STAMP" 2>/dev/null || echo 0)"
   case "$firstseen" in (''|*[!0-9]*) firstseen=0;; esac
 
-  # Session usage-limit: alert owner (rate-limited) before letting decide_action hold.
+  # Session usage-limit: check whether the reset time has already passed.
+  # If yes -> escalate (alert + fall through to the normal stuck path so
+  # the session is actually recovered via Escape / respawn). If no -> hold.
   if [ "$state" = "limited" ]; then
-    alert_limited "$pane" "$now"
+    local reset_ep overdue=0
+    reset_ep="$(printf '%s' "$pane" | parse_reset_epoch)"
+    if [ -n "$reset_ep" ]; then
+      [ $(( now - reset_ep )) -ge "$LIMIT_OVERDUE_GRACE" ] && overdue=1
+    else
+      # No parseable reset time: fall back to stamp-based 6-hour cap.
+      local first_alerted=0
+      [ -f "$LIMIT_ALERTED_STAMP" ] && first_alerted="$(stat -c %Y "$LIMIT_ALERTED_STAMP" 2>/dev/null || echo 0)"
+      [ "$first_alerted" -ne 0 ] \
+        && [ $(( now - first_alerted )) -ge "$LIMIT_FALLBACK_SECONDS" ] \
+        && overdue=1
+    fi
+    if [ "$overdue" = "1" ]; then
+      alert_overdue_limit "$pane" "$now"
+      state="stuck"   # engage Escape -> respawn recovery
+    else
+      alert_limited "$pane" "$now"
+    fi
   fi
 
   action="$(decide_action "$state" "$firstseen" "$now")"
   case "$action" in
     clear)
       if [ "$firstseen" != 0 ]; then log "session healthy ($state) -- clearing confirm window"; fi
-      rm -f "$FIRSTSEEN_STAMP" "$RESPAWN_COUNT_FILE" "$BACKOFF_STAMP" 2>/dev/null || true
+      rm -f "$FIRSTSEEN_STAMP" "$RESPAWN_COUNT_FILE" "$BACKOFF_STAMP" \
+            "$LIMIT_ALERTED_STAMP" "$LIMIT_OVERDUE_STAMP" 2>/dev/null || true
       return 0 ;;
     hold)
       return 0 ;;
@@ -309,9 +369,10 @@ run_guard() {
 }
 
 case "${1:-}" in
-  classify)       classify_pane ;;
-  decide)         decide_action "${2:-}" "${3:-0}" "${4:-0}" ;;
-  sanitize-model) sanitize_model "${2:-}" ;;
-  *)              run_guard ;;
+  classify)           classify_pane ;;
+  decide)             decide_action "${2:-}" "${3:-0}" "${4:-0}" ;;
+  sanitize-model)     sanitize_model "${2:-}" ;;
+  parse-reset-epoch)  printf '%s' "${2:-}" | parse_reset_epoch ;;
+  *)                  run_guard ;;
 esac
 exit 0

--- a/scripts/stuck-modal-guard.sh
+++ b/scripts/stuck-modal-guard.sh
@@ -141,20 +141,64 @@ sanitize_model() {
   printf '%s' "${1:-}" | tr -cd 'A-Za-z0-9._:[]-'
 }
 
+# --- portable file mtime (GNU stat -c / BSD stat -f / python3 fallback) --------
+# Returns the Unix mtime of FILE, or 0 if unreachable. Never silent on failure.
+stat_mtime() {
+  local f="$1" result
+  result="$(stat -c %Y "$f" 2>/dev/null)"
+  [ -n "$result" ] && { echo "$result"; return; }
+  result="$(stat -f %m "$f" 2>/dev/null)"
+  [ -n "$result" ] && { echo "$result"; return; }
+  result="$(python3 -c "import os; print(int(os.path.getmtime('$f')))" 2>/dev/null)"
+  [ -n "$result" ] && { echo "$result"; return; }
+  log "stat_mtime: all dialects failed for '$f' -- returning 0"
+  echo 0
+}
+
 # --- parse reset epoch from pane text (pure, testable) -------------------------
 # Reads pane text on stdin. Outputs the Unix epoch of the reset time printed on
 # the pane (e.g. "resets 5:50pm" -> today's epoch at 17:50), or empty string if
 # the reset time is absent or unparseable. Used to detect when the quota has
 # already reset but the session is still showing the limit screen.
 parse_reset_epoch() {
-  local pane time_str ep
+  local pane time_str
   pane="$(cat)"
   time_str="$(printf '%s' "$pane" \
     | grep -oiE 'resets? +[0-9]+(:[0-9]+)? *(am|pm)' | head -1 \
     | grep -oiE '[0-9]+(:[0-9]+)? *(am|pm)')"
   [ -z "$time_str" ] && { echo ""; return; }
-  ep="$(date -d "$time_str" +%s 2>/dev/null)" || { echo ""; return; }
-  echo "$ep"
+  # Portable hh[:mm]am/pm -> epoch. Avoids GNU-only 'date -d'.
+  # If any step fails the failure is logged explicitly rather than silently
+  # folding into an empty return (which would be indistinguishable from "no
+  # reset time present" and would suppress the overdue-detection path).
+  local ts ampm digits hour min
+  ts="$(printf '%s' "$time_str" | tr -d ' ')"
+  ampm="$(printf '%s' "$ts" | grep -oiE '(am|pm)$' | tr '[:upper:]' '[:lower:]')"
+  digits="$(printf '%s' "$ts" | grep -oE '^[0-9]+(:[0-9]+)?')"
+  if [ -z "$digits" ] || [ -z "$ampm" ]; then
+    log "parse_reset_epoch: unrecognised format '$time_str' -- returning empty"
+    echo ""; return
+  fi
+  if printf '%s' "$digits" | grep -q ':'; then
+    hour="${digits%%:*}"; min="${digits##*:}"
+  else
+    hour="$digits"; min=0
+  fi
+  case "$ampm" in
+    pm) [ "$hour" -ne 12 ] 2>/dev/null && hour=$(( hour + 12 )) ;;
+    am) [ "$hour" -eq 12 ] 2>/dev/null && hour=0 ;;
+  esac
+  if ! [ "${hour:-x}" -ge 0 ] 2>/dev/null || ! [ "$hour" -le 23 ] 2>/dev/null \
+     || ! [ "${min:-x}" -ge 0 ] 2>/dev/null || ! [ "$min"  -le 59 ] 2>/dev/null; then
+    log "parse_reset_epoch: out-of-range h=$hour m=$min from '$time_str' -- returning empty"
+    echo ""; return
+  fi
+  # Today's midnight epoch: portable (date +%s and date +%H/%M/%S only)
+  local now cur_h cur_m cur_s midnight_ep
+  now="$(date +%s)"
+  cur_h="$(date +%H)"; cur_m="$(date +%M)"; cur_s="$(date +%S)"
+  midnight_ep=$(( now - 10#$cur_h * 3600 - 10#$cur_m * 60 - 10#$cur_s ))
+  echo $(( midnight_ep + hour * 3600 + min * 60 ))
 }
 
 # --- overdue check (pure, testable) -------------------------------------------
@@ -179,7 +223,7 @@ is_limit_overdue() {
 alert_limited() {
   local pane_text="$1" now="$2"
   local bstamp=0
-  [ -f "$LIMIT_ALERTED_STAMP" ] && bstamp="$(stat -c %Y "$LIMIT_ALERTED_STAMP" 2>/dev/null || echo 0)"
+  [ -f "$LIMIT_ALERTED_STAMP" ] && bstamp="$(stat_mtime "$LIMIT_ALERTED_STAMP")"
   [ $(( now - bstamp )) -lt 3600 ] && return 0   # already alerted within the hour
   # Extract "resets Xpm" / "resets X:XXam" from the pane if present.
   local reset_str reset_info=""
@@ -198,7 +242,7 @@ alert_limited() {
 alert_overdue_limit() {
   local pane_text="$1" now="$2"
   local bstamp=0
-  [ -f "$LIMIT_OVERDUE_STAMP" ] && bstamp="$(stat -c %Y "$LIMIT_OVERDUE_STAMP" 2>/dev/null || echo 0)"
+  [ -f "$LIMIT_OVERDUE_STAMP" ] && bstamp="$(stat_mtime "$LIMIT_OVERDUE_STAMP")"
   [ $(( now - bstamp )) -lt 3600 ] && return 0
   local reset_str reset_info=""
   reset_str="$(printf '%s' "$pane_text" | grep -oiE 'resets? +[0-9]+(:[0-9]+)? *(am|pm)?' | head -1)"
@@ -397,6 +441,7 @@ case "${1:-}" in
   sanitize-model)     sanitize_model "${2:-}" ;;
   parse-reset-epoch)  printf '%s' "${2:-}" | parse_reset_epoch ;;
   is-overdue)         is_limit_overdue "${2:-}" "${3:-0}" "${4:-0}" ;;
+  stat-mtime)         stat_mtime "${2:-}" ;;
   *)                  run_guard ;;
 esac
 exit 0

--- a/scripts/stuck-modal-guard.sh
+++ b/scripts/stuck-modal-guard.sh
@@ -157,6 +157,24 @@ parse_reset_epoch() {
   echo "$ep"
 }
 
+# --- overdue check (pure, testable) -------------------------------------------
+# Args: RESET_EPOCH ANCHOR_EPOCH NOW_EPOCH
+# ANCHOR_EPOCH is the time of first limit detection (LIMIT_ALERTED_STAMP mtime,
+# or 'now' on the very first tick before the stamp exists).
+# Midnight-rollover guard: if reset_ep < anchor the reset is actually tomorrow
+# (e.g. "resets 1am" parsed at 19:00 gives today 01:00 < 19:00 → +86400).
+# Prints 1 if the reset time has passed by >= LIMIT_OVERDUE_GRACE, else 0.
+is_limit_overdue() {
+  local reset_ep="$1" anchor="$2" now="$3"
+  [ -z "$reset_ep" ] && { echo 0; return; }
+  case "$reset_ep" in (''|*[!0-9]*) echo 0; return ;; esac
+  # Roll forward to next day if reset looks like it's in the past relative to
+  # when we first detected the limit (anchor). A fresh session limit always has
+  # reset_ep >= anchor; if it's earlier the date has rolled over.
+  [ "$reset_ep" -lt "$anchor" ] && reset_ep=$(( reset_ep + 86400 ))
+  if [ $(( now - reset_ep )) -ge "$LIMIT_OVERDUE_GRACE" ]; then echo 1; else echo 0; fi
+}
+
 # --- session usage-limit notification (rate-limited to once/hour) --------------
 alert_limited() {
   local pane_text="$1" now="$2"
@@ -249,16 +267,21 @@ run_guard() {
   # If yes -> escalate (alert + fall through to the normal stuck path so
   # the session is actually recovered via Escape / respawn). If no -> hold.
   if [ "$state" = "limited" ]; then
-    local reset_ep overdue=0
+    local reset_ep overdue anchor
     reset_ep="$(printf '%s' "$pane" | parse_reset_epoch)"
+    # Anchor: time of first limit detection (stamp mtime), or now on first tick.
+    anchor="$now"
+    [ -f "$LIMIT_ALERTED_STAMP" ] && {
+      local fs; fs="$(stat -c %Y "$LIMIT_ALERTED_STAMP" 2>/dev/null || echo 0)"
+      [ "$fs" -gt 0 ] && anchor="$fs"
+    }
     if [ -n "$reset_ep" ]; then
-      [ $(( now - reset_ep )) -ge "$LIMIT_OVERDUE_GRACE" ] && overdue=1
+      overdue="$(is_limit_overdue "$reset_ep" "$anchor" "$now")"
     else
-      # No parseable reset time: fall back to stamp-based 6-hour cap.
-      local first_alerted=0
-      [ -f "$LIMIT_ALERTED_STAMP" ] && first_alerted="$(stat -c %Y "$LIMIT_ALERTED_STAMP" 2>/dev/null || echo 0)"
-      [ "$first_alerted" -ne 0 ] \
-        && [ $(( now - first_alerted )) -ge "$LIMIT_FALLBACK_SECONDS" ] \
+      # No parseable reset time: stamp-based 6-hour cap.
+      overdue=0
+      [ "$anchor" -lt "$now" ] \
+        && [ $(( now - anchor )) -ge "$LIMIT_FALLBACK_SECONDS" ] \
         && overdue=1
     fi
     if [ "$overdue" = "1" ]; then
@@ -373,6 +396,7 @@ case "${1:-}" in
   decide)             decide_action "${2:-}" "${3:-0}" "${4:-0}" ;;
   sanitize-model)     sanitize_model "${2:-}" ;;
   parse-reset-epoch)  printf '%s' "${2:-}" | parse_reset_epoch ;;
+  is-overdue)         is_limit_overdue "${2:-}" "${3:-0}" "${4:-0}" ;;
   *)                  run_guard ;;
 esac
 exit 0

--- a/scripts/stuck-modal-guard.sh
+++ b/scripts/stuck-modal-guard.sh
@@ -30,8 +30,16 @@
 #     watchdogs never double-respawn (no storm), plus its own consecutive cap.
 #   - Stamp writes are best-effort (disk-full tolerance).
 #
+# Detection (extended):
+#   - LIMITED: session usage-limit banner visible in the pane ("You hit your
+#              session limit · resets Npm"). No idle/busy markers but the cause
+#              is quota exhaustion, NOT a modal. Escape and respawn are useless;
+#              only the quota reset clears it. The guard holds and alerts the
+#              owner (rate-limited to once/hour) with the real reason + reset
+#              time extracted from the pane.
+#
 # Modes (for tests; mirror the pure functions in src/pane-state.ts):
-#   stuck-modal-guard.sh classify         < pane.txt   -> prints idle|busy|stuck|empty
+#   stuck-modal-guard.sh classify         < pane.txt   -> prints idle|busy|limited|stuck|empty
 #   stuck-modal-guard.sh decide STATE FIRSTSEEN NOW     -> prints the action
 #   stuck-modal-guard.sh                                -> run the guard live
 
@@ -43,6 +51,7 @@ FIRSTSEEN_STAMP="$STORE/.stuck-modal-firstseen"
 RESPAWN_STAMP="$STORE/.channel-last-respawn"           # SHARED with channel-watchdog.sh
 RESPAWN_COUNT_FILE="$STORE/.stuck-modal-respawns"
 BACKOFF_STAMP="$STORE/.stuck-modal-backoff-alerted"
+LIMIT_ALERTED_STAMP="$STORE/.stuck-modal-limit-alerted"
 TG_ENV="$HOME/.claude/channels/telegram/.env"
 LOG_TAG="stuck-modal-guard"
 
@@ -79,7 +88,15 @@ classify_pane() {
   if printf '%s' "$pane" | grep -qE 'esc to interrupt|\([0-9]+s (·|\.)'; then
     echo busy; return
   fi
-  # 3. idle footer present -> idle (healthy prompt)
+  # 3. session/usage limit banner -> limited (quota exhausted, NOT a modal).
+  #    Observed text (bigme 2026-08-08): "You hit your session limit · resets 5:50pm".
+  #    Additional canonical variants from src/model-fallback.ts USAGE_LIMIT_RX.
+  #    Must be checked BEFORE the idle-footer test: the banner replaces the footer.
+  if printf '%s' "$pane" | grep -qiE \
+      'hit (your|the) (session|usage) limit|usage limit reached|[0-9]+-hour limit reached|limit will reset at|upgrade to increase your usage limit'; then
+    echo limited; return
+  fi
+  # 4. idle footer present -> idle (healthy prompt)
   if printf '%s' "$pane" | grep -qaF 'bypass permissions on' \
      || printf '%s' "$pane" | grep -qaF '? for shortcuts'; then
     echo idle; return
@@ -91,7 +108,7 @@ classify_pane() {
 # --- pure decision (testable without tmux) -------------------------------------
 # Args: STATE FIRSTSEEN_EPOCH NOW_EPOCH. Prints one of:
 #   clear         -> pane healthy; drop any confirm window
-#   hold          -> inconclusive (empty capture); preserve the confirm window
+#   hold          -> inconclusive (empty capture OR usage-limit); preserve confirm window
 #   start-confirm -> first stuck observation; begin the confirm window
 #   wait-confirm  -> stuck but not yet persisted long enough
 #   act           -> stuck and persisted >= STUCK_SECONDS; recover now
@@ -100,6 +117,7 @@ decide_action() {
   case "$state" in
     idle|busy) echo clear; return ;;
     empty)     echo hold;  return ;;
+    limited)   echo hold;  return ;;   # quota exhaustion: Escape/respawn useless
     stuck)
       case "$firstseen" in (''|0|*[!0-9]*) echo start-confirm; return ;; esac
       if [ $(( now - firstseen )) -ge "$STUCK_SECONDS" ]; then echo act; else echo wait-confirm; fi
@@ -115,6 +133,21 @@ decide_action() {
 # shell-string, while a legit "claude-opus-4-8[1m]" survives intact.
 sanitize_model() {
   printf '%s' "${1:-}" | tr -cd 'A-Za-z0-9._:[]-'
+}
+
+# --- session usage-limit notification (rate-limited to once/hour) --------------
+alert_limited() {
+  local pane_text="$1" now="$2"
+  local bstamp=0
+  [ -f "$LIMIT_ALERTED_STAMP" ] && bstamp="$(stat -c %Y "$LIMIT_ALERTED_STAMP" 2>/dev/null || echo 0)"
+  [ $(( now - bstamp )) -lt 3600 ] && return 0   # already alerted within the hour
+  # Extract "resets Xpm" / "resets X:XXam" from the pane if present.
+  local reset_str reset_info=""
+  reset_str="$(printf '%s' "$pane_text" | grep -oiE 'resets? [0-9]+(:[0-9]+)?(am|pm)?' | head -1)"
+  [ -n "$reset_str" ] && reset_info=", $reset_str"
+  log "session usage limit hit${reset_info} -- holding (no Escape/respawn)"
+  alert_owner "⏳ The ${SESSION} session hit its usage limit${reset_info}. This is NOT a /mcp modal -- auto-respawn would not help. The session will resume automatically when the quota resets. Messages sent during this window may be queued."
+  date +%s > "$LIMIT_ALERTED_STAMP" 2>/dev/null || true
 }
 
 # --- direct Bot API alert (mirrors channel-watchdog.sh alert_owner) -------------
@@ -171,6 +204,11 @@ run_guard() {
   now="$(date +%s)"
   firstseen=0; [ -f "$FIRSTSEEN_STAMP" ] && firstseen="$(cat "$FIRSTSEEN_STAMP" 2>/dev/null || echo 0)"
   case "$firstseen" in (''|*[!0-9]*) firstseen=0;; esac
+
+  # Session usage-limit: alert owner (rate-limited) before letting decide_action hold.
+  if [ "$state" = "limited" ]; then
+    alert_limited "$pane" "$now"
+  fi
 
   action="$(decide_action "$state" "$firstseen" "$now")"
   case "$action" in


### PR DESCRIPTION
## Summary

- `classify_pane` misclassified a quota-limit pane as `stuck`: the usage-limit banner hides the idle footer and has no live turn — the same surface signature as a modal. The guard queued Escape attempts and a respawn against a pane that only needed to wait for the quota reset (bigme incident 2026-08-08 15:35).
- New `limited` state in `classify_pane`, checked after `busy` and before `idle`. Matched via the observed banner text (`hit your session limit`, bigme 2026-08-08) plus the canonical variants from `src/model-fallback.ts` USAGE_LIMIT_RX.
- `decide_action`: `limited → hold` — Escape and respawn never fire.
- `alert_limited()`: rate-limited (1h) owner notification with the real reason and reset time extracted from the pane, replacing the generic `/mcp modal` message.
- `run_guard`: calls `alert_limited` when `state == limited`, before `decide_action`.
- Test section (g): quota-pane fixture (observed text + 5-hour variant) + `decide limited → hold` (two firstseen values). 23/23 tests pass.
- `slarti-rendszer-ellenorzes/SKILL.md`: §0 added — check for quota line on pane before guessing modal.

## Test plan

- [ ] `bash scripts/__tests__/stuck-modal-guard.test.sh` — all 23 pass
- [ ] Verify `classify` mode: `echo "You hit your session limit · resets 5:50pm" | bash scripts/stuck-modal-guard.sh classify` → `limited`
- [ ] Verify `decide limited 0 1000` → `hold`

🤖 Generated with [Claude Code](https://claude.com/claude-code)