### PR TITLE
fix(memories): require confirm:true on PUT/DELETE, echo prior/deleted…

### DIFF
--- a/src/__tests__/memories-mutate-confirm-gate.test.ts
+++ b/src/__tests__/memories-mutate-confirm-gate.test.ts
@@ -1,0 +1,104 @@
+/**
+ * PUT and DELETE /api/memories/:id used to take no confirmation and 200
+ * unconditionally, so a caller that meant to probe a different verb (or hit
+ * the wrong id) could silently overwrite or permanently remove a live row
+ * with no trace of what changed.
+ *
+ * Fix: both verbs require a `confirm: true` field in the JSON body -- without
+ * it they 400 and do not mutate. DELETE's success response echoes the removed
+ * row; PUT's success response echoes the row's previous content.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import http from 'node:http'
+import { Readable } from 'node:stream'
+import { initDatabase, saveAgentMemory, getDb } from '../db.js'
+import { tryHandleMemories } from '../web/routes/memories.js'
+import type { RouteContext } from '../web/routes/types.js'
+
+vi.mock('../config.js', async () => {
+  const actual = await vi.importActual<typeof import('../config.js')>('../config.js')
+  return { ...actual, MAIN_AGENT_ID: 'agent-a', ALLOWED_CHAT_ID: 'test-chat', OLLAMA_URL: '' }
+})
+
+vi.mock('../logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+}))
+
+function mkRes() {
+  const state = { statusCode: 0, body: '' }
+  return {
+    state,
+    writeHead(code: number) { state.statusCode = code; return this },
+    setHeader() {},
+    end(data?: unknown) { if (data !== undefined) state.body += String(data) },
+  }
+}
+
+async function call(method: string, id: number, body?: unknown): Promise<{ statusCode: number; json: any }> {
+  const req = Readable.from([Buffer.from(body === undefined ? '' : JSON.stringify(body))]) as unknown as http.IncomingMessage & Record<string, unknown>
+  req.headers = {}
+  const res = mkRes()
+  const ctx: RouteContext = {
+    req: req as http.IncomingMessage,
+    res: res as unknown as http.ServerResponse,
+    path: `/api/memories/${id}`,
+    method,
+    url: new URL(`http://127.0.0.1:3420/api/memories/${id}`),
+    fedPeer: null,
+  }
+  const handled = await tryHandleMemories(ctx)
+  expect(handled).toBe(true)
+  return { statusCode: res.state.statusCode || 200, json: res.state.body ? JSON.parse(res.state.body) : null }
+}
+
+const MARKER = 'confirm-gate-poz-kontroll-torzs-XJ4q'
+
+describe('PUT/DELETE /api/memories/:id require confirmation', () => {
+  let id: number
+
+  beforeEach(() => {
+    initDatabase(':memory:')
+    id = saveAgentMemory('agent-a', MARKER, 'warm', 'confirm-gate-teszt').id
+  })
+
+  it('DELETE without confirm: true is refused, and the row survives', async () => {
+    const before = getDb().prepare('SELECT content FROM memories WHERE id = ?').get(id) as { content: string } | undefined
+    expect(before?.content).toBe(MARKER)
+
+    const { statusCode, json } = await call('DELETE', id) // no body at all
+    expect(statusCode).toBe(400)
+    expect(json.error).toMatch(/confirm/i)
+
+    const after = getDb().prepare('SELECT content FROM memories WHERE id = ?').get(id) as { content: string } | undefined
+    expect(after?.content).toBe(MARKER)
+  })
+
+  it('DELETE with confirm: true removes the row and echoes what was deleted', async () => {
+    const { statusCode, json } = await call('DELETE', id, { confirm: true })
+    expect(statusCode).toBe(200)
+    expect(json.ok).toBe(true)
+    expect(json.deleted?.content).toBe(MARKER)
+
+    const after = getDb().prepare('SELECT content FROM memories WHERE id = ?').get(id)
+    expect(after).toBeUndefined()
+  })
+
+  it('PUT without confirm: true is refused, and the row is unchanged', async () => {
+    const { statusCode, json } = await call('PUT', id, { content: 'overwritten-by-mistake' })
+    expect(statusCode).toBe(400)
+    expect(json.error).toMatch(/confirm/i)
+
+    const after = getDb().prepare('SELECT content FROM memories WHERE id = ?').get(id) as { content: string } | undefined
+    expect(after?.content).toBe(MARKER)
+  })
+
+  it('PUT with confirm: true overwrites and echoes the PREVIOUS content', async () => {
+    const { statusCode, json } = await call('PUT', id, { content: 'new-content', confirm: true })
+    expect(statusCode).toBe(200)
+    expect(json.ok).toBe(true)
+    expect(json.previous_content).toBe(MARKER)
+
+    const after = getDb().prepare('SELECT content FROM memories WHERE id = ?').get(id) as { content: string } | undefined
+    expect(after?.content).toBe('new-content')
+  })
+})

--- a/src/web/routes/memories.ts
+++ b/src/web/routes/memories.ts
@@ -238,20 +238,48 @@ Respond ONLY with JSON, nothing else:
   if (memUpdateMatch && method === 'PUT') {
     const id = parseInt(memUpdateMatch[1], 10)
     const body = await readBody(req)
-    const { content, category, tier, agent_id, keywords } = JSON.parse(body.toString()) as { content: string; category?: string; tier?: string; agent_id?: string; keywords?: string }
-    if (updateMemory(id, content, tier || category, agent_id, keywords)) { json(res, { ok: true }); return true }
+    const { content, category, tier, agent_id, keywords, confirm } = JSON.parse(body.toString()) as { content: string; category?: string; tier?: string; agent_id?: string; keywords?: string; confirm?: boolean }
+    // This endpoint used to overwrite a live row with no confirmation and no
+    // way back. A confirm flag turns an accidental call into a loud 400
+    // instead of a quiet overwrite.
+    if (!confirm) {
+      json(res, { error: 'Confirmation required: resend with "confirm": true. This overwrites an existing memory.' }, 400)
+      return true
+    }
+    // Captured before the write so a mistaken overwrite is still visible in
+    // the response -- the row's prior content, not just an opaque "ok".
+    const previous = getDb().prepare('SELECT content FROM memories WHERE id = ?').get(id) as { content: string } | undefined
+    if (updateMemory(id, content, tier || category, agent_id, keywords)) {
+      json(res, { ok: true, previous_content: previous?.content ?? null })
+      return true
+    }
     json(res, { error: 'Memory not found' }, 404)
     return true
   }
 
   if (memUpdateMatch && method === 'DELETE') {
     const id = parseInt(memUpdateMatch[1], 10)
+    // No body is the common case (a bare `DELETE`), so an empty buffer must
+    // NOT be treated as JSON -- it means "unconfirmed", same as an explicit
+    // confirm: false.
+    const body = await readBody(req)
+    let confirm = false
+    if (body.length) {
+      try { confirm = (JSON.parse(body.toString()) as { confirm?: boolean }).confirm === true } catch { /* malformed body -> stays unconfirmed */ }
+    }
+    if (!confirm) {
+      json(res, { error: 'Confirmation required: resend with a JSON body {"confirm": true}. This permanently deletes the memory.' }, 400)
+      return true
+    }
     const db2 = getDb()
