### PR TITLE
fix(governance): the email gate never fired for MCP mail tools

### DIFF
--- a/scripts/email-send-gate.mjs
+++ b/scripts/email-send-gate.mjs
@@ -42,17 +42,53 @@ const SEND_PATTERNS = [
   /\bsendMail\s*\(/i,
 ]
 
+// Outbound-shaped operations of the multiplexed manage_email tool. Each of
+// these sends for real unless the call explicitly asks for a draft.
+const MANAGE_EMAIL_SEND_OPS = new Set(['send', 'reply', 'replyall', 'forward'])
+
 // Pure decision: does this tool call send (or attempt to send) email?
+// Returns { deny, kind? }. `kind` selects the deny wording at the hook
+// entrypoint: 'draft-required' is the manage_email case (drafting is fine,
+// only the actual send is refused), everything else is the sub-agent
+// governance block.
 export function gateDecision(toolName, toolInput) {
   const name = String(toolName ?? '')
   // Any MCP send_email tool, name-agnostic (gmail or a differently-named
   // server in a customer install -> the matcher + this both key on send_email).
   if (/send_email/i.test(name)) return { deny: true }
+  // @aaronsb/google-workspace-mcp multiplexes read, draft and send behind one
+  // manage_email tool, so the tool NAME cannot decide this one -- the operation
+  // plus the draft flag can. This is what replaces the server's own
+  // draft-only-email safety policy, which blocks drafting too: that policy keys
+  // on ctx.operation alone and never looks at draft:true, so with it enabled the
+  // mailbox is effectively read-only (verified live, 2026-08-10).
+  if (/(^|__)manage_email$/i.test(name)) {
+    const op = String(toolInput?.operation ?? '').toLowerCase()
+    if (!MANAGE_EMAIL_SEND_OPS.has(op)) return { deny: false }
+    // Fail safe: only an explicit draft request passes. A missing/ambiguous
+    // flag is treated as a real send, even though the server would itself
+    // force a draft when attachments are present.
+    const draft = toolInput?.draft
+    if (draft === true || draft === 'true') return { deny: false }
+    return { deny: true, kind: 'draft-required' }
+  }
   if (name === 'Bash') {
     const cmd = String(toolInput?.command ?? '')
     if (SEND_PATTERNS.some((re) => re.test(cmd))) return { deny: true }
   }
   return { deny: false }
+}
+
+// Deny wording for the manage_email case. Unlike the sub-agent governance
+// block this is not about who the agent is: drafting stays open, so the fix is
+// to re-issue the same call with draft: true and hand the draft to the owner.
+export function buildDraftOnlyMsg(ownerName) {
+  return (
+    'Kimeno email kuldese tiltott (draft-kapu). ' +
+    'Ird meg ugyanezt draft: true kapcsoloval, es szolj ' +
+    `${ownerName}nek, hogy a Gmail piszkozatok kozott varja a jovahagyasat. ` +
+    'Csak VERIFIKALT cimre. A kuldes gombot ember nyomja meg.'
+  )
 }
 
 // Pure builder for the deny message, so the brand/owner substitution is
@@ -126,10 +162,10 @@ if (isInvokedDirectly()) {
   } catch {
     allow() // malformed/empty input must never break the agent's tool calls
   }
-  const { deny: shouldDeny } = gateDecision(payload?.tool_name, payload?.tool_input)
+  const { deny: shouldDeny, kind } = gateDecision(payload?.tool_name, payload?.tool_input)
   if (shouldDeny) {
     const { botName, ownerName } = readBrandEnv()
-    deny(buildGateMsg(botName, ownerName))
+    deny(kind === 'draft-required' ? buildDraftOnlyMsg(ownerName) : buildGateMsg(botName, ownerName))
   }
   allow()
 }

--- a/src/__tests__/email-send-gate.test.ts
+++ b/src/__tests__/email-send-gate.test.ts
@@ -18,6 +18,48 @@ describe('gateDecision', () => {
     expect(gateDecision('mcp__server-gmail-autoauth-mcp__draft_email', {}).deny).toBe(false)
   })
 
