### PR TITLE
fix(kanban): self-heal updated_at on raw SQL status writes (0664aadf)

### DIFF
--- a/src/__tests__/kanban-archive-stale-updated-at.test.ts
+++ b/src/__tests__/kanban-archive-stale-updated-at.test.ts
@@ -1,0 +1,109 @@
+// kanban 0664aadf: a raw SQL status write that only touches the `status`
+// column (no updated_at) leaves the card's OLD updated_at in place. Since
+// listKanbanCards()'s auto-archive sweep archives 'done' cards purely by
+// comparing updated_at to a cutoff, a card that was just moved to 'done'
+// this way looks like it has been sitting untouched for weeks and gets
+// archived on the very next page load -- before anyone sees it.
+//
+// The fix is a self-healing trigger (kanban_cards_status_bumps_updated_at):
+// any status-changing UPDATE that leaves updated_at unchanged gets it bumped
+// to now. These tests exercise the trigger directly, then the archive sweep
+// end-to-end on both sides: a card that just changed via raw SQL (must NOT
+// archive) and a genuinely old done card that never changed status this way
+// (must still archive -- otherwise this "fix" would just be turning the
+// feature off).
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { initDatabase, getDb, listKanbanCards, getKanbanCard, createKanbanCard } from '../db.js'
+
+beforeEach(() => {
+  initDatabase(':memory:')
+})
+
+const DAY = 86400
+const OLD = Math.floor(Date.now() / 1000) - 40 * DAY // older than the 30-day default cutoff
+
+describe('kanban_cards_status_bumps_updated_at trigger', () => {
+  it('bumps updated_at when a raw SQL UPDATE changes status without touching updated_at', () => {
+    const db = getDb()
+    db.prepare(
+      `INSERT INTO kanban_cards (id, title, status, priority, created_at, updated_at)
+       VALUES ('raw-1', 'raw card', 'planned', 'normal', ?, ?)`
+    ).run(OLD, OLD)
+
+    db.prepare("UPDATE kanban_cards SET status = 'done' WHERE id = ?").run('raw-1')
+
+    const card = getKanbanCard('raw-1')!
+    expect(card.status).toBe('done')
+    expect(card.updated_at).toBeGreaterThan(OLD)
+    expect(card.updated_at).toBeGreaterThanOrEqual(Math.floor(Date.now() / 1000) - 5)
+  })
+
+  it('does not touch updated_at when a raw SQL UPDATE sets status to its current value (no-op)', () => {
+    const db = getDb()
+    db.prepare(
+      `INSERT INTO kanban_cards (id, title, status, priority, created_at, updated_at)
+       VALUES ('raw-2', 'raw card', 'planned', 'normal', ?, ?)`
+    ).run(OLD, OLD)
+
+    db.prepare("UPDATE kanban_cards SET status = 'planned' WHERE id = ?").run('raw-2')
+
+    expect(getKanbanCard('raw-2')!.updated_at).toBe(OLD)
+  })
+
+  it('does not touch updated_at when the same statement already sets it (normal write path)', () => {
+    const db = getDb()
+    const now = Math.floor(Date.now() / 1000)
+    db.prepare(
+      `INSERT INTO kanban_cards (id, title, status, priority, created_at, updated_at)
+       VALUES ('raw-3', 'raw card', 'planned', 'normal', ?, ?)`
+    ).run(OLD, OLD)
+
+    // Mirrors updateKanbanCard/moveKanbanCard: status and updated_at land in
+    // the same UPDATE. The trigger's WHEN clause (updated_at unchanged) must
+    // not fire here, or it would just be racing production's own timestamp.
+    db.prepare("UPDATE kanban_cards SET status = 'done', updated_at = ? WHERE id = ?").run(now, 'raw-3')
+
+    expect(getKanbanCard('raw-3')!.updated_at).toBe(now)
+  })
+})
+
+describe('listKanbanCards auto-archive vs. raw SQL status writes', () => {
+  it('does NOT archive a card moved to done via raw SQL this run, even though its old updated_at predates the cutoff', () => {
+    const db = getDb()
+    db.prepare(
+      `INSERT INTO kanban_cards (id, title, status, priority, created_at, updated_at)
+       VALUES ('freshly-done', 'old card, just closed', 'planned', 'normal', ?, ?)`
+    ).run(OLD, OLD)
+
+    // The exact shape of the bug: status-only raw SQL write, no updated_at.
+    db.prepare("UPDATE kanban_cards SET status = 'done' WHERE id = ?").run('freshly-done')
+
+    listKanbanCards()
+
+    expect(getKanbanCard('freshly-done')!.archived_at).toBeNull()
+  })
+
+  it('POZ. KONTROLL: still archives a genuinely old done card that never had a status UPDATE', () => {
+    const db = getDb()
+    // Written 'done' directly at INSERT time (e.g. a seed/import), so the
+    // trigger (which only fires on UPDATE OF status) never touched it --
+    // this is the case the sweep exists to catch, and must keep catching.
+    db.prepare(
+      `INSERT INTO kanban_cards (id, title, status, priority, created_at, updated_at)
+       VALUES ('genuinely-old', 'old and done', 'done', 'normal', ?, ?)`
+    ).run(OLD, OLD)
+
+    listKanbanCards()
+
+    expect(getKanbanCard('genuinely-old')!.archived_at).not.toBeNull()
+  })
+
+  it('does not archive a done card moved via the production entry point (createKanbanCard + status: done)', () => {
+    createKanbanCard({ id: 'prod-done', title: 'created done today', status: 'done' })
+
+    listKanbanCards()
+
+    expect(getKanbanCard('prod-done')!.archived_at).toBeNull()
+  })
+})

