### PR TITLE
fix(stuck-input): unwedge a sub-agent whose parked text has no soft remedy -- submit it instead of destroying it

### DIFF
--- a/src/__tests__/stale-hold-unwedge.test.ts
+++ b/src/__tests__/stale-hold-unwedge.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest'
+import {
+  shouldClearStaleHold,
+  decideStuckInputAction,
+  STALE_HOLD_CLEAR_MS,
+  STALE_HOLD_CLEAR_COOLDOWN_MS,
+  type StuckInputActionFacts,
+  type StaleHoldFacts,
+} from '../pane-state.js'
+
+// The wedge this closes (measured 2026-08-12 on the live install): 100
+// `multi-row plain re-inject SUPPRESSED ... holding` lines in dashboard.log,
+// across every sub-agent. decideStuckInputAction correctly refuses to submit
+// (multi-row) or re-inject (lossy scrape) such a box, but 'hold' was TERMINAL:
+// the attempts budget ran out, the watcher alerted "probably needs a manual
+// restart", and the pane stayed full until a human pressed Ctrl-C. Aura sat
+// wedged for hours and missed its own scheduled restart.
+
+const BASE: StaleHoldFacts = {
+  action: 'hold',
+  isSubAgent: true,
+  parkedForMs: STALE_HOLD_CLEAR_MS,
+  sinceLastClearMs: null,
+}
+
+describe('stale no-remedy hold -> dump + clear', () => {
+  it('clears a sub-agent box wedged in hold past the stale window', () => {
+    expect(shouldClearStaleHold(BASE)).toBe(true)
+  })
+
+  it('never clears the MAIN session (its box can hold a human draft)', () => {
+    expect(shouldClearStaleHold({ ...BASE, isSubAgent: false })).toBe(false)
+  })
+
+  it('waits out the stale window -- one tick short does not clear', () => {
+    expect(shouldClearStaleHold({ ...BASE, parkedForMs: STALE_HOLD_CLEAR_MS - 1 })).toBe(false)
+  })
+
+  it('leaves every action that still has a real move alone', () => {
+    for (const action of ['enter', 'reinject-block', 'reinject-plain', 'clear-preamble', 'clear-scheduled'] as const) {
+      expect(shouldClearStaleHold({ ...BASE, action })).toBe(false)
+    }
+  })
+
+  it('honours the cooldown so an unclearable box is not a Ctrl-C storm', () => {
+    expect(shouldClearStaleHold({ ...BASE, sinceLastClearMs: STALE_HOLD_CLEAR_COOLDOWN_MS - 1 })).toBe(false)
+    expect(shouldClearStaleHold({ ...BASE, sinceLastClearMs: STALE_HOLD_CLEAR_COOLDOWN_MS })).toBe(true)
+  })
+})
+
+// The gate is only useful if the branch it targets is REACHABLE -- i.e. the
+// facts of the real wedge really do decide 'hold'. This pins the shape that
+// produced the 100 log lines: a sub-agent, multi-row, machine-injected but
+// head-lost parked text (no surviving wrapper marker -> machineOrigin false).
+describe('the wedge shape actually reaches hold', () => {
+  const HEAD_LOST_SUBAGENT_PARK: StuckInputActionFacts = {
+    escalate: true,
+    rowCount: 7,
+    blockComplete: false,
+    blockTruncated: false,
+    truncatedPreamble: false,
+    allowPlainReinject: true,
+    hasPlainText: true,
+    scheduledTaskBlock: false,
+    machineOrigin: false,
+  }
+
+  it('a head-lost multi-row sub-agent park decides hold', () => {
+    expect(decideStuckInputAction(HEAD_LOST_SUBAGENT_PARK)).toBe('hold')
+  })
+
+  it('and that hold is what the stale gate then clears', () => {
+    expect(shouldClearStaleHold({
+      action: decideStuckInputAction(HEAD_LOST_SUBAGENT_PARK),
+      isSubAgent: true,
+      parkedForMs: STALE_HOLD_CLEAR_MS,
+      sinceLastClearMs: null,
+    })).toBe(true)
+  })
+
+  it('a RECOGNISED machine-origin park still re-injects -- unchanged', () => {
+    expect(decideStuckInputAction({ ...HEAD_LOST_SUBAGENT_PARK, machineOrigin: true })).toBe('reinject-plain')
+  })
+})