+  // @aaronsb/google-workspace-mcp multiplexes read/draft/send behind one tool,
+  // so the gate has to read the operation + draft flag, not just the name.
+  // This replaces the server's draft-only-email policy, which blocks drafting too.
+  describe('manage_email (multiplexed google-workspace tool)', () => {
+    const call = (input: Record<string, unknown>) =>
+      gateDecision('mcp__google-workspace__manage_email', input)
+
+    it('blocks the outbound operations when no draft is asked for', () => {
+      for (const operation of ['send', 'reply', 'replyAll', 'forward']) {
+        expect(call({ operation }).deny).toBe(true)
+        expect(call({ operation }).kind).toBe('draft-required')
+        expect(call({ operation, draft: false }).deny).toBe(true)
+      }
+    })
+
+    it('allows the same operations when they only create a draft', () => {
+      for (const operation of ['send', 'reply', 'replyAll', 'forward']) {
+        expect(call({ operation, draft: true }).deny).toBe(false)
+      }
+    })
+
+    it('allows read-shaped operations', () => {
+      for (const operation of ['search', 'read', 'triage', 'labels', 'threads', 'modify']) {
+        expect(call({ operation }).deny).toBe(false)
+      }
+    })
+
+    it('fails safe on a missing or non-boolean draft flag', () => {
+      expect(call({ operation: 'send', draft: 'yes' }).deny).toBe(true)
+      expect(call({ operation: 'send', draft: 1 }).deny).toBe(true)
+      expect(call({}).deny).toBe(false) // no operation at all is not send-shaped
+      // the string 'true' survives a JSON round-trip that stringified the flag
+      expect(call({ operation: 'send', draft: 'true' }).deny).toBe(false)
+    })
+
+    it('is name-agnostic across server prefixes but does not match look-alikes', () => {
+      expect(gateDecision('manage_email', { operation: 'send' }).deny).toBe(true)
+      expect(gateDecision('mcp__other__manage_email', { operation: 'send' }).deny).toBe(true)
+      expect(gateDecision('manage_emails_bulk', { operation: 'send' }).deny).toBe(false)
+    })
+  })
+
   it('blocks Bash mail-send commands', () => {
     const bash = (command: string) => gateDecision('Bash', { command })
     expect(bash('python3 scripts/support-mail/send.py --to x@y.hu').deny).toBe(true)
@@ -70,9 +112,28 @@ describe('injectEmailSendGate', () => {
     injectEmailSendGate(s)
     const hooks = (s.hooks as Record<string, unknown>).PreToolUse as Array<Record<string, unknown>>
     expect(hooks).toHaveLength(1)
-    expect(hooks[0].matcher).toBe('Bash|send_email')
+    expect(hooks[0].matcher).toBe('Bash|.*send_email.*|.*manage_email.*')
     const inner = (hooks[0].hooks as Array<{ command: string }>)[0]
     expect(inner.command).toContain('email-send-gate.mjs')
+  })
+
+  // Regression (2026-08-10): the matcher is full-matched against the tool name,
+  // and MCP tools arrive qualified as `mcp__<server>__<tool>` -- with the old
+  // bare `send_email|manage_email` alternatives the hook never fired for ANY MCP
+  // mail tool, so both the sub-agent governance gate and the draft-kapu were
+  // silently open. Assert against the real qualified names.
+  it('matcher full-matches qualified MCP tool names', () => {
+    const s: Record<string, unknown> = {}
+    injectEmailSendGate(s)
+    const hooks = (s.hooks as Record<string, unknown>).PreToolUse as Array<Record<string, unknown>>
+    const re = new RegExp(`^(?:${hooks[0].matcher as string})$`)
+    expect(re.test('mcp__google-workspace__manage_email')).toBe(true)
+    expect(re.test('mcp__server-gmail-autoauth-mcp__send_email')).toBe(true)
+    expect(re.test('manage_email')).toBe(true)
+    expect(re.test('send_email')).toBe(true)
+    expect(re.test('Bash')).toBe(true)
+    expect(re.test('Read')).toBe(false)
+    expect(re.test('mcp__google-workspace__manage_calendar')).toBe(false)
   })
 
   it('is idempotent (no duplicate entries on re-apply / respawn)', () => {

--- a/src/__tests__/hook-command-quoting.test.ts
+++ b/src/__tests__/hook-command-quoting.test.ts
@@ -10,6 +10,8 @@ import {
   injectEgressGate,
   ensureEgressGate,
   ensureGovernanceGateCommands,
+  emailGateMatcherStale,
+  EMAIL_GATE_MATCHER,
 } from '../web/agent-scaffold.js'
 import { PROJECT_ROOT } from '../config.js'
 
@@ -135,5 +137,58 @@ describe('ensure* migrations are idempotent (true, then false)', () => {
       expect(cmd.includes(`"${HOOK_NODE_BIN}" "`)).toBe(true)
       expect(cmd).not.toMatch(/^node /)
     }
+  })
+
+  // 2026-08-10: the second silently-non-enforcing shape. Here the command is
+  // already correct (absolute, quoted interpreter), so the wiring check reports
+  // the gate healthy -- but the matcher is the pre-fix bare one, which never
+  // matches `mcp__<server>__manage_email`, so the hook never runs. The migration
+  // must repair the matcher too, or every install scaffolded before the fix
+  // keeps a gate that passes every check and blocks nothing.
+  it('ensureGovernanceGateCommands repairs a stale matcher on a correctly-wired command', () => {
+    mkdirSync(join(testAgentDir, '.claude'), { recursive: true })
+    const settingsPath = join(testAgentDir, '.claude', 'settings.json')
+    writeFileSync(settingsPath, JSON.stringify({
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: 'Bash|send_email|manage_email',
+            hooks: [{ type: 'command', command: hookCommand(join(PROJECT_ROOT, 'scripts', 'email-send-gate.mjs')), timeout: 10 }],
+          },
+          {
+            matcher: 'Bash',
+            hooks: [{ type: 'command', command: hookCommand(join(PROJECT_ROOT, 'scripts', 'self-pace-gate.mjs')), timeout: 10 }],
+          },
+        ],
+      },
+    }, null, 2))
+
+    expect(ensureGovernanceGateCommands(TEST_AGENT)).toBe(true)
+    expect(ensureGovernanceGateCommands(TEST_AGENT)).toBe(false)
+
+    const written = JSON.parse(readFileSync(settingsPath, 'utf-8'))
+    const ptu = (written.hooks as Record<string, unknown>).PreToolUse as { matcher: string, hooks: { command: string }[] }[]
+    const gate = ptu.find((e) => e.hooks.some((h) => h.command.includes('email-send-gate.mjs')))
+    expect(gate?.matcher).toBe(EMAIL_GATE_MATCHER)
+    // Repaired in place, not duplicated.
+    expect(ptu.filter((e) => e.hooks.some((h) => h.command.includes('email-send-gate.mjs')))).toHaveLength(1)
+    // The unrelated self-pace entry survives untouched.
+    expect(ptu.some((e) => e.hooks.some((h) => h.command.includes('self-pace-gate.mjs')))).toBe(true)
+  })
+})
+
+describe('emailGateMatcherStale', () => {
+  const cmd = { type: 'command', command: hookCommand(join(PROJECT_ROOT, 'scripts', 'email-send-gate.mjs')), timeout: 10 }
+
+  it('flags a pre-fix matcher', () => {
+    expect(emailGateMatcherStale([{ matcher: 'Bash|send_email|manage_email', hooks: [cmd] }])).toBe(true)
+    expect(emailGateMatcherStale([{ matcher: 'Bash|send_email', hooks: [cmd] }])).toBe(true)
+  })
+
+  it('accepts the current matcher and ignores unrelated entries', () => {
+    expect(emailGateMatcherStale([{ matcher: EMAIL_GATE_MATCHER, hooks: [cmd] }])).toBe(false)
+    expect(emailGateMatcherStale([{ matcher: 'WebFetch', hooks: [{ type: 'command', command: 'x egress-gate.mjs' }] }])).toBe(false)
+    expect(emailGateMatcherStale([])).toBe(false)
+    expect(emailGateMatcherStale(undefined)).toBe(false)
   })
 })

