### PR TITLE
fix(model-fallback): add 'session limit' variant to USAGE_LIMIT_RX

### DIFF
--- a/src/__tests__/model-fallback.test.ts
+++ b/src/__tests__/model-fallback.test.ts
@@ -20,6 +20,9 @@ describe('detectsUsageLimit', () => {
     expect(detectsUsageLimit('Approaching usage limit')).toBe(true)
     expect(detectsUsageLimit('Your limit will reset at 18:00')).toBe(true)
     expect(detectsUsageLimit('/upgrade to increase your usage limit')).toBe(true)
+    // "session limit" variant observed 2026-08-08 -- was missing from the original regex
+    expect(detectsUsageLimit('You hit your session limit · resets 5:50pm')).toBe(true)
+    expect(detectsUsageLimit('You hit the session limit')).toBe(true)
   })
 
   it('does NOT match a transient API 429 / generic rate limit', () => {

--- a/src/model-fallback.ts
+++ b/src/model-fallback.ts
@@ -69,8 +69,11 @@ const USAGE_LIMIT_BANNER_REGION_LINES = 15
 // / "API Error: 429" (transient overload, handled elsewhere) must NOT match --
 // that is a momentary blip, not a plan-budget exhaustion that warrants a model
 // switch.
+// "session limit" variant observed in production (2026-08-08):
+//   "You hit your session limit · resets 5:50pm"
+// The original regex only covered "usage limit"; "session" was missing.
 const USAGE_LIMIT_RX =
-  /(usage limit reached|reached your usage limit|hit (?:your|the) usage limit|approaching (?:your )?usage limit|usage limit (?:will )?reset|limit will reset at|\d+-hour limit reached|upgrade to increase your usage limit)/i
+  /(usage limit reached|reached your usage limit|hit (?:your|the) (?:session|usage) limit|approaching (?:your )?usage limit|usage limit (?:will )?reset|limit will reset at|\d+-hour limit reached|upgrade to increase your usage limit)/i
 
 /**
  * True when the live pane shows a Claude *plan usage-limit* banner (not a


### PR DESCRIPTION
## Summary

- The actual usage-limit banner observed 2026-08-08: `"You hit your session limit · resets 5:50pm"`
- `USAGE_LIMIT_RX` only covered `hit (your|the) USAGE limit` -- `detectsUsageLimit()` returned **false** for the real banner.
- This left the `context-restart-gate.ts` `paneUsageLimited` guard (#938) blind to the exact incident that motivated it.
- Fix: `hit (?:your|the) usage limit` → `hit (?:your|the) (?:session|usage) limit`
- The shell-side greps in `channel-watchdog.sh` (#956) and `stuck-modal-guard.sh` (#937) already covered `(session|usage)`; this brings the canonical TS detector into parity.

Found during review of PR #956 (channel-watchdog quota gate) by bigme.

## Test plan

- [ ] `vitest run src/__tests__/model-fallback.test.ts` → 18/18 pass
- [ ] `detectsUsageLimit('You hit your session limit · resets 5:50pm')` → `true` (the real 2026-08-08 banner)
- [ ] `detectsUsageLimit('You hit the session limit')` → `true`
- [ ] Existing cases unchanged: `usage limit reached`, `5-hour limit reached`, transient 429 still false

🤖 Generated with [Claude Code](https://claude.com/claude-code)