### PR TITLE
fix(vault): store the SSH import key with the newline it was validate…

### DIFF
--- a/src/__tests__/vault-ssh-keys-import.test.ts
+++ b/src/__tests__/vault-ssh-keys-import.test.ts
@@ -1,0 +1,91 @@
+// The import route validates the key with a trailing-newline-restored copy
+// (needed for ssh-keygen to accept the PEM) but historically stored the raw,
+// possibly newline-stripped client value. That passes ssh-keygen validation
+// and returns 201, then fails later when something actually reads the stored
+// key: an OpenSSH parser rejects a PEM without its closing newline. The gate
+// here therefore checks the STORED value, not the response status.
+import { describe, it, expect, vi } from 'vitest'
+import type http from 'node:http'
+import { Readable } from 'node:stream'
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, mkdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import type { RouteContext } from '../web/routes/types.js'
+
+const tmpRoot = mkdtempSync(join(tmpdir(), 'vault-ssh-keys-import-'))
+mkdirSync(join(tmpRoot, 'store'), { recursive: true })
+
+vi.mock('../config.js', async (orig) => {
+  const actual = await orig<typeof import('../config.js')>()
+  return { ...actual, PROJECT_ROOT: tmpRoot, STORE_DIR: join(tmpRoot, 'store') }
+})
+
+const { initDatabase, getVaultSshKey } = await import('../db.js')
+const { tryHandleVaultSshKeys } = await import('../web/routes/vault-ssh-keys.js')
+const { getSecret } = await import('../web/vault.js')
+
+initDatabase(':memory:')
+
+interface MockRes {
+  statusCode: number
+  body: string
+  writeHead(status: number): MockRes
+  end(data?: string): void
+}
+function mkRes(): MockRes {
+  return {
+    statusCode: 0,
+    body: '',
+    writeHead(status) { this.statusCode = status; return this },
+    end(data) { if (data !== undefined) this.body += data },
+  }
+}
+
+async function importKey(privateKey: string) {
+  const payload = Buffer.from(JSON.stringify({ label: 'test-key', username: 'deploy', privateKey }))
+  const req = Readable.from([payload]) as unknown as http.IncomingMessage
+  const res = mkRes()
+  const ctx: RouteContext = {
+    req,
+    res: res as unknown as http.ServerResponse,
+    path: '/api/vault/ssh-keys/import',
+    method: 'POST',
+    url: new URL('http://127.0.0.1:3420/api/vault/ssh-keys/import'),
+  }
+  await tryHandleVaultSshKeys(ctx)
+  return { res, json: () => JSON.parse(res.body || '{}') }
+}
+
+function freshPrivateKeyWithNewline(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'vault-ssh-keys-fixture-'))
+  const keyPath = join(dir, 'k')
+  execFileSync('ssh-keygen', ['-t', 'ed25519', '-f', keyPath, '-N', '', '-C', 'fixture'], { stdio: 'pipe' })
+  return readFileSync(keyPath, 'utf-8')
+}
+
+describe('POST /api/vault/ssh-keys/import: stored value trailing newline', () => {
+  it('stores the private key WITH its trailing newline even when the client body had it stripped', async () => {
+    const withNewline = freshPrivateKeyWithNewline()
+    expect(withNewline.endsWith('\n')).toBe(true)
+    const stripped = withNewline.replace(/\n+$/, '')
+    expect(stripped.endsWith('\n')).toBe(false)
+
+    const { res, json } = await importKey(stripped)
+
+    // Sanity: the request itself must succeed (this is NOT the bug surface).
+    expect(res.statusCode).toBe(201)
+
+    const id = json().key.id as string
+    const row = getVaultSshKey(id)
+    expect(row).toBeDefined()
+    const stored = getSecret(row!.vault_key_id)
+
+    // THE ACTUAL BUG SURFACE: the value that lands in the vault, not the
+    // response code. A stored PEM without its closing newline is rejected by
+    // OpenSSH's parser the next time it is actually used.
+    expect(stored).not.toBeNull()
+    expect(stored!.endsWith('\n')).toBe(true)
+    expect(stored).toBe(withNewline)
+  })
+})

