### PR TITLE
fix(context-restart-gate): stop the blocking clock from outliving its session

### DIFF
--- a/src/__tests__/context-restart-gate.test.ts
+++ b/src/__tests__/context-restart-gate.test.ts
@@ -8,6 +8,7 @@ import {
 } from '../web/context-restart-gate-runner.js'
 import {
   decideGate,
+  nextBlockClock,
   DEFAULT_THRESHOLD_TOKENS,
   DEFAULT_STALE_CUTOFF_MS,
   DEFAULT_PERSISTENT_BLOCK_ALERT_MS,
@@ -84,6 +85,18 @@ describe('decideGate -- trigger (threshold)', () => {
     const d = decide({ contextTokens: null })
     expect(d.action).toBe('block')
     expect(d.reason).toMatch(/fail-closed/)
+  })
+
+  // The alert tells the owner the agent reached the threshold and the gate will
+  // not open. An unmeasured reading cannot support that claim, and every fresh
+  // session reads null for about a minute, so this must never escalate.
+  it('never escalates an unmeasurable reading to block-alert, however old the clock', () => {
+    const d = decideGate(
+      { ...CLEAR_INPUTS, contextTokens: null },
+      ENABLED,
+      NOW - 100 * DEFAULT_PERSISTENT_BLOCK_ALERT_MS,
+    )
+    expect(d.action).toBe('block')
   })
 })
 
@@ -235,6 +248,38 @@ describe('decideGate -- persistent block alert', () => {
       null,
     )
     expect(d.action).toBe('block')
+  })
+})
+
+// The clock is what turns a block into an alert, so a clock that cannot stop
+// turns any later block into a false alarm with a fabricated duration.
+describe('nextBlockClock -- the blocking-streak clock', () => {
+  const THRESHOLD = DEFAULT_THRESHOLD_TOKENS
+
+  it('starts the clock when at the threshold and not already running', () => {
+    expect(nextBlockClock(null, THRESHOLD, THRESHOLD, NOW)).toBe(NOW)
+  })
+
+  it('keeps the original start time while the streak continues', () => {
+    const started = NOW - 60_000
+    expect(nextBlockClock(started, THRESHOLD + 1, THRESHOLD, NOW)).toBe(started)
+  })
+
+  it('does not start the clock below the threshold', () => {
+    expect(nextBlockClock(null, THRESHOLD - 1, THRESHOLD, NOW)).toBeNull()
+  })
+
+  // The 2026-08-12 false alarm: an evening session legitimately started the
+  // clock, the host froze, and the fresh two-minute-old session that came back
+  // was reported as "blocked for 662 minutes".
+  it('CLEARS a running clock once a measured reading is below the threshold', () => {
+    expect(nextBlockClock(NOW - 11 * 3600_000, 67_000, THRESHOLD, NOW)).toBeNull()
+  })
+
+  it('leaves the clock untouched when the reading is unmeasurable', () => {
+    const started = NOW - 60_000
+    expect(nextBlockClock(started, null, THRESHOLD, NOW)).toBe(started)
+    expect(nextBlockClock(null, null, THRESHOLD, NOW)).toBeNull()
   })
 })
 

