### PR TITLE
fix(installer): make the ollama+model step truly non-fatal (BC100FAIL810 fix A)

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -1489,21 +1489,37 @@ fi
 # stream:false --> szinkron, egyetlen valaszt ad vissza a letoltes utan
 ollama_pull() {
   local model="$1" size="$2"
+  # API-up guard (BC100FAIL810): this whole step is declared optional/non-fatal,
+  # but on a host where the ollama BINARY installed yet its SERVICE never came up
+  # (no ollama.service unit, API at :11434 dead -- measured on ai-bootcamp-vps100
+  # 2026-08-10), the pull below would abort the whole install. Under `set -e` the
+  # `status=$(curl ... | python3 json.load)` assignment inherits the pipeline's
+  # exit code -- an empty curl (connection refused) makes json.load raise, python3
+  # exits non-zero, the assignment inherits it, and the ERR trap kills the
+  # install at step "ollama-whisper". So skip -- non-fatal -- whenever the API is
+  # not answering, instead of trying a pull that cannot work.
+  if ! curl -s --max-time 5 http://localhost:11434/api/version &>/dev/null; then
+    warn "ollama API nem valaszol (:11434) -- $model letoltese kimarad (a szolgaltatas nem all fel). Kesobb: ollama serve && ollama pull $model"
+    return 0
+  fi
   if curl -s http://localhost:11434/api/tags | grep -q "\"$model\""; then
     ok "$model mar letoltve"
     return 0
   fi
   echo -e "  $model letoltese ($size)..."
   local status
+  # `|| status=""` is load-bearing under `set -e`: a command-substitution
+  # assignment aborts the script when its pipeline exits non-zero (empty body ->
+  # json.load raises -> python3 exits 1). The guard turns that into the warn path.
   status=$(curl -s --max-time 600 \
     -X POST http://localhost:11434/api/pull \
     -H 'Content-Type: application/json' \
     -d "{\"model\": \"$model\", \"stream\": false}" |
-    python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('status','?'))" 2>/dev/null)
+    python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('status','?'))" 2>/dev/null) || status=""
   if [ "$status" = "success" ]; then
     ok "$model kesz"
   else
-    warn "$model letoltese sikertelen (status: $status) -- kezzel: ollama pull $model"
+    warn "$model letoltese sikertelen (status: ${status:-<ures valasz>}) -- kezzel: ollama pull $model"
   fi
 }
 

--- a/src/__tests__/installer-ollama-nonfatal.test.ts
+++ b/src/__tests__/installer-ollama-nonfatal.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { readFileSync, writeFileSync, mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+// BC100FAIL810 (measured on ai-bootcamp-vps100, 2026-08-10): the Linux installer
+// died with "installer exited with code 1 at step ollama-whisper" on a host
+// where the ollama BINARY was installed but its SERVICE never came up (no
+// ollama.service unit, API at :11434 dead). The ollama+model step is DECLARED
+// optional/non-fatal (every branch warns and continues), yet it hard-failed.
+//
+// Cause: under `set -e`, the `status=$(curl POST /api/pull | python3 json.load)`
+// assignment in ollama_pull inherits the pipeline's exit code. With the API down
+// the curl body is empty, json.load raises, python3 exits non-zero, the
+// assignment inherits it, and the ERR trap aborts the whole install.
+//
+// This test executes the REAL ollama block out of the shipped install-linux.sh
+// under `set -e` + the REAL ERR trap, with the exact host shape that failed:
+// ollama present, service absent, API not answering. The install must survive
+// and continue. A green run against a WORKING API proves nothing here -- the
+// point is to reproduce the dead-API host and take it from red to green.
+
+const ROOT = join(__dirname, '..', '..')
+const LINUX = readFileSync(join(ROOT, 'install-linux.sh'), 'utf-8')
+
+/** Pull the `if command -v ollama ... fi` block (defs + call) out of the script. */
+function ollamaBlock(src: string): string {
+  // The second `if command -v ollama` opens the service+pull block (the first is
+  // the install-or-skip block just above); slice from there to its labelled fi.
+  const firstIdx = src.indexOf('if command -v ollama &>/dev/null; then')
+  const start = src.indexOf('if command -v ollama &>/dev/null; then', firstIdx + 1)
+  const end = src.indexOf('fi  # command -v ollama')
+  if (start < 0 || end < 0 || end <= start) throw new Error('ollama block not found')
+  return src.slice(start, end + 'fi  # command -v ollama'.length)
+}
+
+/**
+ * Run the REAL ollama block under `set -e` + the REAL ERR trap.
+ * apiUp=false simulates the failing host (curl to ollama never connects);
+ * apiUp=true + pullBody lets us exercise the pull path with a chosen response.
+ */
+function runOllamaBlock(opts: { apiUp: boolean; pullBody?: string }): { code: number; out: string } {
+  const curlStub = opts.apiUp
+    ? [
+        'curl() {',
+        '  local url="${!#}"',
+        '  case "$*" in',
+        '    *api/version*) return 0 ;;',
+        '    *api/tags*) echo "{\\"models\\":[]}" ;;',
+        `    *api/pull*) printf '%s' ${JSON.stringify(opts.pullBody ?? '')} ;;`,
+        '    *) return 0 ;;',
+        '  esac',
+        '}',
+      ]
+    : [
+        // Nothing listens on :11434 -- curl exits non-zero with an empty body,
+        // exactly like connection-refused. This is the measured failing host.
+        'curl() { return 7; }',
+      ]
+  const script = [
+    'set -e',
+    'on_error() { echo "TRAP_FIRED line $1"; exit 1; }',
+    "trap 'on_error $LINENO' ERR",
+    'ok() { echo "ok: $*"; }',
+    'warn() { echo "warn: $*"; }',
+    '_t() { echo "$1"; }',
+    'sudo() { return 0; }',       // service enable is best-effort; never real here
+    'seq() { command seq "$@"; }',
+    'sleep() { return 0; }',      // no real waiting in the test
+    // ollama is PRESENT (binary installed) -- the exact BC100 shape.
+    'command() { if [ "$1" = "-v" ] && [ "$2" = "ollama" ]; then return 0; fi; builtin command "$@"; }',
+    ...curlStub,
+    ollamaBlock(LINUX),
+    'echo REACHED_THE_END',
+  ].join('\n')
+
+  const file = join(mkdtempSync(join(tmpdir(), 'marveen-ollama-')), 'block.sh')
+  writeFileSync(file, script)
+  try {
+    const out = execFileSync('/bin/bash', [file], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] })
+    return { code: 0, out }
+  } catch (e: unknown) {
+    const err = e as { status?: number; stdout?: string; stderr?: string }
+    return { code: err.status ?? -1, out: `${err.stdout ?? ''}${err.stderr ?? ''}` }
+  }
+}
+
+describe('install-linux.sh: ollama+model step is non-fatal (BC100FAIL810)', () => {
+  it('the measured failing host (binary present, service absent, API dead) CONTINUES', () => {
+    const { code, out } = runOllamaBlock({ apiUp: false })
+    expect(out).not.toContain('TRAP_FIRED')
+    expect(out).toContain('REACHED_THE_END')
+    expect(out).toContain('warn:')
+    expect(code).toBe(0)
+  })
+
+  it('an empty / non-JSON pull response does not abort the install', () => {
+    // API answers /api/version but the pull returns garbage -> json.load raises.
+    // The `|| status=""` guard must catch it instead of the ERR trap.
+    const { code, out } = runOllamaBlock({ apiUp: true, pullBody: '' })
+    expect(out).not.toContain('TRAP_FIRED')
+    expect(out).toContain('REACHED_THE_END')
+    expect(out).toContain('warn:')
+    expect(code).toBe(0)
+  })
+
+  it('a successful pull still reports success', () => {
+    const { code, out } = runOllamaBlock({ apiUp: true, pullBody: '{"status":"success"}' })
+    expect(out).not.toContain('TRAP_FIRED')
+    expect(out).toContain('REACHED_THE_END')
+    expect(out).toContain('ok:')
+    expect(code).toBe(0)
+  })
+})