--- a/src/__tests__/stale-hold-unwedge.test.ts
+++ b/src/__tests__/stale-hold-unwedge.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   shouldClearStaleHold,
+  staleHoldEnterSubmitted,
   decideStuckInputAction,
   STALE_HOLD_CLEAR_MS,
   STALE_HOLD_CLEAR_COOLDOWN_MS,
@@ -80,5 +81,64 @@ describe('the wedge shape actually reaches hold', () => {
 
   it('a RECOGNISED machine-origin park still re-injects -- unchanged', () => {
     expect(decideStuckInputAction({ ...HEAD_LOST_SUBAGENT_PARK, machineOrigin: true })).toBe('reinject-plain')
+  })
+})
+
+// ============================================================================
+// The bare Enter that runs BEFORE the destructive clear (2026-08-13)
+// ============================================================================
+//
+// The clear was built on the premise that a head-lost park is unrecoverable.
+// It is not: sendPromptToSession flattens every prompt to one logical line, and
+// the TUI *buffer* keeps the whole payload even when the box renders only its
+// tail -- measured on agent-kiddo at 14:07, where a single Enter released a
+// 1087-char message whose visible tail was ~360 chars, and the receiving agent
+// acted on a paragraph from the message's first third.
+//
+// The check is OUTCOME-based on purpose: "is this one logical line?" is not
+// decidable from the pane (the TUI word-wraps with real newlines, so
+// `capture-pane -J` cannot tell a wrap from a typed newline -- measured the
+// same day). So we look at what the Enter DID.
+describe('bare Enter before the clear -- did it submit?', () => {
+  const SEP = '─'.repeat(80)
+  const FOOTER = '  ⏵⏵ bypass permissions on (shift+tab to cycle)'
+  const box = (...rows: string[]): string => ['', SEP, ...rows, SEP, FOOTER].join('\n')
+
+  const STILL_PARKED = box(
+    '❯ [Uzenet @marveen-tol] a hosszu uzenet feje mar lecsuszott a kepernyorol,',
+    '  ez csak a farka, tobb sorban tordelve a TUI sajat tordelesevel.',
+  )
+
+  it('a box that is still typing means the Enter did NOT submit', () => {
+    expect(staleHoldEnterSubmitted(STILL_PARKED)).toBe(false)
+  })
+
+  it('an emptied box means the parked text left -- no clear needed', () => {
+    expect(staleHoldEnterSubmitted(box('❯ '))).toBe(true)
+  })
+
+  it('a busy pane also means it left (the agent is processing it)', () => {
+    expect(staleHoldEnterSubmitted(['', '✻ Cogitated for 4s (esc to interrupt)', SEP, '❯ ', SEP, FOOTER].join('\n')))
+      .toBe(true)
+  })
+
+  // The case that decides the whole design: if the Enter inserted a NEWLINE
+  // instead of submitting, the text is still in the box -- just reshaped. A
+  // signature comparison (submitLanded) would call that a landed submit,
+  // because the signature changed. This must report false so the caller falls
+  // back to the dump+clear it would have done anyway.
+  it('an inserted newline is NOT a submit, even though the text changed shape', () => {
+    const before = STILL_PARKED
+    const afterNewline = box(
+      '❯ [Uzenet @marveen-tol] a hosszu uzenet feje mar lecsuszott a kepernyorol,',
+      '  ez csak a farka, tobb sorban tordelve a TUI sajat tordelesevel.',
+      '  ',
+    )
+    expect(afterNewline).not.toBe(before)
+    expect(staleHoldEnterSubmitted(afterNewline)).toBe(false)
+  })
+
+  it('a failed capture is never read as success', () => {
+    expect(staleHoldEnterSubmitted(null)).toBe(false)
   })
 })

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -1647,6 +1647,11 @@ export function decideStuckInputAction(f: StuckInputActionFacts): StuckInputActi
 //     storm against a live session.
 export const STALE_HOLD_CLEAR_MS = 5 * 60 * 1000
 export const STALE_HOLD_CLEAR_COOLDOWN_MS = 5 * 60 * 1000