+    // The deleted row is echoed back so a mistaken id is at least
+    // recoverable from the response/log, not just a silent 200.
+    const deleted = db2.prepare('SELECT * FROM memories WHERE id = ?').get(id) as Memory | undefined
     const changes = db2.prepare('DELETE FROM memories WHERE id = ?').run(id).changes
     // Invalidate the in-process TTL cache so a deleted memory does not
     // resurface in the agent-filtered list for the cache lifetime.
     if (changes > 0) clearMemoryCache()
-    if (changes > 0) { json(res, { ok: true }); return true }
+    if (changes > 0) { json(res, { ok: true, deleted }); return true }
     json(res, { error: 'Memory not found' }, 404)
     return true
   }

--- a/web/app.js
+++ b/web/app.js
@@ -6673,7 +6673,8 @@ document.getElementById('saveMemBtn').addEventListener('click', async () => {
       await fetch(`/api/memories/${editId}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ content, tier, agent_id: agentId, keywords }),
+        // confirm: true -- this Save click IS the user's confirmation.
+        body: JSON.stringify({ content, tier, agent_id: agentId, keywords, confirm: true }),
       })
       showToast(t('memories.toast.updated'))
     } else {
@@ -6808,7 +6809,12 @@ function renderMemories(memories) {
       e.stopPropagation()
       if (!confirm('Biztosan torlod ezt az emleket?')) return
       try {
-        await fetch(`/api/memories/${mem.id}`, { method: 'DELETE' })
+        // The dialog above IS the confirmation the API now requires.
+        await fetch(`/api/memories/${mem.id}`, {
+          method: 'DELETE',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ confirm: true }),
+        })
         showToast(t('memories.toast.deleted'))
         loadMemories()
         loadMemStats()


### PR DESCRIPTION
… content

PUT and DELETE /api/memories/:id mutate a live row with no confirmation and no trace of what changed: a caller that hits the wrong verb or the wrong id gets a silent 200, and DELETE's response carries nothing of the removed row, so a mistaken id leaves no way back.

Both verbs now require confirm:true in the JSON body (400 + no mutation otherwise). DELETE echoes the removed row; PUT echoes the row's content as it stood before the overwrite. The dashboard's own edit-save and delete-confirm-dialog flows already gate on user intent, so they now send confirm:true.

RED proved first against pre-fix code (all four assertions in memories-mutate-confirm-gate.test.ts fail without this change).

<!--
  HU + EN. Töltsd ki minden szakaszt. / Fill in every section.
  A jelölőnégyzeteket így pipáld: [x]  /  Tick a box like this: [x]
-->

## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

PUT/DELETE /api/memories/:id megerősítés nélkül módosít, illetve töröl, és a válasz semmit nem visz vissza a törölt sorból - egy elgépelt id után nincs visszaút. Mindkét ige confirm: true-t követel meg (különben 400, módosítás nélkül); a DELETE visszaadja a törölt sort, a PUT az felülírás előtti tartalmat. A dashboard saját szerkesztő- és törlés-megerősítő folyamata már felhasználói szándékhoz kötött, ezért azok most confirm: true-t küldenek.

## Kapcsolódó issue / Related issue

Closes #

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [x] a `docs/` mappa nem érintett
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).