--- a/src/db.ts
+++ b/src/db.ts
@@ -400,6 +400,26 @@ export function initDatabase(dbPathOverride?: string): void {
   `)
   db.exec(`CREATE INDEX IF NOT EXISTS idx_kanban_events_card ON kanban_card_events(card_id, created_at)`)
 
+  // listKanbanCards()'s auto-archive sweep (below) treats a card's updated_at
+  // as "when did this card last change", and archives a done card once that
+  // timestamp is older than KANBAN_ARCHIVE_DONE_DAYS. Both production status
+  // writers (updateKanbanCard, moveKanbanCard) always bump updated_at in the
+  // same statement as the status change -- but a raw SQL UPDATE that only
+  // touches status (kanban 0664aadf: an ad hoc status fix) leaves the OLD
+  // updated_at in place, so a card that just became 'done' looks like it has
+  // been sitting untouched for weeks and gets archived on the very next page
+  // load, before anyone sees it. Self-healing rather than a CHECK constraint,
+  // same reasoning as agent_messages_delivered_needs_ts above: the point is
+  // to keep updated_at honest for any writer, not to police the write path.
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS kanban_cards_status_bumps_updated_at
+    AFTER UPDATE OF status ON kanban_cards
+    FOR EACH ROW WHEN NEW.status != OLD.status AND NEW.updated_at = OLD.updated_at
+    BEGIN
+      UPDATE kanban_cards SET updated_at = CAST(strftime('%s','now') AS INTEGER) WHERE id = NEW.id;
+    END
+  `)
+
   // --- Kanban labels (tags) -----------------------------------------------
   // Labels are a separate registry (not hardcoded per-card strings) so the
   // same label can be reused across many cards and recolored in one place.


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

`archiveOldDoneCards` decides what is "old" from `kanban_cards.updated_at`. That column is
only maintained by the TypeScript write path -- a status change made with raw SQL leaves
`updated_at` at whatever it was before.

The effect is not a cosmetic timestamp drift: a card moved to `done` by a raw SQL write keeps
an old `updated_at`, so the archiver can consider it stale and archive it immediately, and
every "what changed today" view and every `ORDER BY updated_at` sorts it wrong.

Fix: a trigger that bumps `updated_at` when a raw status write would otherwise leave it
untouched (`NEW.status != OLD.status AND NEW.updated_at = OLD.updated_at`). The guard on
`updated_at` is what makes it a no-op for the normal TypeScript path, which already sets the
column itself -- so this does not double-write or override an explicit value.

Verified on this branch, on top of develop, in both directions:
- with the fix: 6 passed
- without it (src/db.ts reverted to develop's version): 2 failed | 4 passed

The two failures are the intended ones -- a freshly-done card archived when it should not be,
and the stale-`updated_at` case. The other four cover the no-op path, so the trigger is pinned
in both directions.

## Kapcsolódó issue / Related issue

None -- found while running a fork whose agents write the board directly over SQL. The fix
itself is not specific to that setup; it applies to any raw status write, including a manual
`sqlite3` session.

## Ellenőrzőlista / Checklist

- [ ] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak.
- [x] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat).
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra).

<!-- Note on the first checkbox: not ticked, because it would not be true. This change is a
SQLite trigger on the kanban table; the Telegram/Slack + dashboard agent path was not
exercised. What was run on this branch: the new targeted test both ways (6 passed with the
fix, 2 failed without it). The full suite was not run for this one. -->