+/** How long to let the TUI settle before checking whether the last-resort
+ * bare Enter submitted the parked text. Long enough for the box to repaint
+ * (the submit is one frame), short enough that a failed attempt still leaves
+ * the clear inside the same watcher tick. */
+export const STALE_HOLD_ENTER_SETTLE_MS = 1500
 
 export interface StaleHoldFacts {
   /** The move decideStuckInputAction chose for this pane at full escalation. */
@@ -1666,6 +1671,48 @@ export function shouldClearStaleHold(f: StaleHoldFacts): boolean {
   if (f.parkedForMs < STALE_HOLD_CLEAR_MS) return false
   if (f.sinceLastClearMs !== null && f.sinceLastClearMs < STALE_HOLD_CLEAR_COOLDOWN_MS) return false
   return true
+}
+
+// Did the last-resort bare Enter actually SUBMIT the parked text? (2026-08-13)
+//
+// WHY THIS EXISTS. The stale-hold unwedge used to go straight from "dump" to
+// "Ctrl-C", on the premise that the parked payload was already unrecoverable:
+// the pane scrape is lossy, so nobody could deliver it anyway. That premise is
+// FALSE, measured 2026-08-13:
+//
+//   1. sendPromptToSession flattens every prompt to ONE logical line before
+//      typing it (`const oneLine = text.replace(/\r?\n/g, ' ')`), so a
+//      system-injected parked payload never contains a real newline -- the
+//      reason Enter was banned on multi-row boxes ("it inserts a newline")
+//      does not apply to it.
+//   2. The TUI *buffer* keeps the whole payload even when the visible box
+//      shows only its tail. Measured on agent-kiddo at 14:07: a 1087-char
+//      parked message (box shows ~360 chars) was released with a single
+//      `tmux send-keys Enter`, and the receiving agent acted on a paragraph
+//      from the message's FIRST THIRD -- i.e. outside the visible tail.
+//
+// So the clear was destroying a fully deliverable message. This predicate lets
+// the caller TRY the non-destructive move first and verify the outcome, rather
+// than reasoning about what is in the buffer.
+//
+// OUTCOME-BASED ON PURPOSE. We do not try to prove "the box holds one logical
+// line" -- that is not decidable from the pane (measured the same day: the TUI
+// word-wraps with REAL newlines and a 2-space indent, so `capture-pane -J`
+// cannot tell a wrapped line from a genuinely multi-line one). Instead we look
+// at what the Enter DID: the parked text is gone from the box only if the pane
+// is no longer 'typing'. If Enter merely inserted a newline, the box is still
+// 'typing' and this returns false -- the caller then falls back to the exact
+// dump+clear it would have done anyway, so the failure mode is no worse than
+// the status quo.
+//
+// Note it deliberately does NOT reuse submitLanded(): that compares signatures,
+// and an inserted newline CHANGES the signature -- it would report a landed
+// submit for the one case we must catch.
+export function staleHoldEnterSubmitted(paneAfter: string | null): boolean {
+  // No capture -> cannot confirm -> treat as not submitted (fall through to
+  // the clear). Never assume success from missing evidence.
+  if (paneAfter == null) return false
+  return stuckInputSignature(paneAfter) == null
 }
 
 // Would the soft stuck-input recovery have ANY submitting/clearing move for

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -1606,6 +1606,68 @@ export function decideStuckInputAction(f: StuckInputActionFacts): StuckInputActi
   return multiRow ? 'hold' : 'enter'
 }
 
