### PR TITLE
fix(onboarding): wizard waits for a MEASURED channel-live signal after the bot token (WIZFLOW809)

### DIFF
--- a/src/__tests__/onboarding-channel-live-wait.test.ts
+++ b/src/__tests__/onboarding-channel-live-wait.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+// WIZFLOW809. After saving the bot token the wizard used to advance on a fixed
+// setTimeout (4s), while the restart response is only a dispatch receipt and
+// the cold start takes ~minutes -- the pairing step opened against a booting
+// session and looked done-and-empty (three identical field reports on 0.3.15).
+//
+// The acceptance criterion (coordinator, msg 10154): the test must FORCE the
+// slow path -- a delayed ready signal -- and assert the wizard WAITS. A
+// "works on my machine" run proves nothing for a timing bug, because on a fast
+// machine 4 seconds can be enough by luck.
+//
+// The wizard step itself is not unit-mountable (repo convention: structural
+// assertions over web/app.js). The wait logic is therefore a NAMED, anchored,
+// dependency-injected function, extracted here BY ITS ANCHORS and run for
+// real: the slow path is exercised at runtime, not just pinned textually.
+
+const APP = readFileSync(join(__dirname, '..', '..', 'web', 'app.js'), 'utf-8')
+
+const BEGIN = '// WIZFLOW809 BEGIN waitForChannelLive'
+const END = '// WIZFLOW809 END waitForChannelLive'
+
+function extractWaitForChannelLive(): (
+  fetchStatus: () => Promise<unknown>,
+  delayMs: number,
+  maxTries: number,
+) => Promise<'live' | 'timeout'> {
+  const b = APP.indexOf(BEGIN)
+  const e = APP.indexOf(END)
+  // Loud failure on a missing anchor: a silent miss would turn every runtime
+  // assertion below into a test of nothing (this repo's own instrument lesson).
+  expect(b, `anchor missing: ${BEGIN}`).toBeGreaterThan(-1)
+  expect(e, `anchor missing: ${END}`).toBeGreaterThan(b)
+  const src = APP.slice(b + BEGIN.length, e)
+  expect(src).toContain('async function waitForChannelLive')
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval
+  return new Function(`${src}; return waitForChannelLive;`)() as ReturnType<typeof extractWaitForChannelLive>
+}
+
+describe('waitForChannelLive -- runtime semantics with a forced-slow ready signal', () => {
+  it('WAITS through a delayed signal: false x5 then true -> live, polled 6 times', async () => {
+    const waitForChannelLive = extractWaitForChannelLive()
+    let calls = 0
+    const fetchStatus = async () => ({ channelLive: ++calls > 5 })
+    const outcome = await waitForChannelLive(fetchStatus, 1, 40)
+    expect(outcome).toBe('live')
+    expect(calls).toBe(6) // kept polling exactly until the signal, no early advance
+  })
+
+  it('timeout is NOT success: signal never comes -> "timeout" after exactly maxTries polls', async () => {
+    const waitForChannelLive = extractWaitForChannelLive()
+    let calls = 0
+    const fetchStatus = async () => { calls++; return { channelLive: false } }
+    const outcome = await waitForChannelLive(fetchStatus, 1, 4)
+    expect(outcome).toBe('timeout')
+    expect(calls).toBe(4)
+  })
+
+  it('already-live channel advances on the FIRST poll (checks before sleeping)', async () => {
+    const waitForChannelLive = extractWaitForChannelLive()
+    let calls = 0
+    const started = Date.now()
+    const fetchStatus = async () => { calls++; return { channelLive: true } }
+    const outcome = await waitForChannelLive(fetchStatus, 5000, 40)
+    expect(outcome).toBe('live')
+    expect(calls).toBe(1)
+    expect(Date.now() - started).toBeLessThan(1000) // no 5s sleep was paid
+  })
+
+  it('a null status (fetch error) keeps waiting instead of crashing or advancing', async () => {
+    const waitForChannelLive = extractWaitForChannelLive()
+    let calls = 0
+    const fetchStatus = async () => (++calls < 3 ? null : { channelLive: true })
+    const outcome = await waitForChannelLive(fetchStatus, 1, 40)
+    expect(outcome).toBe('live')
+    expect(calls).toBe(3)
+  })
+})
+
+describe('structural pins -- the fixed-wait shape must not return', () => {
+  it('the banned shape setTimeout(refreshOnboarding is gone from the STEP-3 handler', () => {
+    // This exact shape WAS the bug at this call site: advance to the pairing
+    // step on a timer instead of the measured signal. Scoped to step 3 on
+    // purpose: the identity/auth/approve steps also refresh on timers, but
+    // there the refresh only re-reads status (the next screen does not
+    // require a live channel), a different and lower harm profile -- fixing
+    // those is a separate scope decision, named in the PR, not smuggled in.
+    const s3 = APP.indexOf("} else if (step === 3)")
+    const s4 = APP.indexOf("} else if (step === 4)")
+    expect(s3, 'step-3 block anchor missing').toBeGreaterThan(-1)
+    expect(s4, 'step-4 block anchor missing').toBeGreaterThan(s3)
+    expect(APP.slice(s3, s4)).not.toContain('setTimeout(refreshOnboarding')
+  })
+
+  it('step-3 handler waits on the measured signal and its timeout branch does not advance', () => {
+    const sliceStart = APP.indexOf("t('onboarding.step2.waiting_channel')")
+    const sliceEnd = APP.indexOf("} else if (step === 4)")
+    expect(sliceStart, 'step-3 waiting_channel anchor missing').toBeGreaterThan(-1)
+    expect(sliceEnd, 'step-4 boundary anchor missing').toBeGreaterThan(sliceStart)
+    const step3Tail = APP.slice(sliceStart, sliceEnd)
+    expect(step3Tail).toContain('waitForChannelLive(fetchOnboardingStatus')
+    // The live branch is the ONLY advance; the timeout branch re-enables the
+    // button and says the channel is still starting.
+    expect(step3Tail).toMatch(/if \(outcome === 'live'\) \{ await refreshOnboarding\(\) \}/)
+    expect(step3Tail).toMatch(/else \{ botBtn\.disabled = false; onbMsg\(t\('onboarding\.step2\.channel_slow'\), true\) \}/)
+    const advances = step3Tail.match(/refreshOnboarding/g) ?? []
+    expect(advances.length).toBe(1)
+  })
+
+  it('the backend status route computes channelLive from the shared liveness probe', () => {
+    const route = readFileSync(join(__dirname, '..', 'web', 'routes', 'onboarding.ts'), 'utf-8')
+    expect(route).toContain("import { getClaudePidForSession, hasChannelPluginAlive } from '../../channel-coordinator/liveness.js'")
+    expect(route).toMatch(/channelLive = claudePid != null && hasChannelPluginAlive\(claudePid, CHANNEL_PROVIDER\)/)
+    expect(route).toMatch(/^\s*channelLive,$/m) // and it is actually in the response
+  })
+
+  it('both languages carry the waiting and slow keys', () => {
+    for (const lang of ['hu', 'en']) {
+      const src = readFileSync(join(__dirname, '..', '..', 'web', 'lang', `${lang}.js`), 'utf-8')
+      expect(src).toContain("'onboarding.step2.waiting_channel'")
+      expect(src).toContain("'onboarding.step2.channel_slow'")
+    }
+  })
+})

