### PR TITLE
fix(slack): expose hasSlack in agent summary so the dashboard shows s…

### DIFF
--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -60,6 +60,7 @@ import {
 import {
   readAgentTelegramConfig,
   readAgentDiscordConfig,
+  readAgentSlackConfig,
   readAgentGooglechatConfig,
   readAgentTeamsConfig,
   readMarveenTelegramConfig,
@@ -400,6 +401,7 @@ interface AgentSummary {
   hasTelegram: boolean
   telegramBotUsername?: string
   hasDiscord: boolean
+  hasSlack: boolean
   hasGooglechat: boolean
   hasTeams: boolean
   status: 'configured' | 'draft'
@@ -438,6 +440,7 @@ function getAgentSummary(name: string): AgentSummary {
   const soulMd = readFileOr(join(dir, 'SOUL.md'), '')
   const tg = readAgentTelegramConfig(name)
   const dc = readAgentDiscordConfig(name)
+  const sc = readAgentSlackConfig(name)
   const gc = readAgentGooglechatConfig(name)
   const tc = readAgentTeamsConfig(name)
   const hasClaudeMd = claudeMd.trim().length > 0
@@ -479,6 +482,7 @@ function getAgentSummary(name: string): AgentSummary {
     hasTelegram: tg.hasTelegram,
     telegramBotUsername: tg.botUsername,
     hasDiscord: dc.hasDiscord,
+    hasSlack: sc.hasSlack,
     hasGooglechat: gc.hasGooglechat,
     hasTeams: tc.hasTeams,
     status: hasClaudeMd && hasSoulMd ? 'configured' : 'draft',

--- a/src/web/telegram.ts
+++ b/src/web/telegram.ts
@@ -27,6 +27,15 @@ export function readAgentDiscordConfig(name: string): { hasDiscord: boolean; bot
   return { hasDiscord: true }
 }
 
+export function readAgentSlackConfig(name: string): { hasSlack: boolean } {
+  const envPath = join(agentDir(name), '.claude', 'channels', 'slack', '.env')
+  if (!existsSync(envPath)) return { hasSlack: false }
+  const content = readFileOr(envPath, '')
+  const tokenMatch = content.match(/SLACK_BOT_TOKEN=(.+)/)
+  if (!tokenMatch || !tokenMatch[1].trim()) return { hasSlack: false }
+  return { hasSlack: true }
+}
+
 // Google Chat is creds-based (no bot token): a configured agent has
 // GOOGLECHAT_PROJECT_ID in its channel .env (see channel-provider readChannelToken).
 export function readAgentGooglechatConfig(name: string): { hasGooglechat: boolean } {


### PR DESCRIPTION

## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

HU: 

Hiba: A dashboard sub-ágens API-ja (GET /api/agents) nem adta vissza a hasSlack mezőt, mert a backend csak a Telegram/Discord/Google Chat/Teams konfigurációt olvasta be, a Slacket nem. A frontend a Csatorna fülön providerenként ezt a flaget nézi (agentIsConnected), így Slack provider esetén a hasSlack mindig undefined volt → a UI egy Slackre már bekonfigurált, futó sub-ágensnél is a "nincs csatlakoztatva" setup nézetet mutatta a connected nézet (bot állapot, függő párosítások, allowlist, meghívók) helyett. Emiatt a Slack-párosítás jóváhagyó felülete meg sem jelent. A fő Marveen ágenst a hiba nem érintette, ott a Slack-olvasás már korábban megvolt.

Javítás: Új readAgentSlackConfig(name) függvény a src/web/telegram.ts-ben — megnézi, hogy az ágens .claude/channels/slack/.env fájljában van-e nem üres SLACK_BOT_TOKEN —, és a src/web/routes/agents.ts ennek eredményét hasSlack: boolean-ként belerakja az agent summary-be, a többi providerrel azonos mintára. Ettől a dashboard Slack esetén is a valós csatlakozási állapotot mutatja.

EN: 

Bug: The dashboard's sub-agent API (GET /api/agents) did not include a hasSlack field — the backend read Telegram/Discord/Google Chat/Teams config for each agent, but not Slack. The frontend's Channel tab decides "connected vs. not connected" per provider from these flags (agentIsConnected), so with Slack selected the flag was always undefined → the UI showed the "not connected" setup form even for a sub-agent that already had Slack configured and running, hiding the connected view (bot status, pending pairings, allowlist, invites). As a side effect, the Slack pairing-approval UI never appeared. The main Marveen agent was unaffected, since its own Slack config reader already existed.

Fix: Added readAgentSlackConfig(name) in src/web/telegram.ts — it checks the agent's .claude/channels/slack/.env for a non-empty SLACK_BOT_TOKEN — and src/web/routes/agents.ts now includes the result as hasSlack: boolean in each agent summary, mirroring the existing pattern for the other providers. The dashboard now reflects the real Slack connection state for sub-agents.

## Kapcsolódó issue / Related issue

Closes #

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [ ] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).

## Tesztelés

- Amikor a bug benne volt

<img width="507" height="187" alt="marvee-sub-agent-config-issue-03-after-pairing" src="https://github.com/user-attachments/assets/ad1c1ba2-66e9-4ad4-878f-c8fb2d509246" />

 - Pairing elott
<img width="832" height="586" alt="marvee-sub-agent-config-issue-04-after-pairing-still-not-showing-slack-configs" src="https://github.com/user-attachments/assets/ba131fe8-55b9-45c2-8671-fca4f31295ec" />

- Manualis pairing utan:

<img width="804" height="628" alt="marvee-sub-agent-config-issue-01" src="https://github.com/user-attachments/assets/926a7bfc-0520-4a45-b8ab-83f8475c5571" />

<img width="955" height="220" alt="marvee-sub-agent-config-issue-02" src="https://github.com/user-attachments/assets/65b5e3c6-86af-4071-a97e-214f6d82a789" />

- Fix utan jol mutatja a sub agent chanels configját:

<img width="789" height="817" alt="marvee-sub-agent-config-issue-05-with-fix" src="https://github.com/user-attachments/assets/f66f71ac-d75c-4fe4-8f32-c0d2b38ab06c" />