--- a/src/web/routes/vault-ssh-keys.ts
+++ b/src/web/routes/vault-ssh-keys.ts
@@ -109,22 +109,28 @@ export async function tryHandleVaultSshKeys(ctx: RouteContext): Promise<boolean>
       const body = await readBody(req)
       const data = JSON.parse(body.toString())
 
-      const label      = typeof data.label      === 'string' ? data.label.trim()      : ''
-      const username   = typeof data.username   === 'string' ? data.username.trim()   : ''
-      const privateKey = typeof data.privateKey === 'string' ? data.privateKey.trim() : ''
+      const label        = typeof data.label      === 'string' ? data.label.trim()      : ''
+      const username     = typeof data.username   === 'string' ? data.username.trim()   : ''
+      const rawPrivateKey = typeof data.privateKey === 'string' ? data.privateKey.trim() : ''
 
-      if (!label || !username || !privateKey) {
+      if (!label || !username || !rawPrivateKey) {
         json(res, { error: 'label, username and privateKey are required' }, 400)
         return true
       }
+
+      // Restore the closing newline ONCE, before validation, and use this
+      // normalized value for BOTH validation and storage -- ssh-keygen needs
+      // a trailing newline to accept the PEM, and whatever is not stored
+      // exactly as validated will fail an OpenSSH parser later, silently
+      // (the request itself still returns 201).
+      const privateKey = rawPrivateKey.endsWith('\n') ? rawPrivateKey : rawPrivateKey + '\n'
 
       // Validate key and extract public key via ssh-keygen -y (same pattern as extractPublicKeyFromVault)
       const tmpDir = mkdtempSync(join(tmpdir(), 'marveen-ssh-'))
       const keyPath = join(tmpDir, 'key')
       let publicKey: string
       try {
-        const keyContent = privateKey.endsWith('\n') ? privateKey : privateKey + '\n'
-        writeFileSync(keyPath, keyContent, { mode: 0o600 })
+        writeFileSync(keyPath, privateKey, { mode: 0o600 })
         chmodSync(keyPath, 0o600)
         publicKey = execFileSync('ssh-keygen', ['-y', '-f', keyPath], { stdio: 'pipe' }).toString().trim()
       } catch (err: any) {


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

The import route trimmed the client-sent privateKey, then restored a trailing newline
in a separate `keyContent` copy used only for ssh-keygen validation. `setSecret()` stored
the original, still-trimmed string.

The request still returns 201 -- validation ran on the fixed copy -- but the stored key
lacks its closing newline, and an OpenSSH parser rejects that the next time the key is
actually used. The failure surfaces far from its cause.

Fix: restore the newline once, before validation, and use that single normalized value
for both the validation file and `setSecret()`. The temporary repair inside the try-block
becomes redundant and is removed.

Verified on this branch, on top of develop:
- new test drives a real ed25519 key through the import route with its trailing newline
  stripped, then reads back the STORED secret (not the response code)
- before the fix: response 201, stored value fails `endsWith('\n')`
- after the fix: stored value intact, `tsc --noEmit` clean

## Kapcsolódó issue / Related issue

None -- found while reviewing the vault code, no existing issue.

## Ellenőrzőlista / Checklist

- [ ] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak.
- [x] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat).
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra).

<!-- Note on the first checkbox: not ticked, because it would not be true.
This change touches SSH key import in the vault; we did not exercise the
Telegram/Slack + dashboard agent path. What was run on this branch:
the new targeted test (green), `tsc --noEmit` (clean), and the full suite
(3570 pass / 20 fail). Those 20 failures were re-run on a clean develop
checkout and fail there identically -- environment-dependent (bash version,
timing), not caused by this change. -->