### PR TITLE
feat(egress-gate): payload-field recording + quarantine tier (split from #920)

### DIFF
--- a/scripts/hooks/egress-gate.mjs
+++ b/scripts/hooks/egress-gate.mjs
@@ -146,11 +146,31 @@ export function isEgressBlocked(toolName, toolInput, runtimeList = { domains: []
   return true
 }
 
-function logBlocked(url, reason) {
+// The payload's top-level FIELD NAMES, sorted -- never a value.
+//
+// This exists to answer one open question with data instead of a guess: does
+// the PreToolUse payload carry anything that identifies the CALLER? The gate
+// decides on the URL alone, so a main agent and a quarantine-reader sub-agent
+// are indistinguishable to it, and the sub-agent is the escape hatch the block
+// message itself prescribes -- which is why the RSS path is currently dead
+// (kanban #224). A caller-aware tier can only be built on a field that is
+// verified to exist; building it on an assumed one would produce a guard that
+// looks like it protects and does not.
+//
+// Keys only, by construction: a value could carry a url, a prompt, or a
+// secret, and this log is read casually. Nested objects contribute nothing but
+// their own key.
+export function payloadKeySignature(payload) {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return ''
+  return Object.keys(payload).sort().join(',')
+}
+
+function logBlocked(url, reason, keys = '') {
   try {
     mkdirSync(join(REPO_ROOT, 'store'), { recursive: true })
     const ts = new Date().toISOString()
-    appendFileSync(EGRESS_BLOCK_LOG, `${ts} BLOCKED url="${url}" reason="${reason}"\n`, 'utf-8')
+    const keyPart = keys ? ` payload_keys="${keys}"` : ''
+    appendFileSync(EGRESS_BLOCK_LOG, `${ts} BLOCKED url="${url}" reason="${reason}"${keyPart}\n`, 'utf-8')
   } catch {
     // Never let log failure cascade into blocking the agent process itself.
   }
@@ -199,7 +219,7 @@ if (isInvokedDirectly()) {
   const url = String(payload?.tool_input?.url ?? '')
   const runtimeList = loadRuntimeAllowlist()
   if (isEgressBlocked(payload?.tool_name, payload?.tool_input, runtimeList)) {
-    logBlocked(url, 'not on egress allowlist')
+    logBlocked(url, 'not on egress allowlist', payloadKeySignature(payload))
     deny(BLOCK_MESSAGE)
   }
   allow()

--- a/scripts/hooks/egress-gate.mjs
+++ b/scripts/hooks/egress-gate.mjs
@@ -87,6 +87,62 @@ const ALLOWED_PREFIXES = [
   `http://127.0.0.1:${DASHBOARD_PORT}/`,
 ]
 
+// The quarantine tier.
+//
+// The block message tells the caller to fetch through the quarantine-reader
+// sub-agent -- and until now this same hook blocked that sub-agent too, so the
+// escape hatch the gate prescribed was one the gate closed (kanban #224).
+//
+// A sub-agent's PreToolUse payload carries two fields a main agent's does not:
+// `agent_id` and `agent_type` (measured 2026-08-03, both key sets recorded in
+// store/egress-blocked.log). `agent_type` is what separates the tiers.
+//
+// FAIL-CLOSED: only an exact `agent_type` match opens this tier. A missing,
+// empty, unknown or misspelled value is treated as a main agent, i.e. blocked.
+// A mistake here can only deny a fetch, never grant one.
+//
+// The domain list mirrors the one in the sub-agent's own definition
+// (templates/sub-agents/quarantine-reader.md). That copy is a promise the
+// sub-agent makes to itself in its prompt; this one is enforcement. Keep them
+// in step -- and when they disagree, this file is the one that decides.
+const QUARANTINE_AGENT_TYPE = 'quarantine-reader'
+
+// `path` (optional) narrows a domain to the URLs the sub-agent's definition
+// actually promises. Reddit is the reason it exists: the definition allows RSS
+// feeds only, and hostname matching alone would hand over the entire site.
+const QUARANTINE_DOMAINS = [
+  { domain: 'status.anthropic.com' },
+  { domain: 'status.claude.com' },
+  { domain: 'feeds.feedburner.com' },
+  { domain: 'rss.arxiv.org' },
+  { domain: 'export.arxiv.org' },
+  { domain: 'hnrss.org' },
+  { domain: 'feeds.arstechnica.com' },
+  { domain: 'techcrunch.com' },
+  { domain: 'feeds.reuters.com' },
+  { domain: 'feeds.bbci.co.uk' },
+  { domain: 'www.reddit.com', path: (p) => p.endsWith('.rss') },
+]
+
+function matchesQuarantineDomain(url, extraDomains = []) {
+  let parsed
+  try {
+    parsed = new URL(url)
+  } catch {
+    return false
+  }
+  const hostMatches = (d) => parsed.hostname === d || parsed.hostname.endsWith('.' + d)
+  for (const entry of QUARANTINE_DOMAINS) {
+    if (!hostMatches(entry.domain)) continue
+    if (entry.path && !entry.path(parsed.pathname)) return false
+    return true
+  }
+  // Operator additions carry no path rule: an entry someone typed into the
+  // store file is a deliberate act, and second-guessing its shape here would
+  // only make the file's behaviour harder to predict.
+  return extraDomains.some(hostMatches)
+}
+
 // Load the runtime allowlist from store/egress-allowlist.json.
 // FAIL-OPEN on the file: missing or malformed -> empty lists, NOT an error.
 // The caller must still apply the built-in ALLOWED_PREFIXES.
@@ -97,36 +153,52 @@ export function loadRuntimeAllowlist() {
     return {
       domains: Array.isArray(parsed.domains) ? parsed.domains.filter((d) => typeof d === 'string') : [],
       prefixes: Array.isArray(parsed.prefixes) ? parsed.prefixes.filter((p) => typeof p === 'string') : [],
+      // Operator-managed extension of the QUARANTINE tier. Reachable ONLY by
+      // the quarantine-reader sub-agent -- putting a domain here does not open
+      // it to the main agent, which is the whole point of the split.
+      quarantineDomains: Array.isArray(parsed.quarantine_domains)
+        ? parsed.quarantine_domains.filter((d) => typeof d === 'string')
+        : [],
     }
   } catch {
     // Missing file or JSON parse error: treat as empty, never propagate.
-    return { domains: [], prefixes: [] }
+    return { domains: [], prefixes: [], quarantineDomains: [] }
   }
 }
 
-// Pure decision: allowed (false) or blocked (true)?
+// Pure decision, with the tier that decided it.
 //
 // `runtimeList` is the decoded store/egress-allowlist.json (or any equivalent
-// object). Keeping file I/O out of this function makes it fully unit-testable
+// object) and `agentType` is the payload's `agent_type` -- empty for a main
+// agent. Keeping file I/O out of this function makes it fully unit-testable
 // without touching the filesystem.
+//
+// The tier is returned because the quarantine tier is the security-relevant
+// exception and its grants are audited: a fetch nobody can see is a hole
+// nobody can find.
 //
 // Domain matching uses URL-parsed hostname ONLY, not string-contains, to prevent
 // bypasses like `https://evil.com/?x=docs.anthropic.com` matching the domain
 // "docs.anthropic.com" via a simple includes() check.
-export function isEgressBlocked(toolName, toolInput, runtimeList = { domains: [], prefixes: [] }) {
-  if (toolName !== 'WebFetch') return false
+export function egressDecision(
+  toolName,
+  toolInput,
+  runtimeList = { domains: [], prefixes: [], quarantineDomains: [] },
+  agentType = '',
+) {
+  if (toolName !== 'WebFetch') return { blocked: false, tier: 'not-webfetch' }
   const url = String(toolInput?.url ?? '')
-  if (!url) return false
+  if (!url) return { blocked: false, tier: 'no-url' }
 
   // 1. Built-in prefix check (startsWith is correct here: the prefix already
   //    includes the trailing slash so a prefix-extension attack is impossible,
   //    e.g. 'https://api.github.com.evil.com/' does not start with
   //    'https://api.github.com/').
-  if (ALLOWED_PREFIXES.some((prefix) => url.startsWith(prefix))) return false
+  if (ALLOWED_PREFIXES.some((prefix) => url.startsWith(prefix))) return { blocked: false, tier: 'builtin' }
 
   // 2. Runtime prefix check.
   const rtPrefixes = runtimeList.prefixes ?? []
-  if (rtPrefixes.some((p) => url.startsWith(p))) return false
+  if (rtPrefixes.some((p) => url.startsWith(p))) return { blocked: false, tier: 'runtime-prefix' }
 
   // 3. Runtime domain check: parse the URL to extract a verified hostname.
   //    URL parsing fails on non-URLs -> block (fail-safe).
@@ -137,13 +209,27 @@ export function isEgressBlocked(toolName, toolInput, runtimeList = { domains: []
       hostname = new URL(url).hostname
     } catch {
       // Unparseable URL: block, don't throw.
-      return true
+      return { blocked: true, tier: 'unparseable' }
     }
     // Match exact hostname OR any subdomain (host.endsWith('.' + domain)).
-    if (rtDomains.some((d) => hostname === d || hostname.endsWith('.' + d))) return false
+    if (rtDomains.some((d) => hostname === d || hostname.endsWith('.' + d))) return { blocked: false, tier: 'runtime-domain' }
   }
 
-  return true
+  // 4. Quarantine tier -- the ONLY tier a main agent cannot reach. Exact
+  //    agent_type match required (fail-closed: anything else falls through to
+  //    the block below).
+  if (String(agentType ?? '') === QUARANTINE_AGENT_TYPE) {
+    if (matchesQuarantineDomain(url, runtimeList.quarantineDomains ?? [])) {
+      return { blocked: false, tier: 'quarantine' }
+    }
+  }
+
+  return { blocked: true, tier: 'none' }
+}
+
+// Back-compatible boolean form.
+export function isEgressBlocked(toolName, toolInput, runtimeList, agentType) {
+  return egressDecision(toolName, toolInput, runtimeList, agentType).blocked
 }
 
 // The payload's top-level FIELD NAMES, sorted -- never a value.
@@ -165,12 +251,17 @@ export function payloadKeySignature(payload) {
   return Object.keys(payload).sort().join(',')
 }
 
-function logBlocked(url, reason, keys = '') {
+// `agentType` IS logged by value, unlike everything else in the payload. It is
+// an agent-type name from a fixed set -- not content, not a url, not a secret
+// -- and without it a denied sub-agent call cannot be told apart from a denied
+// main-agent one, which is exactly the distinction this log now exists to make.
+function logLine(kind, url, detail, keys = '', agentType = '') {
   try {
     mkdirSync(join(REPO_ROOT, 'store'), { recursive: true })
     const ts = new Date().toISOString()
     const keyPart = keys ? ` payload_keys="${keys}"` : ''
-    appendFileSync(EGRESS_BLOCK_LOG, `${ts} BLOCKED url="${url}" reason="${reason}"${keyPart}\n`, 'utf-8')
+    const agentPart = agentType ? ` agent_type="${agentType}"` : ''
+    appendFileSync(EGRESS_BLOCK_LOG, `${ts} ${kind} url="${url}" ${detail}${agentPart}${keyPart}\n`, 'utf-8')
   } catch {
     // Never let log failure cascade into blocking the agent process itself.
   }
@@ -217,10 +308,18 @@ if (isInvokedDirectly()) {
     allow() // malformed/empty input must never block the agent
   }
   const url = String(payload?.tool_input?.url ?? '')
+  const agentType = String(payload?.agent_type ?? '')
   const runtimeList = loadRuntimeAllowlist()
-  if (isEgressBlocked(payload?.tool_name, payload?.tool_input, runtimeList)) {
-    logBlocked(url, 'not on egress allowlist', payloadKeySignature(payload))
+  const decision = egressDecision(payload?.tool_name, payload?.tool_input, runtimeList, agentType)
+  if (decision.blocked) {
+    logLine('BLOCKED', url, 'reason="not on egress allowlist"', payloadKeySignature(payload), agentType)
     deny(BLOCK_MESSAGE)
+  }
+  // Audited, not silent: the quarantine tier is the one grant a main agent
+  // cannot obtain, so every use of it leaves a line next to the denials. The
+  // other tiers are the ordinary allowlist and stay quiet.
+  if (decision.tier === 'quarantine') {
+    logLine('ALLOWED_QUARANTINE', url, 'reason="quarantine-reader tier"', '', agentType)
   }
   allow()
 }

--- a/src/__tests__/egress-gate.test.ts
+++ b/src/__tests__/egress-gate.test.ts
@@ -1,0 +1,84 @@
+// The WebFetch egress gate: what it blocks, and what it now records about a
+// block.
+//
+// The gate decides on the URL alone, so a main agent and a quarantine-reader
+// sub-agent look identical to it -- which is why the sub-agent path the block
+// message prescribes is itself blocked (kanban #224). Whether a caller-aware
+// tier can be built at all depends on the PreToolUse payload carrying a field
+// that identifies the caller, and that question is answered by recording the
+// payload's FIELD NAMES on every block. Names only: this log is read casually
+// and a value could be a url, a prompt or a secret.
+//
+// The gate is a .mjs hook script run by Claude Code, not application code. It
+// guards its own entry point (isInvokedDirectly), so importing it here runs no
+// side effects.
+import { describe, it, expect } from 'vitest'
+// @ts-expect-error -- plain .mjs hook script, no types
+import { isEgressBlocked, payloadKeySignature } from '../../scripts/hooks/egress-gate.mjs'
+
+describe('what the gate lets through', () => {
+  it('passes a built-in allowed prefix', () => {
+    expect(isEgressBlocked('WebFetch', { url: 'https://api.github.com/repos/a/b' })).toBe(false)
+  })
+
+  it('blocks arbitrary web content', () => {
+    expect(isEgressBlocked('WebFetch', { url: 'https://hnrss.org/frontpage' })).toBe(true)
+  })
+
+  it('ignores every tool that is not WebFetch', () => {
+    expect(isEgressBlocked('Bash', { command: 'curl https://hnrss.org/frontpage' })).toBe(false)
+  })
+
+  it('does not fall for a prefix-extension lookalike', () => {
+    // 'https://api.github.com.evil.com/' does not start with the allowed
+    // prefix, because the prefix carries its trailing slash.
+    expect(isEgressBlocked('WebFetch', { url: 'https://api.github.com.evil.com/x' })).toBe(true)
+  })
+
+  it('matches a runtime domain on the hostname, not on the string', () => {
+    const list = { domains: ['api.frankfurter.app'], prefixes: [] }
+    expect(isEgressBlocked('WebFetch', { url: 'https://api.frankfurter.app/latest' }, list)).toBe(false)
+    // The domain appearing in a query string must not open the gate.
+    expect(isEgressBlocked('WebFetch', { url: 'https://evil.com/?x=api.frankfurter.app' }, list)).toBe(true)
+  })
+
+  it('allows a subdomain of a runtime domain', () => {
+    const list = { domains: ['example.com'], prefixes: [] }
+    expect(isEgressBlocked('WebFetch', { url: 'https://docs.example.com/x' }, list)).toBe(false)
+  })
+
+  it('blocks an unparseable url instead of throwing', () => {
+    expect(isEgressBlocked('WebFetch', { url: 'not a url' }, { domains: ['example.com'], prefixes: [] })).toBe(true)
+  })
+})
+
+describe('what a block records about the caller', () => {
+  it('lists the payload field names, sorted', () => {
+    const keys = payloadKeySignature({
+      tool_name: 'WebFetch',
+      session_id: 's1',
+      cwd: '/home/x',
+      tool_input: { url: 'https://hnrss.org/frontpage' },
+    })
+    expect(keys).toBe('cwd,session_id,tool_input,tool_name')
+  })
+
+  it('never records a value -- not from the top level, not from a nested object', () => {
+    // The whole point: this line goes into a log an operator greps. A url, a
+    // prompt or a token must not ride along with the diagnostic.
+    const keys = payloadKeySignature({
+      tool_name: 'WebFetch',
+      tool_input: { url: 'https://secret.example/path?token=SHOULD-NOT-APPEAR' },
+      transcript_path: '/home/viktor/.claude/projects/p/SHOULD-NOT-APPEAR.jsonl',
+    })
+    expect(keys).not.toContain('SHOULD-NOT-APPEAR')
+    expect(keys).not.toContain('https://')
+    expect(keys).toBe('tool_input,tool_name,transcript_path')
+  })
+
+  it('survives a payload that is not an object', () => {
+    for (const bad of [null, undefined, 'string', 42, ['a']]) {
+      expect(payloadKeySignature(bad as never)).toBe('')
+    }
+  })
+})

--- a/src/__tests__/egress-gate.test.ts
+++ b/src/__tests__/egress-gate.test.ts
@@ -14,7 +14,10 @@
 // side effects.
 import { describe, it, expect } from 'vitest'
 // @ts-expect-error -- plain .mjs hook script, no types
-import { isEgressBlocked, payloadKeySignature } from '../../scripts/hooks/egress-gate.mjs'
+import { isEgressBlocked, egressDecision, payloadKeySignature } from '../../scripts/hooks/egress-gate.mjs'
+
+const QUARANTINE = 'quarantine-reader'
+const EMPTY = { domains: [], prefixes: [], quarantineDomains: [] }
 
 describe('what the gate lets through', () => {
   it('passes a built-in allowed prefix', () => {
@@ -49,6 +52,65 @@ describe('what the gate lets through', () => {
 
   it('blocks an unparseable url instead of throwing', () => {
     expect(isEgressBlocked('WebFetch', { url: 'not a url' }, { domains: ['example.com'], prefixes: [] })).toBe(true)
+  })
+})
+
+// The tier that made the gate's own escape hatch usable. A sub-agent payload
+// carries `agent_type`, a main agent's does not (measured 2026-08-03) -- that
+// field, and nothing else, separates the two.
+describe('the quarantine tier', () => {
+  const feed = { url: 'https://techcrunch.com/feed/' }
+
+  it('lets the quarantine-reader fetch a feed on its list', () => {
+    expect(isEgressBlocked('WebFetch', feed, EMPTY, QUARANTINE)).toBe(false)
+    expect(egressDecision('WebFetch', feed, EMPTY, QUARANTINE).tier).toBe('quarantine')
+  })
+
+  it('STILL blocks the same url for a main agent', () => {
+    // The property the whole design rests on: opening the tier for the
+    // sub-agent must not open it for everyone. A main agent fetching a news
+    // feed puts unwrapped, untrusted text straight into its own context.
+    expect(isEgressBlocked('WebFetch', feed, EMPTY, '')).toBe(true)
+    expect(isEgressBlocked('WebFetch', feed, EMPTY, undefined)).toBe(true)
+  })
+
+  it('blocks a domain the quarantine-reader was never given', () => {
+    expect(isEgressBlocked('WebFetch', { url: 'https://evil.example/feed' }, EMPTY, QUARANTINE)).toBe(true)
+  })
+
+  it('fails closed on anything that is not an exact agent_type match', () => {
+    // A typo, a rename, a spoofed-looking value: all fall through to the
+    // block. A mistake here can only deny a fetch, never grant one.
+    for (const bad of ['quarantine_reader', 'Quarantine-Reader', 'quarantine-reader ', 'general-purpose', null, 42]) {
+      expect(isEgressBlocked('WebFetch', feed, EMPTY, bad as never)).toBe(true)
+    }
+  })
+
+  it('holds the reddit promise its definition makes: RSS only', () => {
+    // The sub-agent's definition allows reddit RSS feeds; hostname matching
+    // alone would hand over the whole site, including the json endpoints a
+    // main agent was blocked from earlier.
+    expect(isEgressBlocked('WebFetch', { url: 'https://www.reddit.com/r/devops/new.rss' }, EMPTY, QUARANTINE)).toBe(false)
+    expect(isEgressBlocked('WebFetch', { url: 'https://www.reddit.com/r/devops/about/rules.json' }, EMPTY, QUARANTINE)).toBe(true)
+  })
+
+  it('inherits the ordinary allowlist rather than replacing it', () => {
+    expect(isEgressBlocked('WebFetch', { url: 'https://api.github.com/x' }, EMPTY, QUARANTINE)).toBe(false)
+  })
+
+  it('takes operator additions from quarantine_domains -- for the sub-agent only', () => {
+    const list = { domains: [], prefixes: [], quarantineDomains: ['feeds.example.org'] }
+    expect(isEgressBlocked('WebFetch', { url: 'https://feeds.example.org/rss' }, list, QUARANTINE)).toBe(false)
+    // Putting a domain in the quarantine list must not open it to a main agent.
+    expect(isEgressBlocked('WebFetch', { url: 'https://feeds.example.org/rss' }, list, '')).toBe(true)
+  })
+
+  it('reports the tier so the grant can be audited', () => {
+    // A fetch nobody can see is a hole nobody can find: the entry point logs
+    // an ALLOWED_QUARANTINE line off this tier.
+    expect(egressDecision('WebFetch', { url: 'https://api.github.com/x' }, EMPTY, QUARANTINE).tier).toBe('builtin')
+    expect(egressDecision('WebFetch', feed, EMPTY, QUARANTINE).tier).toBe('quarantine')
+    expect(egressDecision('WebFetch', feed, EMPTY, '').tier).toBe('none')
   })
 })
 


### PR DESCRIPTION
Split out of #920 per the maintainer's fault-line request (item 2): the egress-gate work rides alone so it can get its own verify pass.

**Commits (2, cherry-picked onto v1.31.0 main):**
- `feat(egress-gate): record which payload fields a blocked call carries` — a blocked call's ledger row now names the payload fields (names only, never values), so the missing dimension in an audit is visible instead of guessed.
- `feat(egress-gate): open the quarantine tier the block message already promised` — the block message referred to a quarantine tier that did not exist; this adds it, fail-closed.

**Verification on this branch:** `tsc --noEmit` clean; full `vitest run` result posted in a comment below (run on the split branch, not inherited from the bundle).

**What I do not claim:** no re-verification of the original bundle's conflict resolutions — this branch is a fresh cherry-pick onto current main, so the diff here is the review surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
