### PR TITLE
fix(context-restart-gate): completion reports are not dispatched work

### DIFF
--- a/src/__tests__/db.test.ts
+++ b/src/__tests__/db.test.ts
@@ -21,6 +21,9 @@ import {
   deletePendingTaskRetryById,
   markPendingTaskRetryAlert,
   clearPendingTaskRetryAlert,
+  createAgentMessage,
+  getDispatchedPendingStats,
+  COMPLETION_REPORT_PREFIX,
 } from '../db.js'
 import { DB_FILENAME } from '../config.js'
 
@@ -304,5 +307,31 @@ describe('database file permissions', () => {
     if (!existsSync(journalPath)) return
     const mode = statSync(journalPath).mode & 0o777
     expect(mode).toBe(0o600)
+  })
+})
+
+// A context-restart gate ezt szamolja "dispatcholt, meg nem lezart munkakent".
+// Egy lezaraskor auto-generalt [Eredmény] visszajelzes NEM munka: senki nem
+// valaszol ra, sosem lesz done, tehat orokre gyulik -- es igy egy aktiv agens
+// tartosan alkalmatlanna valik a puha ujrainditasra (2026-08-12).
+describe('getDispatchedPendingStats -- a lezaro visszajelzes nem dispatcholt munka', () => {
+  const NOW = Date.now()
+  const CUTOFF = 2 * 60 * 60 * 1000
+
+  it('szamolja a valodi kiadott feladatot, de kihagyja a completion reportot', () => {
+    createAgentMessage('stat-a', 'stat-b', 'csinald meg X-et')
+    const before = getDispatchedPendingStats('stat-a', NOW, CUTOFF).count
+    expect(before).toBeGreaterThanOrEqual(1)
+
+    createAgentMessage('stat-a', 'stat-b', `${COMPLETION_REPORT_PREFIX} msg_id:1 status:done\n\nkesz`)
+    const after = getDispatchedPendingStats('stat-a', NOW, CUTOFF).count
+    expect(after).toBe(before)
+  })
+
+  it('csak a sajat kimeno uzeneteket szamolja', () => {
+    createAgentMessage('stat-c', 'stat-a', 'ez masik agens kimenoje')
+    expect(getDispatchedPendingStats('stat-a', NOW, CUTOFF).count)
+      .toBe(getDispatchedPendingStats('stat-a', NOW, CUTOFF).count)
+    expect(getDispatchedPendingStats('stat-c', NOW, CUTOFF).count).toBe(1)
   })
 })

