### PR TITLE
fix(schedule-runner): a parked prompt fragment deferred every scheduled task forever

### DIFF
--- a/src/__tests__/schedule-runner-parked-janitor.test.ts
+++ b/src/__tests__/schedule-runner-parked-janitor.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ScheduledTask } from '../web/scheduled-tasks-io.js'
+
+// SCHEDPARK814. A scheduled task can be deferred forever by a session that is
+// not working at all: an interrupted turn can leave a FRAGMENT of an earlier
+// prompt parked in the input box, which keeps isSessionReadyForPrompt false, so
+// every retry reads 'busy'. Observed 2026-08-14 on a two-hourly mailbox
+// heartbeat: 277 consecutive 'busy' retries over 69 minutes, fixed by hand with
+// C-c/C-u, then delivered on the next tick.
+//
+// The post-send resubmit ladder cannot see this case -- it runs only in the
+// seconds after OUR injection and only when the marker is parked in the input
+// region -- so the retry queue runs the same stale-parked-input janitor the
+// message-router already runs on its own queue.
+//
+// What this pins:
+//   * a long-waiting 'busy' retry asks the janitor, aimed at the SAME session
+//     the fire path would have written to;
+//   * a young retry does not (an ordinary long turn is not a wedge);
+//   * a non-'busy' verdict does not (emptying the box fixes none of those);
+//   * the fire path itself is untouched -- a ready session still fires and
+//     drains the row without the janitor being consulted.
+
+const mockDeletePendingRetry = vi.fn()
+const mockUpdatePendingRetry = vi.fn(() => true)
+const mockListPendingRetries = vi.fn(() => [] as unknown[])
+const mockSessionExists = vi.fn(() => true)
+const mockSessionReady = vi.fn(async () => false)
+const mockClearParked = vi.fn(async () => true)
+const mockListScheduledTasks = vi.fn(() => [] as ScheduledTask[])
+
+vi.mock('../logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+}))
+
+// The runner persists its last-run map on every fire. Stub the writer so the
+// suite never touches the operator's real store.
+vi.mock('../web/atomic-write.js', () => ({
+  atomicWriteFileSync: vi.fn(),
+}))
+
+vi.mock('../db.js', () => ({
+  appendTaskRun: vi.fn(),
+  listPendingTaskRetries: () => mockListPendingRetries(),
+  deletePendingTaskRetry: (...a: unknown[]) => mockDeletePendingRetry(...a),
+  updatePendingTaskRetry: () => mockUpdatePendingRetry(),
+  insertPendingTaskRetryIfNew: vi.fn(),
+  markPendingTaskRetryAlert: vi.fn(() => false),
+  clearPendingTaskRetryAlert: vi.fn(),
+  markScheduledTaskKanbanWaiting: vi.fn(),
+}))
+
+// The alert paths resolve a REAL bot token from install-level config and send
+// to the real owner chat. Neutralize the sink: a green suite must never cost
+// the operator's attention.
+vi.mock('../web/telegram.js', () => ({
+  sendTelegramMessage: vi.fn(async () => {}),
+  sendTelegramPhoto: vi.fn(async () => {}),
+}))
+
+vi.mock('../web/scheduled-tasks-io.js', () => ({
+  listScheduledTasks: () => mockListScheduledTasks(),
+  SCHEDULED_TASKS_DIR: '/tmp/marveen-parked-janitor-no-tasks-dir',
+}))
+
+vi.mock('../web/agent-process.js', () => ({
+  agentSessionName: (name: string) => `agent-${name}`,
+  isAgentRunning: () => true,
+  isSessionReadyForPrompt: () => mockSessionReady(),
+  sendPromptToSession: vi.fn(() => 'sent'),
+  startAgentProcess: vi.fn(() => ({ ok: false, error: 'tmux unavailable' })),
+  sessionExistsOnHost: () => mockSessionExists(),
+  // null capture => no first-run gate is detected, and the post-send resubmit
+  // loop sees nothing parked and stops.
+  capturePane: () => null,
+  sendEnterToSession: vi.fn(),
+  clearStaleParkedInput: (...a: unknown[]) => mockClearParked(...(a as [])),
+}))
+
+const TASK: ScheduledTask = {
+  name: 'parked-janitor-fixture',
+  description: 'parked-input janitor fixture',
+  prompt: 'Do the thing.',
+  schedule: '0 8 * * *',
+  agent: 'parkedagent',
+  enabled: true,
+  createdAt: 0,
+  type: 'heartbeat',
+  targetSession: 'parked-test-session',
+}
+
+function retryRow(ageMs: number, overrides: Record<string, unknown> = {}) {
+  return {
+    task_name: TASK.name,
+    agent_name: 'parkedagent',
+    first_attempt: Date.now() - ageMs,
+    last_attempt: Date.now() - 15_000,
+    attempt_count: Math.round(ageMs / 15_000),
+    last_reason: 'busy',
+    alerted_at: null,
+    ...overrides,
+  }
+}
+
+async function runOneTick() {
+  vi.resetModules()
+  const { startScheduleRunner } = await import('../web/schedule-runner.js')
+  const stop = startScheduleRunner()
+  await vi.advanceTimersByTimeAsync(16_000)
+  clearInterval(stop)
+}
+
+describe('schedule runner: stale-parked-input janitor on the retry queue', () => {
+  beforeEach(() => {
+    vi.stubEnv('SCHEDULER_TZ', 'Europe/Budapest')
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    // A quiet moment: no cron occurrence for the fixture, so only the
+    // pending-retry loop acts.
+    vi.setSystemTime(new Date('2026-08-14T10:30:00.000Z'))
+    mockListScheduledTasks.mockReturnValue([TASK])
+    mockSessionExists.mockReturnValue(true)
+    mockSessionReady.mockResolvedValue(false)
+    mockClearParked.mockResolvedValue(true)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllEnvs()
+  })
+
+  it('asks the janitor once a busy retry has waited past the threshold', async () => {
+    mockListPendingRetries.mockReturnValue([retryRow(69 * 60_000)])
+    await runOneTick()
+
+    // Aimed at the session the fire path resolves (targetSession override =>
+    // local, host null), not at a re-derived guess.
+    expect(mockClearParked).toHaveBeenCalledWith('parked-test-session', null)
+    // The row is never dropped by the janitor -- delivery happens on the next
+    // tick, through the normal retry path.
+    expect(mockDeletePendingRetry).not.toHaveBeenCalled()
+  })
+
+  it('leaves a young busy retry alone', async () => {
+    // Below SCHEDULE_JANITOR_PARKED_MIN_AGE_MS: an ordinary long turn, not a wedge.
+    mockListPendingRetries.mockReturnValue([retryRow(45_000)])
+    await runOneTick()
+
+    expect(mockClearParked).not.toHaveBeenCalled()
+  })
+
+  it('does not touch the box for a non-busy verdict', async () => {
+    // Session gone + auto-start fails => 'missing'. Old enough to pass the age
+    // gate, so only the reason keeps the janitor out.
+    mockSessionExists.mockReturnValue(false)
+    mockListPendingRetries.mockReturnValue([retryRow(69 * 60_000)])
+    await runOneTick()
+
+    expect(mockClearParked).not.toHaveBeenCalled()
+  })
+
+  it('stays out of the way when the retry simply fires', async () => {
+    mockSessionReady.mockResolvedValue(true)
+    mockListPendingRetries.mockReturnValue([retryRow(69 * 60_000)])
+    await runOneTick()
+
+    expect(mockDeletePendingRetry).toHaveBeenCalledWith(TASK.name, 'parkedagent')
+    expect(mockClearParked).not.toHaveBeenCalled()
+  })
+})

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -209,6 +209,28 @@ export function decideScheduledResubmitAction(
 //      OWN scheduled prompt, never an unrelated message that happened to park
 //      (an unrelated parked message has no marker in the input region, so no
 //      keystroke fires at all).
+// SCHEDPARK814: how long a retry row must have been waiting before the
+// stale-parked-input janitor is allowed to touch the target session.
+//
+// The post-send ladder above (decideScheduledResubmitAction) only covers the
+// seconds right after OUR injection, and only when the marker is parked in the
+// input region. It is blind to the other way a session pins itself busy: a
+// FRAGMENT of an earlier prompt left in the box after that turn was interrupted
+// (observed 2026-08-14 on a two-hourly mailbox heartbeat: 277 consecutive
+// 'busy' retries over 69 minutes, cleared by hand with C-c/C-u and delivered on
+// the next tick). No marker in the input region, no in-flight entry, so nothing
+// in the runner ever looked. The message-router already runs exactly this janitor
+// on its own queue (JANITOR_PARKED_MIN_AGE_MS, 45s); the schedule queue gets
+// the same treatment on a longer fuse, because a deferred heartbeat is less
+// urgent than a stranded message and an ordinary long turn must never be
+// mistaken for a wedge.
+//
+// The safety lives in clearStaleParkedInput itself: it acts only on the idle
+// 'typing' state, only when the dim-stripped text is unchanged across a settle,
+// never on the main agent's box, and at most once per cooldown window per
+// session. This threshold only decides WHEN the runner is allowed to ask.
+export const SCHEDULE_JANITOR_PARKED_MIN_AGE_MS = 120_000
+
 export function isScheduledPromptStuck(pane: string | null, marker: string): boolean {
   if (!pane || !pane.trim()) return false
   if (detectPaneState(pane) === 'busy') return false
@@ -490,13 +512,15 @@ function mcpMissingReason(taskName: string, agentName: string): string {
 // task missed its normal tick and is only firing now as a catch-up; it is
 // recorded as a distinct 'fired_late' run status further down instead of
 // silently folding into 'fired'.
-async function attemptFireTask(
-  task: ScheduledTask,
+// Where a task's prompt is delivered: tmux session + (for a remote sub-agent)
+// the host its session lives on. Split out of attemptFireTask so the retry-queue
+// janitor targets the SAME pane the fire path would have written to -- a second
+// copy of this derivation would drift, and a janitor aimed at the wrong session
+// is worse than no janitor at all.
+export function resolveTaskTarget(
+  task: Pick<ScheduledTask, 'targetSession'>,
   agentName: string,
-  now: number,
-  preCheckPrefix?: string,
-  lateCatchUpMs?: number,
-): Promise<'fired' | 'busy' | 'missing' | 'starting' | 'error' | 'mcp-missing' | 'first-run'> {
+): { session: string; host: string | null } {
   const isMainAgent = agentName === MAIN_AGENT_ID
   // Allow per-task session override via targetSession config field.
   // Falls back to the standard agent session name derivation.
@@ -508,6 +532,17 @@ async function attemptFireTask(
   // existence/readiness checks and the send cross the ssh boundary. A custom
   // targetSession override and the main channels agent stay local (host=null).
   const host = (task.targetSession || isMainAgent) ? null : readAgentRemoteHost(agentName)
+  return { session, host }
+}
+
+async function attemptFireTask(
+  task: ScheduledTask,
+  agentName: string,
+  now: number,
+  preCheckPrefix?: string,
+  lateCatchUpMs?: number,
+): Promise<'fired' | 'busy' | 'missing' | 'starting' | 'error' | 'mcp-missing' | 'first-run'> {
+  const { session, host } = resolveTaskTarget(task, agentName)
 
   if (!sessionExistsOnHost(host, session)) {
     // Auto-start the agent, then deliver on a later tick. A daily batch agent
@@ -1211,6 +1246,25 @@ export function startScheduleRunner(): NodeJS.Timeout {
       const reason = result === 'mcp-missing' ? mcpMissingReason(row.task_name, row.agent_name) : result
       const stillPresent = updatePendingTaskRetry(row.task_name, row.agent_name, now, reason)
       if (stillPresent && view.alertDue) sendPendingRetryAlert(view, now)
+
+      // SCHEDPARK814 stale-parked-input janitor. A 'busy' verdict that keeps
+      // repeating past the threshold is the one case worth a second look: the
+      // pane may not be working at all, just holding an unsubmitted line that
+      // pins isSessionReadyForPrompt false forever (see the constant's note).
+      // Only 'busy' qualifies -- 'starting', 'missing', 'first-run' and
+      // 'mcp-missing' each have their own owner, and none of them is fixed by
+      // emptying the input box. clearStaleParkedInput does the identifying and
+      // refuses anything that is genuinely mid-turn; if it clears, the next
+      // tick's retry delivers on its own.
+      if (stillPresent && result === 'busy' && view.ageMs > SCHEDULE_JANITOR_PARKED_MIN_AGE_MS) {
+        const { session, host } = resolveTaskTarget(taskDef, row.agent_name)
+        if (await clearStaleParkedInput(session, host)) {
+          logger.warn(
+            { task: row.task_name, agent: row.agent_name, session, waitingMs: view.ageMs, attempts: row.attempt_count },
+            'schedule-runner: cleared stale parked input on a long-deferred retry target; delivery resumes next tick',
+          )
+        }
+      }
     }
 
     // Fire in injection-priority order, not directory order: with several


### PR DESCRIPTION
## The failure

An interrupted turn can leave a **fragment of an earlier scheduled prompt** sitting unsubmitted in the target session's input box. Parked text keeps `isSessionReadyForPrompt()` false, so `attemptFireTask` returns `'busy'` on every tick and **no scheduled task reaches that agent again** until someone empties the box by hand.

## Where this was found

Live install, 2026-08-14. A two-hourly mailbox heartbeat sat in `pending_task_retries` for 69 minutes:

```
{"id":6,"taskName":"...","attemptCount":277,"lastReason":"busy","ageMs":4148737}
```

The pane was not working. It showed `⎿ Interrupted · What should Claude do instead?` and a stranded chunk of the 18:00 prompt in the input box. `tmux send-keys C-c` + `C-u` emptied it, and the retry delivered on the very next tick — no restart, no manual hand-off.

The operator only learned of it because the pending-retry alert fired at the 60-minute mark. Nothing recovered it automatically.

## Why the existing nets miss it

- **Post-send resubmit ladder** (`decideScheduledResubmitAction` / `isScheduledPromptStuck`) runs only in the seconds after *our* injection, and only when the marker is parked in the input region. A fragment of an *earlier* prompt has no marker there and no in-flight entry.
- **Task-fire watchdog** (`decideTaskTimeout`) only alerts on a `'busy'` pane; a parked box reads `'typing'`.
- **`message-router`** already runs exactly the right janitor on *its* queue (`JANITOR_PARKED_MIN_AGE_MS`, 45s) — the schedule queue simply never got one.

## The change

The pending-retry loop now asks `clearStaleParkedInput()` when a retry has been waiting past `SCHEDULE_JANITOR_PARKED_MIN_AGE_MS` (120s) **and** the verdict is `'busy'`. Longer fuse than the router's 45s on purpose: a deferred heartbeat is less urgent than a stranded message, and an ordinary long turn must never be mistaken for a wedge.

All the safety is `clearStaleParkedInput`'s own, unchanged: idle `'typing'` state only, dim-stripped text unchanged across a settle, never the main agent's box, at most once per cooldown window per session. Only `'busy'` qualifies — `'starting'`, `'missing'`, `'first-run'` and `'mcp-missing'` each have their own owner, and none of them is fixed by emptying the input box. The janitor never deletes the retry row; delivery happens on the next tick through the normal path.

Session/host derivation is extracted into `resolveTaskTarget()` so the janitor aims at exactly the pane the fire path would have written to — a second copy of that derivation would drift.

## Verification

- `src/__tests__/schedule-runner-parked-janitor.test.ts` (4 cases): long-waiting busy retry asks the janitor at the resolved session; a young retry does not; a non-`'busy'` verdict does not; a retry that simply fires still drains the row without consulting it.
- Confirmed the first case **fails** on this branch without the runner change, so the test pins the fix rather than the mocks.
- Full suite on this branch: **3613 passed (269 files)**, `tsc --noEmit` clean. (Run from a checkout under `$HOME` — the suite refuses a live install, and a `/tmp` checkout fails ~19 unrelated tests because the hook-path guard rejects temp-prefixed roots.)
