### PR TITLE
feat(updates): show the running version in the Updates page header

### DIFF
--- a/src/__tests__/update-checker-branch.test.ts
+++ b/src/__tests__/update-checker-branch.test.ts
@@ -8,7 +8,9 @@
 // so it is pinned here.
 import { describe, it, expect } from 'vitest'
 import { execFileSync } from 'node:child_process'
-import { trackedBranch } from '../web/update-checker.js'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { trackedBranch, currentVersion, getUpdateStatus } from '../web/update-checker.js'
 import { PROJECT_ROOT } from '../config.js'
 
 function gitBranch(): string {
@@ -36,5 +38,20 @@ describe('update checker branch selection', () => {
     const actual = gitBranch()
     if (!actual || actual === 'HEAD' || actual === 'main') return // nothing to prove here
     expect(trackedBranch()).not.toBe('main')
+  })
+})
+
+// The Updates panel shows the running instance's semver; it must come from
+// package.json and never be fabricated. currentVersion() is the single source.
+describe('update checker current version', () => {
+  it('returns the semver from package.json at PROJECT_ROOT', () => {
+    const pkg = JSON.parse(readFileSync(join(PROJECT_ROOT, 'package.json'), 'utf-8'))
+    expect(currentVersion()).toBe(pkg.version)
+    // sanity: it is a real semver, not an empty/garbage value
+    expect(currentVersion()).toMatch(/^\d+\.\d+\.\d+/)
+  })
+
+  it('is exposed on the /api/updates status object', () => {
+    expect(getUpdateStatus().version).toBe(currentVersion())
   })
 })

--- a/src/__tests__/update-checker-branch.test.ts
+++ b/src/__tests__/update-checker-branch.test.ts
@@ -54,4 +54,9 @@ describe('update checker current version', () => {
   it('is exposed on the /api/updates status object', () => {
     expect(getUpdateStatus().version).toBe(currentVersion())
   })
+
+  it('returns empty (never fabricates) when package.json is missing/unreadable', () => {
+    expect(currentVersion('/nonexistent-root-xyz')).toBe('')
+    expect(currentVersion('/etc')).toBe('') // dir exists, no package.json -> ''
+  })
 })