+// =============================================================================
+// Stale no-remedy hold: last-resort unwedge (2026-08-12)
+// =============================================================================
+//
+// decideStuckInputAction ends in 'hold' whenever the parked text can neither be
+// submitted (multi-row: a bare Enter inserts a newline) nor re-injected (the
+// pane scrape is a lossy tail, so re-typing it would deliver a corrupted
+// message) nor safely cleared by one of the identified-origin branches. That
+// hold is CORRECT as a per-tick move -- but it was also the FINAL state: the
+// attempts budget runs out, the watcher alerts "probably needs a manual
+// restart", and the box stays full FOREVER. A sub-agent in that state is
+// silently mute: every later delivery parks behind the wedge, and only a human
+// Ctrl-C brings it back.
+//
+// Measured 2026-08-12 on this install: 100 `multi-row plain re-inject
+// SUPPRESSED ... holding` lines in store/dashboard.log, hitting every sub-agent
+// (aura, blitz, iris). Aura had been wedged for hours and had missed its own
+// 03:00 restart when the owner reported it -- the same complaint had recurred
+// for weeks, each time ended by a manual keystroke.
+//
+// The trade the hold was protecting -- "never destroy a payload that has no
+// re-delivery" -- is not the real trade, because by the time we get here the
+// payload is ALREADY corrupted (head-lost / tail-scraped) and cannot be
+// delivered by anyone. What the hold actually buys is a human being able to
+// read it off the pane. So the fix keeps that and drops the wedge: DUMP the
+// parked text to disk first, then clear. Nothing is lost that was not already
+// lost, and the agent is live again within one tick.
+//
+// Gated hard, because clearing is destructive:
+//   - SUB-AGENTS ONLY (isSubAgent -- the caller's allowPlainReinject flag). The
+//     MAIN session's box can hold a HUMAN draft mid-composition; MAIN keeps its
+//     existing owner-alert + channel-monitor restart path.
+//   - Only after the text has sat UNCHANGED past the stale window. A live
+//     delivery or a human still typing changes the signature, which resets
+//     firstSeenAt and so restarts this clock.
+//   - Only when the chosen action is 'hold'. Every branch that still has a real
+//     move (enter / reinject-* / clear-*) runs first and is untouched.
+//   - Cooldown between clears, so an unclearable box cannot turn into a Ctrl-C
+//     storm against a live session.
+export const STALE_HOLD_CLEAR_MS = 5 * 60 * 1000
+export const STALE_HOLD_CLEAR_COOLDOWN_MS = 5 * 60 * 1000
+
+export interface StaleHoldFacts {
+  /** The move decideStuckInputAction chose for this pane at full escalation. */
+  action: StuckInputAction
+  /** True for a sub-agent session; MAIN must never auto-clear (human drafts). */
+  isSubAgent: boolean
+  /** How long the SAME text has been parked (now - firstSeenAt). */
+  parkedForMs: number
+  /** Since the last stale-hold clear on this session, or null if never. */
+  sinceLastClearMs: number | null
+}
+
+/** Pure: may the watcher dump-and-clear a box wedged in the no-remedy hold? */
+export function shouldClearStaleHold(f: StaleHoldFacts): boolean {
+  if (f.action !== 'hold') return false
+  if (!f.isSubAgent) return false
+  if (f.parkedForMs < STALE_HOLD_CLEAR_MS) return false
+  if (f.sinceLastClearMs !== null && f.sinceLastClearMs < STALE_HOLD_CLEAR_COOLDOWN_MS) return false
+  return true
+}
+
 // Would the soft stuck-input recovery have ANY submitting/clearing move for
 // the MAIN session's parked input at full escalation, or is it wedged in the
 // no-remedy 'hold' branch? Used by the hard-restart busy-guard: a 'typing'

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -1745,7 +1745,11 @@ const PLACEHOLDER_DISCARD_SETTLE_MS = 450
 // detectsPastePlaceholder guarantees at the call site. We re-check before each
 // press and stop the instant the placeholder is gone, so we never press Ctrl-C
 // into an already-empty box. Returns true if the placeholder was cleared.
