### PR TITLE
feat(scaffold): teach every agent the deferred-MCP ToolSearch protocol (FLEETDEFER809)

### DIFF
--- a/src/__tests__/agent-scaffold-claude-md-prompt.test.ts
+++ b/src/__tests__/agent-scaffold-claude-md-prompt.test.ts
@@ -65,3 +65,19 @@ describe('generateClaudeMd: stranger-sender ARANYSZABÁLY block is bot-name agno
     expect(src).toMatch(/import\s*{[^}]*\bBOT_NAME\b[^}]*}\s*from\s*'\.\.\/config\.js'/)
   })
 })
+
+describe('deferred MCP tool hint (FLEETDEFER809)', () => {
+  const SRC = readFileSync(SCAFFOLD_PATH, 'utf-8')
+  // The load-bearing rule: a deferred tool's failed direct call must not be
+  // read as absence. Without this section an agent whose scaffold predates
+  // deferred loading reports "not available" while the tool sits in its own
+  // deferred list (measured: HBCALMCP808, a full day of empty calendar rounds).
+  it('the shared scaffold teaches select-then-keyword ToolSearch before claiming absence', () => {
+    expect(SRC).toContain('deferred betöltése (FLEETDEFER809)')
+    expect(SRC).toContain('select:<tool_nev>')
+    // keyword fallback is part of the contract: server names differ per install
+    expect(SRC).toMatch(/KULCSSZÓVAL/)
+    // absence may only be claimed after the keyword search also failed
+    expect(SRC).toMatch(/Csak akkor mondd ki a hiányt/)
+  })
+})

--- a/src/web/agent-scaffold.ts
+++ b/src/web/agent-scaffold.ts
@@ -1060,11 +1060,11 @@ system-reminder listában, de a séma nincs betöltve, és a közvetlen hívás
 úgy bukik, mintha a tool nem létezne. Ez a bukás NEM hiány. Mielőtt azt
 mondanád egy toolra, hogy "nem elérhető":
 
-1. \`ToolSearch\` a pontos névvel: \`select:<tool_nev>\` — utána a tool normálisan hívható.
-2. Ha a select nem hoz találatot, keress KULCSSZÓVAL (pl. \`calendar\`, \`gmail\`) — a szerver-név telepítésenként eltérhet.
-3. Csak akkor mondd ki a hiányt, ha a kulcsszavas keresés sem hozza fel — az már valódi tény, nem betöltési állapot.
+1. \`ToolSearch\` a pontos névvel: \`select:<tool_nev>\`. Utána a tool normálisan hívható.
+2. Ha a select nem hoz találatot, keress KULCSSZÓVAL (pl. \`calendar\`, \`gmail\`), mert a szerver-név telepítésenként eltérhet.
+3. Csak akkor mondd ki a hiányt, ha a kulcsszavas keresés sem hozza fel. Az már valódi tény, nem betöltési állapot.
 
-(Mért eset: HBCALMCP808 — a heartbeat egy napig üres naptár-szekciót adott,
+(Mért eset: HBCALMCP808. A heartbeat egy napig üres naptár-szekciót adott,
 miközben mind a 13 calendar-tool ott ült a saját deferred listájában.)
 
 ## Új ismeretlen sender első üzenete (ARANYSZABÁLY)

--- a/src/web/agent-scaffold.ts
+++ b/src/web/agent-scaffold.ts
@@ -1053,6 +1053,20 @@ MINDIG az install időzónáját használd: **${APP_TZ}** (a teljes telepítés 
 
 Heartbeat-eknél és minden időpontot kezelő feladatnál kötelező: \`date\` Bash parancs az elemzés ELŐTT.
 
+## MCP-toolok deferred betöltése (FLEETDEFER809)
+
+Az MCP-toolok érkezhetnek DEFERRED módon: a nevük megjelenik egy
+system-reminder listában, de a séma nincs betöltve, és a közvetlen hívás
+úgy bukik, mintha a tool nem létezne. Ez a bukás NEM hiány. Mielőtt azt
+mondanád egy toolra, hogy "nem elérhető":
+
+1. \`ToolSearch\` a pontos névvel: \`select:<tool_nev>\` — utána a tool normálisan hívható.
+2. Ha a select nem hoz találatot, keress KULCSSZÓVAL (pl. \`calendar\`, \`gmail\`) — a szerver-név telepítésenként eltérhet.
+3. Csak akkor mondd ki a hiányt, ha a kulcsszavas keresés sem hozza fel — az már valódi tény, nem betöltési állapot.
+
+(Mért eset: HBCALMCP808 — a heartbeat egy napig üres naptár-szekciót adott,
+miközben mind a 13 calendar-tool ott ült a saját deferred listájában.)
+
 ## Új ismeretlen sender első üzenete (ARANYSZABÁLY)
 
 Ha egy senderId üzen a csatornán AKIT EDDIG NEM ISMERSZ — nem szerepel az aktív interakciós kontextusodban, és nem találsz róla memóriabejegyzést a vault-ban — KÖTELEZŐ ELSŐKÉNT inter-agent message-t küldeni ${BOT_NAME}-nek MIELŐTT érdemi választ adsz.


### PR DESCRIPTION
## Mit ad

A #942 (HBCALMCP808) heartbeat-fix általánosítása a közös agent-scaffoldra: rövid szekció, ami minden agensnek megtanítja a deferred-MCP létrát, mielőtt "nem elérhető"-t mondana egy toolra:

1. `ToolSearch select:<tool_nev>` -- utána normál hívás
2. Ha a select üres: KULCSSZAVAS keresés (a szerver-név telepítésenként eltér -- a #942 review-észrevétele beépítve)
3. Hiány csak akkor mondható ki, ha a kulcsszavas keresés is üres

## Hatókör-indoklás (FLEETDEFER809 kártya)

A flotta-mérés szerint a heartbeat volt az egyetlen BIZONYÍTOTTAN érintett; boni/iris/zara/jumanji már használja a ToolSearch-öt; dani/geri/qwen/deeper expozíciója méretlen -- ez a hint pont arra a halmazra olcsó biztosítás.

## Deploy (szándékos döntés, a maintainer kikötése szerint)

NINCS kényszerített flotta-szintű fresh restart: a szekció agensenként a következő természetes restartnál landol. A kényszerített restart ára (kontextus-vesztés mindenkinél) méretlen kockázatért nem indokolt.

## Verify

Kontrakt-teszt pinnli a szekciót; mutációs kontroll: a szekció kivételével a teszt bukik (zöld-piros-zöld futás igazolva). Scaffold-tesztek: 42/42 zöld.

🤖 Generated with [Claude Code](https://claude.com/claude-code)