### PR TITLE
fix(router): session-stuck escalation + working-session silence (split from #920, third delivery-path candidate)

### DIFF
--- a/src/__tests__/router-stuck-alert.test.ts
+++ b/src/__tests__/router-stuck-alert.test.ts
@@ -1,0 +1,44 @@
+// Contract tests for formatStuckSessionAlert: a session continuously not-ready
+// past the escalation threshold must produce an ALERT the main agent receives,
+// not only a warn log.
+//
+// Root cause (2026-07-27 incident, card 0a641b52): two messages to prisma sat
+// pending for 2.5h while its session was wedged at 100% context. The router
+// logged 'session STUCK' at warn level every escalation window -- but the log
+// reaches nobody, so the stall was found by hand. The fix routes the same
+// escalation into the main agent's inbox as a [session-stuck] message; the
+// escalation-window reset in the tick doubles as the notification cooldown.
+// formatStuckSessionAlert is the pure decision extracted from the notifier;
+// these tests pin it.
+
+import { describe, it, expect } from 'vitest'
+import { formatStuckSessionAlert } from '../web/message-router.js'
+
+const MAIN = 'marveen'
+
+describe('formatStuckSessionAlert: silent stall becomes a main-agent alert', () => {
+  it('produces a [session-stuck] alert naming agent, session, duration and queue depth', () => {
+    const alert = formatStuckSessionAlert('prisma', MAIN, 'agent-prisma', 150 * 60 * 1000, 2)
+    expect(alert).not.toBeNull()
+    // The marker the main agent's triage keys on.
+    expect(alert).toContain('[session-stuck]')
+    // Enough to act without a second lookup: who, where, how long, how much is blocked.
+    expect(alert).toContain("'prisma'")
+    expect(alert).toContain('agent-prisma')
+    expect(alert).toContain('150 min')
+    expect(alert).toContain('2 pending message(s)')
+    // Points at the runbook step rather than leaving "now what".
+    expect(alert).toContain('delivery-stall diagnosis')
+  })
+
+  it('never alerts the main agent about itself (no self-loop)', () => {
+    // Messages TO the main agent use the pull model and never enter the stuck
+    // branch; this guards the invariant if that ever changes.
+    expect(formatStuckSessionAlert(MAIN, MAIN, 'marveen-channels', 20 * 60 * 1000, 5)).toBeNull()
+  })
+
+  it('rounds the stall duration to whole minutes', () => {
+    // 11 min 29 s -> 11 min; the alert is triage, not telemetry.
+    expect(formatStuckSessionAlert('edina1', MAIN, 'agent-edina1', 689_000, 1)).toContain('11 min')
+  })
+})

--- a/src/__tests__/router-stuck-alert.test.ts
+++ b/src/__tests__/router-stuck-alert.test.ts
@@ -12,9 +12,34 @@
 // these tests pin it.
 
 import { describe, it, expect } from 'vitest'
-import { formatStuckSessionAlert } from '../web/message-router.js'
+import { formatStuckSessionAlert, shouldEscalateStuckSession } from '../web/message-router.js'
+import { detectPaneState } from '../pane-state.js'
 
 const MAIN = 'marveen'
+
+const SEP = '─'.repeat(80)
+const MIN = 60 * 1000
+
+// Real pane shapes, run through detectPaneState rather than passing the
+// 'busy' literal directly -- the escalation is only as good as the detection
+// that feeds it, and a test that hands in the answer would pass even if the
+// pane were read wrong.
+const BUSY_PANE = [
+  '✢ Combobulating… (52s · ↓ 2.6k tokens · thinking some more)',
+  '',
+  SEP,
+  '❯ ',
+  SEP,
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle) · esc to interrupt',
+].join('\n')
+
+const IDLE_PANE = [
+  '',
+  SEP,
+  '❯ ',
+  SEP,
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+].join('\n')
 
 describe('formatStuckSessionAlert: silent stall becomes a main-agent alert', () => {
   it('produces a [session-stuck] alert naming agent, session, duration and queue depth', () => {
@@ -40,5 +65,65 @@ describe('formatStuckSessionAlert: silent stall becomes a main-agent alert', () 
   it('rounds the stall duration to whole minutes', () => {
     // 11 min 29 s -> 11 min; the alert is triage, not telemetry.
     expect(formatStuckSessionAlert('edina1', MAIN, 'agent-edina1', 689_000, 1)).toContain('11 min')
+  })
+
+  it('says "working, do not restart" when the pane was busy', () => {
+    // A busy-pane alert that reads like the wedged one gets acted on like the
+    // wedged one. It has to name what it actually saw.
+    const alert = formatStuckSessionAlert('prisma', MAIN, 'agent-prisma', 35 * MIN, 2, 'busy')!
+    expect(alert).toContain('BUSY')
+    expect(alert).toContain('Do NOT restart on this alert alone')
+    expect(alert).not.toContain('restart the agent if it is wedged')
+  })
+})
+
+// A session mid-turn is not ready for a prompt for the same reason a wedged one
+// is not, so the queue side alone cannot tell them apart. On 2026-07-31 that
+// cost three false alarms in one day, each one a main-agent diagnosis round
+// whose answer was "it is working".
+describe('shouldEscalateStuckSession: a busy pane is work, not a stall', () => {
+  it('does NOT escalate the 2026-07-31 18:56 atlas case (busy pane, 1 pending)', () => {
+    // atlas: pane busy with `esc to interrupt` visible, one message queued,
+    // not-ready past the 10 min threshold. Alerted; should not have.
+    expect(shouldEscalateStuckSession(detectPaneState(BUSY_PANE), 12 * MIN)).toBe(false)
+  })
+
+  it('does NOT escalate the 2026-07-31 19:27 prisma case (10 min orientation, 2 pending)', () => {
+    // prisma: ten minutes into a long orientation turn, two messages queued.
+    expect(shouldEscalateStuckSession(detectPaneState(BUSY_PANE), 10 * MIN + 30_000)).toBe(false)
+  })
+
+  it('still escalates a busy pane once the long watchdog passes', () => {
+    // A tool call can wedge with the spinner up. Half an hour of busy with mail
+    // queued behind it is worth a look either way.
+    expect(shouldEscalateStuckSession(detectPaneState(BUSY_PANE), 31 * MIN)).toBe(true)
+    expect(shouldEscalateStuckSession(detectPaneState(BUSY_PANE), 29 * MIN)).toBe(false)
+  })
+
+  it('keeps the normal threshold for a pane that is not busy', () => {
+    // The 2026-07-27 case this alert exists for: not-ready while NOT working
+    // (wedged at 100% context, idle-looking or unreadable pane).
+    expect(shouldEscalateStuckSession(detectPaneState(IDLE_PANE), 11 * MIN)).toBe(true)
+    expect(shouldEscalateStuckSession(detectPaneState(IDLE_PANE), 9 * MIN)).toBe(false)
+  })
+
+  it('treats an unreadable pane as a reason to look sooner, not later', () => {
+    // capturePane returns null when the host is down or tmux is gone. Silence
+    // is not evidence of work.
+    expect(shouldEscalateStuckSession(null, 11 * MIN)).toBe(true)
+  })
+
+  it('does not let a quoted "esc to interrupt" in scrollback mute the alert', () => {
+    // A watchdog report pasted into the pane must not read as busy -- that
+    // would mute the alert on exactly the session discussing stalls.
+    const quoted = [
+      'The runbook says: "esc to interrupt" means the agent is still working.',
+      '',
+      SEP,
+      '❯ ',
+      SEP,
+      '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+    ].join('\n')
+    expect(shouldEscalateStuckSession(detectPaneState(quoted), 11 * MIN)).toBe(true)
   })
 })

--- a/src/web/message-router.ts
+++ b/src/web/message-router.ts
@@ -24,7 +24,9 @@ import {
   clearStaleParkedInput,
   sendPromptToSession,
   sessionExistsOnHost,
+  capturePane,
 } from './agent-process.js'
+import { detectPaneState, type PaneState } from '../pane-state.js'
 import { setLastInboundModality } from './voice-modality.js'
 import { classifyAgentMessage, wrapAgentMessageForDelivery } from './agent-message-wrap.js'
 import { MAIN_CHANNELS_SESSION } from './main-agent.js'
@@ -81,17 +83,33 @@ export function shouldGiveUpOnInject(failCount: number, maxFailures: number): bo
 //
 // Pure part exported for tests: returns the alert text, or null when no alert
 // may be sent (the main agent must never alert itself about itself).
-export function formatStuckSessionAlert(agent: string, mainAgentId: string, session: string, stuckMs: number, pendingCount: number): string | null {
+export function formatStuckSessionAlert(
+  agent: string,
+  mainAgentId: string,
+  session: string,
+  stuckMs: number,
+  pendingCount: number,
+  paneState: PaneState | null = null,
+): string | null {
   if (agent === mainAgentId) return null
-  return `[session-stuck] Agent '${agent}' (tmux ${session}) has been not-ready for ${Math.round(stuckMs / 60000)} min with ${pendingCount} pending message(s) queued. Run the delivery-stall diagnosis: check the pane (busy vs idle vs full context) and restart the agent if it is wedged.`
+  const min = Math.round(stuckMs / 60000)
+  const queue = `${pendingCount} pending message(s) queued`
+  // A busy pane means the session is working, so the alert must not read like
+  // "wedged, restart it" -- that framing is what turned the earlier busy-pane
+  // alerts into wasted restarts-in-waiting. It says what it is: a long turn,
+  // worth a look, not a restart on sight.
+  if (paneState === 'busy') {
+    return `[session-stuck] Agent '${agent}' (tmux ${session}) has been BUSY (actively working, spinner up) for ${min} min with ${queue}. Not a stall by itself -- check whether the turn is progressing or a tool call is wedged. Do NOT restart on this alert alone.`
+  }
+  return `[session-stuck] Agent '${agent}' (tmux ${session}) has been not-ready for ${min} min with ${queue}. Run the delivery-stall diagnosis: check the pane (busy vs idle vs full context) and restart the agent if it is wedged.`
 }
 
-function notifyOrchestratorOfStuckSession(agent: string, session: string, stuckMs: number, pendingCount: number): void {
+function notifyOrchestratorOfStuckSession(agent: string, session: string, stuckMs: number, pendingCount: number, paneState: PaneState | null): void {
   try {
-    const alert = formatStuckSessionAlert(agent, MAIN_AGENT_ID, session, stuckMs, pendingCount)
+    const alert = formatStuckSessionAlert(agent, MAIN_AGENT_ID, session, stuckMs, pendingCount, paneState)
     if (!alert) return
     createAgentMessage('system', MAIN_AGENT_ID, alert)
-    logger.info({ agent, session, stuckMs, pendingCount }, 'session-stuck surfaced to orchestrator')
+    logger.info({ agent, session, stuckMs, pendingCount, paneState }, 'session-stuck surfaced to orchestrator')
   } catch (err) {
     logger.warn({ err, agent }, 'Failed to enqueue session-stuck notification')
   }
@@ -148,6 +166,32 @@ function notifyDelegationFailed(msg: AgentMessage, error: string): void {
 // message backlog grows large. State cleared when session becomes ready or absent.
 const STUCK_ESCALATE_MS = 10 * 60 * 1000  // 10 min continuously stuck -> escalate
 const agentStuckSince = new Map<string, number>()  // agent -> first tick stuck (Date.now)
+
+// A session in the middle of a long turn is NOT ready for a prompt, which is
+// exactly what a wedged session looks like from the queue side. On 2026-07-31
+// that produced three false alarms in one day (atlas 18:56, prisma 19:27, and
+// an earlier pair): busy pane, spinner and `esc to interrupt` visible, one or
+// two messages queued behind a turn that was working fine. Each one spent a
+// main-agent LLM round on a diagnosis whose answer was "it is working".
+//
+// The delivery-stall runbook's first pane rule -- "esc to interrupt = still
+// working, leave it alone" -- is mechanical, so the router applies it itself:
+// a busy pane does not escalate at the normal threshold. It still escalates
+// eventually, because a tool call CAN wedge with the spinner up, and a session
+// that has been busy for half an hour with mail queued behind it is worth a
+// look either way.
+const BUSY_STUCK_ESCALATE_MS = 30 * 60 * 1000  // busy pane: only after a much longer watchdog
+
+/**
+ * Pure decision: may a continuously not-ready session escalate now?
+ *
+ * `paneState` is what the pane showed at the escalation check, or null when it
+ * could not be read (remote host down, tmux gone). Unreadable is NOT treated as
+ * busy: a pane we cannot see is a reason to look sooner, not later.
+ */
+export function shouldEscalateStuckSession(paneState: PaneState | null, stuckMs: number): boolean {
+  return stuckMs > (paneState === 'busy' ? BUSY_STUCK_ESCALATE_MS : STUCK_ESCALATE_MS)
+}
 
 // ---- reconnect-backlog batching (card 2922e380 thread b) --------------------
 // When a session was absent and reconnects, old pending messages are summarized
@@ -528,22 +572,40 @@ export async function runMessageRouterTick(): Promise<void> {
         if (!stuckStart) {
           agentStuckSince.set(msg.to_agent, now)
         } else if (now - stuckStart > STUCK_ESCALATE_MS) {
-          // Session has been continuously stuck past the escalation threshold.
-          // Log at warn level so monitoring/revival tooling can act — the
-          // stuck-input-watcher and channel-monitor pick these patterns up.
-          const pendingMsgCount = pending.filter(m => m.to_agent === msg.to_agent).length
-          logger.warn({
-            to: msg.to_agent, session,
-            stuckDurationMs: now - stuckStart,
-            pendingMsgCount,
-          }, 'message-router: session STUCK — continuously not-ready past escalation threshold')
-          // Card 0a641b52: a log line nobody reads is not an alert. Surface the
-          // stall to the main agent's inbox so it can run the delivery-stall
-          // diagnosis (pane state, full context, restart). The escalation-window
-          // reset below doubles as the notification cooldown.
-          notifyOrchestratorOfStuckSession(msg.to_agent, session, now - stuckStart, pendingMsgCount)
-          // Reset timer so we don't spam every tick; re-escalate after another window.
-          agentStuckSince.set(msg.to_agent, now)
+          // Past the normal threshold -- now, and only now, read the pane. A
+          // session mid-turn is not-ready for the same reason a wedged one is,
+          // so the queue side alone cannot tell them apart; the pane can.
+          // Capturing here (rather than every tick) keeps the healthy path at
+          // zero extra tmux calls.
+          const stuckMs = now - stuckStart
+          const pane = capturePane(session, host)
+          const paneState = pane != null ? detectPaneState(pane) : null
+          if (shouldEscalateStuckSession(paneState, stuckMs)) {
+            // Session has been continuously stuck past the escalation threshold.
+            // Log at warn level so monitoring/revival tooling can act — the
+            // stuck-input-watcher and channel-monitor pick these patterns up.
+            const pendingMsgCount = pending.filter(m => m.to_agent === msg.to_agent).length
+            logger.warn({
+              to: msg.to_agent, session,
+              stuckDurationMs: stuckMs,
+              pendingMsgCount,
+              paneState,
+            }, 'message-router: session STUCK — continuously not-ready past escalation threshold')
+            // Card 0a641b52: a log line nobody reads is not an alert. Surface the
+            // stall to the main agent's inbox so it can run the delivery-stall
+            // diagnosis (pane state, full context, restart). The escalation-window
+            // reset below doubles as the notification cooldown.
+            notifyOrchestratorOfStuckSession(msg.to_agent, session, stuckMs, pendingMsgCount, paneState)
+            // Reset timer so we don't spam every tick; re-escalate after another window.
+            agentStuckSince.set(msg.to_agent, now)
+          } else {
+            // Busy pane before the long watchdog: working, not wedged. The timer
+            // is deliberately NOT reset -- it has to keep running so a turn that
+            // never ends still reaches BUSY_STUCK_ESCALATE_MS.
+            logger.debug({
+              to: msg.to_agent, session, stuckDurationMs: stuckMs, paneState,
+            }, 'message-router: not-ready but pane is busy — deferring stuck escalation')
+          }
         }
         // Stale-parked-input janitor: a non-submitted line stuck in the input
         // box (e.g. a weak local model that typed its heartbeat reply into the

--- a/src/web/message-router.ts
+++ b/src/web/message-router.ts
@@ -74,6 +74,29 @@ export function shouldGiveUpOnInject(failCount: number, maxFailures: number): bo
  * note is addressed to the main agent, which drains via the pull model and
  * never hits this inject path.
  */
+// A stuck session blocks EVERY pending message to that agent, silently. The
+// warn log above never reached anyone on 2026-07-27 (2.5h stall found by hand),
+// so the stall goes to the main agent's inbox too. Rate limit comes from the
+// caller: it fires at most once per STUCK_ESCALATE_MS window per agent.
+//
+// Pure part exported for tests: returns the alert text, or null when no alert
+// may be sent (the main agent must never alert itself about itself).
+export function formatStuckSessionAlert(agent: string, mainAgentId: string, session: string, stuckMs: number, pendingCount: number): string | null {
+  if (agent === mainAgentId) return null
+  return `[session-stuck] Agent '${agent}' (tmux ${session}) has been not-ready for ${Math.round(stuckMs / 60000)} min with ${pendingCount} pending message(s) queued. Run the delivery-stall diagnosis: check the pane (busy vs idle vs full context) and restart the agent if it is wedged.`
+}
+
+function notifyOrchestratorOfStuckSession(agent: string, session: string, stuckMs: number, pendingCount: number): void {
+  try {
+    const alert = formatStuckSessionAlert(agent, MAIN_AGENT_ID, session, stuckMs, pendingCount)
+    if (!alert) return
+    createAgentMessage('system', MAIN_AGENT_ID, alert)
+    logger.info({ agent, session, stuckMs, pendingCount }, 'session-stuck surfaced to orchestrator')
+  } catch (err) {
+    logger.warn({ err, agent }, 'Failed to enqueue session-stuck notification')
+  }
+}
+
 function notifyOrchestratorOfFailedHandoff(msg: AgentMessage, reason: string): void {
   try {
     // A failed message to the main agent can't happen (pull model), but guard
@@ -508,11 +531,17 @@ export async function runMessageRouterTick(): Promise<void> {
           // Session has been continuously stuck past the escalation threshold.
           // Log at warn level so monitoring/revival tooling can act — the
           // stuck-input-watcher and channel-monitor pick these patterns up.
+          const pendingMsgCount = pending.filter(m => m.to_agent === msg.to_agent).length
           logger.warn({
             to: msg.to_agent, session,
             stuckDurationMs: now - stuckStart,
-            pendingMsgCount: pending.filter(m => m.to_agent === msg.to_agent).length,
+            pendingMsgCount,
           }, 'message-router: session STUCK — continuously not-ready past escalation threshold')
+          // Card 0a641b52: a log line nobody reads is not an alert. Surface the
+          // stall to the main agent's inbox so it can run the delivery-stall
+          // diagnosis (pane state, full context, restart). The escalation-window
+          // reset below doubles as the notification cooldown.
+          notifyOrchestratorOfStuckSession(msg.to_agent, session, now - stuckStart, pendingMsgCount)
           // Reset timer so we don't spam every tick; re-escalate after another window.
           agentStuckSince.set(msg.to_agent, now)
         }


### PR DESCRIPTION
Split out of #920 per the maintainer's fault-line request (item 3). Heads-up acknowledged: you have a standing hold on delivery-path changes and two competing designs (#899 and your own card) — this PR is the third candidate and is offered for that decide-between-three, not for merging alongside them. If one of the other two wins, close this without ceremony.

**Commits (2, cherry-picked onto v1.31.0 main):**
- `fix(router): surface session-stuck escalation to the main agent's inbox`
- `fix(router): stop alerting on sessions that are simply working`

**Dropped from this group:** `4fe1d84` (scheduler catch-up summary alert recording) turned out to depend on `852d796` (#817): both `recordSchedulerAlert` and the wiring test file originate there, so it cannot compile standalone. It is a two-line follow-up that should re-materialize when #817 is rebased onto current main; I left a note there rather than force it in here.

**Verification on this branch:** `tsc --noEmit` clean; full `vitest run` result posted in a comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