-async function discardPlaceholderBuffer(session: string, host: string | null = null): Promise<boolean> {
+// Exported for the stale-hold unwedge in channel-monitor: that is the only
+// other caller allowed to empty a sub-agent's box, and it needs the SAME
+// verified clear (capture -> classify -> Ctrl-C -> re-verify) rather than a
+// second, weaker implementation of it.
+export async function discardPlaceholderBuffer(session: string, host: string | null = null): Promise<boolean> {
   for (let i = 0; i < PLACEHOLDER_DISCARD_MAX; i++) {
     const pane = capturePane(session, host)
     // Stop pressing once the stub is gone -- a further Ctrl-C on an empty box

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -396,14 +396,31 @@ async function maybeClearStaleHold(
   // Ordering matters: the dump above already happened, so a human draft that
   // this Enter submits is still on disk, and the cooldown is already stamped.
   // If the Enter does nothing (or inserts a newline), we fall through to the
-  // identical clear below -- this branch can only add a recovery, never
-  // remove one.
+  // identical clear below.
+  //
+  // SCOPE OF THE RESIDUAL RISK, stated precisely because it is NOT nil: the
+  // justification above (system-injected text is one logical line) holds for a
+  // MACHINE payload -- and the 'hold' branch is exactly the bucket where the
+  // origin could NOT be established (machineOrigin: false). So on this branch a
+  // human's half-typed draft can be submitted rather than destroyed. That is a
+  // safe non-action turned into an action, which is why the submit branch MUST
+  // alert (below): the risk stays narrow, but it must not also be unobservable.
   if (sendEnterToSession(session)) {
     await delay(STALE_HOLD_ENTER_SETTLE_MS)
     if (staleHoldEnterSubmitted(captureParkedInputView(session))) {
       logger.warn(
         { session, parkedForMs, dump },
         'Stale-hold unwedge: a bare Enter SUBMITTED the parked text -- message delivered, no clear needed',
+      )
+      // ALERT ON THE CONSEQUENTIAL BRANCH TOO (#962 review). Without this the
+      // LESS consequential outcome (cleared, nothing acted on it) was loud and
+      // the MORE consequential one (an agent just received an instruction
+      // nobody pressed Enter on) was silent -- exactly backwards.
+      sendAlert(
+        `📨 A(z) ${session} bemenetében ${minutes} perce állt egy szöveg, amit sem elküldeni, sem újraküldeni nem lehetett. `
+          + `Egy Enterrel ELKÜLDTEM az agensnek, tehát mostantol abbol dolgozik. `
+          + (dump != null ? `A szöveg elmentve: ${dump}. ` : 'A szöveget nem sikerült fájlba menteni. ')
+          + 'Ha ez a TE félbehagyott vázlatod volt, nézd meg -- ezen az agon nem tudtuk igazolni a gep-eredetet.',
       )
       return
     }

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -14,6 +14,7 @@ import {
   capturePane,
   captureParkedInputView,
   clearInputBuffer,
+  discardPlaceholderBuffer,
   dismissResumeSummaryModalIfPresent,
   dismissModelConsentDialogIfPresent,
   stampFableOverageConsentSharedRoots,

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -27,6 +27,7 @@ import {
   hasFleetOauthToken,
   FLEET_OAUTH_TOKEN_PATH,
   answerFirstRunGates,
+  sendEnterToSession,
   shSingleQuote,
 } from './agent-process.js'
 import { withSessionSendLock } from './session-send-lock.js'
@@ -39,7 +40,7 @@ import {
   parkedInputText, shouldClearTruncatedPreamble,
   parkedInputRowCount, submitLanded, decideStuckInputAction,
   parkedScheduledTaskInput, parkedMachineOriginInput, parkedMainInputHasRemedy,
-  shouldClearStaleHold,
+  shouldClearStaleHold, staleHoldEnterSubmitted, STALE_HOLD_ENTER_SETTLE_MS,
   type StuckInputState, type StuckInputThresholds, type StuckInputAction,
   type StuckInputActionFacts,
 } from '../pane-state.js'
@@ -384,6 +385,33 @@ async function maybeClearStaleHold(
     { session, parkedForMs, rowCount: facts.rowCount, dump },
     'Stuck input -- no-remedy hold past the stale window; dumped the parked text and clearing the box',
   )
+
+  // NON-DESTRUCTIVE ATTEMPT FIRST (2026-08-13). Before Ctrl-C, try a bare
+  // Enter: the TUI buffer holds the WHOLE payload even when the box only
+  // shows its tail, and system-injected text is a single logical line, so a
+  // submit delivers the message intact instead of destroying it. Full
+  // reasoning + the measurements: staleHoldEnterSubmitted in pane-state.ts.
+  //
+  // Ordering matters: the dump above already happened, so a human draft that
+  // this Enter submits is still on disk, and the cooldown is already stamped.
+  // If the Enter does nothing (or inserts a newline), we fall through to the
+  // identical clear below -- this branch can only add a recovery, never
+  // remove one.
+  if (sendEnterToSession(session)) {
+    await delay(STALE_HOLD_ENTER_SETTLE_MS)
+    if (staleHoldEnterSubmitted(captureParkedInputView(session))) {
+      logger.warn(
+        { session, parkedForMs, dump },
+        'Stale-hold unwedge: a bare Enter SUBMITTED the parked text -- message delivered, no clear needed',
+      )
+      return
+    }
+    logger.warn(
+      { session },
+      'Stale-hold unwedge: the bare Enter did not submit (text still parked); falling back to the clear',
+    )
+  }
+
   const cleared = await discardPlaceholderBuffer(session)
   if (!cleared) {
     logger.warn({ session }, 'Stale-hold unwedge: could not confirm the box was emptied; retrying after the cooldown')

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, statSync, writeFileSync, utimesSync } from 'node:fs'
+import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync, utimesSync } from 'node:fs'
 import { hostname } from 'node:os'
 import { join } from 'node:path'
 import { execFileSync, spawn } from 'node:child_process'
@@ -39,6 +39,7 @@ import {
   parkedInputText, shouldClearTruncatedPreamble,
   parkedInputRowCount, submitLanded, decideStuckInputAction,
   parkedScheduledTaskInput, parkedMachineOriginInput, parkedMainInputHasRemedy,
+  shouldClearStaleHold,
   type StuckInputState, type StuckInputThresholds, type StuckInputAction,
   type StuckInputActionFacts,
 } from '../pane-state.js'
@@ -301,6 +302,102 @@ export function applyStuckRestartBusyGuard(
 //      (e.g. an inter-agent notification) -> clear + re-inject the collapsed
 //      text. A sub-agent's input box never holds a human draft, so this is
 //      safe; the main session stays conservative (Enter / <channel>-only).
+// Last stale-hold clear per session, for the cooldown. Module-level (not part
+// of StuckInputState) because the state map is owned by the CALLERS
+// (stuck-input-watcher + the channel-monitor tick) and both drive this same
+// function -- a per-caller field would let two callers clear twice in a row.
+const staleHoldClearedAt = new Map<string, number>()
+
+/** Test seam: forget the stale-hold cooldowns. */
+export function resetStaleHoldClears(): void {
+  staleHoldClearedAt.clear()
+}
+
+const PARKED_DUMP_DIR = join(PROJECT_ROOT, 'store', 'parked-input')
+
+// Write the parked text to disk BEFORE clearing it. This is the whole reason
+// the clear is allowed: the hold existed so a human could still read the box,
+// and a dump preserves exactly that (more, in fact -- it survives the next
+// screen repaint). Best-effort: a dump failure must not block the unwedge,
+// because a wedged agent is the worse outcome. Returns the path, or null.
+function dumpParkedInput(session: string, pane: string): string | null {
+  try {
+    mkdirSync(PARKED_DUMP_DIR, { recursive: true })
+    const stamp = new Date().toISOString().replace(/[:.]/g, '-')
+    const path = join(PARKED_DUMP_DIR, `${session}-${stamp}.txt`)
+    const flat = parkedInputText(pane)
+    writeFileSync(
+      path,
+      `# Parked input auto-cleared by the stale-hold unwedge\n`
+        + `# session: ${session}\n# at: ${new Date().toISOString()}\n`
+        + `# NOTE: the pane scrape is LOSSY -- the TUI drops head rows of an\n`
+        + `# overfull box, so this may be a tail fragment, not the whole payload.\n\n`
+        + `## flattened parked text\n${flat ?? '(none)'}\n\n## raw pane view\n${pane}\n`,
+    )
+    return path
+  } catch (err) {
+    logger.warn({ err, session }, 'Stale-hold unwedge: could not dump the parked input (clearing anyway)')
+    return null
+  }
+}
+
+// A sub-agent box wedged in the no-remedy 'hold' past the stale window: dump
+// and clear it so the session is live again. See the STALE-HOLD block in
+// pane-state.ts for why this is safe and why 'hold' alone was not enough.
+async function maybeClearStaleHold(
+  session: string,
+  pane: string,
+  state: StuckInputState,
+  allowPlainReinject: boolean,
+): Promise<void> {
+  const now = Date.now()
+  const lastClear = staleHoldClearedAt.get(session)
+  const block = parkedChannelInput(pane)
+  // escalate: true -- by the time the stale window has elapsed the attempts
+  // budget is long spent, so the full-escalation move is the honest question.
+  const facts: StuckInputActionFacts = {
+    escalate: true,
+    rowCount: parkedInputRowCount(pane),
+    blockComplete: block != null && block.complete && block.block != null,
+    blockTruncated: block != null && !block.complete,
+    truncatedPreamble: shouldClearTruncatedPreamble(pane),
+    allowPlainReinject,
+    hasPlainText: allowPlainReinject && parkedInputText(pane) != null,
+    scheduledTaskBlock: parkedScheduledTaskInput(pane),
+    machineOrigin: parkedMachineOriginInput(pane),
+  }
+  const parkedForMs = state.firstSeenAt == null ? 0 : now - state.firstSeenAt
+  if (!shouldClearStaleHold({
+    action: decideStuckInputAction(facts),
+    isSubAgent: allowPlainReinject,
+    parkedForMs,
+    sinceLastClearMs: lastClear == null ? null : now - lastClear,
+  })) return
+
+  // Stamp BEFORE acting: if the clear throws or cannot confirm, the cooldown
+  // still holds and the next attempt waits a full window instead of pressing
+  // Ctrl-C on every 15s tick.
+  staleHoldClearedAt.set(session, now)
+  const dump = dumpParkedInput(session, pane)
+  const minutes = Math.round(parkedForMs / 60_000)
+  logger.warn(
+    { session, parkedForMs, rowCount: facts.rowCount, dump },
+    'Stuck input -- no-remedy hold past the stale window; dumped the parked text and clearing the box',
+  )
+  const cleared = await discardPlaceholderBuffer(session)
+  if (!cleared) {
+    logger.warn({ session }, 'Stale-hold unwedge: could not confirm the box was emptied; retrying after the cooldown')
+    return
+  }
+  logger.warn({ session, dump }, 'Stale-hold unwedge: box cleared, session accepting input again')
+  sendAlert(
+    `🧹 A(z) ${session} bemenete ${minutes} perce beragadt egy kibogozhatatlan szövegen (nem lehetett sem elküldeni, sem újraküldeni). `
+      + `Kitakarítottam, az agens újra fogad üzenetet. `
+      + (dump != null ? `A beragadt szöveg elmentve: ${dump}` : 'A szöveget nem sikerült fájlba menteni.')
+      + ' Ütemezett feladat esetén a következő futás újraküldi; ha inter-agent üzenet volt, a küldő nem kapott visszajelzést.',
+  )
+}
+
 export async function recoverStuckInputForSession(
   session: string,
   prev: StuckInputState,
@@ -313,6 +410,15 @@ export async function recoverStuckInputForSession(
   const pane = captureParkedInputView(session)
   const sig = pane != null ? stuckInputSignature(pane) : null
   const decision = decideStuckInputRecovery(sig, prev, Date.now(), thresholds)
+  // STALE HOLD (2026-08-12): the attempts budget is spent long before a wedged
+  // box is noticed, and decideStuckInputRecovery then returns recover=false on
+  // every later tick -- so without this branch the ONLY code path that can look
+  // at a no-remedy hold is the one that already gave up. Evaluate the stale
+  // clear on the not-recovering ticks; it is separately time-gated and cannot
+  // race the active escalation (which owns the recovering ticks).
+  if (!decision.recover && pane != null && sig != null) {
+    await maybeClearStaleHold(session, pane, decision.next, allowPlainReinject)
+  }
   if (decision.recover && pane != null) {
     const attempt = decision.next.attempts
     const block = parkedChannelInput(pane)


### PR DESCRIPTION
## The bug

`decideStuckInputAction` ends in `hold` whenever a sub-agent's parked text can neither be
submitted (multi-row: "a bare Enter inserts a newline") nor re-injected (the pane scrape is a
lossy tail). That hold is **terminal**: the attempts budget runs out, the watcher alerts
"probably needs a manual restart", and the box stays full until a human presses Ctrl-C. The
agent is silently mute in the meantime -- every later delivery parks behind the wedge, and on
our install the `skipIfBusy` scheduled tasks of that agent then skip their own occurrences too.

Measured on one install, one day of `dashboard.log`: **100** `multi-row plain re-inject
SUPPRESSED ... holding` lines, hitting three of four sub-agents (4 / 4 / 3 / 0). One agent had
been wedged for hours and had missed its own scheduled restart.

## Why it stayed unnoticed

1. **The hold is the correct per-tick move**, so nothing in the log looks like a bug -- the line
   says "holding", which reads as deliberate.
2. **The symptom is silence.** A wedged sub-agent produces no error; it just stops answering.
   It only becomes visible on the agent someone happens to write to daily.
3. The one log line that *does* escalate says "probably needs a manual restart" -- which is
   true, and therefore never questioned.

## The fix, in two steps

**Step 1 (`fix(stuck-input): unwedge a sub-agent whose parked text has no soft remedy`)** --
after 5 minutes of an unchanged signature on a **sub-agent** pane, dump the parked text to
`store/parked-input/` and clear the box with the existing verified `discardPlaceholderBuffer`
(capture -> classify -> Ctrl-C -> re-verify), with a 5-minute cooldown. **MAIN is excluded**:
its box can hold a human draft mid-composition.

**Step 2 (`fix(stuck-input): try a bare Enter before the stale-hold clear`)** -- try the
**non-destructive** move first, because the premise behind step 1's clear turned out to be
false. Two measurements, both on 2026-08-13:

1. `sendPromptToSession` flattens every prompt to **one logical line** before typing it
   (`const oneLine = text.replace(/\r?\n/g, ' ')`). A system-injected parked payload therefore
   never contains a real newline -- the stated reason for banning Enter on a multi-row box does
   not apply to it.
2. **The TUI buffer keeps the whole payload even when the box renders only its tail.** On a live
   sub-agent pane a **1087-character** parked message (visible tail ~360 chars) was released
   with a single `tmux send-keys Enter`, and the receiving agent then acted on a paragraph from
   the message's **first third** -- i.e. from outside the visible region. The head was missing
   from the *display*, not from the buffer.

So the clear in step 1 was destroying a fully deliverable message. Step 2 sends the Enter first
and verifies the outcome; only if the text is still parked does it fall through to the identical
dump+clear.

**Scope of the residual risk (narrowed after review).** For a MACHINE payload this can only add a
recovery, never remove one. It is not that general: the `hold` branch is exactly the bucket where
the origin could NOT be established (`machineOrigin: false`), so a human's half-typed draft can be
submitted rather than destroyed -- a safe non-action turned into an action. The direction of the
error across the series is: before the PR, paralysis (safe, but the agent goes mute); after step 1,
destruction with a dump (a human can retype it); after step 2, execution. The submit branch now
alerts for exactly this reason -- the risk stays narrow, but it must not also be unobservable.

## Why the check is outcome-based

"Is this box one logical line?" is **not decidable from the pane**. Measured the same day: the
Claude TUI word-wraps with real newlines and a two-space indent, so `capture-pane -J` (join
wrapped lines) returns the box unchanged -- it cannot tell a wrapped line from a typed one.

`staleHoldEnterSubmitted()` therefore looks at what the Enter *did*: the parked text is gone only
if the pane is no longer `typing`. If the Enter merely inserted a newline, the box is still
`typing` and the function returns false.

It deliberately does **not** reuse the existing `submitLanded()`: that compares signatures, and an
inserted newline *changes* the signature -- it would report a landed submit for the one case that
must be caught. There is a test pinning exactly this.

## The third commit

`discardPlaceholderBuffer` is module-private in `agent-process.ts`; step 1 needs it. Exported
rather than reimplemented, so both callers share one verified clear.
(Commit order note: the export lands last in the series; the final tree type-checks, but the
middle commit alone does not. Happy to reorder if you prefer a bisectable series.)

## Tests

`src/__tests__/stale-hold-unwedge.test.ts`, 13 tests, including the newline case above and
"a failed capture is never read as success".

```
$ ./node_modules/.bin/tsc --noEmit
(clean)

$ ./node_modules/.bin/vitest run src/__tests__/stale-hold-unwedge.test.ts
 ✓ src/__tests__/stale-hold-unwedge.test.ts (13 tests) 62ms
 Test Files  1 passed (1)
      Tests  13 passed (13)
```

Full suite on this branch: 3 failing files. Two of them (`installer-start-and-fallback`,
`channels-never-started-backoff`) fail identically on **clean `origin/develop`** in the same
worktree -- both assume a non-root user (one makes `store/` unwritable, which does not stop
root). The third is the `memory-performance` Ollama timeout, which is flaky here. Zero new
failures.