--- a/src/web/agent-scaffold.ts
+++ b/src/web/agent-scaffold.ts
@@ -377,6 +377,28 @@ export function agentGetsEmailGate(name: string): boolean {
   return name !== MAIN_AGENT_ID
 }
 
+// The matcher is a FULL-match regex against the tool name, and an MCP tool's
+// name is the qualified `mcp__<server>__<tool>` -- so a bare `send_email`
+// alternative never fires for an MCP server (verified live 2026-08-10: a
+// manage_email send went through while the gate script itself denied the same
+// payload, because the hook never ran). The `.*` wrappers are what make the gate
+// reach MCP tools at all. Exported so the startup migration can recognize a
+// stale matcher on an already-scaffolded agent.
+export const EMAIL_GATE_MATCHER = 'Bash|.*send_email.*|.*manage_email.*'
+
+// Does an existing PreToolUse array carry an email-gate entry whose matcher is
+// NOT the current one? Pure + exported: this is the predicate that lets
+// ensureGovernanceGateCommands repair installs scaffolded before the matcher
+// fix, where the hook COMMAND is correctly wired (so the wiring check passes)
+// but the matcher never matches the qualified MCP tool name.
+export function emailGateMatcherStale(preToolUse: unknown): boolean {
+  if (!Array.isArray(preToolUse)) return false
+  return preToolUse.some((e) => {
+    if (!JSON.stringify(e).includes('email-send-gate.mjs')) return false
+    return (e as { matcher?: unknown })?.matcher !== EMAIL_GATE_MATCHER
+  })
+}
+
 // Idempotently wire the email-send-gate PreToolUse hook into a settings.json
 // object. A deny-list rule alone would NOT enforce this: permissive profiles
 // launch with --dangerously-skip-permissions, which bypasses allow/deny --
