### PR TITLE
fix(heartbeat): teach the scaffold the deferred-MCP ToolSearch protocol (HBCALMCP808)

### DIFF
--- a/src/__tests__/heartbeat-agent-scaffold.test.ts
+++ b/src/__tests__/heartbeat-agent-scaffold.test.ts
@@ -271,3 +271,16 @@ describe('no unfalsifiable warnings metric (HBWARN807)', () => {
     }
   })
 })
+
+describe('deferred MCP tools (HBCALMCP808)', () => {
+  it('the calendar step teaches the ToolSearch select protocol', () => {
+    const md = renderHeartbeatClaudeMd(ID)
+    // The load-bearing line: without it, a deferred calendar tool reads as
+    // absent and the section silently goes empty (measured 2026-08-08/09:
+    // 13 not-available reports, zero ToolSearch calls, all 13 tools present
+    // in the session's own deferred list).
+    expect(md).toContain('select:mcp__server-google-calendar-mcp__list-events')
+    // "not available" may only be claimed after ToolSearch also failed.
+    expect(md).toMatch(/ONLY[\s\S]{0,80}ToolSearch itself cannot surface/)
+  })
+})

--- a/src/web/heartbeat-agent-scaffold.ts
+++ b/src/web/heartbeat-agent-scaffold.ts
@@ -180,11 +180,27 @@ When you receive the heartbeat prompt:
      Call it as a TOOL, directly. Do not try to reach an MCP server
      from Bash, python, curl or any other subprocess: MCP tools exist
      only in your own tool list, so a subprocess will always come back
-     empty and that emptiness says nothing about the server. If the
-     tool is genuinely absent from your tool list, say
-     "calendar tool not available in this session" -- that is a
-     different fact from a failed call, and only the tool itself can
-     produce the latter.
+     empty and that emptiness says nothing about the server.
+
+     DEFERRED LOADING (2026-08-09, HBCALMCP808): MCP tools may arrive
+     DEFERRED -- their names appear in a system-reminder listing but
+     the schema is not loaded, and a direct call fails as if the tool
+     did not exist. That failure is NOT absence. Before concluding
+     anything, run:
+
+     ToolSearch with query "select:mcp__server-google-calendar-mcp__list-events"
+
+     and then call the tool normally. Between 2026-08-08 20:00 and
+     2026-08-09 every hourly round reported "calendar tool not
+     available" while all 13 calendar tools sat in the deferred list
+     of the very same session -- the section went empty for a day
+     because this step was missing.
+
+     You may say "calendar tool not available in this session" ONLY
+     when ToolSearch itself cannot surface the tool either -- that is
+     a different fact from a failed direct call on a deferred tool,
+     and a different fact again from a failed call (token revoked /
+     401), which only the loaded tool can produce.
      If the call fails (token revoked / 401), record the failure
      reason rather than the events; the main agent can act on the
      failure.


### PR DESCRIPTION
## Mit javít

2026-08-08 20:00 óta a heartbeat naptár-szekciója minden körben üres volt, "calendar tool not available in this execution context" szöveggel. A mért gyökérok (HBCALMCP808 kártya): a Claude Code az MCP-toolokat DEFERRED módon adja át (a név listázva, a séma nincs betöltve ToolSearch-ig), a scaffold naptár-lépése pedig a sikertelen direkt hívást hiányként olvasta -- pontosan azt az ágat követve, amit a saját szövege írt elő.

**Bizonyíték a kártyán**: a 10:00-ás kör transcriptjében mind a 13 calendar-tool ott ül a deferred_tools_delta listában, nulla ToolSearch és nulla mcp-hívás mellett; a júl. 28 / aug. 2-i transcriptek 469/65 valódi calendar-hívása a pozitív kontroll. A friss session-restart nem segített -- a mechanizmus verzió-viselkedés, nem session-állapot.

## A fix

A scaffold naptár-lépése megtanulja a protokollt: előbb `ToolSearch "select:mcp__server-google-calendar-mcp__list-events"`, aztán a normál hívás; "not available" csak akkor mondható ki, ha a ToolSearch sem hozza fel a toolt. Kontrakt-teszt pinnli az instrukciót (mutációs kontroll: a bekezdés kivételével 2 teszt bukik).

## KÖTELEZŐ deploy-lépés (SCAFFOLDDEAD807)

A scaffold-változás CSAK friss restarttal ér célba: kill + dashboard kickstart a heartbeat agensre -- a --continue respawn a régi kontextust tartja.

## Átvételi kritérium (ezen mérendő)

A restart utáni ELSŐ kör naptár-sora valós eseményt vagy "nincs esemény"-t ad, NEM tool-hiány-szöveget; és a kör transcriptjében ToolSearch-hívás + mcp calendar-hívás szerepel.

## Ami szándékosan NEM része

A közös agent-scaffold általános ToolSearch-hintje -- külön döntés (FLEETDEFER809): a flotta-mérés szerint egyedül a heartbeat bizonyítottan érintett, boni/iris/zara/jumanji már használja a protokollt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)