### PR TITLE
fix(stuck-tool-call-watcher): an arriving message must not open the gate on stale evidence

### DIFF
--- a/src/__tests__/stuck-tool-call.test.ts
+++ b/src/__tests__/stuck-tool-call.test.ts
@@ -360,6 +360,35 @@ describe('stuck-tool-call-watcher wiring contract', () => {
     expect(watcherSrc).toMatch(/confirmsWedgeProfile\(/)
   })
 
+  it('skips recovery while an inbound channel message is parked in the prompt (2026-08-15)', () => {
+    // Owner-observed false positive: the idle-prompt guard is the only thing
+    // holding back a residual footer, and it stops applying the moment an
+    // inbound message is injected (detectPaneState reads 'typing', not 'idle').
+    // Measured that day: counter frozen at 49s and correctly skipped as
+    // residual at 14:52/14:56/15:00; the owner's message landed 15:03:06; at
+    // 15:04:05 the guard no longer applied and the pane was respawned, taking
+    // the not-yet-processed message with it. A parked channel block belongs to
+    // stuck-input-watcher, so this watcher must stand down.
+    expect(watcherSrc).toMatch(/parkedChannelInput\(pane\)\s*!=\s*null/)
+    // Ordering matters: the parked-input guard must be evaluated BEFORE the
+    // CPU-profile guard, otherwise a freshly-arrived message (turn not started,
+    // CPU still low) walks straight through to the respawn.
+    // Anchor on the CALL SITE, not the exported definition (which sits near the
+    // top of the file and would make any ordering assertion vacuously false).
+    const cpuGuardCall = watcherSrc.indexOf('!confirmsWedgeProfile(cpuPercent, WEDGE_MAX_CPU_PERCENT)')
+    expect(cpuGuardCall, 'CPU guard call site not found').toBeGreaterThan(-1)
+    expect(watcherSrc.indexOf('parkedChannelInput(pane)')).toBeLessThan(cpuGuardCall)
+  })
+
+  it('the owner-facing alert does not present the frozen counter as a duration', () => {
+    // The number in the message is the FROZEN COUNTER value, not how long the
+    // session has been stuck; the acting threshold is freezeSeconds. The old
+    // wording ("49s óta nem haladt") made the owner read it as a 49-second hair
+    // trigger and ask about it (2026-08-15).
+    expect(watcherSrc).not.toMatch(/s óta nem haladt/)
+    expect(watcherSrc).toMatch(/THRESHOLDS\.freezeSeconds/)
+  })
+
   it('the watcher logs an audit line when it acts', () => {
     expect(watcherSrc).toMatch(/stuck-tool-call-watcher:/)
     expect(watcherSrc).toMatch(/logger\.warn/)

--- a/src/web/stuck-tool-call-watcher.ts
+++ b/src/web/stuck-tool-call-watcher.ts
@@ -47,6 +47,7 @@ import {
   stuckToolCallSignature,
   decideStuckToolCallRecovery,
   detectPaneState,
+  parkedChannelInput,
   type StuckToolCallState,
   type StuckToolCallThresholds,
 } from '../pane-state.js'
@@ -176,6 +177,28 @@ async function checkSession(label: string, session: string): Promise<void> {
       watchState.delete(session)
       return
     }
+    // Parked-channel-input guard (2026-08-15, owner-observed false positive).
+    // The idle-prompt guard above is the ONLY thing holding back a residual
+    // footer -- and it stops holding the instant an inbound channel message is
+    // injected into the prompt box, because detectPaneState then reads 'typing',
+    // not 'idle'. Measured sequence that day: the counter had been frozen at 49s
+    // since ~14:52 and was correctly skipped as residual at 14:52, 14:56 and
+    // 15:00; the owner's message landed at 15:03:06; at 15:04:05 the guard no
+    // longer applied, CPU was still low (the turn had not started yet), and this
+    // watcher respawned the pane -- taking the not-yet-processed message with it.
+    // So the ARRIVAL of a message opened the gate on evidence that predated it.
+    // A parked channel block is not wedge evidence: it means the session is
+    // about to be driven, and that case belongs to stuck-input-watcher, which
+    // has its own escalation (Enter -> clear+re-inject -> respawn). Clear the
+    // stale spell so the residual cannot re-arm on the next poll.
+    if (pane != null && parkedChannelInput(pane) != null) {
+      logger.info(
+        { label, session, tag: next.tag, seconds: next.lastSeconds, spellPeakSeconds: next.spellPeakSeconds },
+        'stuck-tool-call-watcher: counter stagnant but an inbound channel message is parked in the prompt (stuck-input-watcher owns this) -- skipping recovery',
+      )
+      watchState.delete(session)
+      return
+    }
     // Post-respawn grace: defer if a respawn (this watcher, channel-monitor's
     // cascade, channel-watchdog.sh, or the #264 stuck-modal-guard on Linux)
     // happened within the grace window. Two reasons: (1) a freshly respawned
@@ -241,7 +264,12 @@ async function checkSession(label: string, session: string): Promise<void> {
     // FAILED recovery is exactly when the owner must know.
     sendAlert(
       ok
-        ? `🔧 A fő session beragadt (${Math.round(next.lastSeconds ?? 0)}s óta nem haladt), automatikusan újraindítottam a beszélgetés megtartásával. Ha volt megválaszolatlan üzeneted, mindjárt válaszolok rá.`
+        // A számot ne úgy írjuk ki, mintha időtartam lenne: a lastSeconds a
+        // KIJELZŐN BEFAGYOTT számláló értéke, a beavatkozás küszöbe viszont a
+        // stagnálás wall-clock hossza (freezeSeconds). A korábbi szöveg ("49s óta
+        // nem haladt") azt sugallta a tulajnak, hogy 49 másodperc után
+        // újraindítunk -- 2026-08-15-én pontosan ezt kérdezte vissza.
+        ? `🔧 A fő session beragadt: a kijelző számlálója ${Math.round(next.lastSeconds ?? 0)}s-nál megállt, és több mint ${THRESHOLDS.freezeSeconds}s-ig nem mozdult. Automatikusan újraindítottam a beszélgetés megtartásával. Ha volt megválaszolatlan üzeneted, mindjárt válaszolok rá.`
         : `🚨 A fő session beragadt, és az automatikus újraindítás NEM sikerült. Kézi beavatkozás kellhet: tmux attach -t ${session}, vagy scripts/stop.sh && scripts/start.sh a marveen mappából.`,
     )
   }


### PR DESCRIPTION
## What breaks

The idle-prompt guard is the only thing holding back a residual `<verb> for Ns` footer, and it stops applying the instant an inbound channel message is injected into the prompt box: `detectPaneState` then reads `typing`, not `idle`.

## Evidence (live install, 2026-08-15, owner-visible)

```
14:52:05  counter frozen at 49s -> skipped, "pane is at the idle prompt"
14:56:05  same -> skipped
15:00:05  same -> skipped
15:03:06  owner's Telegram message lands in the prompt box
15:04:05  recover: "stagnant past freeze threshold + idle wedge profile"
15:04:09  session respawned with --continue
```

The evidence that triggered the respawn predated the message by twelve minutes. The CPU-profile guard did not catch it either, because a freshly-arrived message is exactly the state where the turn has not started and CPU is still low. The respawn took the not-yet-processed message with it; only a separate ledger-drain safety net recovered it. The owner noticed and asked why a 49-second stall caused a restart.

## Fix

1. **Parked-input guard.** A parked channel block is not wedge evidence: it means the session is about to be driven, and that case already belongs to `stuck-input-watcher`, which has its own escalation (Enter -> clear+re-inject -> respawn). Skip recovery and clear the stale spell so the residual cannot re-arm on the next poll. Placed **before** the CPU-profile guard, for the reason above.

2. **Alert wording.** The owner-facing message rendered `lastSeconds` as a duration, which reads as a 49-second hair trigger. That number is the frozen counter value; the acting threshold is `freezeSeconds`. The message now states both.

## Verification

- `tsc --noEmit` clean
- `vitest run src/__tests__/stuck-tool-call.test.ts` -> 37/37 green
- Two new wiring-contract assertions: the guard exists and is ordered before the CPU guard, and the old duration wording is rejected. Anchored on the call site rather than the exported signature, since the latter also matches `confirmsWedgeProfile(cpuPercent` and would make the ordering assertion vacuous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)