@@ -390,7 +412,7 @@ export function injectEmailSendGate(existing: Record<string, unknown>): void {
   // Registration guard: a /tmp or missing path must never enter shared settings.
   if (isUnsafeHookCommand(command)) return
   const entry = {
-    matcher: 'Bash|send_email',
+    matcher: EMAIL_GATE_MATCHER,
     hooks: [{ type: 'command', command, timeout: 10 }],
   }
   const prev = Array.isArray(hooks.PreToolUse) ? (hooks.PreToolUse as unknown[]) : []
@@ -587,6 +609,10 @@ export function renderQuarantineReader(template: string, domains: string[]): str
 // bare `node`, which is missing from the non-interactive hook PATH on nvm
 // installs -- exit 127 counts as a non-blocking hook error, so those gates were
 // silently non-enforcing. Called at server startup (alongside ensureEgressGate).
+// Also repairs a stale email-gate MATCHER (pre-2026-08-10 installs wrote a bare
+// `send_email|manage_email`, which never matches a qualified MCP tool name), so
+// an agent scaffolded before the fix is not left with a gate that looks wired
+// and enforces nothing.
 // NOTE: a running session does NOT re-read settings.json -- the rewritten
 // command takes effect at that agent's next (re)spawn; this call only makes
 // the migration zero-touch, not instantaneous.
@@ -602,8 +628,14 @@ export function ensureGovernanceGateCommands(name: string): boolean {
   const hooks = (settings.hooks && typeof settings.hooks === 'object')
     ? settings.hooks as Record<string, unknown>
     : {}
-  const ptuJson = JSON.stringify(Array.isArray(hooks.PreToolUse) ? hooks.PreToolUse : [])
-  const needEmail = agentGetsEmailGate(name) && !hookCommandWired(ptuJson, emailCmd)
+  const ptu = Array.isArray(hooks.PreToolUse) ? hooks.PreToolUse : []
+  const ptuJson = JSON.stringify(ptu)
+  // Two separate failure modes, both silently non-enforcing: the command is not
+  // wired at all, or it IS wired but under a pre-2026-08-10 matcher that cannot
+  // match a qualified MCP tool name. The second one is why the wiring check
+  // alone is not enough -- it would report the gate healthy forever.
+  const needEmail = agentGetsEmailGate(name)
+    && (!hookCommandWired(ptuJson, emailCmd) || emailGateMatcherStale(ptu))
   const needPace = agentGetsGovernanceGates(name) && !hookCommandWired(ptuJson, paceCmd)
   if (!needEmail && !needPace) return false
   // The injectors dedupe by script basename, so a stale bare-`node` entry is


### PR DESCRIPTION
The `PreToolUse` matcher is full-matched against the tool name, and an MCP tool arrives qualified as `mcp__<server>__<tool>`. The gate was registered as `Bash|send_email|manage_email`, so for **any** MCP mail server the hook was never invoked at all. The sub-agent email block was open on every MCP `send_email` tool, and only the `Bash` patterns were doing any work.

Found live, not in review: with the gate reportedly in place, a real `mcp__google-workspace__manage_email` send went out, while the same payload piped straight into the hook script returned `deny`. The script was right the whole time; nothing was running it.

## Changes

- **Matcher** → `Bash|.*send_email.*|.*manage_email.*` (`EMAIL_GATE_MATCHER`), so it reaches both bare and qualified tool names.
- **`gateDecision` handles the multiplexed `manage_email`** of `@aaronsb/google-workspace-mcp`: `send` / `reply` / `replyAll` / `forward` deny unless `draft === true`, fail-safe on a missing or ambiguous draft flag. This replaces that server's own draft-only-email policy, which keys on `ctx.operation` alone and so blocks drafting too (verified live: the mailbox goes read-only).
- **`ensureGovernanceGateCommands` now repairs a stale matcher**, not just a legacy bare-`node` command. Installs scaffolded before this commit have the command correctly wired under the old matcher, so the wiring check alone would report the gate healthy forever.

## Verification

Verified live on the real tool, not only in the suite: send without `draft` blocked, `draft: true` through, `search` and `trash` unaffected. Full suite on this branch against current `develop`: **3618 passed**, 268 files, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
