### PR TITLE
fix(taskstate): replay on source=clear -- the gate's own restart path dropped it

### DIFF
--- a/src/__tests__/agent-taskstate.test.ts
+++ b/src/__tests__/agent-taskstate.test.ts
@@ -38,8 +38,17 @@ describe('shouldReplayTaskState', () => {
   it('replays on startup too (crash respawn mid-task)', () => {
     expect(shouldReplayTaskState(rec(), 'startup', NOW + 1000)).toBe(true)
   })
+  // The context-restart gate restarts by sending /clear, so source=clear is the
+  // MOST common restart this record exists for (2026-08-14). Pinned: excluding
+  // it silently emptied every gate-initiated restart.
+  it('replays on clear (the context-restart gate restarts with /clear)', () => {
+    expect(shouldReplayTaskState(rec(), 'clear', NOW + 1000)).toBe(true)
+  })
   it('does NOT replay an unknown source', () => {
-    expect(shouldReplayTaskState(rec(), 'clear', NOW + 1000)).toBe(false)
+    expect(shouldReplayTaskState(rec(), 'prompt-input-exit', NOW + 1000)).toBe(false)
+  })
+  it('does NOT replay a consumed record on clear either', () => {
+    expect(shouldReplayTaskState(rec({ consumed: true }), 'clear', NOW + 1000)).toBe(false)
   })
   it('does NOT replay an empty record on startup either', () => {
     const empty = rec({ doneSteps: [], alreadyDelegated: [], nextAction: '', pendingDecision: '', summary: 'idle' })

--- a/src/__tests__/session-start-matcher-sync.test.ts
+++ b/src/__tests__/session-start-matcher-sync.test.ts
@@ -1,0 +1,99 @@
+// Two guards for the SessionStart task-state replay, both aimed at the same
+// failure: the hook is registered, but not for the sources that matter.
+//
+//   (a) Coverage: the template's SessionStart matcher must COVER REPLAY_SOURCES.
+//       Asserted as containment, not equality -- an equality assertion passes
+//       today and drifts silently the next time a source is added to one side
+//       only, which is exactly how the replay went dead the first time.
+//
+//   (b) Convergence: an install created with an older matcher must converge on
+//       the template's matcher on the next scaffold run. Adding a source to the
+//       template alone reaches new installs and never the running ones, so the
+//       fix looks complete while the fleet stays broken.
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { REPLAY_SOURCES } from '../web/agent-taskstate.js'
+import { syncHookMatchers } from '../web/agent-scaffold.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ROOT = join(__dirname, '..', '..')
+const TEMPLATE = join(ROOT, 'templates', 'settings.json.template')
+
+const REPLAY_HOOK = 'taskstate-replay.py'
+
+function templateSessionStartMatcher(): string {
+  // The template carries {{PLACEHOLDER}} tokens that are not valid JSON values
+  // on their own; they sit inside strings, so JSON.parse handles the file fine.
+  const parsed = JSON.parse(readFileSync(TEMPLATE, 'utf-8')) as {
+    hooks?: Record<string, Array<{ matcher?: string; hooks?: Array<{ command?: string }> }>>
+  }
+  const entries = parsed.hooks?.SessionStart ?? []
+  const entry = entries.find((e) => (e.hooks ?? []).some((h) => h.command?.includes(REPLAY_HOOK)))
+  if (!entry) throw new Error(`no SessionStart entry registers ${REPLAY_HOOK} in the template`)
+  return entry.matcher ?? ''
+}
+
+describe('template SessionStart matcher covers REPLAY_SOURCES', () => {
+  it('registers the replay hook at all', () => {
+    expect(templateSessionStartMatcher()).not.toBe('')
+  })
+
+  // Containment, deliberately not equality: the matcher may legitimately list
+  // MORE sources than the replay acts on, but never fewer.
+  it.each([...REPLAY_SOURCES])('matcher includes source %s', (source) => {
+    const alternatives = templateSessionStartMatcher().split('|')
+    expect(alternatives).toContain(source)
+  })
+})
+
+describe('syncHookMatchers (existing installs converge)', () => {
+  const tplEntry = {
+    matcher: 'compact|resume|startup|clear',
+    hooks: [{ type: 'command', command: `python3 /opt/marveen/scripts/hooks/${REPLAY_HOOK}` }],
+  }
+
+  it('widens the matcher of a group the template fully owns', () => {
+    const existing = [
+      { matcher: 'compact|resume', hooks: [{ type: 'command', command: tplEntry.hooks[0].command }] },
+    ]
+    expect(syncHookMatchers(existing, tplEntry)).toBe(true)
+    expect(existing[0].matcher).toBe('compact|resume|startup|clear')
+  })
+
+  it('is idempotent once converged', () => {
+    const existing = [
+      {
+        matcher: 'compact|resume|startup|clear',
+        hooks: [{ type: 'command', command: tplEntry.hooks[0].command }],
+      },
+    ]
+    expect(syncHookMatchers(existing, tplEntry)).toBe(false)
+  })
+
+  // The important negative: a group holding a hook we did not put there keeps
+  // its own matcher. Widening it would change when that foreign hook runs.
+  it('leaves a group alone when it also holds a foreign command', () => {
+    const existing = [
+      {
+        matcher: 'compact|resume',
+        hooks: [
+          { type: 'command', command: tplEntry.hooks[0].command },
+          { type: 'command', command: 'python3 /opt/local/notify-me.py' },
+        ],
+      },
+    ]
+    expect(syncHookMatchers(existing, tplEntry)).toBe(false)
+    expect(existing[0].matcher).toBe('compact|resume')
+  })
+
+  it('ignores unrelated groups', () => {
+    const existing = [
+      { matcher: 'startup', hooks: [{ type: 'command', command: 'python3 /opt/other/hook.py' }] },
+    ]
+    expect(syncHookMatchers(existing, tplEntry)).toBe(false)
+    expect(existing[0].matcher).toBe('startup')
+  })
+})

--- a/src/web/agent-scaffold.ts
+++ b/src/web/agent-scaffold.ts
@@ -129,7 +129,10 @@ export function agentSettingsPath(name: string): string {
 const _TMP_PREFIXES = ['/tmp/', '/var/tmp/', '/private/tmp/', '/dev/shm/']
 
 // Shared hook-entry type used by ensureAgentHooks and upgradeLegacyHookCommands.
-type HookEntry = { hooks?: Array<{ command?: string; timeout?: number; [k: string]: unknown }> }
+type HookEntry = {
+  matcher?: string
+  hooks?: Array<{ command?: string; timeout?: number; [k: string]: unknown }>
+}
 
 /**
  * Returns true when the command is unsafe to register in shared settings:
@@ -202,6 +205,44 @@ export function upgradeLegacyHookCommands(
 // file is permissions-only. Merge the template's hooks block in place.
 // Also handles the main agent (MAIN_AGENT_ID) whose settings.json is at
 // ~/.claude/settings.json -- voice hook is added alongside existing hooks.
+/**
+ * Converge the MATCHER of existing hook groups on the template's matcher.
+ *
+ * Without this an install keeps the matcher it was created with forever. The
+ * add pass in `ensureAgentHooks` only fires when a COMMAND is missing, so
+ * widening a matcher in the template reaches new installs and never the running
+ * ones. That is how the SessionStart task-state replay stayed dead on existing
+ * installs after the source list grew: the hook was registered all along, just
+ * not for the sources that had come to matter.
+ *
+ * Only groups whose every command comes from this template entry are converged.
+ * A group that also holds a hook we did not put there (a hand-added notifier,
+ * say) keeps its own matcher, because widening it would silently change when
+ * that foreign hook runs.
+ *
+ * Exported for unit tests. Mutates `existEntries`; returns true if it changed
+ * anything.
+ */
+export function syncHookMatchers(existEntries: HookEntry[], tplEntry: HookEntry): boolean {
+  const tplCommands = new Set(
+    (tplEntry.hooks ?? []).map((h) => h.command).filter(Boolean) as string[],
+  )
+  if (tplCommands.size === 0) return false
+  let changed = false
+  for (const existEntry of existEntries) {
+    const existCommands = (existEntry.hooks ?? [])
+      .map((h) => h.command)
+      .filter(Boolean) as string[]
+    if (existCommands.length === 0) continue
+    if (!existCommands.every((c) => tplCommands.has(c))) continue
+    if (existEntry.matcher === tplEntry.matcher) continue
+    if (tplEntry.matcher == null) delete existEntry.matcher
+    else existEntry.matcher = tplEntry.matcher
+    changed = true
+  }
+  return changed
+}
+
 export function ensureAgentHooks(name: string): boolean {
   const settingsPath = agentSettingsPath(name)
   const tplPath = join(PROJECT_ROOT, 'templates', 'settings.json.template')
@@ -230,6 +271,8 @@ export function ensureAgentHooks(name: string): boolean {
     //   2. If the event exists: add any template hook commands not yet present
     //      as a new hook group entry (preserves existing hooks like telegram_progress.py).
     //   3. Sync the timeout of any command hook whose command matches but timeout differs.
+    //   4. Sync the matcher of any group the template fully owns, so an install
+    //      created with an older matcher converges instead of keeping it forever.
     const existingHooks = existing.hooks as Record<string, unknown>
     let changed = upgradeLegacyHookCommands(existingHooks, tplHooks)
     for (const [event, handlers] of Object.entries(tplHooks)) {
@@ -264,6 +307,7 @@ export function ensureAgentHooks(name: string): boolean {
               }
             }
           }
+          if (syncHookMatchers(existEntries, tplEntry)) changed = true
         }
       }
     }

--- a/src/web/agent-taskstate.ts
+++ b/src/web/agent-taskstate.ts
@@ -43,7 +43,10 @@ export const TASKSTATE_TTL_MS = 12 * 60 * 60 * 1000
 // silently dropped the task-state on every restart it performed, while the
 // ledger and daily-log hooks (registered for clear) still injected theirs. The
 // symptom is invisible: a fresh session with chat history and no task list.
-const REPLAY_SOURCES = new Set(['compact', 'resume', 'startup', 'clear'])
+// Exported so the template's SessionStart matcher can be asserted to COVER this
+// set (containment, not equality) -- an equality assertion would pass today and
+// drift silently the next time a source is added here but not to the template.
+export const REPLAY_SOURCES = new Set(['compact', 'resume', 'startup', 'clear'])
 
 export interface AgentTaskState {
   agent: string

--- a/src/web/agent-taskstate.ts
+++ b/src/web/agent-taskstate.ts
@@ -37,7 +37,13 @@ export const TASKSTATE_TTL_MS = 12 * 60 * 60 * 1000
 // planned restart right after finishing work replays nothing (the record was
 // either consumed or is empty), and at worst a stale-but-unconsumed record
 // costs one short injected block that the agent can discard.
-const REPLAY_SOURCES = new Set(['compact', 'resume', 'startup'])
+// 'clear' IS included (2026-08-14): the context-restart gate restarts an agent
+// by sending /clear (context-restart-gate-runner.ts), which the harness reports
+// as source=clear. Excluding it meant the gate -- OUR primary restart path --
+// silently dropped the task-state on every restart it performed, while the
+// ledger and daily-log hooks (registered for clear) still injected theirs. The
+// symptom is invisible: a fresh session with chat history and no task list.
+const REPLAY_SOURCES = new Set(['compact', 'resume', 'startup', 'clear'])
 
 export interface AgentTaskState {
   agent: string
@@ -76,8 +82,8 @@ export function isEmptyTaskState(r: Pick<AgentTaskState, 'doneSteps' | 'alreadyD
 
 /**
  * Pure decision: should this record be re-injected at SessionStart?
- * Replays ONLY when: record exists, not yet consumed, source is compact|resume
- * (never cold startup), within TTL, and the record actually holds a task.
+ * Replays ONLY when: record exists, not yet consumed, source is one of
+ * REPLAY_SOURCES, within TTL, and the record actually holds a task.
  */
 export function shouldReplayTaskState(
   record: AgentTaskState | null,

--- a/templates/settings.json.template
+++ b/templates/settings.json.template
@@ -18,7 +18,7 @@
     ],
     "SessionStart": [
       {
-        "matcher": "compact|resume",
+        "matcher": "compact|resume|startup|clear",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
## What

`REPLAY_SOURCES` in `src/web/agent-taskstate.ts` did not include `clear`, so a restart performed by the context-restart gate never replayed the task-state record.

The gate restarts an agent by sending `/clear` (`context-restart-gate-runner.ts`), and the harness reports that to SessionStart hooks as `source=clear`. So the restart path the fleet uses in normal operation was the one path that dropped the handover.

## Why it is easy to miss

The other two SessionStart hooks (ledger-replay, daily-log digest) **are** registered for `clear`. The fresh session therefore comes up with chat history and a daily-log digest and looks healthy -- it simply has no done-steps list and no already-delegated list, which is precisely the state that invites re-running or re-delegating finished work.

Observed 2026-08-14 on a live fleet: an agent restarted mid-thread returned without its handover record. The record was intact on disk; the source filter withheld it.

## Also in this PR

`templates/settings.json.template` still carried `"matcher": "compact|resume"`, i.e. narrower than what the server serves since #782. Every agent scaffolded from it was missing `startup` replay as well, so crash respawns lost their record too. Measured on this host: six scaffolded agents had been running that way for 15 days.

## Scope

Nothing else loosens: an unconsumed, non-empty, within-TTL record is still required, and the `consumed` flag still guarantees a single replay. A planned `/clear` right after finishing work replays nothing.

## Verification

- `src/__tests__/agent-taskstate.test.ts`: 21 pass, 3 new (clear replays; a consumed record on clear does not; an unknown source still does not)
- `tsc --noEmit` clean; template parses as JSON
- Live check against a running dashboard: `source=clear|startup|compact` return the injection, an unknown source returns `null`


## Behaviour change (stated explicitly, per review)

After this PR a manual `/clear` behaves differently than it does today. Today a
`/clear` starts the fresh session empty. After this, `clear` is a replay source
like `compact` and `resume`, so an unconsumed, non-empty, within-TTL record is
injected into the fresh session as a task-continuation block.

That is the point of the change -- the context-restart gate restarts by sending
`/clear` -- but it also applies to a `/clear` a human types. Anyone deliberately
clearing to start clean will see the previous task's done-steps and next-action
injected. The `consumed` flag still limits that to one replay, and a record
written after the work finished is empty and replays nothing.

## Matcher convergence (added after review)

The template fix alone reaches new installs only. `ensureAgentHooks` adds missing
commands and syncs timeouts, but never touches the matcher, so an install keeps
the matcher it was created with. Widening the template therefore looked complete
while every running install kept dropping the replay.

`syncHookMatchers` converges a hook group **only when every command in it comes
from the template entry**. A group that also holds a hook we did not put there
keeps its own matcher, since widening it would silently change when that foreign
hook runs.

Kept in this PR rather than split out: it is the same defect and the fix is inert
without it. Happy to split if you would rather review it separately.

## Coverage test (added after review)

`REPLAY_SOURCES` is now exported and the template matcher is asserted to **cover**
it, per source, not to equal it. An equality assertion passes today and drifts
silently the next time a source is added to one side only -- which is how the
replay went dead in the first place. Three negative cases lock the convergence
rule: idempotent once converged, a group with a foreign command untouched, an
unrelated group untouched.

Verification after the review round: `npm run build` clean, and
`session-start-matcher-sync.test.ts` + `agent-taskstate.test.ts` +
`hook-path-guard.test.ts` = 48 pass.

Note for anyone reproducing: the suite refuses to run in a live install and must
not run from `/tmp` either -- the hook-path guard rejects `/tmp`-prefixed roots,
so the gate tests go falsely red there. A worktree under `$HOME` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
