### PR TITLE
feat(support-mail): split login mailbox from outgoing From address (split from #920)

### DIFF
--- a/scripts/support-mail/lib.py
+++ b/scripts/support-mail/lib.py
@@ -39,6 +39,9 @@ SMTP_HOST = _env("SUPPORT_SMTP_HOST", "smtp.hostinger.com")
 SMTP_PORT = int(_env("SUPPORT_SMTP_PORT", "465"))  # implicit TLS/SSL
 
 FROM_NAME = _env("SUPPORT_FROM_NAME", "Support")
+# Outgoing From address; may differ from the login mailbox (e.g. a product
+# alias hosted on a primary account). Defaults to the login address.
+FROM_ADDRESS = _env("SUPPORT_FROM_ADDRESS") or EMAIL
 WEB_PORT = _env("WEB_PORT", "3420")
 
 

--- a/scripts/support-mail/send.py
+++ b/scripts/support-mail/send.py
@@ -24,7 +24,7 @@ def main():
     body = a.body if a.body is not None else sys.stdin.read()
 
     msg = EmailMessage()
-    msg["From"] = f"{lib.FROM_NAME} <{lib.EMAIL}>"
+    msg["From"] = f"{lib.FROM_NAME} <{lib.FROM_ADDRESS}>"
     msg["To"] = a.to
     if a.cc:
         msg["Cc"] = a.cc
@@ -45,7 +45,7 @@ def main():
                           context=ssl.create_default_context(), timeout=45) as s:
         s.login(lib.EMAIL, lib.password())
         s.send_message(msg, to_addrs=rcpts)
-    print(f"SENT from {lib.EMAIL} to {a.to}" + (f" cc {a.cc}" if a.cc else ""))
+    print(f"SENT from {lib.FROM_ADDRESS} to {a.to}" + (f" cc {a.cc}" if a.cc else ""))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Split out of #920 per the maintainer's fault-line request (item 4): changing which identity outbound mail authenticates as versus which it sends as is a configuration-surface decision for every install, so it stands alone.

**Commit (1, cherry-picked onto v1.31.0 main):**
- `feat(support-mail): split login mailbox from outgoing From address`

Default behaviour is unchanged when the new setting is absent: From falls back to the login mailbox, so existing installs see no difference until they opt in.

**Verification on this branch:** `tsc --noEmit` clean; full `vitest run` result posted in a comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
