### PR TITLE
fix(isolated-config): keep hooks the isolated dir alone defines

### DIFF
--- a/.testout
+++ b/.testout
@@ -1,0 +1,439 @@
+
+ RUN  v2.1.9 /home/janos/wt-978
+
+ ✓ src/__tests__/context-guard.test.ts (58 tests) 62ms
+ ✓ src/__tests__/process-lock.test.ts (63 tests) 71ms
+ ✓ src/__tests__/pane-state.test.ts (217 tests) 132ms
+ ✓ src/__tests__/governance-gates.test.ts (76 tests) 78ms
+ ✓ src/__tests__/stuck-tool-call.test.ts (35 tests) 39ms
+ ✓ src/__tests__/prompt-injection-defense.test.ts (58 tests) 37ms
+ ✓ src/__tests__/context-restart-gate.test.ts (62 tests) 51ms
+ ✓ src/__tests__/mcp-list-parser.test.ts (59 tests) 108ms
+ ✓ src/__tests__/token-usage.test.ts (23 tests) 215ms
+ ✓ src/__tests__/remote-enroll-core.test.ts (44 tests) 61ms
+ ✓ src/__tests__/federation-lifecycle.test.ts (18 tests) 165ms
+ ✓ src/__tests__/federation-config.test.ts (27 tests) 74ms
+[23:52:56.143] [32mINFO[39m (978396): [36mdashboard user created[39m
+    [35musername[39m: "alice"
+[23:52:56.596] [32mINFO[39m (978396): [36mdashboard user created[39m
+    [35musername[39m: "alice"
+[23:52:57.098] [32mINFO[39m (978396): [36mdashboard user created[39m
+    [35musername[39m: "alice"
+[23:52:57.762] [32mINFO[39m (978396): [36mdashboard user created[39m
+    [35musername[39m: "alice"
+[23:52:58.448] [32mINFO[39m (978396): [36mdashboard user created[39m
+    [35musername[39m: "alice"
+[23:52:59.441] [32mINFO[39m (978396): [36mdashboard user created[39m
+    [35musername[39m: "alice"
+[23:53:00.406] [32mINFO[39m (978396): [36mdashboard user created[39m
+    [35musername[39m: "alice"
+[23:53:01.698] [32mINFO[39m (978396): [36mdashboard user created[39m
+    [35musername[39m: "alice"
+ ✓ src/__tests__/fleet-transfer.test.ts (17 tests) 7417ms
+   ✓ encrypt/decrypt round-trip > decrypts to the original plaintext 2145ms
+   ✓ encrypt/decrypt round-trip > throws on wrong password (GCM auth tag mismatch) 1364ms
+   ✓ encrypt/decrypt round-trip > produces a non-trivially-parseable blob that differs from plaintext JSON 644ms
+   ✓ importFleet: encrypted wrapper detection > returns error DiffReport when encrypted but no password given 663ms
+   ✓ importFleet: encrypted wrapper detection > returns error DiffReport on wrong password (no file writes) 1296ms
+   ✓ importFleet: encrypted wrapper detection > succeeds (dry-run) with correct password 1286ms
+ ✓ src/__tests__/bridge-enroll.test.ts (13 tests) 137ms
+ ✓ src/__tests__/template-identity-hygiene.test.ts (10 tests) 196ms
+ ✓ src/__tests__/channel-mcp-reconnect.test.ts (27 tests) 29ms
+[23:53:03.846] [32mINFO[39m (978396): [36mdashboard user created[39m
+    [35musername[39m: "alice"
+[23:53:04.565] [32mINFO[39m (978396): [36mdashboard user created[39m
+    [35musername[39m: "alice"
+ ✓ src/__tests__/channel-coordinator.test.ts (31 tests) 66ms
+ ✓ src/__tests__/db.test.ts (30 tests) 132ms
+[23:53:06.439] [32mINFO[39m (978396): [36mdashboard user created[39m
+    [35musername[39m: "alice"
+[23:53:06.814] [33mWARN[39m (978396): [36mbreak-glass password reset via bearer token[39m
+    [35musername[39m: "alice"
+  prune: python3 /tmp/scratchpad/staleness-guard.py
+boot-hook-prune: pruned 1 stale hook(s) from /tmp/boot-prune-test-h4lOY4/.claude/settings.json (backup: /tmp/boot-prune-test-h4lOY4/.claude/settings.json.bak)
+boot-hook-prune: 1 stale hook(s) removed across 1 file(s)
+  prune: python3 /opt/removed-checkout/scripts/hooks/staleness-guard.py
+boot-hook-prune: pruned 1 stale hook(s) from /tmp/boot-prune-test-56Ings/.claude/settings.json (backup: /tmp/boot-prune-test-56Ings/.claude/settings.json.bak)
+boot-hook-prune: 1 stale hook(s) removed across 1 file(s)
+ ✓ src/__tests__/hook-path-guard.test.ts (18 tests) 279ms
+ ❯ src/__tests__/installer-start-and-fallback.test.ts (26 tests | 1 failed) 10503ms
+   × the ERR-trap abort is real (guards the premise of the tests above) > an unguarded capture aborts, and bash blames the enclosing `fi` 31ms
+     → expected 'TRAP:5' to be 'TRAP:6' // Object.is equality
+   ✓ install-macos.sh -- launchd units must be verified, not assumed > never trusts load/bootstrap alone -- it always kickstarts 2058ms
+   ✓ install-macos.sh -- launchd units must be verified, not assumed > returns the pid once the unit is actually up 2051ms
+   ✓ install-macos.sh -- launchd units must be verified, not assumed > returns NOTHING when the spawn stays pended, so the caller can fail loudly 2060ms
+   ✓ install-macos.sh -- launchd units must be verified, not assumed > returns NOTHING for a crash-looping unit whose first pid was transient 2107ms
+   ✓ install-macos.sh -- launchd units must be verified, not assumed > does not abort the installer when launchd refuses to start the unit 2071ms
+[23:53:07.587] [32mINFO[39m (978396): [36mdashboard user created[39m
+    [35musername[39m: "alice"
+ ✓ src/__tests__/claude-config-dir.test.ts (41 tests) 28ms
+ ✓ src/__tests__/serve-file-cache.test.ts (25 tests) 50ms
+ ✓ src/__tests__/channels-never-started-backoff.test.ts (12 tests) 356ms
+ ✓ src/__tests__/heartbeat-agent-scaffold.test.ts (32 tests) 57ms
+
+gzip: stdin: not in gzip format
+tar: Child returned status 1
+tar: Error is not recoverable: exiting now
+ ✓ src/__tests__/agent-bundle.test.ts (16 tests) 289ms
+ ✓ src/__tests__/channel-deafness-recovery.test.ts (33 tests) 38ms
+ ✓ src/__tests__/auth-device-keys.test.ts (24 tests) 104ms
+[23:53:09.982] [32mINFO[39m (978396): [36mdashboard user created[39m
+    [35musername[39m: "alice"
+[23:53:10.467] [32mINFO[39m (978396): [36mdashboard user created[39m
+    [35musername[39m: "alice"
+[23:53:11.015] [32mINFO[39m (978396): [36mdashboard user created[39m
+    [35musername[39m: "alice"
+ ✓ src/__tests__/kanban-breakdown.test.ts (25 tests) 69ms
+ ✓ src/__tests__/agent-restart-policy.test.ts (45 tests) 27ms
+[23:53:11.545] [32mINFO[39m (978396): [36mdashboard user created[39m
+    [35musername[39m: "alice"
+ ✓ src/__tests__/update-preflight.test.ts (40 tests) 23ms
+[23:53:12.041] [32mINFO[39m (978396): [36mdashboard user deleted[39m
+    [35musername[39m: "alice"
+    [35mremaining[39m: 0
+[23:53:12.559] [32mINFO[39m (978396): [36mdashboard user created[39m
+    [35musername[39m: "alice"
+ ✓ src/__tests__/hook-registration-guard.test.ts (23 tests) 37ms
+ ✓ src/__tests__/federation-inbox.test.ts (13 tests) 84ms
+[23:53:13.010] [32mINFO[39m (978396): [36mdashboard user created[39m
+    [35musername[39m: "bob"
+[23:53:13.011] [32mINFO[39m (978396): [36mdashboard user deleted[39m
+    [35musername[39m: "bob"
+    [35mremaining[39m: 1
+[23:53:13.528] [32mINFO[39m (978396): [36mdashboard user created[39m
+    [35musername[39m: "alice"
+ ✓ src/__tests__/federation-onboarding.test.ts (17 tests) 79ms
+ ✓ src/__tests__/skills-local-api.test.ts (14 tests) 58ms
+ ✓ src/__tests__/model-suggest.test.ts (29 tests) 35ms
+[23:53:14.473] [32mINFO[39m (978396): [36mdashboard user created[39m
+    [35musername[39m: "alice"
+ ✓ src/__tests__/federation-capabilities.test.ts (16 tests) 66ms
+ ✓ src/__tests__/model-id-injection.test.ts (14 tests) 84ms
+[23:53:15.480] [32mINFO[39m (978396): [36mdashboard user created[39m
+    [35musername[39m: "alice"
+ ✓ src/__tests__/refactor-config-widget-index.test.ts (17 tests) 102ms
+[23:53:16.370] [32mINFO[39m (978396): [36mdashboard user created[39m
+    [35musername[39m: "alice"
+ ✓ src/__tests__/auth-routes.test.ts (24 tests) 21197ms
+   ✓ GET /api/auth/status > reports login_available once a user exists and unauth for no principal 499ms
+   ✓ GET /api/auth/status > reports session method + user for a session principal 452ms
+   ✓ POST /api/auth/login > sets HttpOnly; SameSite=Strict; Path=/ and NO Secure over plain http 839ms
+   ✓ POST /api/auth/login > adds Secure only under x-forwarded-proto: https 644ms
+   ✓ POST /api/auth/login > mints a fresh session id on every login (fixation defence) 1032ms
+   ✓ POST /api/auth/login > revokes a presented (valid) session cookie on login 976ms
+   ✓ POST /api/auth/login > returns IDENTICAL 401 bodies for bad user vs bad password 1279ms
+   ✓ POST /api/auth/login > 429s once the per-username lock trips, with retry_after_s 2091ms
+   ✓ POST /api/auth/logout > clears the cookie and revokes the row 750ms
+   ✓ POST /api/auth/password > requires a correct current_password on the session path 1828ms
+   ✓ POST /api/auth/password > does NOT require current_password on the token break-glass path 1136ms
+   ✓ POST /api/auth/password > revokes OTHER sessions on password change but keeps the caller 2307ms
+   ✓ POST /api/auth/password > enforces the password policy on the new password 501ms
+   ✓ users CRUD > rejects a duplicate username with 409 483ms
+   ✓ users CRUD > lists users without password hashes 549ms
+   ✓ users CRUD > deletes a user and revokes their sessions (back to token-only) 1025ms
+   ✓ users CRUD > still allows a SESSION principal to manage users (existing behavior) 968ms
+   ✓ credential-kind allowlists (default-deny for future kinds) > denies future device kind on users GET/POST/DELETE and break-glass password reset 993ms
+   ✓ credential-kind allowlists (default-deny for future kinds) > denies federation kind on users GET/POST/DELETE and break-glass password reset 1008ms
+   ✓ credential-kind allowlists (default-deny for future kinds) > denies missing principal on users GET/POST/DELETE and break-glass password reset 932ms
+   ✓ credential-kind allowlists (default-deny for future kinds) > keeps the token break-glass reset working (allowlist did not over-tighten) 853ms
+ ✓ src/__tests__/costops-ledger.test.ts (14 tests) 272ms
+ ✓ src/__tests__/pane-first-run-gate.test.ts (17 tests) 20ms
+ ✓ src/__tests__/channels-unit-restart-policy.test.ts (13 tests) 2072ms
+   ✓ update.sh migration for already-installed machines > rewrites an existing on-failure channels unit and leaves no backup file 594ms
+   ✓ update.sh migration for already-installed machines > is idempotent: a second run changes nothing and reports nothing 732ms
+   ✓ update.sh migration for already-installed machines > migrates a renamed install too (unit name derives from the bot name) 639ms
+ ✓ src/__tests__/pane-looks-idle.test.ts (25 tests) 30ms
+ ✓ src/__tests__/federation-poller.test.ts (15 tests) 91ms
+ ✓ src/__tests__/prompt-safety.test.ts (37 tests) 40ms
+ ✓ src/__tests__/seed-refresh-untouched-only.test.ts (11 tests) 4033ms
+   ✓ seed refresh touches only provably untouched copies > refreshes a copy that matches an OLDER shipped version (two releases behind) 441ms
+   ✓ seed refresh touches only provably untouched copies > NEVER overwrites a locally modified copy -- the failure that would be silent 532ms
+   ✓ seed refresh touches only provably untouched copies > a one-character edit is enough to be left alone 519ms
+   ✓ seed refresh touches only provably untouched copies > handles the TEMPLATED task copies in rendered form 543ms
+   ✓ seed refresh touches only provably untouched copies > leaves a modified TEMPLATED copy alone too 557ms
+   ✓ seed refresh touches only provably untouched copies > is idempotent: a second pass changes nothing and reports nothing 834ms
+ ✓ src/__tests__/main-restart-platform.test.ts (15 tests) 24ms
+ ✓ src/__tests__/schedule-task-timeout.test.ts (24 tests) 25ms
+ ✓ src/__tests__/channel-plugin-unlock.test.ts (13 tests) 19ms
+[23:53:21.728] [32mINFO[39m (980322): [36mdashboard user created[39m
+    [35musername[39m: "alice"
+[23:53:22.202] [33mWARN[39m (980322): [36mbreak-glass password reset via bearer token[39m
+    [35musername[39m: "alice"
+ ✓ src/__tests__/isolated-channel-config.test.ts (18 tests) 60ms
+[23:53:22.693] [32mINFO[39m (980322): [36mdashboard user created[39m
+    [35musername[39m: "bob"
+ ✓ src/__tests__/stuck-input-action.test.ts (22 tests) 18ms
+ ✓ src/__tests__/auth-recovery.test.ts (7 tests) 2436ms
+   ✓ HTTP break-glass password reset audit > writes an audit row with the target username on the token path 995ms
+   ✓ HTTP break-glass password reset audit > does NOT audit a normal session-path password change as break-glass 1340ms
+ ✓ src/__tests__/reauth-detect.test.ts (18 tests) 25ms
+ ✓ src/__tests__/otel-distributed-tracing.test.ts (11 tests) 42ms
+ ✓ src/__tests__/installer-noninteractive-apt.test.ts (8 tests) 164ms
+ ✓ src/__tests__/ghost-suggestion-strip.test.ts (12 tests) 30ms
+ ✓ src/__tests__/worker-liveness.test.ts (17 tests) 53ms
+ ✓ src/__tests__/cron.test.ts (19 tests) 4542ms
+   ✓ sparse-cron starvation is fixed under realistic tick drift > fires a daily cron exactly once over 24h despite 61s tick drift 1907ms
+   ✓ sparse-cron starvation is fixed under realistic tick drift > fires a twice-daily cron exactly twice over 24h despite drift 1299ms
+   ✓ sparse-cron starvation is fixed under realistic tick drift > fires a */15 interval cron on essentially every occurrence (tz-invariant survivor) 741ms
+   ✓ sparse-cron starvation is fixed under realistic tick drift > a 3-minute tick gap still catches a daily occurrence (exactly once) 458ms
+ ✓ src/__tests__/provider-poller-match.test.ts (23 tests) 29ms
+ ✓ src/__tests__/channel-monitor-resume-recovery.test.ts (11 tests) 735ms
+   ✓ channel-monitor: periodic detached-claude reap (CB6CF755 durable fix) > shouldRunPeriodicReap fires only once the interval has elapsed 724ms
+ ✓ src/__tests__/inbound-probe.test.ts (14 tests) 28ms
+ ✓ src/__tests__/background-tasks.test.ts (10 tests) 42ms
+ ✓ src/__tests__/liveness-masking.test.ts (11 tests) 18ms
+ ✓ src/__tests__/agent-scaffold-dashboard-origin.test.ts (21 tests) 26ms
+ ✓ src/__tests__/channel-inbound-framing.test.ts (15 tests) 41ms
+ ✓ src/__tests__/main-model-resolution-parity.test.ts (15 tests) 1003ms
+ ✓ src/__tests__/federation-ui-contract.test.ts (12 tests) 228ms
+ ✓ src/__tests__/model-profiles.test.ts (21 tests) 24ms
+ ✓ src/__tests__/approvals.test.ts (22 tests) 672ms
+ ✓ src/__tests__/reauth-healer.test.ts (19 tests) 26ms
+ ✓ src/__tests__/agent-put-fields.test.ts (15 tests) 19ms
+ ✓ src/__tests__/channel-poller-reap.test.ts (14 tests) 39ms
+ ✓ src/__tests__/claude-credentials-guard.test.ts (19 tests) 255ms
+ ✓ src/__tests__/team-trust.test.ts (23 tests) 16ms
+ ✓ src/__tests__/brand-completeness.test.ts (15 tests) 72ms
+ ✓ src/__tests__/schedule-catchup.test.ts (25 tests) 143ms
+ ✓ src/__tests__/channel-monitor-session-recreate.test.ts (11 tests) 27ms
+ ✓ src/__tests__/federation-bridge.test.ts (15 tests) 87ms
+ ✓ src/__tests__/channel-provider.test.ts (27 tests) 38ms
+ ✓ src/__tests__/skill-usage.test.ts (16 tests) 65ms
+ ✓ src/__tests__/main-agent-isolated-config.test.ts (9 tests) 40ms
+ ✓ src/__tests__/installer-service-auth-gate.test.ts (27 tests) 228ms
+ ✓ src/__tests__/scope-channel-plugins.test.ts (18 tests) 20ms
+ ✓ src/__tests__/isolated-config-mcp-reconcile.test.ts (9 tests) 58ms
+ ✓ src/__tests__/configurable-brand.test.ts (18 tests) 25ms
+ ✓ src/__tests__/isolated-hook-merge.test.ts (17 tests) 29ms
+ ✓ src/__tests__/managed-settings.test.ts (14 tests) 366ms
+ ✓ src/__tests__/skill-index.test.ts (12 tests) 945ms
+ ✓ src/__tests__/port-chain-no-hardcode.test.ts (22 tests) 338ms
+ ✓ src/__tests__/quarantine-allowlist-render.test.ts (21 tests) 49ms
+ ✓ src/__tests__/channel-stability-contract.test.ts (20 tests) 46ms
+ ✓ src/__tests__/egress-gate.test.ts (18 tests) 43ms
+ ✓ src/__tests__/heartbeat-urgent-open-only.test.ts (10 tests) 40ms
+ ✓ src/__tests__/parked-machine-input.test.ts (17 tests) 33ms
+ ✓ src/__tests__/reauth-quiet-hours.test.ts (11 tests) 35ms
+ ✓ src/__tests__/agent-worker.test.ts (18 tests) 22ms
+ ✓ src/__tests__/schedule-runner-retry-missing.test.ts (3 tests) 481ms
+   ✓ schedule runner: pending retry survives a missing target session > keeps the retry row on 'missing' and logs the transition once across ticks 319ms
+ ✓ src/__tests__/auth-gate.test.ts (20 tests) 66ms
+ ✓ src/__tests__/installer-node22-abi.test.ts (4 tests) 190ms
+ ✓ src/__tests__/installer-apt-lock-set-e.test.ts (6 tests) 68ms
+ ✓ src/__tests__/inbox-nudge.test.ts (10 tests) 22ms
+ ✓ src/__tests__/onboarding-channel-live-wait.test.ts (8 tests) 62ms
+ ✓ src/__tests__/auth-sessions.test.ts (12 tests) 257ms
+ ✓ src/__tests__/autonomy-section.test.ts (8 tests) 48ms
+ ✓ src/__tests__/recall.test.ts (33 tests) 257ms
+ ✓ src/__tests__/queued-messages-not-idle.test.ts (5 tests) 16ms
+ ✓ src/__tests__/update-unit-maintenance-order.test.ts (6 tests) 3256ms
+   ✓ the maintenance itself, executed for real > repairs BOTH unit kinds in one pass 1548ms
+   ✓ the maintenance itself, executed for real > is idempotent: the second pass changes nothing and says nothing 1662ms
+ ✓ src/__tests__/silent-degradation-alert.test.ts (17 tests) 19ms
+ ✓ src/__tests__/context-guard-hidden-worker.test.ts (5 tests) 30ms
+ ✓ src/__tests__/session-send-lock.test.ts (7 tests) 129ms
+ ✓ src/__tests__/shipped-recipes-no-sqlite-cli.test.ts (6 tests) 20ms
+ ✓ src/__tests__/approvals-ui-contract.test.ts (11 tests) 111ms
+ ✓ src/__tests__/heartbeat-oauth-token.test.ts (10 tests | 1 skipped) 18ms
+ ✓ src/__tests__/wizard-pending-agent-id.test.ts (9 tests) 25ms
+ ✓ src/__tests__/hook-command-quoting.test.ts (9 tests) 43ms
+ ❯ src/__tests__/memory-performance.test.ts (11 tests | 2 failed) 10146ms
+   × backfillEmbeddings > returns 0 when all memories already have embeddings or Ollama is unreachable 5016ms
+     → Test timed out in 5000ms.
+If this is a long-running test, pass a timeout value as the last argument or configure it globally with "testTimeout".
+   × backfillEmbeddings > processes rows without embeddings and updates them when Ollama responds 5013ms
+     → Test timed out in 5000ms.
+If this is a long-running test, pass a timeout value as the last argument or configure it globally with "testTimeout".
+ ✓ src/__tests__/router-stuck-alert.test.ts (10 tests) 24ms
+ ✓ src/__tests__/fable-overage-consent.test.ts (15 tests) 40ms
+ ✓ src/__tests__/model-profiles-wiring.test.ts (9 tests) 30ms
+ ✓ src/__tests__/memory-listing-staleness.test.ts (6 tests) 237ms
+ ✓ src/__tests__/federation-directory.test.ts (4 tests) 114ms
+ ✓ src/__tests__/schedule-runner-precheck.test.ts (12 tests) 89ms
+ ✓ src/__tests__/platform-bin-resolve.test.ts (12 tests) 36ms
+ ✓ src/__tests__/test-run-marker.test.ts (9 tests) 51ms
+ ✓ src/__tests__/agent-taskstate.test.ts (19 tests) 49ms
+ ✓ src/__tests__/schedule-runner-resubmit-escalation.test.ts (14 tests) 17ms
+ ✓ src/__tests__/pane-writers-under-send-lock.test.ts (10 tests) 37ms
+ ✓ src/__tests__/installer-token-probe.test.ts (9 tests) 154ms
+ ✓ src/__tests__/research-routes.test.ts (8 tests) 30ms
+ ✓ src/__tests__/tool-call-audit-metadata.test.ts (9 tests) 276ms
+ ✓ src/__tests__/scheduled-task-kanban-waiting.test.ts (12 tests) 345ms
+ ✓ src/__tests__/federation-delegation-feedback.test.ts (4 tests) 70ms
+ ✓ src/__tests__/model-fallback.test.ts (18 tests) 23ms
+ ✓ src/__tests__/remote-enroll-fs.test.ts (8 tests) 45ms
+ ✓ src/__tests__/installer-ollama-nonfatal.test.ts (3 tests) 537ms
+   ✓ install-linux.sh: ollama+model step is non-fatal (BC100FAIL810) > an empty / non-JSON pull response does not abort the install 438ms
+ ✓ src/__tests__/stuck-input-restart.test.ts (16 tests) 42ms
+ ✓ src/__tests__/installer-whisper-optional.test.ts (4 tests) 70ms
+ ✓ src/__tests__/main-model-env-precedence.test.ts (8 tests) 24ms
+ ✓ src/__tests__/owner-chat-fresh-install.test.ts (2 tests) 276ms
+ ✓ src/__tests__/agent-scaffold-tasks.test.ts (5 tests) 17ms
+ ✓ src/__tests__/email-send-gate.test.ts (10 tests) 30ms
+ ✓ src/__tests__/channel-request.test.ts (14 tests) 60ms
+ ✓ src/__tests__/costops-api.test.ts (5 tests) 175ms
+ ✓ src/__tests__/pending-retries.test.ts (19 tests) 24ms
+ ✓ src/__tests__/config-app-tz.test.ts (12 tests) 116ms
+ ✓ src/__tests__/messages-view-display-name.test.ts (9 tests) 16ms
+ ✓ src/__tests__/installer-auth-deferred-marker.test.ts (4 tests) 34ms
+ ✓ src/__tests__/kanban-archive-stale-updated-at.test.ts (6 tests) 267ms
+ ✓ src/__tests__/scheduled-resubmit-stuck.test.ts (8 tests) 10ms
+ ✓ src/__tests__/egress-gate-port-validation.test.ts (6 tests) 1815ms
+   ✓ egress-gate dashboard-port validation (cards 266d8248, 417cf07a) > a rejected port cannot put a foreign host on the allowlist, and falls back to the default 1385ms
+ ✓ src/__tests__/approvals-prompt-contract.test.ts (9 tests) 15ms
+ ✓ src/__tests__/owner-chat.test.ts (8 tests) 27ms
+ ✓ src/__tests__/message-router-tick-cap.test.ts (2 tests) 15ms
+ ✓ src/__tests__/wizard-rename.test.ts (9 tests) 1118ms
+   ✓ identitySavePlan (identity-save decision core) > mid-setup rename with the fleet up restarts the channels session (the VPS wizard path) 925ms
+ ✓ src/__tests__/approvals-notify.test.ts (3 tests) 133ms
+ ✓ src/__tests__/agent-scaffold-claude-md-prompt.test.ts (4 tests) 10ms
+ ✓ src/__tests__/agent-delete-clears-desired.test.ts (3 tests) 73ms
+ ✓ src/__tests__/heartbeat-claude-json-bridge.test.ts (9 tests) 15ms
+ ✓ src/__tests__/default-agent-model.test.ts (11 tests) 21ms
+ ✓ src/__tests__/channel-watchdog-busy-guard.test.ts (12 tests) 17ms
+ ✓ src/__tests__/heartbeat-worker-isolation.test.ts (9 tests) 13ms
+ ✓ src/__tests__/agent-create-no-destructive-rollback.test.ts (5 tests) 25ms
+ ✓ src/__tests__/skills-local-on-page.test.ts (12 tests) 31ms
+ ✓ src/__tests__/slack-half-configured-onboarding.test.ts (4 tests) 10ms
+ ✓ src/__tests__/ssh-tmux.test.ts (14 tests) 23ms
+ ✓ src/__tests__/schedule-mcp-precheck.test.ts (9 tests) 27ms
+ ✓ src/__tests__/agent-conversation.test.ts (7 tests) 53ms
+ ✓ src/__tests__/dual-worker.test.ts (16 tests) 15ms
+ ✓ src/__tests__/settings-store.test.ts (8 tests) 14ms
+ ✓ src/__tests__/remote-launch-command.test.ts (14 tests) 18ms
+ ✓ src/__tests__/bridge-enroll-host.test.ts (10 tests) 16ms
+ ✓ src/__tests__/worker-firstrun-cc202.test.ts (10 tests) 20ms
+ ✓ src/__tests__/kanban-dispatch.test.ts (13 tests) 18ms
+ ✓ src/__tests__/delivered-needs-timestamp.test.ts (5 tests) 53ms
+ ✓ src/__tests__/channels-reap-scope.test.ts (5 tests) 49ms
+ ✓ src/__tests__/parked-clear-sequence.test.ts (9 tests) 15ms
+ ✓ src/__tests__/format.test.ts (23 tests) 50ms
+ ✓ src/__tests__/memory-recency-weighting.test.ts (7 tests) 86ms
+ ✓ src/__tests__/kanban-labels.test.ts (11 tests) 350ms
+ ✓ src/__tests__/settings-heartbeat-calendar.test.ts (7 tests) 17ms
+ ✓ src/__tests__/update-release-grouping.test.ts (6 tests) 13ms
+ ✓ src/__tests__/send-prompt-force-send-gate.test.ts (5 tests) 11ms
+ ✓ src/__tests__/verify-channels-health-static.test.ts (5 tests) 7ms
+ ✓ src/__tests__/lsof-path.test.ts (6 tests) 64ms
+ ✓ src/__tests__/fleet-roster-section.test.ts (5 tests) 17ms
+ ✓ src/__tests__/full-width-layout-css-contract.test.ts (10 tests) 21ms
+ ✓ src/__tests__/channel-health-monitor.test.ts (4 tests) 22ms
+ ✓ src/__tests__/channel-inbound-tee.test.ts (2 tests) 140ms
+ ✓ src/__tests__/welcome-screen-recovery.test.ts (2 tests) 14ms
+ ✓ src/__tests__/service-label.test.ts (13 tests) 14ms
+ ✓ src/__tests__/staleness-guard.test.ts (8 tests) 278ms
+ ✓ src/__tests__/config-registry.test.ts (11 tests) 18ms
+ ✓ src/__tests__/vault-ssh-keys-import.test.ts (1 test) 243ms
+ ✓ src/__tests__/parked-input-escalation.test.ts (3 tests) 11249ms
+   ✓ clearStaleParkedInput > NEVER auto-clears the main agent box, and (escalation muted) never notifies 8030ms
+   ✓ clearStaleParkedInput > attempts the Ctrl-U clear for a SUB-agent box with a REAL parked line 3207ms
+ ✓ src/__tests__/telegram-inbox-wake.test.ts (11 tests) 15ms
+ ✓ src/__tests__/memories-get-agent-id-alias.test.ts (3 tests) 85ms
+ ✓ src/__tests__/completion-notification.test.ts (5 tests) 52ms
+ ✓ src/__tests__/stuck-input-fast-recovery.test.ts (4 tests) 15ms
+ ✓ src/__tests__/main-agent-detail-guards.test.ts (5 tests) 41ms
+ ✓ src/__tests__/bridge-enroll-host-validation.test.ts (5 tests) 31ms
+ ✓ src/__tests__/channel-conflict-probe.test.ts (6 tests) 36ms
+ ✓ src/__tests__/main-agent-config-dir.test.ts (8 tests) 26ms
+ ✓ src/__tests__/schedule-runner-injection-priority.test.ts (6 tests) 14ms
+ ✓ src/__tests__/hidden-attribute-css-contract.test.ts (2 tests) 21ms
+ ✓ src/__tests__/schedule-runner-autostart.test.ts (4 tests) 9ms
+ ✓ src/__tests__/agent-delete-stops-session.test.ts (2 tests) 11ms
+ ✓ src/__tests__/federation-address.test.ts (13 tests) 20ms
+ ✓ src/__tests__/federation-classify.test.ts (8 tests) 11ms
+ ✓ src/__tests__/autonomy-standalone-removal.test.ts (8 tests) 33ms
+ ✓ src/__tests__/kanban-move-audit.test.ts (5 tests) 183ms
+ ✓ src/__tests__/auto-restart.test.ts (13 tests) 26ms
+ ✓ src/__tests__/token-usage-collapse.test.ts (5 tests) 15ms
+ ✓ src/__tests__/activity-no-main-duplicate.test.ts (6 tests) 16ms
+ ✓ src/__tests__/agent-result-classification.test.ts (8 tests) 15ms
+ ✓ src/__tests__/google-api-token-cache.test.ts (5 tests) 13ms
+ ✓ src/__tests__/remote-api.test.ts (6 tests) 34ms
+ ✓ src/__tests__/session-title-banner.test.ts (7 tests) 15ms
+ ✓ src/__tests__/kanban-ref-normalize.test.ts (8 tests) 13ms
+ ✓ src/__tests__/kanban-delete-fk.test.ts (4 tests) 135ms
+ ✓ src/__tests__/password-hash.test.ts (10 tests) 5146ms
+   ✓ hashPassword / verifyPassword > produces a PHC scrypt string and round-trips 1187ms
+   ✓ hashPassword / verifyPassword > rejects the wrong password 1436ms
+   ✓ hashPassword / verifyPassword > uses a unique salt per hash (no deterministic output) 2020ms
+   ✓ hashPassword / verifyPassword > verifies against the STORED params, not the current defaults 487ms
+ ✓ src/__tests__/poller-evidence.test.ts (6 tests) 16ms
+ ✓ src/__tests__/worker-selfheal.test.ts (7 tests) 19ms
+ ✓ src/__tests__/shared-claude-onboarded.test.ts (6 tests) 72ms
+ ✓ src/__tests__/login-throttle.test.ts (9 tests) 1348ms
+   ✓ known vs unknown username indistinguishability > runDummyVerify resolves without throwing (timing equalizer path) 1314ms
+ ✓ src/__tests__/schedule-runner-bound-chatid.test.ts (8 tests) 17ms
+ ✓ src/__tests__/dashboard-modal-css-contract.test.ts (4 tests) 11ms
+ ✓ src/__tests__/claude-plans.test.ts (7 tests) 23ms
+ ✓ src/__tests__/update-checker-branch.test.ts (6 tests) 116ms
+ ✓ src/__tests__/slack-manifest.test.ts (12 tests) 22ms
+ ✓ src/__tests__/lang-parity.test.ts (4 tests) 304ms
+ ✓ src/__tests__/channel-monitor-keepalive-shortcircuit.test.ts (3 tests) 20ms
+ ✓ src/__tests__/command-task-eval.test.ts (6 tests) 41ms
+ ✓ src/__tests__/network-info.test.ts (8 tests) 23ms
+ ✓ src/__tests__/csrf-origin.test.ts (12 tests) 19ms
+ ✓ src/__tests__/env.test.ts (5 tests) 27ms
+ ✓ src/__tests__/remote-config.test.ts (10 tests) 27ms
+ ✓ src/__tests__/pending-backlog-by-agent.test.ts (3 tests) 88ms
+ ✓ src/__tests__/origin-note-sanitize.test.ts (5 tests) 19ms
+ ✓ src/__tests__/tmux-keys.test.ts (9 tests) 85ms
+ ✓ src/__tests__/remote-routing.test.ts (4 tests) 16ms
+ ✓ src/__tests__/schedule-runner-heartbeat-prefix.test.ts (4 tests) 37ms
+ ✓ src/__tests__/mcp-list-no-boot-warmup.test.ts (2 tests) 41ms
+ ✓ src/__tests__/memory-boundary.test.ts (5 tests) 226ms
+ ✓ src/__tests__/conversation-ledger-schema.test.ts (5 tests) 57ms
+ ✓ src/__tests__/auto-update-seed-task.test.ts (6 tests) 22ms
+ ✓ src/__tests__/router-abandon.test.ts (4 tests) 12ms
+ ✓ src/__tests__/agent-scaffold-formatting-rules.test.ts (9 tests) 26ms
+ ✓ src/__tests__/janitor-parked-input.test.ts (3 tests) 13ms
+ ✓ src/__tests__/security-profile-resolution.test.ts (4 tests) 19ms
+ ✓ src/__tests__/liveness-probe-retry.test.ts (5 tests) 21ms
+ ✓ src/__tests__/remote-status-cache.test.ts (5 tests) 15ms
+ ✓ src/__tests__/heartbeat-card-labels.test.ts (5 tests) 17ms
+ ✓ src/__tests__/voice-inbound-audio.test.ts (6 tests) 12ms
+ ✓ src/__tests__/schedule-run-now.test.ts (4 tests) 12ms
+ ✓ src/__tests__/update-agent-capability.test.ts (8 tests) 16ms
+ ✓ src/__tests__/team-cycle.test.ts (6 tests) 13ms
+ ✓ src/__tests__/validate-discord-channel-id.test.ts (12 tests) 17ms
+ ✓ src/__tests__/router-inject-retry.test.ts (3 tests) 16ms
+ ✓ src/__tests__/graph-mail.test.ts (6 tests) 22ms
+ ✓ src/__tests__/md-rendering-unify.test.ts (5 tests) 22ms
+ ✓ src/__tests__/kanban-dispatch-instructions.test.ts (3 tests) 12ms
+ ✓ src/__tests__/auto-restart-main-mechanism.test.ts (3 tests) 23ms
+ ✓ src/__tests__/claim-pending-for-agent.test.ts (2 tests) 55ms
+ ✓ src/__tests__/post-rollback-diagnose-seed.test.ts (3 tests) 12ms
+ ✓ src/__tests__/active-model.test.ts (5 tests) 14ms
+ ✓ src/__tests__/agent-restart-routing.test.ts (3 tests) 7ms
+ ✓ src/__tests__/config-change-log.test.ts (2 tests) 42ms
+ ✓ src/__tests__/agent-terminal-sanitize.test.ts (6 tests) 22ms
+ ✓ src/__tests__/agent-identity-setup.test.ts (2 tests) 10ms
+
+⎯⎯⎯⎯⎯⎯⎯ Failed Tests 3 ⎯⎯⎯⎯⎯⎯⎯
+
+ FAIL  src/__tests__/installer-start-and-fallback.test.ts > the ERR-trap abort is real (guards the premise of the tests above) > an unguarded capture aborts, and bash blames the enclosing `fi`
+AssertionError: expected 'TRAP:5' to be 'TRAP:6' // Object.is equality
+
+Expected: "TRAP:6"
+Received: "TRAP:5"
+
+ ❯ src/__tests__/installer-start-and-fallback.test.ts:118:19
+    116|   it('an unguarded capture aborts, and bash blames the enclosing `fi`'…
+    117|     const r = runScriptFile([...TRAP, 'if [ -n "x" ]; then', '  out="$…
+    118|     expect(r.out).toBe('TRAP:6')
+       |                   ^
+    119|     expect(r.out).not.toContain('REACHED')
+    120|     expect(r.code).toBe(9)
+
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/3]⎯
+
+ FAIL  src/__tests__/memory-performance.test.ts > backfillEmbeddings > returns 0 when all memories already have embeddings or Ollama is unreachable
+ FAIL  src/__tests__/memory-performance.test.ts > backfillEmbeddings > processes rows without embeddings and updates them when Ollama responds
+Error: Test timed out in 5000ms.
+If this is a long-running test, pass a timeout value as the last argument or configure it globally with "testTimeout".
+⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/3]⎯
+
+ Test Files  2 failed | 267 passed (269)
+      Tests  3 failed | 3624 passed | 1 skipped (3628)
+   Start at  23:52:49
+   Duration  121.40s (transform 9.49s, setup 3.49s, collect 86.47s, tests 106.66s, environment 143ms, prepare 54.71s)
+

--- a/src/__tests__/isolated-hook-merge.test.ts
+++ b/src/__tests__/isolated-hook-merge.test.ts
@@ -84,6 +84,35 @@ describe('isDurableIsolatedHook', () => {
     const wt = join(homedir(), 'marveen-review-copy', 'scripts', 'hooks', 'ledger-replay.py')
     expect(isDurableIsolatedHook({ type: 'command', command: `python3 ${wt}` })).toBe(false)
   })
+
+  // The blind spot found in review (2026-09-03): the common operator shape is a
+  // hook body that names its script through a variable. The tail of such a body
+  // looks like an absolute path but exists nowhere, so judging it literally
+  // dropped the entry -- the very disappearance this merge prevents.
+  it('keeps an entry whose script path comes from a variable', () => {
+    for (const cmd of [
+      'python3 "$CLAUDE_PROJECT_DIR/scripts/hooks/outgoing-copy-gate.py"',
+      'python3 "${CLAUDE_PROJECT_DIR}/scripts/hooks/outgoing-copy-gate.py"',
+      'bash $HOME/.claude/hooks/notify.sh',
+      'node "$(dirname "$0")/../hooks/gate.mjs"',
+    ]) {
+      expect(isDurableIsolatedHook({ type: 'command', command: cmd })).toBe(true)
+    }
+  })
+
+  // Skipping the unresolvable half must not soften the literal half: a body that
+  // ALSO pins an interpreter that no longer exists is still a zombie.
+  it('still drops a variable-pathed entry whose literal interpreter is gone', () => {
+    const cmd = 'test -x "/usr/lib/node-22.3.0/bin/node" || exit 2; node "$CLAUDE_PROJECT_DIR/scripts/hooks/gate.mjs"'
+    expect(isDurableIsolatedHook({ type: 'command', command: cmd })).toBe(false)
+  })
+
+  // A variable is not a way around the transient-root rule either, when the
+  // transient part is stated literally.
+  it('still drops a literal /tmp path that sits beside a variable one', () => {
+    const cmd = 'python3 "$CLAUDE_PROJECT_DIR/scripts/hooks/gate.py" --aux /tmp/staging/helper.py'
+    expect(isDurableIsolatedHook({ type: 'command', command: cmd })).toBe(false)
+  })
 })
 
 describe('mergeIsolatedHooks upgrade path', () => {

--- a/src/__tests__/isolated-hook-merge.test.ts
+++ b/src/__tests__/isolated-hook-merge.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { mergeIsolatedHooks, hookEntryId } from '../web/agent-process.js'
+
+describe('hookEntryId', () => {
+  it('identifies command and agent hooks, rejects the rest', () => {
+    expect(hookEntryId({ type: 'command', command: 'a.py' })).toBe('command a.py')
+    expect(hookEntryId({ type: 'agent', prompt: 'do x' })).toBe('agent do x')
+    expect(hookEntryId({ type: 'command', command: '   ' })).toBeNull()
+    expect(hookEntryId('nope')).toBeNull()
+  })
+})
+
+describe('mergeIsolatedHooks', () => {
+  const shared = { UserPromptSubmit: [{ hooks: [{ type: 'command', command: 'shared.py' }] }] }
+
+  it('returns shared untouched when the isolated file has no hooks', () => {
+    expect(mergeIsolatedHooks(shared, undefined).hooks).toBe(shared)
+  })
+
+  it('adds isolated-only entries and reports them', () => {
+    const own = { UserPromptSubmit: [{ hooks: [{ type: 'command', command: 'own.py' }] }] }
+    const r = mergeIsolatedHooks(shared, own)
+    const cmds = (r.hooks!.UserPromptSubmit as any[]).flatMap((g) => g.hooks).map((h) => h.command)
+    expect(cmds).toEqual(['shared.py', 'own.py'])
+    expect(r.kept).toEqual(['UserPromptSubmit:own.py'])
+  })
+
+  it('does not mutate the shared object', () => {
+    const own = { UserPromptSubmit: [{ hooks: [{ type: 'command', command: 'own.py' }] }] }
+    mergeIsolatedHooks(shared, own)
+    expect(shared.UserPromptSubmit[0].hooks).toHaveLength(1)
+  })
+
+  it('keeps a matcher group separate from a differently-matched one', () => {
+    const s = { SessionStart: [{ matcher: 'startup', hooks: [{ type: 'command', command: 's.py' }] }] }
+    const own = { SessionStart: [{ matcher: 'clear', hooks: [{ type: 'command', command: 'c.py' }] }] }
+    const groups = mergeIsolatedHooks(s, own).hooks!.SessionStart as any[]
+    expect(groups).toHaveLength(2)
+    expect(groups[1].matcher).toBe('clear')
+  })
+})

--- a/src/__tests__/isolated-hook-merge.test.ts
+++ b/src/__tests__/isolated-hook-merge.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest'
-import { mergeIsolatedHooks, hookEntryId } from '../web/agent-process.js'
+import { mergeIsolatedHooks, hookEntryId, isDurableIsolatedHook } from '../web/agent-process.js'
+import { join, dirname } from 'node:path'
+import { homedir } from 'node:os'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+const REAL_HOOK = join(ROOT, 'scripts', 'hooks', 'ledger-replay.py')
+const REAL_HOOK_2 = join(ROOT, 'scripts', 'hooks', 'inbox-drain.py')
 
 describe('hookEntryId', () => {
   it('identifies command and agent hooks, rejects the rest', () => {
@@ -37,5 +44,84 @@ describe('mergeIsolatedHooks', () => {
     const groups = mergeIsolatedHooks(s, own).hooks!.SessionStart as any[]
     expect(groups).toHaveLength(2)
     expect(groups[1].matcher).toBe('clear')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The upgrade path: an entry retained in an isolated config is no longer
+// rewritten by the path that heals it, so a stale one must not survive the
+// merge at all. Two failure modes, both permanent once they land.
+// ---------------------------------------------------------------------------
+describe('isDurableIsolatedHook', () => {
+  it('keeps an entry whose paths all exist inside the install', () => {
+    expect(isDurableIsolatedHook({ type: 'command', command: `python3 ${REAL_HOOK}` })).toBe(true)
+  })
+
+  it('keeps a path-free entry (nothing to go stale)', () => {
+    expect(isDurableIsolatedHook({ type: 'command', command: 'echo hi' })).toBe(true)
+  })
+
+  // The zombie: a version-pinned interpreter that stopped resolving after an
+  // upgrade. The hook fails CLOSED, so retaining it blocks every call.
+  it('drops an entry whose pinned interpreter no longer exists', () => {
+    const cmd = `test -x "/usr/lib/node-22.3.0/bin/node" || exit 2; node ${REAL_HOOK}`
+    expect(isDurableIsolatedHook({ type: 'command', command: cmd })).toBe(false)
+  })
+
+  it('drops an entry whose own script no longer exists', () => {
+    expect(isDurableIsolatedHook({
+      type: 'command',
+      command: `python3 ${join(ROOT, 'scripts', 'hooks', 'removed-by-an-upgrade.py')}`,
+    })).toBe(false)
+  })
+
+  it('drops a /tmp-rooted entry', () => {
+    expect(isDurableIsolatedHook({ type: 'command', command: 'python3 /tmp/staging/hook.py' })).toBe(false)
+  })
+
+  // A worktree lives under $HOME, so "somewhere in home" would not catch it.
+  it('drops a script in a git worktree outside the install', () => {
+    const wt = join(homedir(), 'marveen-review-copy', 'scripts', 'hooks', 'ledger-replay.py')
+    expect(isDurableIsolatedHook({ type: 'command', command: `python3 ${wt}` })).toBe(false)
+  })
+})
+
+describe('mergeIsolatedHooks upgrade path', () => {
+  it('does not carry a stale isolated entry into the merged config', () => {
+    const shared = { PreToolUse: [{ hooks: [{ type: 'command', command: `python3 ${REAL_HOOK}` }] }] }
+    const own = {
+      PreToolUse: [{
+        hooks: [{
+          type: 'command',
+          command: `test -x "/usr/lib/node-22.3.0/bin/node" || exit 2; node ${REAL_HOOK_2}`,
+        }],
+      }],
+    }
+    const r = mergeIsolatedHooks(shared, own)
+    const cmds = (r.hooks!.PreToolUse as any[]).flatMap((g) => g.hooks).map((h) => h.command)
+    expect(cmds).toEqual([`python3 ${REAL_HOOK}`])
+    expect(r.kept).toEqual([])
+  })
+
+  // Supersede by basename: the shared side owns the current variant of a hook,
+  // so an older isolated variant of the SAME script does not survive next to it
+  // even though both paths resolve.
+  it('lets a newer shared entry supersede an older isolated variant', () => {
+    const shared = { PreToolUse: [{ hooks: [{ type: 'command', command: `python3 ${REAL_HOOK}` }] }] }
+    const own = {
+      PreToolUse: [{ hooks: [{ type: 'command', command: `python3.11 ${REAL_HOOK} --legacy` }] }],
+    }
+    const r = mergeIsolatedHooks(shared, own)
+    const cmds = (r.hooks!.PreToolUse as any[]).flatMap((g) => g.hooks).map((h) => h.command)
+    expect(cmds).toEqual([`python3 ${REAL_HOOK}`])
+    expect(r.kept).toEqual([])
+  })
+
+  it('still keeps a durable isolated-only hook the shared file never mentions', () => {
+    const shared = { PreToolUse: [{ hooks: [{ type: 'command', command: `python3 ${REAL_HOOK}` }] }] }
+    const own = { PreToolUse: [{ hooks: [{ type: 'command', command: `python3 ${REAL_HOOK_2}` }] }] }
+    const r = mergeIsolatedHooks(shared, own).hooks!.PreToolUse as any[]
+    const cmds = r.flatMap((g) => g.hooks).map((h) => h.command)
+    expect(cmds).toEqual([`python3 ${REAL_HOOK}`, `python3 ${REAL_HOOK_2}`])
   })
 })

--- a/src/__tests__/main-agent-isolated-config.test.ts
+++ b/src/__tests__/main-agent-isolated-config.test.ts
@@ -105,6 +105,50 @@ describe('ensureMainAgentIsolatedConfigDir', () => {
     expect(after.model).toBe('agent-only-model')
   })
 
+  // `hooks` defeats the key rescue above: the shared file almost always defines
+  // it, so the KEY exists and the whole object used to be copied over -- taking
+  // every isolated-only hook with it, on every start. Measured 2026-08-14: the
+  // memory-recall hook was registered into .channels-config/settings.json and
+  // was gone by the next restart, silently, for 26 hours.
+  it('keeps an isolated-only hook entry even though shared defines hooks', () => {
+    writeFileSync(join(HOME, '.claude', 'settings.json'), JSON.stringify({
+      hooks: { UserPromptSubmit: [{ hooks: [{ type: 'command', command: 'shared.py' }] }] },
+    }))
+    const dir = ensureMainAgentIsolatedConfigDir(undefined, 'linux')!
+    const own = join(dir, 'settings.json')
+    writeFileSync(own, JSON.stringify({
+      hooks: {
+        UserPromptSubmit: [{ hooks: [{ type: 'command', command: 'agent-only.py' }] }],
+        SessionStart: [{ matcher: 'clear', hooks: [{ type: 'command', command: 'digest.py' }] }],
+      },
+    }, null, 2) + '\n')
+
+    ensureMainAgentIsolatedConfigDir(undefined, 'linux')
+
+    const after = JSON.parse(readFileSync(own, 'utf-8')) as any
+    const ups = after.hooks.UserPromptSubmit.flatMap((g: any) => g.hooks).map((h: any) => h.command)
+    expect(ups).toContain('shared.py')      // shared still applies
+    expect(ups).toContain('agent-only.py')  // and the isolated-only one survives
+    // An event the shared file does not mention at all comes along too.
+    expect(after.hooks.SessionStart[0].hooks[0].command).toBe('digest.py')
+  })
+
+  it('does not duplicate a hook both files define', () => {
+    const entry = { type: 'command', command: 'both.py' }
+    writeFileSync(join(HOME, '.claude', 'settings.json'), JSON.stringify({
+      hooks: { UserPromptSubmit: [{ hooks: [entry] }] },
+    }))
+    const dir = ensureMainAgentIsolatedConfigDir(undefined, 'linux')!
+    const own = join(dir, 'settings.json')
+    writeFileSync(own, JSON.stringify({ hooks: { UserPromptSubmit: [{ hooks: [entry] }] } }, null, 2) + '\n')
+
+    ensureMainAgentIsolatedConfigDir(undefined, 'linux')
+
+    const after = JSON.parse(readFileSync(own, 'utf-8')) as any
+    const cmds = after.hooks.UserPromptSubmit.flatMap((g: any) => g.hooks).map((h: any) => h.command)
+    expect(cmds.filter((c: string) => c === 'both.py')).toHaveLength(1)
+  })
+
   it('lets the shared file win for every key it DOES define', () => {
     writeFileSync(join(HOME, '.claude', 'settings.json'), JSON.stringify({ model: 'shared-model' }))
     const dir = ensureMainAgentIsolatedConfigDir(undefined, 'linux')!

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -445,6 +445,105 @@ function reconcileMcpServers(
   return true
 }
 
+/**
+ * Identity of ONE hook entry: what it runs, not where it sits in the file.
+ * Command hooks are identified by their command line, `agent` hooks by their
+ * prompt. Anything without either is unidentifiable and never merged.
+ */
+export function hookEntryId(entry: unknown): string | null {
+  if (!isPlainObject(entry)) return null
+  const type = typeof entry.type === 'string' ? entry.type : ''
+  const body =
+    typeof entry.command === 'string' ? entry.command :
+    typeof entry.prompt === 'string' ? entry.prompt : ''
+  if (!body.trim()) return null
+  return `${type} ${body}`
+}
+
+/**
+ * Merge the isolated dir's OWN hooks into the shared ones, keeping entries that
+ * exist only in the isolated file.
+ *
+ * WHY (2026-08-14): the target-only-KEY rescue above cannot help `hooks`. The
+ * shared file almost always defines `hooks`, so the key exists and the whole
+ * object is copied over -- taking every isolated-only hook with it, on every
+ * main-agent start. A hook registered for the channel agent alone therefore
+ * survives exactly until the next restart, and the symptom is silence: the
+ * agent starts fine, the hook simply never runs again. Measured: the
+ * memory-recall hook was registered 2026-08-13 21:20 into
+ * .channels-config/settings.json and was gone by the next start; nobody
+ * noticed for 26 hours, and the operator had been told it was live.
+ *
+ * Semantics mirror the key merge: shared is the source of truth (its groups
+ * come first, unchanged), the isolated file may only ADD. An entry present in
+ * both is kept once, in its shared position.
+ *
+ * Deliberate trade-off, same as the key merge: this cannot tell "the operator
+ * removed it from shared" from "it was never there". An entry deleted from the
+ * shared file but still present in an isolated file keeps running for that
+ * agent until it is removed there too. Additive is the safe direction here --
+ * the failure it replaces is silent loss, and the kept entries are logged.
+ */
+export function mergeIsolatedHooks(
+  shared: unknown,
+  own: unknown,
+): { hooks: Record<string, unknown> | undefined; kept: string[] } {
+  const sharedObj = isPlainObject(shared) ? shared : undefined
+  const ownObj = isPlainObject(own) ? own : undefined
+  if (!ownObj) return { hooks: sharedObj, kept: [] }
+
+  // Shallow-clone every group (and its hooks array): the merge below appends to
+  // matching groups, and mutating the parsed SHARED object would leak this
+  // agent's own hooks into whatever else holds a reference to it.
+  const out: Record<string, unknown> = {}
+  for (const [event, groups] of Object.entries(sharedObj ?? {})) {
+    out[event] = Array.isArray(groups)
+      ? groups.map((g) => (isPlainObject(g) && Array.isArray(g.hooks)
+        ? { ...g, hooks: [...g.hooks] }
+        : g))
+      : groups
+  }
+
+  const kept: string[] = []
+  for (const [event, ownGroups] of Object.entries(ownObj)) {
+    if (!Array.isArray(ownGroups)) {
+      if (!(event in out)) { out[event] = ownGroups; kept.push(`${event}:<non-array>`) }
+      continue
+    }
+    const outGroups: unknown[] = Array.isArray(out[event]) ? [...(out[event] as unknown[])] : []
+    const seen = new Set<string>()
+    for (const group of outGroups) {
+      if (!isPlainObject(group) || !Array.isArray(group.hooks)) continue
+      for (const entry of group.hooks) {
+        const id = hookEntryId(entry)
+        if (id) seen.add(id)
+      }
+    }
+    for (const group of ownGroups) {
+      if (!isPlainObject(group) || !Array.isArray(group.hooks)) continue
+      const fresh = group.hooks.filter((entry) => {
+        const id = hookEntryId(entry)
+        return id !== null && !seen.has(id)
+      })
+      if (!fresh.length) continue
+      for (const entry of fresh) {
+        const id = hookEntryId(entry)!
+        seen.add(id)
+        kept.push(`${event}:${id.slice(id.indexOf(' ') + 1).slice(0, 80)}`)
+      }
+      // Land next to an identical matcher when there is one, so the merged file
+      // keeps the shape a human would have written by hand.
+      const twin = outGroups.find((g) =>
+        isPlainObject(g) && Array.isArray(g.hooks) && g.matcher === group.matcher) as
+        Record<string, unknown> | undefined
+      if (twin) twin.hooks = [...(twin.hooks as unknown[]), ...fresh]
+      else outGroups.push({ ...group, hooks: fresh })
+    }
+    out[event] = outGroups
+  }
+  return { hooks: out, kept }
+}
+
 function isPlainObject(v: unknown): v is Record<string, unknown> {
   return typeof v === 'object' && v !== null && !Array.isArray(v)
 }
@@ -533,6 +632,18 @@ function provisionIsolatedConfigDir(
             if (key !== 'enabledPlugins' && !(key in settings)) {
               settings[key] = value
               inherited.push(key)
+            }
+          }
+          // `hooks` needs more than the key rescue above: the shared file
+          // almost always defines it, so the key EXISTS and the whole object
+          // is copied over -- dropping every isolated-only hook on each start.
+          // Merge per hook entry instead. See mergeIsolatedHooks.
+          if ('hooks' in own) {
+            const merged = mergeIsolatedHooks(settings.hooks, own.hooks)
+            if (merged.hooks !== undefined) settings.hooks = merged.hooks
+            if (merged.kept.length) {
+              logger.info({ name, path: ownSettingsPath, hooks: merged.kept },
+                'isolated-config: kept target-only hook entries')
             }
           }
           // Additive merges must not be silent: the whole point of this block

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -469,6 +469,35 @@ const _ABS_PATH_RX = /\/(?:[\w.@+-]+\/)*[\w.@+-]+/g
 const _SCRIPT_RX = /\.(?:py|mjs|cjs|js|sh)$/
 
 /**
+ * Absolute paths a hook body states LITERALLY -- the only ones we may judge.
+ *
+ * A body written as `python3 "$CLAUDE_PROJECT_DIR/scripts/hooks/gate.py"` is the
+ * common shape for an operator-registered hook, and `_ABS_PATH_RX` sees the tail
+ * `/scripts/hooks/gate.py` in it: a path that exists nowhere on its own. Judged
+ * as a literal it fails both tests below, so the entry would be dropped in
+ * silence -- producing exactly the disappearance this merge exists to prevent.
+ *
+ * We do not resolve the variable either. `$CLAUDE_PROJECT_DIR` is per-agent and
+ * only bound when the hook runs, so substituting anything here would be a guess
+ * that reads as certainty. A path we cannot see is left alone, not condemned.
+ *
+ * Detection is positional: a real absolute path starts a token, so what precedes
+ * it is whitespace, a quote, `=`, `(` or the start of the body. A word character,
+ * `}` or `)` before the leading slash means the slash continues something else --
+ * `$HOME`, `${CLAUDE_PROJECT_DIR}`, `$(dirname "$0")` -- and that path is not
+ * literal.
+ */
+function literalAbsolutePaths(body: string): string[] {
+  const out: string[] = []
+  for (const m of body.matchAll(_ABS_PATH_RX)) {
+    const before = m.index > 0 ? body[m.index - 1] : ''
+    if (before && /[\w})]/.test(before)) continue
+    out.push(m[0])
+  }
+  return out
+}
+
+/**
  * Roots an isolated hook's SCRIPT may durably live under: the install itself,
  * and the operator's own `~/.claude`. A git worktree or a staging checkout sits
  * under `$HOME` too, so "somewhere in home" is not a usable test -- the path has
@@ -495,6 +524,11 @@ function durableScriptRoots(): string[] {
  *     is written into the durable config. So: a script path outside the durable
  *     roots does not come along either.
  *
+ * Both tests apply to the paths a body states LITERALLY. A body that reaches its
+ * script through `$CLAUDE_PROJECT_DIR` or `$HOME` cannot be judged without
+ * guessing at values that are only bound when the hook runs, and guessing here
+ * would drop a working operator hook in silence -- see `literalAbsolutePaths`.
+ *
  * Deliberately NOT reusing `isUnsafeHookCommand` from agent-scaffold: importing
  * it here would pull the scaffold's module graph (and `runAgent` with it) into
  * process startup. The rule is small enough to state twice.
@@ -507,7 +541,7 @@ export function isDurableIsolatedHook(entry: unknown): boolean {
     typeof entry.command === 'string' ? entry.command :
     typeof entry.prompt === 'string' ? entry.prompt : ''
   if (!body.trim()) return false
-  const paths = body.match(_ABS_PATH_RX) ?? []
+  const paths = literalAbsolutePaths(body)
   for (const p of paths) {
     if (_TRANSIENT_PREFIXES.some((prefix) => p.startsWith(prefix))) return false
     if (_SCRIPT_RX.test(p) && !durableScriptRoots().some((root) => p.startsWith(root + '/'))) {
@@ -524,6 +558,8 @@ function hookScriptBasename(entry: unknown): string | null {
   const body =
     typeof entry.command === 'string' ? entry.command :
     typeof entry.prompt === 'string' ? entry.prompt : ''
+  // Basename only, so a `$VAR`-prefixed path still identifies its script here --
+  // this is used to supersede older variants, not to judge durability.
   const script = (body.match(_ABS_PATH_RX) ?? []).find((p) => _SCRIPT_RX.test(p))
   return script ? script.slice(script.lastIndexOf('/') + 1) : null
 }

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -460,6 +460,74 @@ export function hookEntryId(entry: unknown): string | null {
   return `${type} ${body}`
 }
 
+// Volatile roots: a hook body pointing here is transient by construction.
+const _TRANSIENT_PREFIXES = ['/tmp/', '/var/tmp/', '/private/tmp/', '/dev/shm/']
+
+// Any absolute path in a hook body, script or interpreter alike.
+const _ABS_PATH_RX = /\/(?:[\w.@+-]+\/)*[\w.@+-]+/g
+// The subset that is a script we ship or an operator wrote.
+const _SCRIPT_RX = /\.(?:py|mjs|cjs|js|sh)$/
+
+/**
+ * Roots an isolated hook's SCRIPT may durably live under: the install itself,
+ * and the operator's own `~/.claude`. A git worktree or a staging checkout sits
+ * under `$HOME` too, so "somewhere in home" is not a usable test -- the path has
+ * to be inside the install that will still be there next month.
+ */
+function durableScriptRoots(): string[] {
+  return [PROJECT_ROOT, join(homedir(), '.claude')]
+}
+
+/**
+ * Should this entry from the ISOLATED file be carried into the merged config?
+ *
+ * Two failure modes, both measured, both permanent once they land:
+ *
+ *  1. **A zombie that fails closed.** A hook that pins an interpreter path and
+ *     ends in `test -x || exit 2` is safe only while something rewrites it. Once
+ *     an isolated copy is retained, that rewrite no longer reaches it, so a
+ *     routine interpreter upgrade leaves a hook whose path no longer resolves --
+ *     and it blocks every call rather than degrading. So: if any absolute path
+ *     in the body does not exist right now, the entry does not come along.
+ *
+ *  2. **A transient path made permanent.** Anything picked up from `/tmp`, a git
+ *     worktree or a staging checkout outlives the directory it came from once it
+ *     is written into the durable config. So: a script path outside the durable
+ *     roots does not come along either.
+ *
+ * Deliberately NOT reusing `isUnsafeHookCommand` from agent-scaffold: importing
+ * it here would pull the scaffold's module graph (and `runAgent` with it) into
+ * process startup. The rule is small enough to state twice.
+ *
+ * Exported for unit tests.
+ */
+export function isDurableIsolatedHook(entry: unknown): boolean {
+  if (!isPlainObject(entry)) return false
+  const body =
+    typeof entry.command === 'string' ? entry.command :
+    typeof entry.prompt === 'string' ? entry.prompt : ''
+  if (!body.trim()) return false
+  const paths = body.match(_ABS_PATH_RX) ?? []
+  for (const p of paths) {
+    if (_TRANSIENT_PREFIXES.some((prefix) => p.startsWith(prefix))) return false
+    if (_SCRIPT_RX.test(p) && !durableScriptRoots().some((root) => p.startsWith(root + '/'))) {
+      return false
+    }
+    if (!existsSync(p)) return false
+  }
+  return true
+}
+
+/** Basename of the script a hook body runs, used to supersede older variants. */
+function hookScriptBasename(entry: unknown): string | null {
+  if (!isPlainObject(entry)) return null
+  const body =
+    typeof entry.command === 'string' ? entry.command :
+    typeof entry.prompt === 'string' ? entry.prompt : ''
+  const script = (body.match(_ABS_PATH_RX) ?? []).find((p) => _SCRIPT_RX.test(p))
+  return script ? script.slice(script.lastIndexOf('/') + 1) : null
+}
+
 /**
  * Merge the isolated dir's OWN hooks into the shared ones, keeping entries that
  * exist only in the isolated file.
@@ -512,18 +580,27 @@ export function mergeIsolatedHooks(
     }
     const outGroups: unknown[] = Array.isArray(out[event]) ? [...(out[event] as unknown[])] : []
     const seen = new Set<string>()
+    // Script basenames the SHARED side already provides for this event. A newer
+    // shared entry supersedes an older isolated variant of the same hook, so a
+    // stale pinned path cannot survive alongside the fresh one.
+    const sharedScripts = new Set<string>()
     for (const group of outGroups) {
       if (!isPlainObject(group) || !Array.isArray(group.hooks)) continue
       for (const entry of group.hooks) {
         const id = hookEntryId(entry)
         if (id) seen.add(id)
+        const base = hookScriptBasename(entry)
+        if (base) sharedScripts.add(base)
       }
     }
     for (const group of ownGroups) {
       if (!isPlainObject(group) || !Array.isArray(group.hooks)) continue
       const fresh = group.hooks.filter((entry) => {
         const id = hookEntryId(entry)
-        return id !== null && !seen.has(id)
+        if (id === null || seen.has(id)) return false
+        const base = hookScriptBasename(entry)
+        if (base && sharedScripts.has(base)) return false
+        return isDurableIsolatedHook(entry)
       })
       if (!fresh.length) continue
       for (const entry of fresh) {


### PR DESCRIPTION
## What

The target-only-**key** rescue from #861 cannot protect `hooks`. The shared `~/.claude/settings.json` almost always defines that key, so the shared object wins wholesale and every hook that exists **only** in the isolated `settings.json` is dropped -- on every main-agent start, silently. The agent boots fine; the hook simply never runs again.

Measured 2026-08-14 on a live install: a `UserPromptSubmit` hook was registered into `.channels-config/settings.json` at 21:20 and was gone by the next start. Nobody noticed for 26 hours -- during which the operator had been told the feature was live, and a week-long measurement was believed to be running.

Same failure shape as the `statusLine` losses (07-28, 07-30, 08-03) that motivated #861; hooks just fall outside the key-level fix.

## How

Merge per hook **entry**, identified by what it runs (command line, or `prompt` for `agent` hooks):

- shared groups stay first and unchanged -- shared remains the source of truth, matching key-merge semantics
- an entry present in both appears once, in its shared position
- an isolated-only entry is appended to the group with the same `matcher`, or as a new group when there is none
- an event the shared file never mentions comes along whole
- kept entries are logged by command, never silently

## Trade-off (stated, not hidden)

This cannot distinguish "removed from shared" from "never in shared", so an entry deleted upstream keeps running for that agent until it is also removed from the isolated file. Additive is the safe direction here: the failure it replaces is silent loss.

## Verification

- 32 tests pass: 5 new unit tests (`mergeIsolatedHooks`, `hookEntryId`), 2 new provisioning tests, plus the existing `main-agent-isolated-config` / `isolated-channel-config` suites
- `tsc --noEmit` clean
- Live check on the affected install: a hook written only into `.channels-config/settings.json` survived a real provisioning run, and the new log line named it

🤖 Generated with [Claude Code](https://claude.com/claude-code)