### PR TITLE
fix(channel-watchdog): skip respawn when channels session is quota-limited

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,3 +47,4 @@ jobs:
       # regression guard that only runs manually rots exactly like a one-shot
       # seed. Runs natively here (ubuntu = the Linux branch it asserts).
       - run: bash scripts/__tests__/stop-start-system-unit.test.sh
+      - run: bash scripts/__tests__/channel-watchdog-quota.test.sh

--- a/scripts/__tests__/channel-watchdog-quota.test.sh
+++ b/scripts/__tests__/channel-watchdog-quota.test.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+# Contract tests for the channel-watchdog.sh --check-limit subcommand.
+#
+# Guards the quota-limit gate introduced to fix the failure class where a stale
+# keepalive caused by plan quota exhaustion (agent pauses -> keepalive stops)
+# was misread as a wedged session and triggered a useless respawn. The new
+# gate detects the usage-limit banner in the pane and holds instead.
+#
+# Tested via the pure --check-limit subcommand (exit 0 = no limit,
+# exit 1 = limit detected). No tmux, no dashboard, no live session needed.
+#
+# Run: bash scripts/__tests__/channel-watchdog-quota.test.sh
+
+set -u
+
+PASS=0; FAIL=0
+pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
+
+INSTALL_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+WATCHDOG="${WATCHDOG_BIN:-$INSTALL_DIR/scripts/channel-watchdog.sh}"
+
+# Helper: run --check-limit with stdin, return exit code
+check_limit() { printf '%s' "$1" | bash "$WATCHDOG" --check-limit; echo $?; }
+
+echo "channel-watchdog --check-limit tests"
+echo "======================================"
+echo ""
+
+# ---------------------------------------------------------------------------
+# 1. Canonical usage-limit banner variants -> exit 1 (limit detected)
+# ---------------------------------------------------------------------------
+echo "1. Canonical limit-banner variants"
+
+GOT=$(check_limit "You hit your session limit · resets 5:50pm")
+[ "$GOT" = "1" ] && pass "hit your session limit" || fail "hit your session limit (got $GOT)"
+
+GOT=$(check_limit "You hit the usage limit for this session")
+[ "$GOT" = "1" ] && pass "hit the usage limit" || fail "hit the usage limit (got $GOT)"
+
+GOT=$(check_limit "usage limit reached -- please try again later")
+[ "$GOT" = "1" ] && pass "usage limit reached" || fail "usage limit reached (got $GOT)"
+
+GOT=$(check_limit "You reached your usage limit for today")
+[ "$GOT" = "1" ] && pass "reached your usage limit" || fail "reached your usage limit (got $GOT)"
+
+GOT=$(check_limit "5-hour limit reached. Your limit resets at 8pm.")
+[ "$GOT" = "1" ] && pass "N-hour limit reached" || fail "N-hour limit reached (got $GOT)"
+
+GOT=$(check_limit "limit will reset at 08:00 tomorrow")
+[ "$GOT" = "1" ] && pass "limit will reset at" || fail "limit will reset at (got $GOT)"
+
+GOT=$(check_limit "upgrade to increase your usage limit")
+[ "$GOT" = "1" ] && pass "upgrade to increase" || fail "upgrade to increase (got $GOT)"
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# 2. Banner in last 15 lines of a realistic pane -> exit 1
+# ---------------------------------------------------------------------------
+echo "2. Banner in bottom region of realistic pane"
+
+# Build a pane with 20 lines of normal output + the limit banner at the bottom
+PANE_WITH_BANNER="$(printf 'Some output line\n%.0s' {1..20})You hit your session limit · resets 5:50pm"
+GOT=$(check_limit "$PANE_WITH_BANNER")
+[ "$GOT" = "1" ] && pass "banner in bottom 15 lines" || fail "banner in bottom 15 lines (got $GOT)"
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# 3. Scrollback false-positive prevention: banner >15 lines from bottom -> exit 0
+# ---------------------------------------------------------------------------
+echo "3. Scrollback false-positive prevention (banner >15 lines from bottom)"
+
+# 16 lines after the banner -- banner is line 1, so 16 lines below the bottom cutoff
+SUFFIX="$(printf 'normal output\n%.0s' {1..16})"
+PANE_SCROLLBACK="You hit your session limit · resets 5:50pm
+${SUFFIX}"
+GOT=$(check_limit "$PANE_SCROLLBACK")
+[ "$GOT" = "0" ] && pass "banner in scrollback does not trigger" || fail "banner in scrollback does not trigger (got $GOT)"
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# 4. Healthy pane variants -> exit 0
+# ---------------------------------------------------------------------------
+echo "4. Healthy pane -- no limit banner"
+
+GOT=$(check_limit "")
+[ "$GOT" = "0" ] && pass "empty pane" || fail "empty pane (got $GOT)"
+
+GOT=$(check_limit "
+
+")
+[ "$GOT" = "0" ] && pass "whitespace-only pane" || fail "whitespace-only pane (got $GOT)"
+
+GOT=$(check_limit "> bypass permissions on sensitive operations? No")
+[ "$GOT" = "0" ] && pass "idle footer present" || fail "idle footer present (got $GOT)"
+
+GOT=$(check_limit "Working... (42s · 12.3k tokens)")
+[ "$GOT" = "0" ] && pass "busy pane (no limit)" || fail "busy pane (no limit) (got $GOT)"
+
+GOT=$(check_limit "API Error: 429 -- rate limit exceeded, retry in 5s")
+[ "$GOT" = "0" ] && pass "transient 429 rate-limit does not trigger" || fail "transient 429 rate-limit does not trigger (got $GOT)"
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# 5. Case-insensitivity
+# ---------------------------------------------------------------------------
+echo "5. Case-insensitivity"
+
+GOT=$(check_limit "USAGE LIMIT REACHED")
+[ "$GOT" = "1" ] && pass "USAGE LIMIT REACHED (uppercase)" || fail "USAGE LIMIT REACHED (got $GOT)"
+
+GOT=$(check_limit "Usage Limit Reached")
+[ "$GOT" = "1" ] && pass "Usage Limit Reached (mixed case)" || fail "Usage Limit Reached (got $GOT)"
+
+echo ""
+echo "--------------------------------------"
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1

--- a/scripts/__tests__/channel-watchdog-quota.test.sh
+++ b/scripts/__tests__/channel-watchdog-quota.test.sh
@@ -1,14 +1,28 @@
 #!/bin/bash
-# Contract tests for the channel-watchdog.sh --check-limit subcommand.
+# Contract tests for the channel-watchdog.sh quota-gate subcommands.
 #
 # Guards the quota-limit gate introduced to fix the failure class where a stale
 # keepalive caused by plan quota exhaustion (agent pauses -> keepalive stops)
-# was misread as a wedged session and triggered a useless respawn. The new
-# gate detects the usage-limit banner in the pane and holds instead.
+# was misread as a wedged session and triggered a useless respawn.
 #
-# Tested via the pure --check-limit subcommand (exit 0 = no limit,
-# exit 1 = limit detected). No tmux, no dashboard, no live session needed.
+# Two subcommands under test:
+#   --check-limit          pure stdin detector, no side effects
+#   --check-limit-hold     stateful wrapper: manages a tick counter file so the
+#                          quota hold is delayed (timed), not permanent
 #
+# Three sub-cases that require the capped hold (not covered by --check-limit alone):
+#   [case 1] AUTHDEAD bypass: when AUTHDEAD=true the gate 3 block is skipped
+#            entirely in main flow; --check-limit-hold exit codes let the caller
+#            make that decision. Tested indirectly: exit 1 != 0, exit 2 != 0.
+#   [case 2] "approaching usage limit" over-match: detection is correct but a
+#            functional session would hold PERMANENTLY under the old design. The
+#            capped hold bounds this: after QUOTA_HOLD_MAX_TICKS the gate falls
+#            through so respawn/alert machinery can surface the stuck state.
+#   [case 3] Agent own-message in scrollback: an agent message quoting a quota
+#            banner lands in the bottom 15 lines. Detection fires; the cap
+#            prevents silent permanent hold.
+#
+# No tmux, no dashboard, no live session needed.
 # Run: bash scripts/__tests__/channel-watchdog-quota.test.sh
 
 set -u
@@ -115,6 +129,105 @@ GOT=$(check_limit "USAGE LIMIT REACHED")
 
 GOT=$(check_limit "Usage Limit Reached")
 [ "$GOT" = "1" ] && pass "Usage Limit Reached (mixed case)" || fail "Usage Limit Reached (got $GOT)"
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# 6. --check-limit-hold: basic counter behaviour
+# ---------------------------------------------------------------------------
+echo "6. --check-limit-hold -- counter management"
+
+# Helper: run --check-limit-hold with given pane content, count file, and max
+# Returns the exit code as a string.
+hold_tick() {
+  local pane="$1" cf="$2" max="$3"
+  printf '%s' "$pane" | bash "$WATCHDOG" --check-limit-hold "$cf" "$max"
+  echo $?
+}
+
+CF="$(mktemp)"
+MAX=3  # small cap for tests; main script uses QUOTA_HOLD_MAX_TICKS=12
+
+# No banner: exit 0, counter file removed
+rm -f "$CF"
+GOT=$(hold_tick "" "$CF" "$MAX")
+[ "$GOT" = "0" ] && pass "no banner -> exit 0" || fail "no banner -> exit 0 (got $GOT)"
+[ ! -f "$CF" ] && pass "no banner -> count file removed" || fail "no banner -> count file removed (file exists, content=$(cat "$CF" 2>/dev/null))"
+
+# First tick with banner: exit 1, counter = 1
+GOT=$(hold_tick "You hit your session limit · resets 5:50pm" "$CF" "$MAX")
+[ "$GOT" = "1" ] && pass "first banner tick -> exit 1 (hold)" || fail "first banner tick -> exit 1 (got $GOT)"
+CNT=$(cat "$CF" 2>/dev/null || echo "MISSING")
+[ "$CNT" = "1" ] && pass "first banner tick -> counter=1" || fail "first banner tick -> counter=1 (got $CNT)"
+
+# Second tick: exit 1, counter = 2
+GOT=$(hold_tick "You hit your session limit · resets 5:50pm" "$CF" "$MAX")
+[ "$GOT" = "1" ] && pass "second banner tick -> exit 1 (hold)" || fail "second banner tick -> exit 1 (got $GOT)"
+CNT=$(cat "$CF" 2>/dev/null || echo "MISSING")
+[ "$CNT" = "2" ] && pass "second banner tick -> counter=2" || fail "second banner tick -> counter=2 (got $CNT)"
+
+# Third tick (count reaches MAX): exit 2 (cap exceeded), counter file removed
+GOT=$(hold_tick "You hit your session limit · resets 5:50pm" "$CF" "$MAX")
+[ "$GOT" = "2" ] && pass "cap tick -> exit 2 (fall through)" || fail "cap tick -> exit 2 (got $GOT)"
+[ ! -f "$CF" ] && pass "cap tick -> count file removed" || fail "cap tick -> count file removed (file exists)"
+
+# After cap: next banner tick starts fresh from 1, not stuck at cap forever
+GOT=$(hold_tick "You hit your session limit · resets 5:50pm" "$CF" "$MAX")
+[ "$GOT" = "1" ] && pass "post-cap first tick -> exit 1 again" || fail "post-cap first tick -> exit 1 (got $GOT)"
+CNT=$(cat "$CF" 2>/dev/null || echo "MISSING")
+[ "$CNT" = "1" ] && pass "post-cap counter restarts at 1" || fail "post-cap counter restarts at 1 (got $CNT)"
+
+# Banner clears mid-hold: counter reset
+GOT=$(hold_tick "" "$CF" "$MAX")
+[ "$GOT" = "0" ] && pass "banner clears mid-hold -> exit 0" || fail "banner clears mid-hold -> exit 0 (got $GOT)"
+[ ! -f "$CF" ] && pass "banner clears mid-hold -> counter file removed" || fail "banner clears mid-hold -> counter reset (file still exists)"
+
+rm -f "$CF"
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# 7. [case 2] "approaching usage limit" -- detection fires, hold is capped
+# ---------------------------------------------------------------------------
+echo "7. [case 2] approaching-banner is capped, not permanent"
+
+CF="$(mktemp)"
+MAX=2  # cap fires at count=MAX (i.e. after MAX-1 hold ticks + 1 cap tick)
+
+# Detection fires (would trigger permanent hold under old design): count=1 < 2 -> hold
+GOT=$(hold_tick "You are approaching your usage limit for this period" "$CF" "$MAX")
+[ "$GOT" = "1" ] && pass "approaching banner -> exit 1 (detection correct)" || fail "approaching banner -> exit 1 (got $GOT)"
+
+# At cap (count reaches MAX=2, not < MAX): falls through (exit 2), not held permanently
+GOT=$(hold_tick "You are approaching your usage limit for this period" "$CF" "$MAX")
+[ "$GOT" = "2" ] && pass "approaching banner at cap -> exit 2 (not permanent)" || fail "approaching banner at cap -> exit 2 (got $GOT)"
+
+rm -f "$CF"
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# 8. [case 3] Agent own-message in scrollback: capped, not permanent
+# ---------------------------------------------------------------------------
+echo "8. [case 3] agent message about quota in pane -- capped hold, not silent permanent"
+
+CF="$(mktemp)"
+MAX=3  # 3 ticks total: tick 1 -> hold, tick 2 -> hold, tick 3 -> cap (fall through)
+
+# Agent replied: "The Claude plan hit your session limit -- this resets at 6pm."
+# This lands in the bottom 15 lines and fires detection.
+AGENT_MSG="I looked into it. The Claude plan hit your session limit -- this resets at 6pm."
+GOT=$(hold_tick "$AGENT_MSG" "$CF" "$MAX")
+[ "$GOT" = "1" ] && pass "agent message tick 1 -> hold (detection expected)" || fail "agent message tick 1 -> hold (got $GOT)"
+
+GOT=$(hold_tick "$AGENT_MSG" "$CF" "$MAX")
+[ "$GOT" = "1" ] && pass "agent message tick 2 -> hold" || fail "agent message tick 2 -> hold (got $GOT)"
+
+# At cap: falls through so respawn/alert machinery can fire -- NOT silent forever
+GOT=$(hold_tick "$AGENT_MSG" "$CF" "$MAX")
+[ "$GOT" = "2" ] && pass "agent message at cap -> exit 2 (not permanently silent)" || fail "agent message at cap -> exit 2 (got $GOT)"
+
+rm -f "$CF"
 
 echo ""
 echo "--------------------------------------"

--- a/scripts/channel-watchdog.sh
+++ b/scripts/channel-watchdog.sh
@@ -51,12 +51,18 @@ set -u
 # found. Restricted to the bottom 15 lines so scrollback or message bodies that
 # merely quote the phrase do not produce false positives.
 # Mirrors src/model-fallback.ts detectsUsageLimit() and the USAGE_LIMIT_RX
-# constant; kept in sync with stuck-modal-guard.sh classify_pane step 4.
+# constant. That claim is not left to the comment: the alternatives below are
+# the ERE transcription of USAGE_LIMIT_RX, and
+# src/__tests__/channel-watchdog-limit-parity.test.ts runs BOTH implementations
+# over the same banner table and fails if they ever disagree. Reviewers found
+# the drift the hard way (2026-09-03): four weekly/session banners matched in TS
+# and not here, so on a weekly-limit banner the hold below would not engage and
+# the watchdog would respawn -- the exact failure this gate exists to prevent.
 if [ "${1:-}" = "--check-limit" ]; then
   _pane="$(cat)"
   _bottom="$(printf '%s' "$_pane" | tail -15)"
   if printf '%s' "$_bottom" | grep -qiE \
-      'usage limit reached|reached your usage limit|hit (your|the) (session|usage) limit|approaching (your )?usage limit|usage limit (will )?reset|limit will reset at|[0-9]+-hour limit reached|upgrade to increase your usage limit'; then
+      'usage limit reached|reached your (usage|weekly) limit|hit (your|the) (session|usage) limit|approaching (your )?([[:alnum:]_]+ )?(usage|weekly) limit|usage limit (will )?reset|limit will reset at|[0-9]+-hour limit reached|(weekly|session) limit reached|upgrade to increase your usage limit'; then
     exit 1  # usage-limit banner detected
   fi
   exit 0  # no banner

--- a/scripts/channel-watchdog.sh
+++ b/scripts/channel-watchdog.sh
@@ -46,6 +46,22 @@
 
 set -u
 
+# --- --check-limit subcommand (pure, side-effect-free, for testing) ----------
+# Reads pane text from stdin. Exit 0 = no usage-limit banner. Exit 1 = banner
+# found. Restricted to the bottom 15 lines so scrollback or message bodies that
+# merely quote the phrase do not produce false positives.
+# Mirrors src/model-fallback.ts detectsUsageLimit() and the USAGE_LIMIT_RX
+# constant; kept in sync with stuck-modal-guard.sh classify_pane step 4.
+if [ "${1:-}" = "--check-limit" ]; then
+  _pane="$(cat)"
+  _bottom="$(printf '%s' "$_pane" | tail -15)"
+  if printf '%s' "$_bottom" | grep -qiE \
+      'usage limit reached|reached your usage limit|hit (your|the) (session|usage) limit|approaching (your )?usage limit|usage limit (will )?reset|limit will reset at|[0-9]+-hour limit reached|upgrade to increase your usage limit'; then
+    exit 1  # usage-limit banner detected
+  fi
+  exit 0  # no banner
+fi
+
 INSTALL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 STORE="$INSTALL_DIR/store"
 KEEPALIVE_FILE="$STORE/.channel-keepalive"
@@ -145,6 +161,19 @@ fi
 # --- neither signal fired: healthy, reset the shared backoff counter, done ---
 if [ "$STALE" != true ] && [ "$AUTHDEAD" != true ]; then
   rm -f "$RESPAWN_COUNT_FILE" 2>/dev/null || true
+  exit 0
+fi
+
+# --- gate 3: quota-limit gate ------------------------------------------------
+# A stale keepalive or auth-dead signal can be caused by plan quota exhaustion:
+# the agent pauses, the keepalive stops, and auth probes may see degraded pane
+# output. Respawning cannot fix quota -- the new session inherits the same plan
+# limit. Detect the usage-limit banner and hold until it resets automatically.
+# (The TS side handles this via context-restart-gate.ts paneUsageLimited guard,
+# #938. This gate is the shell-side equivalent for the shell-side watchdog.)
+if ! "$TMUX_BIN" capture-pane -p -t "$SESSION" 2>/dev/null \
+    | bash "$0" --check-limit 2>/dev/null; then
+  log "plan usage-limit banner in $SESSION (STALE=$STALE AUTHDEAD=$AUTHDEAD) -- holding (respawn cannot fix quota; resets automatically)"
   exit 0
 fi
 

--- a/scripts/channel-watchdog.sh
+++ b/scripts/channel-watchdog.sh
@@ -62,18 +62,56 @@ if [ "${1:-}" = "--check-limit" ]; then
   exit 0  # no banner
 fi
 
+# --- --check-limit-hold subcommand -------------------------------------------
+# Stateful companion to --check-limit: manages a consecutive-tick counter so
+# the quota hold is delayed (timed), not permanent.
+#
+# Usage: pane_content | bash "$0" --check-limit-hold COUNT_FILE MAX_TICKS
+#   COUNT_FILE  path where the tick counter is persisted across invocations
+#   MAX_TICKS   integer; when count reaches this the banner is treated as a
+#               possible remnant and the caller should fall through (not hold)
+#
+# Exit codes:
+#   0  no banner detected (counter reset)
+#   1  banner detected, count < MAX_TICKS -- caller should hold
+#   2  banner detected, count >= MAX_TICKS -- cap exceeded, caller falls through
+if [ "${1:-}" = "--check-limit-hold" ]; then
+  _cf="${2:?--check-limit-hold requires COUNT_FILE arg}"
+  _max="${3:?--check-limit-hold requires MAX_TICKS arg}"
+  _pane="$(cat)"
+  if printf '%s' "$_pane" | bash "$0" --check-limit 2>/dev/null; then
+    # No banner -- clear the counter so a future genuine quota wait starts fresh.
+    rm -f "$_cf" 2>/dev/null || true
+    exit 0
+  fi
+  # Banner detected: increment tick counter.
+  _count=$(cat "$_cf" 2>/dev/null || echo 0)
+  case "$_count" in (*[!0-9]*|'') _count=0;; esac
+  _count=$(( _count + 1 ))
+  if [ "$_count" -lt "$_max" ]; then
+    printf '%s\n' "$_count" > "$_cf"
+    exit 1  # hold
+  fi
+  # Cap reached: remove the counter so the next cycle starts from 0 again
+  # (avoids alerting on every subsequent tick after the cap fires).
+  rm -f "$_cf" 2>/dev/null || true
+  exit 2  # cap exceeded -- fall through
+fi
+
 INSTALL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 STORE="$INSTALL_DIR/store"
 KEEPALIVE_FILE="$STORE/.channel-keepalive"
 RESPAWN_STAMP="$STORE/.channel-last-respawn"
 RESPAWN_COUNT_FILE="$STORE/.channel-watchdog-respawns"
 AUTH_DEAD_COUNT_FILE="$STORE/.channel-watchdog-auth-dead-count"
+QUOTA_HOLD_COUNT_FILE="$STORE/.channel-watchdog-quota-hold-count"
 LOG_TAG="channel-watchdog"
 
 STALE_SECONDS=$(( 15 * 60 ))    # keepalive older than this => wedged/deaf
 GRACE_SECONDS=$(( 15 * 60 ))    # don't respawn again within this window
 MAX_CONSECUTIVE=3               # after this many respawns w/o recovery, back off + alert
 AUTH_DEAD_THRESHOLD_TICKS=3     # consecutive dead-token ticks (~15min @ 5min/tick) before acting
+QUOTA_HOLD_MAX_TICKS=12         # ~1 hour at 5min/tick; beyond this a banner is probably a remnant
 
 log() { echo "$(date '+%Y-%m-%d %H:%M:%S') [$LOG_TAG] $*"; }
 
@@ -161,20 +199,48 @@ fi
 # --- neither signal fired: healthy, reset the shared backoff counter, done ---
 if [ "$STALE" != true ] && [ "$AUTHDEAD" != true ]; then
   rm -f "$RESPAWN_COUNT_FILE" 2>/dev/null || true
+  rm -f "$QUOTA_HOLD_COUNT_FILE" 2>/dev/null || true
   exit 0
 fi
 
-# --- gate 3: quota-limit gate ------------------------------------------------
+# --- gate 3: quota-limit gate (capped hold) ----------------------------------
 # A stale keepalive or auth-dead signal can be caused by plan quota exhaustion:
 # the agent pauses, the keepalive stops, and auth probes may see degraded pane
 # output. Respawning cannot fix quota -- the new session inherits the same plan
 # limit. Detect the usage-limit banner and hold until it resets automatically.
 # (The TS side handles this via context-restart-gate.ts paneUsageLimited guard,
 # #938. This gate is the shell-side equivalent for the shell-side watchdog.)
-if ! "$TMUX_BIN" capture-pane -p -t "$SESSION" 2>/dev/null \
-    | bash "$0" --check-limit 2>/dev/null; then
-  log "plan usage-limit banner in $SESSION (STALE=$STALE AUTHDEAD=$AUTHDEAD) -- holding (respawn cannot fix quota; resets automatically)"
-  exit 0
+#
+# WHY capped (not permanent):
+#   A permanent hold has three failure modes that are worse than a respawn loop:
+#   (1) AUTHDEAD=true is bypassed: a quota banner in an auth-dead pane blocks
+#       the reauth-backstop respawn, which is this script's own purpose.
+#   (2) A banner remnant after quota resets keeps the channel dead silently
+#       (no noise, no recovery) -- at least a respawn loop makes noise.
+#   (3) An agent message that quotes the quota banner (in the 15-line window)
+#       silently blocks all future respawns of that session.
+#   The cap (QUOTA_HOLD_MAX_TICKS ticks) bounds the silent hold; after it the
+#   gate falls through so grace/backoff/respawn can surface the stuck state.
+#
+# WHY AUTHDEAD is excluded: the AUTHDEAD arm has its own escalation (threshold
+# ticks + backoff). Letting quota-hold block AUTHDEAD suppresses that escalation.
+# An auth-dead pane with a quota banner is more likely a remnant than a live wait.
+if [ "$AUTHDEAD" != true ]; then
+  # Fail-open: capture-pane failure or subcommand error yields exit 0 (no banner
+  # detected), so the gate falls through to grace/respawn rather than holding.
+  # A recovery actor holding on uncertainty is worse than an extra respawn cycle.
+  "$TMUX_BIN" capture-pane -p -t "$SESSION" 2>/dev/null \
+    | bash "$0" --check-limit-hold "$QUOTA_HOLD_COUNT_FILE" "$QUOTA_HOLD_MAX_TICKS" 2>/dev/null
+  _qexit=$?
+  if [ "$_qexit" -eq 1 ]; then
+    _qtick=$(cat "$QUOTA_HOLD_COUNT_FILE" 2>/dev/null || echo '?')
+    log "usage-limit banner in $SESSION (STALE=$STALE tick=${_qtick}/${QUOTA_HOLD_MAX_TICKS}) -- holding (respawn cannot fix quota; resets automatically)"
+    exit 0
+  elif [ "$_qexit" -eq 2 ]; then
+    log "ALERT: usage-limit banner in $SESSION held ${QUOTA_HOLD_MAX_TICKS} ticks (~$((QUOTA_HOLD_MAX_TICKS * 5))min) -- possible remnant; continuing to respawn. Manual check: tmux attach -t $SESSION"
+    # fall through to gate 4 (grace) and gate 5 (backoff/alert)
+  fi
+  # _qexit=0: no quota banner -- counter already reset by --check-limit-hold; fall through
 fi
 
 # --- gate 4: respawn grace (shared with the dashboard watchdog) ---
@@ -244,6 +310,7 @@ if "$TMUX_BIN" respawn-pane -k -t "$SESSION" "$RESPAWN_CMD" 2>/dev/null; then
   date +%s > "$RESPAWN_STAMP"
   echo $(( count + 1 )) > "$RESPAWN_COUNT_FILE"
   rm -f "$AUTH_DEAD_COUNT_FILE" 2>/dev/null || true
+  rm -f "$QUOTA_HOLD_COUNT_FILE" 2>/dev/null || true
   log "respawn-pane issued"
 else
   log "respawn-pane FAILED for $SESSION"

--- a/src/__tests__/channel-watchdog-limit-parity.test.ts
+++ b/src/__tests__/channel-watchdog-limit-parity.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { detectsUsageLimit } from '../model-fallback.js'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+const WATCHDOG = join(ROOT, 'scripts', 'channel-watchdog.sh')
+
+/**
+ * The watchdog's `--check-limit` is a shell transcription of `USAGE_LIMIT_RX`.
+ * A comment claiming they "mirror" each other is worth nothing once they drift,
+ * and drift is exactly what happened: review measured four weekly/session
+ * banners that matched in TS and not in shell (2026-09-03). On such a banner the
+ * quota hold would not engage and the watchdog would respawn a session that
+ * respawning cannot fix -- the failure this gate exists to prevent.
+ *
+ * So the claim is a test, not a comment. Both implementations run over the same
+ * table and must agree on every row.
+ */
+function shellSaysLimit(pane: string): boolean {
+  try {
+    execFileSync('bash', [WATCHDOG, '--check-limit'], { input: pane, stdio: ['pipe', 'ignore', 'ignore'] })
+    return false // exit 0 -- no banner
+  } catch (err) {
+    const status = (err as { status?: number }).status
+    if (status === 1) return true // exit 1 -- banner detected
+    throw err
+  }
+}
+
+// Every banner shape either implementation claims to know, plus the negatives
+// that must stay negative. Rows marked `true` are real Claude usage-limit
+// banners; the rest are text that merely sounds like one.
+const BANNERS: Array<[string, boolean]> = [
+  ['Claude usage limit reached. Your limit will reset at 3pm.', true],
+  ['You have reached your usage limit', true],
+  ['You have reached your weekly limit', true],
+  ['You are approaching your weekly limit', true],
+  ['You are approaching your usage limit', true],
+  ['Approaching your Opus weekly limit', true],
+  ['Weekly limit reached', true],
+  ['Session limit reached', true],
+  ['You hit the session limit', true],
+  ['You hit your usage limit', true],
+  ['5-hour limit reached', true],
+  ['Your usage limit will reset at 3pm', true],
+  ['usage limit reset in 42 minutes', true],
+  ['Upgrade to increase your usage limit', true],
+  ['nothing to see here', false],
+  ['the rate limit on the API returned 429', false],
+  ['git push rejected: limit exceeded', false],
+  ['', false],
+]
+
+describe('channel-watchdog --check-limit parity with detectsUsageLimit', () => {
+  it.each(BANNERS)('agrees on %j', (pane, expected) => {
+    expect(detectsUsageLimit(pane)).toBe(expected)
+    expect(shellSaysLimit(pane)).toBe(expected)
+  })
+
+  // Guards the premise of the table above: if the shell entry point ever stops
+  // being reachable (renamed subcommand, moved file), every row would silently
+  // report "no banner" and the parity test would pass while measuring nothing.
+  it('the shell entry point is live (a known banner really exits 1)', () => {
+    expect(shellSaysLimit('Claude usage limit reached')).toBe(true)
+    expect(shellSaysLimit('plain idle pane')).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

- A stale keepalive can be caused by plan quota exhaustion: the agent pauses, the keepalive heartbeat stops, and the session looks wedged to the watchdog.
- Respawning cannot fix quota -- the new session inherits the same plan limit -- but the old code treated stale-keepalive and wedged-session identically.
- Adds a `--check-limit` subcommand (pure, stdin-driven, testable without tmux) that scans the bottom 15 lines of a pane for the usage-limit banner.
- New gate 3 fires after STALE/AUTHDEAD signals are detected but before the respawn-grace and consecutive-backoff gates: if the channels pane shows a usage-limit banner, the watchdog logs and exits without respawning.

Shell-side complement to the TS-side `paneUsageLimited` guard in `context-restart-gate.ts` (#938). Mirrors `src/model-fallback.ts` `detectsUsageLimit()` / `USAGE_LIMIT_RX` and the pattern in `stuck-modal-guard.sh` classify_pane step 4.

## Test plan

- [ ] `bash scripts/__tests__/channel-watchdog-quota.test.sh` -> 16/16 pass
- [ ] All canonical USAGE_LIMIT_RX variants trigger exit 1 (limit detected)
- [ ] Banner in scrollback (>15 lines from bottom) does not trigger (false-positive prevention)
- [ ] Transient 429 rate-limit does not trigger
- [ ] Empty / healthy / busy panes do not trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)