--- a/src/web/routes/onboarding.ts
+++ b/src/web/routes/onboarding.ts
@@ -9,6 +9,7 @@ import { atomicWriteFileSync } from '../atomic-write.js'
 import { channelStateDir, readChannelToken } from '../../channel-provider.js'
 import { sessionExistsOnHost } from '../agent-process.js'
 import { MAIN_CHANNELS_SESSION } from '../main-agent.js'
+import { getClaudePidForSession, hasChannelPluginAlive } from '../../channel-coordinator/liveness.js'
 import {
   hardRestartMarveenChannels,
   mainChannelsSessionExists,
@@ -252,6 +253,22 @@ export async function tryHandleOnboarding(ctx: RouteContext): Promise<boolean> {
       ? isManagedSettingsReady()
       : null
     const sudoCommand = managedSettingsReady === false ? getManagedSettingsSudoCommand() : null
+    // WIZFLOW809: measured channel liveness for the wizard's step-3 wait.
+    // hardRestartMarveenChannels() answers `restarted: true` when the restart
+    // COMMAND was dispatched, not when the channel is up -- and the cold path
+    // is a ~minutes start. The wizard used to advance after a fixed 4s and
+    // opened the pairing step against a still-booting session (three field
+    // reports, WIZFLOW809). This field is the ready signal it waits on now:
+    // the same bun-child/process liveness definition channel-monitor and
+    // channel-plugin-unlock already agree on. Fail-closed: any probe error
+    // reads as "not live yet" -- the wizard just keeps waiting.
+    let channelLive = false
+    try {
+      const claudePid = getClaudePidForSession(MAIN_CHANNELS_SESSION)
+      channelLive = claudePid != null && hasChannelPluginAlive(claudePid, CHANNEL_PROVIDER)
+    } catch {
+      channelLive = false
+    }
     json(res, {
       identityConfirmed: identityConfirmed(),
       currentAgentName: readEnvValue('BRAND_NAME') || readEnvValue('BOT_NAME') || 'Marveen',
@@ -259,6 +276,7 @@ export async function tryHandleOnboarding(ctx: RouteContext): Promise<boolean> {
       claudeAuthPresent: claude,
       agentsRunning: running,
       channelConfigured: ch,
+      channelLive,
       channelProvider: CHANNEL_PROVIDER,
       agentId: MAIN_AGENT_ID,
       existingBotToken: existingTokens.botToken,

--- a/web/app.js
+++ b/web/app.js
@@ -11889,6 +11889,27 @@ setInterval(pollUpdatesBadge, 5 * 60_000)
 async function fetchOnboardingStatus() {
   try { return await (await fetch('/api/onboarding/status')).json() } catch { return null }
 }
+// WIZFLOW809 BEGIN waitForChannelLive
+// Poll the onboarding status until the channel is MEASURABLY live
+// (status.channelLive: the bun-child/process liveness the channel-monitor
+// uses), instead of a fixed setTimeout. The restart response's
+// `restarted: true` is only a dispatch receipt -- on the cold path the real
+// start takes ~minutes, and a fixed wait opened the pairing step against a
+// still-booting session (WIZFLOW809, three field reports). Checks BEFORE the
+// first sleep so an already-live channel advances immediately; a timeout is
+// NOT success -- the caller must keep the user on this step and say the
+// channel is still starting. Dependencies are parameters so the slow path is
+// unit-testable with a delayed fake signal (the acceptance criterion: the
+// wizard WAITS, it does not get lucky with timing).
+async function waitForChannelLive(fetchStatus, delayMs, maxTries) {
+  for (let i = 0; i < maxTries; i++) {
+    const st = await fetchStatus()
+    if (st && st.channelLive) return 'live'
+    await new Promise((r) => setTimeout(r, delayMs))
+  }
+  return 'timeout'
+}
+// WIZFLOW809 END waitForChannelLive
 function onboardingCurrentStep(s) {
   if (!s.identityConfirmed) return 1
   if (!s.claudeAuthPresent || !s.agentsRunning) return 2
@@ -12120,10 +12141,17 @@ function wireOnboarding(step) {
         }
         if (!res.ok) { botBtn.disabled = false; onbMsg(d.error || t('onboarding.error'), true); return }
         // The server restarts the channels session so the new bot token goes
-        // live -- say so, and give the respawn a beat before advancing so the
-        // pairing step starts against the restarted service.
+        // live. Do NOT advance on a timer: the restart response is a dispatch
+        // receipt, and the cold start is ~minutes. Wait for the MEASURED
+        // channelLive signal, tell the user the channel is starting meanwhile,
+        // and on timeout stay on this step with an honest "still starting"
+        // message -- the old fixed 4s opened the pairing step against a
+        // booting session, which looked done-and-empty (WIZFLOW809).
         onbMsg(d.restarted ? t('onboarding.step2.saved_restarted') : t('onboarding.step2.saved'))
-        setTimeout(refreshOnboarding, d.restarted ? 4000 : 2000)
+        onbMsg(t('onboarding.step2.waiting_channel'))
+        const outcome = await waitForChannelLive(fetchOnboardingStatus, 3000, 40)  // ~2 min bound
+        if (outcome === 'live') { await refreshOnboarding() }
+        else { botBtn.disabled = false; onbMsg(t('onboarding.step2.channel_slow'), true) }
       } catch (e) { botBtn.disabled = false; onbMsg((e && e.message) || t('onboarding.error'), true) }
     })
   } else if (step === 4) {

--- a/web/lang/en.js
+++ b/web/lang/en.js
@@ -1519,6 +1519,8 @@ window._i18n.en = {
   'onboarding.step1.saved_unverified': 'Token saved (verification did not run, it may still be valid).',
   'onboarding.flow_note': 'The four steps build on each other: after each save the system restarts itself, and it begins responding after step 4 (pairing). Until then, messages about missing steps are normal.',
   'onboarding.step2.saved_restarted': 'Bot token saved, the agent is restarting with the new bot -- one moment.',
+  'onboarding.step2.waiting_channel':'The channel is starting with the new bot token -- a cold start can take a few minutes, please wait, it advances on its own.',
+  'onboarding.step2.channel_slow':'The channel is still starting. On a slower machine this can take longer: wait a bit, then press Save again -- if the channel has come up meanwhile, it advances immediately. If nothing changes after 10 minutes, check the store/channels-failures.log file.',
   'onboarding.step3.svc_up': 'The bot service is running, pairing can begin.',
   'onboarding.step3.svc_starting': 'The bot service is still starting -- if the pairing code does not arrive right away, wait a few seconds and refresh.',
   'onboarding.flow_note_last': 'This is the last step: after pairing, the system goes live.',

--- a/web/lang/hu.js
+++ b/web/lang/hu.js
@@ -1522,6 +1522,8 @@ window._i18n.hu = {
   'onboarding.step1.saved_unverified': 'Token elmentve (az ellenőrzés nem futott le, ettől még jó lehet).',
   'onboarding.flow_note': 'A négy lépés egymásra épül: a mentések után a rendszer magától újraindul, és a 4. lépés (párosítás) után kezd válaszolni. Addig a hiányzó lépésekre hivatkozó üzenetek normálisak.',
   'onboarding.step2.saved_restarted': 'Bot token elmentve, az ügynök újraindul az új bottal -- egy pillanat.',
+  'onboarding.step2.waiting_channel':'A csatorna indul az új bot tokennel -- ez hidegindításnál pár percig is eltarthat, kérlek várj, magától lép tovább.',
+  'onboarding.step2.channel_slow':'A csatorna még mindig indul. Lassabb gépen ez tovább tarthat: várj egy kicsit, majd nyomd meg újra a Mentés gombot -- ha a csatorna közben felállt, azonnal továbblép. Ha 10 perc után sincs változás, nézd meg a store/channels-failures.log fájlt.',
   'onboarding.step3.svc_up': 'A bot-szolgáltatás fut, jöhet a párosítás.',
   'onboarding.step3.svc_starting': 'A bot-szolgáltatás még indul -- ha a párosító kód nem érkezik meg azonnal, várj pár másodpercet és frissíts.',
   'onboarding.flow_note_last': 'Ez az utolsó lépés: a párosítás után a rendszer élesben elindul.',


### PR DESCRIPTION
## Root cause (measured by Marveen, msg 10152; confirmed at the code)

Szabi's hypothesis was half right, and the report says so explicitly: the **server-side order is CORRECT** (token atomically to `.env` → access.json → `hardRestartMarveenChannels()`), so "no restart with the real token" does NOT hold. What holds is the second half — the wizard moves on too fast — via a different mechanism: `hardRestartMarveenChannels()` answers `ok:true` when the restart **command was dispatched** (not on liveness), and the frontend advanced on a fixed `setTimeout(refreshOnboarding, 4000)` while the cold start is ~minutes. The pairing step opened against a booting session and looked done-and-empty. Three identical field reports on 0.3.15.

## Fix — a measured ready signal, not a bigger number

- **Backend**: `/api/onboarding/status` now returns `channelLive`, computed from the fleet's agreed liveness definition (`getClaudePidForSession` + `hasChannelPluginAlive` from `channel-coordinator/liveness.ts` — the same signal channel-monitor's ground-truth shortcut and channel-plugin-unlock use). Fail-closed: probe errors read as "not live yet".
- **Frontend step 3**: after the token save, the wizard polls `channelLive` (3s × 40, ~2 min bound; checks BEFORE sleeping so an already-live channel advances instantly), shows "the channel is starting…" meanwhile, and on timeout **stays on the step** with an honest still-starting message + re-enabled button (pressing Save again re-checks; timeout is not success). Mirrors the launch-button pattern that PR #779 already established for step 1→2.
- New i18n keys (hu+en): `onboarding.step2.waiting_channel`, `onboarding.step2.channel_slow`.

## Acceptance criterion (msg 10154 #3): the slow path is FORCED, at runtime

`waitForChannelLive` is a named, anchored, dependency-injected function; the test extracts it by its anchors (loud failure if the anchor is missing) and **runs it** with a delayed fake signal:
- false ×5 then true → resolves `live`, polled exactly 6 times (it waited; no early advance);
- signal never comes → `timeout` after exactly maxTries (timeout ≠ success);
- already-live → advances on the first poll without paying a sleep;
- null status (fetch error) → keeps waiting, no crash.
Plus structural pins: the banned `setTimeout(refreshOnboarding` shape is gone from the step-3 handler; the timeout branch does not advance (`refreshOnboarding` appears exactly once, in the live branch); the backend field is wired from the shared liveness probe; both languages carry the new keys.

## Mutation control (both directions, red runs seen)

- Original bug shape restored (fixed timer back) → **2 structural pins fail**.
- Helper mutated to return `live` immediately (the "got lucky with timing" shape) → **3 runtime tests fail**.
- Restored → 8/8; full suite **3531/3531**; `tsc --noEmit` real exit 0; `node --check` on app.js + both lang files OK.

## Deliberately out of scope, named

The identity / claude-auth / pairing-approve steps also refresh on fixed timers (`app.js` 12064/12065/12087/12088/12212). Their refresh only re-reads status — the next screen there does not require a live channel — a different and lower harm profile. Fixing those is a separate scope decision for the coordinator, not smuggled into this PR.

Review + merge: Marveen (author = Samu; comms/onboarding path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)