### PR TITLE
feat(context-restart-gate): wake the fresh session after /clear

### DIFF
--- a/src/__tests__/context-restart-gate.test.ts
+++ b/src/__tests__/context-restart-gate.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import {
+  gateWakePrompt,
   isInfrastructureChild,
   findClaudePidInTree,
   extractMcpPackageNames,
@@ -11,7 +12,10 @@ import {
 } from '../web/context-restart-gate-runner.js'
 import {
   decideGate,
+  decideWake,
   nextBlockClock,
+  WAKE_DELAY_MS,
+  WAKE_MAX_AGE_MS,
   DEFAULT_THRESHOLD_TOKENS,
   DEFAULT_STALE_CUTOFF_MS,
   DEFAULT_PERSISTENT_BLOCK_ALERT_MS,
@@ -705,5 +709,59 @@ describe('commBasename / findClaudePidInTree -- ps comm portability', () => {
 
   it('does not match a command that merely ends with claude-something', () => {
     expect(findClaudePidInTree(100, '/usr/bin/claude-wrapper', [])).toBeNull()
+  })
+})
+
+// ---- Wake nudge after /clear -------------------------------------------------
+//
+// The gate restarts an agent by sending /clear. A fresh Claude Code session
+// only speaks when prompted, so without this nudge the restarted agent stays
+// mute with its handover record unread (2026-08-14).
+describe('decideWake', () => {
+  const T = 1_800_000_000_000
+
+  it('does nothing when no wake is owed', () => {
+    expect(decideWake(null, T)).toBe('none')
+  })
+
+  it('waits while the fresh session is still booting', () => {
+    expect(decideWake(T, T)).toBe('wait')
+    expect(decideWake(T, T + WAKE_DELAY_MS - 1)).toBe('wait')
+  })
+
+  it('sends once the boot grace has passed', () => {
+    expect(decideWake(T, T + WAKE_DELAY_MS)).toBe('send')
+    expect(decideWake(T, T + WAKE_MAX_AGE_MS)).toBe('send')
+  })
+
+  it('drops a nudge that outlived its restart', () => {
+    expect(decideWake(T, T + WAKE_MAX_AGE_MS + 1)).toBe('drop')
+  })
+
+  // A backwards clock step must not look like an ancient debt and get dropped:
+  // keeping the debt costs one re-check, dropping it costs the wake entirely.
+  it('treats a negative age (clock skew) as wait, never drop', () => {
+    expect(decideWake(T, T - 60_000)).toBe('wait')
+  })
+
+  it('honours explicit overrides', () => {
+    expect(decideWake(T, T + 100, 50, 1000)).toBe('send')
+    expect(decideWake(T, T + 2000, 50, 1000)).toBe('drop')
+  })
+})
+
+describe('gateWakePrompt', () => {
+  // The nudge exists to produce a turn AND a visible sign of life; a nudge that
+  // only said "you restarted" would leave the owner staring at silence again.
+  it('asks the agent to continue and to report on its channel', () => {
+    const p = gateWakePrompt()
+    expect(p).toContain('[CONTEXT-RESTART-GATE]')
+    expect(p.toLowerCase()).toContain('folytasd')
+    expect(p.toLowerCase()).toContain('csatorna')
+  })
+
+  // Guard against the nudge itself becoming a source of invented work.
+  it('tells the agent that "nothing in flight" is a complete state', () => {
+    expect(gateWakePrompt()).toContain('ne talalj ki magadnak feladatot')
   })
 })

--- a/src/context-restart-gate.ts
+++ b/src/context-restart-gate.ts
@@ -300,3 +300,42 @@ export function nextBlockClock(
   if (contextTokens < thresholdTokens) return null
   return firstBlockedAt ?? nowMs
 }
+
+// ---- Wake nudge after a /clear ----------------------------------------------
+//
+// A /clear leaves a fresh session that holds the injected SessionStart context
+// but has NO reason to speak: a Claude Code session produces a turn only when
+// something prompts it. So an agent restarted by the gate sat mute, and the
+// handover record's "next action" was read by nobody until a human happened to
+// write (2026-08-14: 23 minutes of silence, ended by the owner asking "nos?").
+// The hard context-guard already solves this on its own path (inject-resume);
+// these constants are the same idea on the soft path.
+
+/** Grace for the fresh session's boot + SessionStart hooks before nudging. */
+export const WAKE_DELAY_MS = 25_000
+/** Past this age the nudge is dropped instead of typed into moved-on work. */
+export const WAKE_MAX_AGE_MS = 30 * 60_000
+
+export type WakeAction =
+  | 'none'   // nothing owed
+  | 'wait'   // owed, but the fresh session is still booting
+  | 'send'   // due now
+  | 'drop'   // too old to be honest about "you just restarted"
+
+/**
+ * Pure: what to do with a pending wake debt. A negative age (clock skew, a
+ * state file written by a host whose clock then moved back) reads as 'wait',
+ * never 'drop' -- the conservative side is to keep the debt and re-check.
+ */
+export function decideWake(
+  pendingWakeAt: number | null,
+  nowMs: number,
+  delayMs: number = WAKE_DELAY_MS,
+  maxAgeMs: number = WAKE_MAX_AGE_MS,
+): WakeAction {
+  if (pendingWakeAt === null) return 'none'
+  const ageMs = nowMs - pendingWakeAt
+  if (ageMs < delayMs) return 'wait'
+  if (ageMs > maxAgeMs) return 'drop'
+  return 'send'
+}

--- a/src/web/context-restart-gate-runner.ts
+++ b/src/web/context-restart-gate-runner.ts
@@ -5,7 +5,7 @@ import { logger } from '../logger.js'
 import { makeLazyBinResolver } from '../platform.js'
 import { MAIN_AGENT_ID, PROJECT_ROOT } from '../config.js'
 import { listAgentNames, readAgentClaudeConfigDir } from './agent-config.js'
-import { agentSessionName, capturePane } from './agent-process.js'
+import { agentSessionName, capturePane, sendPromptToSession } from './agent-process.js'
 import { detectPaneState } from '../pane-state.js'
 import { detectsUsageLimit } from '../model-fallback.js'
 import { readContextTokensFromProjectDir, projectsDirFor } from './active-model.js'
@@ -20,7 +20,9 @@ import {
 } from '../db.js'
 import {
   decideGate,
+  decideWake,
   nextBlockClock,
+  WAKE_DELAY_MS,
   type GateInputs,
 } from '../context-restart-gate.js'
 
@@ -40,11 +42,33 @@ import {
 
 const INITIAL_DELAY_MS = 3 * 60_000   // 3 min
 
+// The wake-nudge timing lives in context-restart-gate.ts (WAKE_DELAY_MS,
+// WAKE_MAX_AGE_MS, decideWake) so the "is it due yet" rule stays pure and
+// unit-tested; this module only performs the delivery.
+
+/**
+ * The nudge text. Deliberately short: the substance is already in the session
+ * as SessionStart context, and re-stating it here would only compete with it.
+ */
+export function gateWakePrompt(): string {
+  return (
+    '[CONTEXT-RESTART-GATE] Friss kontextussal indultal, mert a kapu ujrainditott (/clear). ' +
+    'A visszatoltott blokkokban ott a beszelgetes vege, a napi naplo kivonata es -- ha volt futo munkad -- ' +
+    'a TASK-FOLYTATAS a mar kesz lepesekkel es a kovetkezo akcioval. ' +
+    'Olvasd be oket, ellenorizd a kanban tabladat es a hot memoriaidat, es FOLYTASD onnan ahol abbamaradt. ' +
+    'Ne kezdd elolrol ami mar kesz, es ne delegald ujra amit mar atadtal. ' +
+    'Ha nem volt futo munkad, az is teljes erteku allapot -- olyankor ne talalj ki magadnak feladatot. ' +
+    'Rovid jelzest kuldj a sajat csatornadon, hogy friss kontextussal folytatod.'
+  )
+}
+
 // tmux path. The hardcoded `/usr/bin/tmux` fallback that used to live here does
 // not exist on a Homebrew macOS install (tmux is /opt/homebrew/bin/tmux), so
 // getPanePid() threw on EVERY sweep, returned null, and the child-process check
 // went fail-closed at its very first line -- this gate could never open here.
 // The rest of the codebase already resolves binaries from PATH; do the same.
+// (#976 rebase note: the wake delivery goes through sendPromptToSession, so the
+// former TMUX constant from the PR branch has no remaining consumer.)
 const tmuxBin = makeLazyBinResolver('tmux')
 
 // Child-process measurement constants.
@@ -506,6 +530,49 @@ export interface GateSnapshot {
   dispatchedStatsFailed: boolean
 }
 
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
+
+/**
+ * Deliver the wake nudge owed for an earlier /clear, if one is due.
+ *
+ * Retries across sweeps while the pane stays busy (the debt survives in the
+ * state file), and gives up once the nudge is older than WAKE_MAX_AGE_MS --
+ * by then the session has either been woken by someone else or moved on, and
+ * typing a "you just restarted" prompt into live work would be worse than mute.
+ */
+async function deliverPendingWake(name: string, session: string, nowMs: number): Promise<void> {
+  const due = readGateRunState(name).pendingWakeAt
+  const action = decideWake(due, nowMs)
+  if (action === 'none' || action === 'wait') return
+
+  const clearDebt = (): void => {
+    writeGateRunState(name, { ...readGateRunState(name), pendingWakeAt: null })
+  }
+
+  if (action === 'drop') {
+    logger.info({ agent: name, ageMs: due === null ? null : nowMs - due },
+      'context-restart-gate: wake nudge dropped (stale)')
+    clearDebt()
+    return
+  }
+
+  try {
+    const outcome = await sendPromptToSession(session, gateWakePrompt(), null, {
+      waitForIdle: true, onBusyTimeout: 'abort',
+    })
+    if (outcome === 'sent') {
+      logger.info({ agent: name }, 'context-restart-gate: wake nudge delivered')
+      clearDebt()
+    } else {
+      // Busy or lane-locked: keep the debt, retry on the next sweep.
+      logger.info({ agent: name, outcome }, 'context-restart-gate: wake nudge deferred')
+    }
+  } catch (err) {
+    logger.warn({ err, agent: name }, 'context-restart-gate: wake nudge failed (will retry)')
+  }
+}
+
+
 /**
  * Gather every gate input for one agent. Pure I/O, no side effects: both the
  * live sweep and the doctor script go through this, so what the diagnostic
@@ -584,6 +651,12 @@ export function diagnoseAgent(name: string, nowMs: number) {
 
 async function checkAgent(name: string, nowMs: number): Promise<void> {
   if (!readGateConfig(name).enabled) return   // fast-exit before any I/O
+
+  // Settle any wake owed from an earlier /clear before measuring anything: the
+  // inline nudge below can be lost to a dashboard restart, and this is what
+  // makes the debt durable. Deliberately NOT in gatherGateInputs -- that is
+  // shared with the read-only doctor path, which must never type into a pane.
+  await deliverPendingWake(name, sessionFor(name), nowMs)
   const { cfg, session, mcpPatterns, inputs, dispatchedStatsFailed } = gatherGateInputs(name, nowMs)
 
   // If the DB query for dispatched stats failed, fail-closed by treating it as
@@ -621,7 +694,13 @@ async function checkAgent(name: string, nowMs: number): Promise<void> {
           ...runState,
           firstBlockedAt: null,
           lastClearAt: nowMs,
+          // Owe the fresh session a wake nudge; see WAKE_DELAY_MS.
+          pendingWakeAt: nowMs,
         })
+        // Fast path: nudge in ~25s rather than at the next sweep (5 min by
+        // default). The persisted debt above is the fallback if this is lost.
+        await sleep(WAKE_DELAY_MS)
+        await deliverPendingWake(name, session, Date.now())
       } catch (err) {
         logger.warn({ err, agent: name }, 'context-restart-gate: /clear send failed')
       }

--- a/src/web/context-restart-gate-store.ts
+++ b/src/web/context-restart-gate-store.ts
@@ -63,12 +63,20 @@ export interface GateRunState {
   lastAlertAt: number | null
   /** Epoch ms when the last /clear was successfully sent. */
   lastClearAt: number | null
+  /**
+   * Epoch ms of a /clear whose wake-nudge has NOT been delivered yet; null when
+   * nothing is owed. Persisted (not just an in-memory timer) so a dashboard
+   * restart between the /clear and the nudge still leaves the fresh session
+   * woken on the next sweep instead of silently mute.
+   */
+  pendingWakeAt: number | null
 }
 
 const EMPTY_STATE: GateRunState = {
   firstBlockedAt: null,
   lastAlertAt: null,
   lastClearAt: null,
+  pendingWakeAt: null,
 }
 
 function readStateRaw(): Record<string, unknown> {
@@ -86,6 +94,7 @@ function normalizeState(raw: unknown): GateRunState {
     firstBlockedAt: msOrNull(o.firstBlockedAt),
     lastAlertAt:    msOrNull(o.lastAlertAt),
     lastClearAt:    msOrNull(o.lastClearAt),
+    pendingWakeAt:  msOrNull(o.pendingWakeAt),
   }
 }
 


### PR DESCRIPTION
## What

After the gate sends `/clear`, it stops. The fresh session has the injected SessionStart context but no reason to speak -- a Claude Code session produces a turn only when something prompts it. So a gate-restarted agent sits mute, and the handover record's "next action", written for exactly this moment, is read by nobody.

Measured 2026-08-14: an agent restarted at 22:24 stayed silent until its owner asked "well?" at 22:47. Nothing crashed, the restart worked, the context arrived. There was simply nothing to trigger the first turn.

This also quietly defeats the gate's own purpose in the unattended case: restarting early is meant to keep the agent working cheaply, and a mute agent does not work.

The hard context-guard already solves this on its own path (`inject-resume` + `resumePrompt`). This is the same idea on the soft path.

## Design

- The "is it due" rule is pure and unit-tested (`decideWake`); the runner only performs delivery.
- The debt is **persisted** (`pendingWakeAt` in the gate run-state), not an in-memory timer, so a dashboard restart between the `/clear` and the nudge still leaves the fresh session woken on the next sweep.
- 25s grace covers boot + SessionStart hooks; delivery additionally waits for an idle pane. A busy pane **defers** to the next sweep rather than typing over live work.
- Past 30 minutes the nudge is **dropped**: "you just restarted" is false half an hour later.
- Negative age (clock skew) reads as `wait`, never `drop`.
- The prompt states explicitly that "no work in flight" is a complete state, so the nudge cannot become a source of invented work.

## Verification

- `src/__tests__/context-restart-gate.test.ts`: 70 pass, 8 new (`decideWake` boundaries incl. clock skew and overrides, plus prompt-content guards)
- `tsc --noEmit` clean
- Live delivery test on a running fleet **without** a real restart: arming `pendingWakeAt` produced the nudge in the agent's session on the next sweep, and the debt cleared -- which the code only does on `outcome === 'sent'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)