--- a/src/context-restart-gate.ts
+++ b/src/context-restart-gate.ts
@@ -152,7 +152,14 @@ export function decideGate(
   // Trigger check first: no point evaluating the gate conditions if we are
   // still below the threshold.
   if (inputs.contextTokens === null) {
-    return block(firstBlockedAt, inputs.nowMs, cfg, 'context-tokens-unmeasurable (fail-closed)')
+    // Fail-closed for the ACTION (never /clear on an unmeasured session), but
+    // deliberately NOT alertable: the alert text tells the owner the agent
+    // "reached the threshold and the gate will not open", and that is exactly
+    // the claim an unmeasured reading cannot support. A fresh session reads as
+    // null for the first minute or so (the transcript carries no `usage` until
+    // the first assistant turn closes), so escalating here reports a phantom
+    // stall on every boot.
+    return { action: 'block', reason: 'context-tokens-unmeasurable (fail-closed)' }
   }
   if (inputs.contextTokens < cfg.thresholdTokens) {
     return { action: 'block', reason: `below-threshold (${inputs.contextTokens} < ${cfg.thresholdTokens})` }
@@ -227,4 +234,32 @@ function block(
   const elapsed = firstBlockedAt !== null ? nowMs - firstBlockedAt : 0
   const action: GateAction = elapsed >= cfg.persistentBlockAlertMs ? 'block-alert' : 'block'
   return { action, reason }
+}
+
+/**
+ * Advance the blocking-streak clock after a 'block' decision.
+ *
+ * The clock measures ONE thing: how long this agent has sat AT OR ABOVE the
+ * threshold with the gate refusing to open. That is the only situation worth
+ * alerting about, so:
+ *
+ *   - measured below the threshold -> not waiting for the gate at all: CLEAR.
+ *   - measured at/above the threshold -> start the clock if it is not running.
+ *   - unmeasurable (null) -> leave the clock as it is; we cannot tell which
+ *     side of the threshold we are on, and a fresh session reads null for
+ *     about a minute after every boot.
+ *
+ * Before this existed the clock stopped only on a successful /clear, so a
+ * legitimate streak outlived the session that caused it -- across restarts and
+ * even a host freeze.
+ */
+export function nextBlockClock(
+  firstBlockedAt: number | null,
+  contextTokens: number | null,
+  thresholdTokens: number,
+  nowMs: number,
+): number | null {
+  if (contextTokens === null) return firstBlockedAt
+  if (contextTokens < thresholdTokens) return null
+  return firstBlockedAt ?? nowMs
 }

--- a/src/web/context-restart-gate-runner.ts
+++ b/src/web/context-restart-gate-runner.ts
@@ -19,6 +19,7 @@ import {
 } from '../db.js'
 import {
   decideGate,
+  nextBlockClock,
   type GateInputs,
 } from '../context-restart-gate.js'
 
@@ -504,13 +505,9 @@ async function checkAgent(name: string, nowMs: number): Promise<void> {
     }
 
     case 'block': {
-      // Normal block: update firstBlockedAt if this is the first block in a streak.
-      const firstBlockedAt = runState.firstBlockedAt ?? (
-        // Only start the clock when we are above the threshold -- otherwise
-        // every idle agent would accumulate a never-expiring blocking streak.
-        inputs.contextTokens !== null && inputs.contextTokens >= cfg.thresholdTokens
-          ? nowMs
-          : null
+      // Advance (or clear) the blocking-streak clock; see nextBlockClock.
+      const firstBlockedAt = nextBlockClock(
+        runState.firstBlockedAt, inputs.contextTokens, cfg.thresholdTokens, nowMs,
       )
       if (firstBlockedAt !== runState.firstBlockedAt) {
         writeGateRunState(name, { ...runState, firstBlockedAt })


### PR DESCRIPTION
## What happened

On 2026-08-12 07:36 the persistent-block alert fired for the main agent:

> A(z) "bigme" agens kapuja **662 perce** folyamatosan blokkolt. Ok: context-tokens-unmeasurable (fail-closed). A(z) **400k tokenes kuszob ele ert**, de a kapu nem enged -- ellenorizd hogy nincs-e elakadt munka.

The session it named was two minutes old and holding **67k** tokens. Nothing was stuck. Two independent defects combined to produce every number in that sentence.

## 1. The blocking-streak clock could not stop

`firstBlockedAt` was cleared only on the `allow` path, i.e. only when a `/clear` actually went out. A block *below* the threshold left it running.

So the clock legitimately started at 20:34 the previous evening, then survived the agent going quiet, a host freeze at 22:19, and the reboot at 00:52. The first alertable block in the **new** session inherited an 11-hour-old start time and reported it as continuous blocking.

Fixed by extracting `nextBlockClock()`, which makes the clock mean one thing -- how long this agent has sat at or above the threshold with the gate refusing to open:

| reading | clock |
|---|---|
| below threshold | **cleared** (not waiting for the gate at all) |
| at/above threshold | started if not running, otherwise kept |
| unmeasurable | left alone (we cannot tell which side we are on) |

## 2. An unmeasurable reading must not be alertable

The `contextTokens === null` branch escalated to `block-alert`, and the alert text asserts the agent *reached the threshold and the gate will not open* -- exactly the claim a null reading cannot support.

`readContextTokensFromProjectDir` returns null while the newest transcript carries no `usage` object, which is true of **every session for roughly its first minute**. So this reported a phantom stall on every boot, and it was the trigger that cashed in the stale clock above.

It now blocks without escalating. The gate still fails closed: an unmeasured session is never sent `/clear`.

## Verification

- `tsc --noEmit` clean.
- Gate suite: 62 passing. Five new tests cover the clock (start, continue, do-not-start below threshold, **clear** on a measured below-threshold reading, hold on unmeasurable) and one asserts an unmeasurable reading never escalates however old the clock is.
- Neighbouring suites (`context-guard`, `hook-registration-guard`) still pass: 81.
- Built in an isolated worktree off `origin/develop`; the live install was not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)