### PR TITLE
perf(active-model): scan session .jsonl tails instead of whole-file r…

### DIFF
--- a/src/__tests__/active-model.test.ts
+++ b/src/__tests__/active-model.test.ts
@@ -1,6 +1,8 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { join } from 'node:path'
-import { projectsDirFor } from '../web/active-model.js'
+import { mkdtempSync, mkdirSync, writeFileSync, appendFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { projectsDirFor, readActiveModelFromProjectDir, readContextTokensFromProjectDir } from '../web/active-model.js'
 
 describe('projectsDirFor', () => {
   it('uses <home>/.claude/projects when no config dir is given', () => {
@@ -28,5 +30,83 @@ describe('projectsDirFor', () => {
     const a = projectsDirFor('/w', '/home/u/.claude', '/home/u')
     const b = projectsDirFor('/w', '/home/u/.claude-coding', '/home/u')
     expect(a).not.toBe(b)
+  })
+})
+
+// kanban api-agents-lassu17: readActiveModelFromProjectDir/readContextTokensFromProjectDir
+// scan a session .jsonl from the END in a growing window (64KB, doubling) instead of
+// reading+splitting the whole file, because a live session log can be tens of MB and both
+// callers only ever need the LAST matching line. These tests prove the windowed scan finds
+// the same result a full-file backward scan would -- including when the match sits BEFORE
+// the initial 64KB window, which forces the fallback-expansion path.
+describe('readActiveModelFromProjectDir / readContextTokensFromProjectDir (bounded tail scan)', () => {
+  let configDir: string
+  beforeEach(() => { configDir = mkdtempSync(join(tmpdir(), 'active-model-test-')) })
+  afterEach(() => { rmSync(configDir, { recursive: true, force: true }) })
+
+  function writeSession(workingDir: string, lines: unknown[]): void {
+    const dir = projectsDirFor(workingDir, configDir)
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(join(dir, 'session.jsonl'), lines.map(l => JSON.stringify(l)).join('\n') + '\n')
+  }
+
+  it('finds the model from the last assistant turn in a small session', () => {
+    writeSession('/case/small-model', [
+      { timestamp: '2026-08-14T10:00:00Z', message: { model: 'claude-sonnet-5', usage: {} } },
+      { timestamp: '2026-08-14T10:01:00Z', message: { model: 'claude-opus-5', usage: {} } },
+    ])
+    expect(readActiveModelFromProjectDir('/case/small-model', undefined, configDir)).toBe('claude-opus-5')
+  })
+
+  it('sums input + cache_read + cache_creation tokens from the last usage-bearing turn', () => {
+    writeSession('/case/small-tokens', [
+      { timestamp: '2026-08-14T10:00:00Z', message: { model: 'claude-opus-5', usage: { input_tokens: 100, cache_read_input_tokens: 200, cache_creation_input_tokens: 50 } } },
+    ])
+    expect(readContextTokensFromProjectDir('/case/small-tokens', configDir)).toBe(350)
+  })
+
+  it('skips a line whose model is present but whose timestamp predates sinceUnixSec', () => {
+    const oldTs = Math.floor(new Date('2026-08-14T09:00:00Z').getTime() / 1000)
+    const cutoff = Math.floor(new Date('2026-08-14T10:00:00Z').getTime() / 1000)
+    writeSession('/case/since-filter', [
+      { timestamp: '2026-08-14T09:00:00Z', message: { model: 'claude-old', usage: {} } },
+    ])
+    expect(oldTs).toBeLessThan(cutoff)
+    expect(readActiveModelFromProjectDir('/case/since-filter', cutoff, configDir)).toBeNull()
+  })
+
+  it('returns null for a missing project dir, and for a dir with no .jsonl files', () => {
+    expect(readActiveModelFromProjectDir('/case/does-not-exist', undefined, configDir)).toBeNull()
+    const dir = projectsDirFor('/case/empty-dir', configDir)
+    mkdirSync(dir, { recursive: true })
+    expect(readActiveModelFromProjectDir('/case/empty-dir', undefined, configDir)).toBeNull()
+  })
+
+  it('FALLBACK PATH: finds a match that sits before the initial 64KB window, by expanding it', () => {
+    // Pad with user-role lines carrying no model/usage (so the tail window has nothing to
+    // match), then one real assistant turn, then enough more padding to push the assistant
+    // turn's line past the first 64KB counted from EOF. ~90KB of padding is comfortably
+    // past the 64KB start window without needing a production-scale (multi-MB) fixture.
+    const padLine = { timestamp: '2026-08-14T09:00:00Z', role: 'user', content: 'x'.repeat(200) }
+    const padCount = 450 // ~200 bytes/line * 450 =~ 90KB, pushes the real line past 64KB from EOF
+    const lines: unknown[] = []
+    for (let i = 0; i < padCount; i++) lines.push(padLine)
+    lines.push({ timestamp: '2026-08-14T10:00:00Z', message: { model: 'claude-deep-history', usage: { input_tokens: 42, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 } } })
+    for (let i = 0; i < padCount; i++) lines.push(padLine)
+    writeSession('/case/fallback-expand', lines)
+
+    expect(readActiveModelFromProjectDir('/case/fallback-expand', undefined, configDir)).toBe('claude-deep-history')
+    expect(readContextTokensFromProjectDir('/case/fallback-expand', configDir)).toBe(42)
+  })
+
+  it('ignores malformed JSON lines and keeps scanning backward', () => {
+    writeSession('/case/malformed', [
+      { timestamp: '2026-08-14T10:00:00Z', message: { model: 'claude-real', usage: { input_tokens: 5, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 } } },
+    ])
+    const dir = projectsDirFor('/case/malformed', configDir)
+    // Append a trailing malformed line after the valid one -- must still find the real entry.
+    const filePath = join(dir, 'session.jsonl')
+    appendFileSync(filePath, 'not valid json\n')
+    expect(readActiveModelFromProjectDir('/case/malformed', undefined, configDir)).toBe('claude-real')
   })
 })

--- a/src/web/active-model.ts
+++ b/src/web/active-model.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
+import { existsSync, readdirSync, statSync, openSync, closeSync, readSync } from 'node:fs'
 import { join } from 'node:path'
 import { homedir } from 'node:os'
 
@@ -28,6 +28,66 @@ export function projectsDirFor(workingDir: string, configDir?: string, homeDirOv
   return join(base, 'projects', encoded)
 }
 
+// Kanban api-agents-lassu17: a live session's newest .jsonl can be tens of MB
+// (measured on this fleet: up to ~58MB). Both callers below only need the
+// LAST line matching a predicate (a model id, or a usage object) -- reading
+// and splitting the WHOLE file to find a match near the end was the dominant
+// cost of /api/agents (measured: ~1.6s summed across the fleet's two callers
+// on a cold cache, the single largest contributor to a "never fast" endpoint).
+//
+// This reads from the END of the file in a growing window (starting at 64KB,
+// doubling), scanning lines backward for the first one `parseLine` accepts.
+// If the window doesn't contain a match, it doubles and retries -- up to the
+// full file -- so the RESULT is identical to a full-file backward scan; only
+// the common case (the match is near EOF, true for a live/active session) is
+// now cheap. A line split by the window boundary is discarded (it is a
+// partial line whenever start > 0), never partially parsed.
+function scanLastLine<T>(filePath: string, fileSize: number, parseLine: (line: string) => T | undefined, startWindowBytes = 64 * 1024): T | undefined {
+  let window = Math.min(startWindowBytes, fileSize)
+  while (true) {
+    const start = Math.max(0, fileSize - window)
+    const readLen = fileSize - start
+    let text = ''
+    if (readLen > 0) {
+      const fd = openSync(filePath, 'r')
+      try {
+        const buf = Buffer.alloc(readLen)
+        readSync(fd, buf, 0, readLen, start)
+        text = buf.toString('utf-8')
+      } finally {
+        closeSync(fd)
+      }
+      // A window that doesn't start at byte 0 almost certainly begins mid-line
+      // -- drop that leading partial line rather than risk parsing a truncated
+      // JSON fragment.
+      if (start > 0) {
+        const nl = text.indexOf('\n')
+        text = nl === -1 ? '' : text.slice(nl + 1)
+      }
+    }
+    const lines = text.split('\n')
+    for (let i = lines.length - 1; i >= 0; i--) {
+      const line = lines[i].trim()
+      if (!line) continue
+      const result = parseLine(line)
+      if (result !== undefined) return result
+    }
+    if (start === 0) return undefined // scanned the whole file, no match
+    window = window * 2
+  }
+}
+
+function newestJsonl(dir: string): { file: string; size: number } | null {
+  const jsonls = readdirSync(dir)
+    .filter(f => f.endsWith('.jsonl'))
+    .map(f => {
+      const st = statSync(join(dir, f))
+      return { f, mtime: st.mtimeMs, size: st.size }
+    })
+    .sort((a, b) => b.mtime - a.mtime)
+  return jsonls.length > 0 ? { file: jsonls[0].f, size: jsonls[0].size } : null
+}
+
 export function readActiveModelFromProjectDir(workingDir: string, sinceUnixSec?: number, configDir?: string): string | null {
   const now = Date.now()
   const cacheKey = `${workingDir}:${sinceUnixSec ?? ''}:${configDir ?? ''}`
@@ -40,34 +100,26 @@ export function readActiveModelFromProjectDir(workingDir: string, sinceUnixSec?:
       cache.set(cacheKey, { value: null, expiresAt: now + TTL_MS })
       return null
     }
-    const jsonls = readdirSync(dir)
-      .filter(f => f.endsWith('.jsonl'))
-      .map(f => ({ f, mtime: statSync(join(dir, f)).mtimeMs }))
-      .sort((a, b) => b.mtime - a.mtime)
-    if (jsonls.length === 0) {
+    const newest = newestJsonl(dir)
+    if (!newest) {
       cache.set(cacheKey, { value: null, expiresAt: now + TTL_MS })
       return null
     }
-    const content = readFileSync(join(dir, jsonls[0].f), 'utf-8')
-    const lines = content.split('\n')
-    for (let i = lines.length - 1; i >= 0; i--) {
-      const line = lines[i].trim()
-      if (!line) continue
+    value = scanLastLine(join(dir, newest.file), newest.size, (line) => {
       try {
         const entry = JSON.parse(line)
         const msg = entry?.message
         const model = msg?.model
-        if (typeof model !== 'string' || model.startsWith('<')) continue
+        if (typeof model !== 'string' || model.startsWith('<')) return undefined
         if (sinceUnixSec !== undefined) {
           const ts = entry?.timestamp
-          if (typeof ts !== 'string') continue
+          if (typeof ts !== 'string') return undefined
           const lineUnix = Math.floor(new Date(ts).getTime() / 1000)
-          if (!Number.isFinite(lineUnix) || lineUnix < sinceUnixSec) continue
+          if (!Number.isFinite(lineUnix) || lineUnix < sinceUnixSec) return undefined
         }
-        value = model
-        break
-      } catch { /* skip malformed JSON line */ }
-    }
+        return model
+      } catch { return undefined /* skip malformed JSON line */ }
+    }) ?? null
   } catch { /* fall through */ }
   cache.set(cacheKey, { value, expiresAt: now + TTL_MS })
   return value
@@ -92,16 +144,9 @@ export function readContextTokensFromProjectDir(workingDir: string, configDir?: 
   try {
     const dir = projectsDirFor(workingDir, configDir)
     if (existsSync(dir)) {
-      const jsonls = readdirSync(dir)
-        .filter(f => f.endsWith('.jsonl'))
-        .map(f => ({ f, mtime: statSync(join(dir, f)).mtimeMs }))
-        .sort((a, b) => b.mtime - a.mtime)
-      if (jsonls.length > 0) {
-        const content = readFileSync(join(dir, jsonls[0].f), 'utf-8')
-        const lines = content.split('\n')
-        for (let i = lines.length - 1; i >= 0; i--) {
-          const line = lines[i].trim()
-          if (!line) continue
+      const newest = newestJsonl(dir)
+      if (newest) {
+        value = scanLastLine(join(dir, newest.file), newest.size, (line) => {
           try {
             const u = JSON.parse(line)?.message?.usage
             if (u && typeof u === 'object') {
@@ -109,10 +154,11 @@ export function readContextTokensFromProjectDir(workingDir: string, configDir?: 
               const cr = Number(u.cache_read_input_tokens) || 0
               const cc = Number(u.cache_creation_input_tokens) || 0
               const total = inp + cr + cc
-              if (total > 0) { value = total; break }
+              if (total > 0) return total
             }
-          } catch { /* skip malformed JSON line */ }
-        }
+            return undefined
+          } catch { return undefined /* skip malformed JSON line */ }
+        }) ?? null
       }
     }
   } catch { /* fall through */ }


### PR DESCRIPTION
…eads

## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

`readActiveModelFromProjectDir` and `readContextTokensFromProjectDir` each read the WHOLE newest session `.jsonl` into memory and split it into lines, just to find the last line matching a predicate. Both callers run once per running agent inside `/api/agents`, so the endpoint could never be fast regardless of load.

Fix: read from the END of the file in a growing window (64KB, doubling on miss), scanning lines backward for the first one the caller's predicate accepts, and falling back to the full file if the match is not in the tail -- so the RESULT is identical to the old full-file backward scan, only the common case (match near EOF) gets cheap.

## Kapcsolódó issue / Related issue

No related issue -- found and measured on a 17-agent installation where `/api/agents` never responded faster than ~2.3 s.

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [x] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture. (No docs change needed: no install- or architecture-level change.)
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).

## Mérés / Measurement

    the bug on this branch's base (develop 9c9e337):
        src/web/active-model.ts:51 and :100 -- readFileSync(<whole newest .jsonl>)

    RED proof: with the fallback-expansion path deliberately disabled, the new
        "match sits before the initial 64KB window" test FAILS; restored, all 11 pass
    correctness on real data: frozen snapshot of 18 agents' newest session logs,
        old-logic vs new-logic on the identical frozen bytes -- 0/18 mismatches
    performance on the same frozen snapshot, fresh Node processes: 1275.9ms -> 13.1ms
    on this branch, off develop: tsc --noEmit rc=0, active-model tests 11/11

Original fix authored by vakond3 <vakond3@marveen.fleet> on the reporting installation; ported to develop and re-verified here by elliot.

<!--
  HU + EN. Töltsd ki minden szakaszt. / Fill in every section.
  A jelölőnégyzeteket így pipáld: [x]  /  Tick a box like this: [x]
-->

## A változtatás típusa / Type of change

- [ ] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

<!-- HU: Foglald össze, milyen problémát old meg a PR és milyen technikai megközelítést alkalmaztál.
     EN: Summarize what problem this PR solves and the technical approach you took. -->

## Kapcsolódó issue / Related issue

Closes #

## Ellenőrzőlista / Checklist

- [ ] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [ ] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
- [ ] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [ ] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).
