### PR TITLE
fix(test): the smoke suite must not default to the live dashboard (SMOKELIVE815)

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,12 +1,30 @@
 import { defineConfig } from '@playwright/test'
 
+// SMOKELIVE815: the suite must never default to the owner's LIVE dashboard.
+// Most specs read and stub, but one typo'd stub, one new un-stubbed route or a
+// future writing test is enough for a default-of-live to mutate the running
+// system -- with the suite staying green. Running against a live instance is
+// still possible, but only as an explicit, deliberate choice.
+const baseURL = process.env.DASHBOARD_URL
+if (!baseURL) {
+  throw new Error(
+    [
+      'DASHBOARD_URL is not set -- the smoke suite refuses to guess a target.',
+      'Point it at a disposable test instance, e.g.:',
+      '  DASHBOARD_URL=http://localhost:3421 npm run smoke',
+      'To measure a LIVE dashboard intentionally, name it explicitly:',
+      '  DASHBOARD_URL=http://localhost:3420 npm run smoke',
+    ].join('\n'),
+  )
+}
+
 export default defineConfig({
   testDir: './tests/smoke',
   timeout: 30_000,
   retries: 0,
   reporter: 'list',
   use: {
-    baseURL: process.env.DASHBOARD_URL || 'http://localhost:3420',
+    baseURL,
     headless: true,
     screenshot: 'only-on-failure',
   },


### PR DESCRIPTION
**The fact (Geri's measurement, card SMOKELIVE815):** `playwright.config.ts` defaulted `baseURL` to `http://localhost:3420` -- whoever simply runs `npm run smoke` measures against the owner's LIVE dashboard. Most specs read and stub, but one typo'd stub, a new un-stubbed route or a future writing test is enough to mutate the running system while the suite stays green.

**Measurement first (per the card):** nothing launches the suite automatically -- no CI workflow references it, no cron/launchd entry, git hooks (post-commit, pre-push, pre-push.d) are clean, no npm pre/post lifecycle script, no scheduled task or skill instructs running it (the two SKILL.md grep hits are review-guidance prose). Positive control: the same grep instrument finds the known `"smoke": "playwright test"` script in package.json. So the suite is manual-only and flipping the default is sufficient.

**The fix:** `DASHBOARD_URL` is now REQUIRED. Without it the config throws with an actionable message (disposable-instance example + the explicit live invocation). Measuring live stays possible -- but as a deliberate, named choice, not the convenient path.

**Guard verified in both directions** (a green verify needs a red): no env -> config refuses, exit 1, nothing runs; `DASHBOARD_URL=http://localhost:3421` -> 11 tests listed in 3 files, the URL threads through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)