### PR DESCRIPTION
## Root cause (measured on ai-bootcamp-vps100, 2026-08-10)

Szabi's test install died: `installer exited with code 1 at step ollama-whisper`. The host had the ollama **binary** installed but its **service never came up** — no `ollama.service` unit, systemd running, API at `:11434` dead (no `ollama` user either; the official ollama installer laid down the binary but skipped the user+service).

The ollama+model step is **declared optional / non-fatal** (every branch `warn`s and continues), yet it hard-failed. Under `set -e`, `ollama_pull`'s `status=$(curl POST /api/pull | python3 json.load)` assignment inherits the pipeline's exit code: with the API down the curl body is empty, `json.load` raises, python3 exits non-zero, the assignment inherits it, and the ERR trap aborts the whole install.

## Fix

`ollama_pull`:
1. **API-up guard** at the top: if `:11434` is not answering, `warn` and `return 0` — a pull that cannot work is skipped, not attempted (avoids the empty-curl/json-parse path entirely on a dead-service host).
2. **`|| status=""`** on the assignment — the load-bearing `set -e` guard for any residual empty/non-JSON body; turns it into the warn path.

Either way: the step warns and the install **continues** to `bumblebee`/units/enroll.

## Acceptance criterion (coordinator, msg 10165): reproduce the failing host, red→green

`src/__tests__/installer-ollama-nonfatal.test.ts` extracts the REAL ollama block from the shipped `install-linux.sh` and runs it under `set -e` + the real ERR trap, with the exact measured shape: **ollama present, service absent, API dead** (curl to `:11434` returns non-zero, empty). Asserts the install reaches the end and warns. A green run against a working API would prove nothing — the test forces the dead-API host.

- 3 cases: dead API (the measured failure), API-up but empty/garbage pull body, and a successful pull.
- **Mutation control (red run seen):** removing both guards turns the two failing-host cases RED; the success path stays green. Restored → 3/3.
- `tsc --noEmit` 0; full suite **3534/3534**; `bash -n install-linux.sh` clean.

## Note

This is fix (A) of two. Fix (B) — the Bridge `provision.ts` retry gate that misclassifies a deferred-auth half-install as EXISTING_INSTALL — is a separate PR. Neither helps Szabi's retry TODAY (the Bridge clones `--branch main`); today's machine unblock + the `ollama serve` workaround were handled live (BC100FAIL810 card). Review + merge: Marveen (install-critical path; author = Samu).

🤖 Generated with [Claude Code](https://claude.com/claude-code)