### PR TITLE
feat(channels): redacted pane diagnostics on stage-1 reconnect failures (383c3463)

### DIFF
--- a/src/__tests__/channel-mcp-reconnect.test.ts
+++ b/src/__tests__/channel-mcp-reconnect.test.ts
@@ -57,6 +57,7 @@ import {
   resolveAgentProviderType,
   selectedSubmenuLine,
   chooseSubmenuTarget,
+  paneDiagSignature,
 } from '../web/channel-mcp-reconnect.js'
 
 // Submenu panes Claude Code renders for each plugin state. The `❯` marks the
@@ -82,6 +83,53 @@ const SUBMENU_DISABLED_TOP = [
   'plugin:telegram:telegram',
   '❯ Enable',
 ].join('\n')
+
+describe('paneDiagSignature', () => {
+  const PLUGIN_RX = /plugin:telegram:telegram/i
+
+  it('null pane -> capture-failed marker only', () => {
+    expect(paneDiagSignature(null, PLUGIN_RX)).toEqual({ paneCaptured: false })
+  })
+
+  it('open /mcp menu with the plugin row -> menu and row both seen', () => {
+    const pane = [
+      'plugin:telegram:telegram',
+      '❯ Reconnect',
+      '  Disable',
+      '',
+      '↑/↓ to navigate · Enter to confirm · Esc to cancel',
+    ].join('\n')
+    const sig = paneDiagSignature(pane, PLUGIN_RX)
+    expect(sig.paneCaptured).toBe(true)
+    expect(sig.inBlockingMenu).toBe(true)
+    expect(sig.sawPluginRow).toBe(true)
+    expect(sig.paneNonEmptyLines).toBe(4)
+  })
+
+  it('plain conversation pane -> no menu, no plugin row, and NO raw text in the signature', () => {
+    const pane = [
+      'Szia, ezt a bizalmas mondatot senki nem lathatja a logban.',
+      '❯ ',
+    ].join('\n')
+    const sig = paneDiagSignature(pane, PLUGIN_RX)
+    expect(sig.inBlockingMenu).toBe(false)
+    expect(sig.sawPluginRow).toBe(false)
+    // The redaction contract: nothing from the pane text may leak through.
+    expect(JSON.stringify(sig)).not.toContain('bizalmas')
+  })
+
+  it('menu open but the plugin row is NOT rendered -> the discriminating case', () => {
+    const pane = [
+      'Manage MCP servers',
+      '❯ some-other-server  connected',
+      '',
+      '↑/↓ to navigate · Enter to confirm · Esc to cancel',
+    ].join('\n')
+    const sig = paneDiagSignature(pane, PLUGIN_RX)
+    expect(sig.inBlockingMenu).toBe(true)
+    expect(sig.sawPluginRow).toBe(false)
+  })
+})
 
 describe('resolveAgentSession', () => {
   it('returns main channels session for main agent', () => {

--- a/src/web/channel-mcp-reconnect.ts
+++ b/src/web/channel-mcp-reconnect.ts
@@ -7,7 +7,7 @@ import { agentSessionName, capturePane } from './agent-process.js'
 import { MAIN_CHANNELS_SESSION } from './main-agent.js'
 import { getProvider, type ChannelProviderType } from '../channel-provider.js'
 import { tryAcquireSessionSendLane } from './session-send-lock.js'
-import { paneLooksIdle, detectPaneState } from '../pane-state.js'
+import { paneLooksIdle, detectPaneState, detectsBlockingMenu } from '../pane-state.js'
 
 const TMUX = resolveFromPath('tmux')
 const MAX_UP_ATTEMPTS = 8
@@ -72,6 +72,29 @@ function getPluginPattern(providerType: ChannelProviderType): RegExp {
   const provider = getProvider(providerType)
   const escaped = provider.pluginPaneId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
   return new RegExp(escaped, 'i')
+}
+
+/**
+ * Redacted diagnostic signature of a captured pane for the failure warns.
+ * Booleans/counts ONLY: the pane is the main session's screen and may contain
+ * conversation content, which must never reach the log. The signature answers
+ * the questions the 383c3463 investigation could not (79 submenu-not-found and
+ * 68 cursor-placement failures in the retained prod log window, none with any
+ * record of what the TUI showed): was a blocking menu open at all, was the
+ * plugin row rendered, and what state the pane was in.
+ */
+export function paneDiagSignature(
+  pane: string | null,
+  pluginPattern: RegExp,
+): Record<string, unknown> {
+  if (pane == null) return { paneCaptured: false }
+  return {
+    paneCaptured: true,
+    paneNonEmptyLines: pane.split('\n').filter((l) => l.trim().length > 0).length,
+    inBlockingMenu: detectsBlockingMenu(pane),
+    sawPluginRow: pluginPattern.test(pane),
+    paneState: detectPaneState(pane),
+  }
 }
 
 // Max Down presses we'll spend trying to land the cursor on the target
@@ -204,6 +227,8 @@ export function attemptChannelMcpReconnect(agentName: string): ReconnectResult {
     }
 
     let matchedAt = -1
+    // Kept for the failure diagnostics below: the last thing the TUI showed.
+    let lastPane: string | null = pane1
     for (let upCount = 1; upCount <= MAX_UP_ATTEMPTS; upCount++) {
       execFileSync(TMUX, ['send-keys', '-t', session, 'Up'], { timeout: 3000 })
       execFileSync('/bin/sleep', ['0.2'], { timeout: 1000 })
@@ -211,6 +236,7 @@ export function attemptChannelMcpReconnect(agentName: string): ReconnectResult {
       execFileSync('/bin/sleep', ['1'], { timeout: 3000 })
 
       const pane = capturePane(session)
+      lastPane = pane ?? lastPane
       if (pane && pluginPattern.test(pane)) {
         matchedAt = upCount
         break
@@ -221,7 +247,14 @@ export function attemptChannelMcpReconnect(agentName: string): ReconnectResult {
 
     if (matchedAt < 0) {
       logger.warn(
-        { agentName, session, maxUpAttempts: MAX_UP_ATTEMPTS, pluginPattern: pluginPattern.source },
+        {
+          agentName,
+          session,
+          maxUpAttempts: MAX_UP_ATTEMPTS,
+          pluginPattern: pluginPattern.source,
+          afterMcp: paneDiagSignature(pane1, pluginPattern),
+          lastAttempt: paneDiagSignature(lastPane, pluginPattern),
+        },
         'channel-mcp-reconnect: plugin submenu not found',
       )
       dismissMcpMenu(session)
@@ -259,7 +292,13 @@ export function attemptChannelMcpReconnect(agentName: string): ReconnectResult {
 
     if (!onTarget) {
       logger.warn(
-        { agentName, session, target: target.source, maxSteps: SUBMENU_MAX_STEPS },
+        {
+          agentName,
+          session,
+          target: target.source,
+          maxSteps: SUBMENU_MAX_STEPS,
+          submenu: paneDiagSignature(submenu, pluginPattern),
+        },
         'channel-mcp-reconnect: could not place cursor on target option',
       )
       dismissMcpMenu(session)


### PR DESCRIPTION
## Finding (383c3463 reassessment, prod log measurement 2026-08-10)

The card asked whether the 2026-06-02 'plugin submenu not found' incident was a #238 regression or a TUI render change. Measuring the CURRENT prod dashboard.log instead of chasing the two-month-old incident:

- **89** `channel-mcp-reconnect: completed` (stage-1 works)
- **79** `plugin submenu not found` + **68** `could not place cursor on target option` (it also fails a lot)
- **16** pane-busy defers
- The failures CLUSTER by dashboard generation: pid 34662 produced 28/28 submenu failures with zero successes, while other generations succeed — a per-generation persistent condition (CC version? pane state? menu render variant?), not random flake.
- An honest self-correction is part of the record: my first per-pid slice suggested 48/48 structural failure; the refuter grep on the success-path wording (`completed`) overturned it.

**The blocker for root-causing — in June and now — is that neither failure warn records what the TUI showed.**

## Change

`paneDiagSignature()`: a REDACTED signature attached to both failure warns — `inBlockingMenu` (was any menu open), `sawPluginRow` (was the plugin row rendered), `paneState` class, non-empty line count, capture flag. Booleans/counts only: the pane is the main session's screen and may carry conversation text, so raw pane content never reaches the log. A test pins the redaction contract (`JSON.stringify(sig)` must not contain pane text).

Next time the failure fires, the log discriminates the hypotheses directly: menu open without the plugin row (row-id/pagination issue) vs no menu at all (lost keystroke / wrong pane state) vs busy race.

## Verification

- `tsc --noEmit` 0; full suite **3527/3527** (4 new tests).
- Mutation control: forcing `sawPluginRow: true` makes exactly the 2 discriminating tests fail; restored, all green.
- Diff is log-only (no behavior change on any path): the walk gains a `lastPane` holder, both warns gain fields.

Investigation continues on the card once live signatures accumulate; this PR is the instrument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)