--- a/src/web/update-checker.ts
+++ b/src/web/update-checker.ts
@@ -68,9 +68,9 @@ export function getUpdateStatus(): UpdateStatus {
 // '' on ANY failure (missing / unreadable / malformed / no string "version"):
 // the caller must never display a fabricated version, so the field is simply
 // empty and the UI falls back to the commit SHA alone.
-export function currentVersion(): string {
+export function currentVersion(root: string = PROJECT_ROOT): string {
   try {
-    const pkg = JSON.parse(readFileSync(join(PROJECT_ROOT, 'package.json'), 'utf-8'))
+    const pkg = JSON.parse(readFileSync(join(root, 'package.json'), 'utf-8'))
     return typeof pkg?.version === 'string' ? pkg.version : ''
   } catch {
     return ''

--- a/src/web/update-checker.ts
+++ b/src/web/update-checker.ts
@@ -1,4 +1,6 @@
 import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { PROJECT_ROOT } from '../config.js'
 import { TOOL_TIMEOUTS } from '../tool-timeouts.js'
 
@@ -21,6 +23,11 @@ export interface UpdateRelease {
 
 export interface UpdateStatus {
   current: string
+  /** Semver of the running instance (package.json "version"), e.g. "1.32.1".
+   * Resolved live per request. Empty/absent when package.json is missing,
+   * unreadable, or malformed -- the UI then shows the SHA alone and NEVER a
+   * fabricated version. */
+  version?: string
   latest: string
   behind: number
   commits: UpdateCommit[]
@@ -51,9 +58,23 @@ let updateStatusCache: UpdateStatus = {
 }
 
 export function getUpdateStatus(): UpdateStatus {
-  // branch is resolved live (cheap local rev-parse): the cache may predate the
-  // first refresh cycle, and a checkout switch should be visible immediately.
-  return { ...updateStatusCache, branch: trackedBranch() }
+  // branch and version are resolved live (cheap local rev-parse / file read):
+  // the cache may predate the first refresh cycle, and a checkout switch or
+  // in-place version bump should be visible immediately.
+  return { ...updateStatusCache, branch: trackedBranch(), version: currentVersion() }
+}
+
+// Semver of the running instance, read from package.json at PROJECT_ROOT. Returns
+// '' on ANY failure (missing / unreadable / malformed / no string "version"):
+// the caller must never display a fabricated version, so the field is simply
+// empty and the UI falls back to the commit SHA alone.
+export function currentVersion(): string {
+  try {
+    const pkg = JSON.parse(readFileSync(join(PROJECT_ROOT, 'package.json'), 'utf-8'))
+    return typeof pkg?.version === 'string' ? pkg.version : ''
+  } catch {
+    return ''
+  }
 }
 
 export function currentGitHead(): string {

--- a/web/app.js
+++ b/web/app.js
@@ -11746,6 +11746,26 @@ async function pollUpdatesBadge() {
   } catch {}
 }
 
+// Render the running instance's identity into the page-header subtitle -- the
+// same .subtitle slot every other page header uses, so it stays consistent with
+// the rest of the dashboard and is visible in ALL update states (up-to-date,
+// behind, error) because it lives in the header, not the state-specific summary.
+// The semver is primary; the 7-char commit SHA follows as secondary context
+// (e.g. "Jelenlegi: v1.32.1 · db1ed3f"). When the backend could not read a
+// version, the SHA stands alone -- we never fabricate a version. With neither
+// available, the static brand subtitle (rendered from data-i18n) is left as-is.
+function renderUpdatesVersion(data) {
+  const sub = document.getElementById('updatesSubtitle')
+  if (!sub) return
+  const ver = (data && typeof data.version === 'string') ? data.version.trim() : ''
+  const sha = ((data && data.current) || '').slice(0, 7)
+  const parts = []
+  if (ver) parts.push('v' + escapeHtmlUpdates(ver))
+  if (sha) parts.push(`<code>${escapeHtmlUpdates(sha)}</code>`)
+  if (parts.length === 0) return // no version and no SHA: keep the brand subtitle
+  sub.innerHTML = `${t('updates.current_label')} ${parts.join(' · ')}`
+}
+
 async function loadUpdates() {
   const summary = document.getElementById('updatesSummary')
   const list = document.getElementById('updatesCommitList')
@@ -11759,17 +11779,16 @@ async function loadUpdates() {
     const data = await res.json()
     window._updatesStatus = data
     renderUpdatesBadge(data)
+    renderUpdatesVersion(data)
     updateBranchDriftUI(data)
     renderBranchNotice(data)
-    const cur = (data.current || '').slice(0, 7) || '–'
-    const lat = (data.latest || '').slice(0, 7) || '–'
     if (data.error) {
       summary.className = 'updates-summary error'
-      summary.innerHTML = `<strong>${t('updates.check_failed')}:</strong> ${escapeHtmlUpdates(data.error)}<br>${t('updates.current_label')} <code>${cur}</code>`
+      summary.innerHTML = `<strong>${t('updates.check_failed')}:</strong> ${escapeHtmlUpdates(data.error)}`
       applyBtn.hidden = true
     } else if (data.behind === 0) {
       summary.className = 'updates-summary up-to-date'
-      summary.innerHTML = `<strong>${t('updates.up_to_date_html')}</strong> (<code>${cur}</code>). ${t('updates.no_changes')}`
+      summary.innerHTML = `<strong>${t('updates.up_to_date_html')}</strong>. ${t('updates.no_changes')}`
       applyBtn.hidden = true
     } else {
       summary.className = 'updates-summary behind'

--- a/web/app.js
+++ b/web/app.js
@@ -658,6 +658,11 @@ function renderStaticI18n() {
   document.querySelectorAll('[data-i18n-html]').forEach(el => {
     el.innerHTML = t(el.dataset.i18nHtml)
   })
+  // #updatesSubtitle opts out of the [data-i18n] sweep (renderUpdatesVersion owns
+  // it). Re-apply from the cached status so a language switch re-localizes its
+  // "Current:" label immediately -- never leaving a clobbered/mixed header even
+  // if loadUpdates' refetch is slow or fails.
+  if (typeof renderUpdatesVersion === 'function') renderUpdatesVersion(window._updatesStatus)
   if (typeof applyOnboardingProviderTab === 'function') applyOnboardingProviderTab()
 }
 
@@ -11762,7 +11767,13 @@ function renderUpdatesVersion(data) {
   const parts = []
   if (ver) parts.push('v' + escapeHtmlUpdates(ver))
   if (sha) parts.push(`<code>${escapeHtmlUpdates(sha)}</code>`)
-  if (parts.length === 0) return // no version and no SHA: keep the brand subtitle
+  if (parts.length === 0) {
+    // No version AND no SHA (no git checkout and unreadable package.json): fall
+    // back to the localized brand subtitle. Set as text (not innerHTML) so no
+    // stale markup lingers, and keep it localized on every render.
+    sub.textContent = t('updates.brand_subtitle')
+    return
+  }
   sub.innerHTML = `${t('updates.current_label')} ${parts.join(' · ')}`
 }
 

--- a/web/index.html
+++ b/web/index.html
@@ -1852,7 +1852,12 @@
         <div class="page-header-row">
           <div>
             <h1 data-i18n="updates.page_title">Frissítések</h1>
-            <p class="subtitle" id="updatesSubtitle" data-i18n="updates.brand_subtitle">Marveen verzió ellenőrzés</p>
+            <!-- No data-i18n here: renderUpdatesVersion() owns this element's
+                 content (the running version), so it must opt OUT of the generic
+                 [data-i18n] sweep in renderStaticI18n(), which would otherwise
+                 clobber the rendered version on a language switch. The label is
+                 re-localized by renderUpdatesVersion on every render instead. -->
+            <p class="subtitle" id="updatesSubtitle">Marveen verzió ellenőrzés</p>
           </div>
           <div style="display:flex;gap:8px">
             <button class="btn-secondary btn-compact" id="updatesCheckBtn" data-i18n="updates.btn.check">

--- a/web/lang/en.js
+++ b/web/lang/en.js
@@ -1233,7 +1233,6 @@ window._i18n.en = {
   'updates.details':             'Details ({n} commits)',
   'updates.upcoming_note':       'These changes will land in the next release.',
   'updates.available_on':        'on {remote}.',
-  'updates.latest_label':        'Latest:',
   'updates.confirm.stash':       'There are local changes in the working tree. Stash them automatically, update, then restore?',
   'updates.confirm.apply':       'Update now. Services will restart; dashboard will be unavailable for ~30 seconds. Continue?',
   'updates.install_failed':      'Install failed',

--- a/web/lang/hu.js
+++ b/web/lang/hu.js
@@ -1236,7 +1236,6 @@ window._i18n.hu = {
   'updates.details':             'Részletek ({n} commit)',
   'updates.upcoming_note':       'Ezek a változások a következő kiadásba kerülnek.',
   'updates.available_on':        'a {remote} repón.',
-  'updates.latest_label':        'Legfrissebb:',
   'updates.confirm.stash':       'A working tree-ben lokális változtatások vannak. Stash-eljem őket automatikusan, frissítsek, majd visszaállítsam?',
   'updates.confirm.apply':       'Frissítés most. A szolgáltatások újraindulnak, a dashboard ~30 másodpercig nem érhető el. Folytatod?',
   'updates.install_failed':      'Telepítés sikertelen',


### PR DESCRIPTION
## Cél

A Frissítések panel írja ki a futó példány **jelenlegi verzióját**, az alkalmazás többi felületéhez illeszkedő módon. Eddig csak a commit SHA látszott, az is csak két állapotban (naprakész / ellenőrzés-hiba); ha volt elérhető frissítés, a jelenlegi állapot sehol nem jelent meg. A semver (package.json) a dashboardon sehol nem szerepelt.

## Változások

**Backend** (`src/web/update-checker.ts`)
- A `GET /api/updates` válasza (`getUpdateStatus`) új `version` mezőt ad vissza: a futó példány semverje, `package.json` `"version"`, élőben olvasva `PROJECT_ROOT`-ból (új `currentVersion()`).
- Bármilyen hiba esetén (hiányzó / olvashatatlan / hibás JSON / nincs string `version`) `''`-t ad -> a mező üres, verziót SOHA nem fabrikál.

**Frontend** (`web/app.js`)
- A jelenlegi verzió a **page-header subtitle**-be (`#updatesSubtitle`) kerül, így **mind a három állapotban** látszik (naprakész / van frissítés / hiba), nem állapotonként ismételve. A semver az elsődleges, a 7 karakteres SHA másodlagos: `Jelenlegi: v1.32.1 · db1ed3f`. Ha nincs verzió, a SHA önmagában áll.
- Az állapot-összefoglalók már nem ismétlik a SHA-t (a fejlécbe került). A SHA nem tűnt el a felületről, csak a fejlécbe költözött a semver mellé.

**Design-illeszkedés**
- A **subtitle** mintát választottam a `.badge` pill helyett: mind a 22 oldal fejléce `.subtitle`-t használ, a `.badge` kizárólag tartalmon belül szerepel, fejlécben soha. Csak meglévő markup/osztály (`.subtitle`, `<code>`), **nincs új CSS, nincs hardcode szín vagy betűméret**.

**Takarítás**
- Törölve a halott `lat` változó a `loadUpdates()`-ből és a sehol nem renderelt `updates.latest_label` kulcs mindkét nyelvi fájlból. Újrahasznosítva a meglévő `updates.current_label` ("Jelenlegi:" / "Current:") a fejléc-címkéhez.
- i18n: minden szöveg kulcson át, nincs új hardcode magyar szöveg.

**Teszt** (`src/__tests__/update-checker-branch.test.ts`)
- `currentVersion()` egyezik a `package.json` verzióval (és valódi semver); `getUpdateStatus().version` visszaadja.

## Ellenőrzés

**A verzió a package.json-ból jön és egyezik a git taggel**
```
package.json: 1.32.1
git tag:      v1.32.1
```

**Hiányzó/olvashatatlan package.json -> nincs hamis verzió** (`currentVersion` logika):
```
real root      -> "1.32.1"
missing dir    -> ""
malformed json -> ""
```

**A három állapot renderje** (a subtitle állapotfüggetlen, ezért mindháromban ott a verzió):

| Állapot | Subtitle (fejléc) | Summary |
|--------|-------------------|---------|
| naprakész | `Jelenlegi: v1.32.1 · db1ed3f` | **You are on the latest version**. No changes |
| van frissítés | `Jelenlegi: v1.32.1 · db1ed3f` | **2 new versions available** `v1.33.0` |
| ellenőrzés-hiba | `Jelenlegi: v1.32.1 · db1ed3f` | **Could not check for updates:** GitHub /commits/develop -> 503 |
| verzió hiányzik | `Jelenlegi: db1ed3f` (SHA önmagában) | - |

Tesztek: az update suite zöld (`update-checker-branch` 5 + `update-release-grouping` 6), `tsc --noEmit` tiszta, `node --check` az app.js-re és mindkét lang fájlra OK.

## Scope
Ez nem a Frissítések oldal redesignja. Csak a fenti mezők + a jelzett takarítás.