--- a/src/db.ts
+++ b/src/db.ts
@@ -2239,23 +2239,39 @@ export interface DispatchedPendingStats {
  * Check how many outbound messages this agent dispatched that have not yet
  * received a result (status pending or delivered), separating live (within
  * staleCutoffMs) from stale (beyond it). Used by the context-restart gate.
+ *
+ * Completion reports are excluded. Closing an inbound message auto-creates an
+ * `[Eredmény] msg_id:<n> status:<s>` message back to the sender (see the PUT
+ * /api/messages/:id route, which uses this same prefix to avoid ping-pong).
+ * Those are notifications, not dispatched work: nobody is expected to answer
+ * them, and they are never marked done, so they accumulate. Counting them made
+ * a busy agent permanently ineligible for a soft restart -- on 2026-08-12 the
+ * gate reported 11 blocking messages for the main agent and several were its
+ * own acknowledgements.
  */
+export const COMPLETION_REPORT_PREFIX = '[Eredmény]'
+
 export function getDispatchedPendingStats(
   fromAgent: string,
   nowMs: number,
   staleCutoffMs: number,
 ): DispatchedPendingStats {
   const cutoffEpoch = Math.floor((nowMs - staleCutoffMs) / 1000)
+  // Bound parameter, not interpolation: the prefix contains no LIKE wildcards
+  // today, but a future edit adding one would silently widen the exclusion.
+  const ackPattern = `${COMPLETION_REPORT_PREFIX}%`
   const liveRow = db.prepare(
     `SELECT COUNT(*) AS cnt FROM agent_messages
        WHERE from_agent = ? AND status IN ('pending','delivered')
+         AND content NOT LIKE ?
          AND CAST(created_at AS INTEGER) > ?`,
-  ).get(fromAgent, cutoffEpoch) as { cnt: number }
+  ).get(fromAgent, ackPattern, cutoffEpoch) as { cnt: number }
   const staleRow = db.prepare(
     `SELECT COUNT(*) AS cnt FROM agent_messages
        WHERE from_agent = ? AND status IN ('pending','delivered')
+         AND content NOT LIKE ?
          AND CAST(created_at AS INTEGER) <= ?`,
-  ).get(fromAgent, cutoffEpoch) as { cnt: number }
+  ).get(fromAgent, ackPattern, cutoffEpoch) as { cnt: number }
   return {
     count:    liveRow?.cnt ?? 0,
     hasStale: (staleRow?.cnt ?? 0) > 0,

--- a/src/web/routes/messages.ts
+++ b/src/web/routes/messages.ts
@@ -5,6 +5,7 @@ import {
   markMessageDone, markMessageFailed, getAgentMessage,
   closeOtelSpan,
   getPendingBacklogByAgent,
+  COMPLETION_REPORT_PREFIX,
   type AgentMessage,
 } from '../../db.js'
 import { logger } from '../../logger.js'
@@ -196,12 +197,12 @@ export async function tryHandleMessages(ctx: RouteContext): Promise<boolean> {
       // ping-pong chains (the delegator might write back, which would trigger
       // markMessageDone on this notification; we skip creating ANOTHER notification
       // when the original content is already a completion report).
-      if (done && done.from_agent !== done.to_agent && !done.content.startsWith('[Eredmény]')) {
+      if (done && done.from_agent !== done.to_agent && !done.content.startsWith(COMPLETION_REPORT_PREFIX)) {
         const summary = result ? result.slice(0, 500) : '(nincs eredmény)'
         createAgentMessage(
           done.to_agent,
           done.from_agent,
-          `[Eredmény] msg_id:${id} status:${newStatus}\n\n${summary}`,
+          `${COMPLETION_REPORT_PREFIX} msg_id:${id} status:${newStatus}\n\n${summary}`,
         )
       }
       json(res, { ok: true }); return true


### PR DESCRIPTION
## The problem

The gate treats an agent's pending/delivered outbound messages as work in flight and will not open while any exist. Closing an inbound message auto-creates an `[Eredmény] msg_id:<n> status:<s>` message back to the sender (the `PUT /api/messages/:id` route), and `getDispatchedPendingStats` counted those as well.

Nobody answers a completion report, so it never reaches `done`: it sits at `delivered` forever. An agent that diligently closes its inbox therefore builds up **permanent** blockers against its own soft restart.

Observed on 2026-08-12 on the main agent at 596k context: the gate reported

> A(z) "bigme" agens kapuja 121 perce folyamatosan blokkolt. Ok: pending-outbound-messages (11 within 2h cutoff) ... ellenorizd hogy nincs-e elakadt munka.

Several of those 11 were the agent's own acknowledgements. There was no stuck work to find, but the alert asked the owner to go looking for it, and the restart the gate exists to perform stayed blocked.

## The fix

`getDispatchedPendingStats` excludes messages whose content starts with the completion-report prefix, via a bound parameter rather than interpolation.

The prefix becomes an exported `COMPLETION_REPORT_PREFIX`. The notification writer already used the same literal (to avoid ping-pong when a delegator writes back), so both sides now reference one constant and cannot drift apart.

Stale counting is unchanged otherwise: a genuinely dispatched task still blocks, and `hasStale` still reports old dispatches beyond the cutoff.

## Verification

- `tsc --noEmit` clean.
- `db.test.ts`: 30 passing, including two new cases. A real dispatched task counts; adding a completion report leaves the count unchanged; the query stays scoped to the agent's own outbound.
- Built in an isolated worktree off `origin/develop`.

Follows #959, which fixed the other half of the same family: a blocking clock that outlived its session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)