### PR TITLE
fix(update): a Node-pin macOS-en sosem oldódott fel, ezért rossz major-ral fordult a build

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -97,21 +97,43 @@ done
 # hardcoded nvm version disagreed with .nvmrc (22) and package.json engines
 # (<24); compiling for the wrong ABI crash-looped the service. Resolution:
 #   1) the node exe of the live dashboard process; 2) .nvmrc via nvm; 3) PATH node.
+# `ps -o comm=` is tried FIRST because it is the only method that needs no extra
+# binary and works on both platforms. lsof is NOT on the default PATH on macOS
+# (it lives in /usr/sbin, which login shells omit), so `command -v lsof` failed
+# there, /proc does not exist, and a Homebrew-node box with no ~/.nvm fell all
+# the way through to PATH node -- a different major than the service, which is
+# exactly the ABI mismatch this function exists to prevent.
 resolve_service_node_dir() {
   local pid exe
   pid="$(pgrep -f "$INSTALL_DIR/dist/index.js" 2>/dev/null | head -n1)"
   if [ -n "$pid" ]; then
-    if command -v lsof >/dev/null 2>&1; then
-      exe="$(lsof -p "$pid" -Fn 2>/dev/null | awk '/\/node$/{print substr($0,2); exit}')"
+    exe="$(ps -o comm= -p "$pid" 2>/dev/null | sed 's/^ *//;s/ *$//')"
+    case "$exe" in /*) ;; *) exe="" ;; esac
+    if [ -z "$exe" ]; then
+      for _lsof in lsof /usr/sbin/lsof /usr/bin/lsof; do
+        command -v "$_lsof" >/dev/null 2>&1 || continue
+        exe="$("$_lsof" -p "$pid" -Fn 2>/dev/null | awk '/\/node$/{print substr($0,2); exit}')"
+        [ -n "$exe" ] && break
+      done
     fi
     [ -z "$exe" ] && [ -r "/proc/$pid/exe" ] && exe="$(readlink -f "/proc/$pid/exe" 2>/dev/null)"
     if [ -n "$exe" ] && [ -x "$exe" ]; then dirname "$exe"; return 0; fi
   fi
-  if [ -f "$INSTALL_DIR/.nvmrc" ] && [ -s "$HOME/.nvm/nvm.sh" ]; then
-    local want cand
-    want="$(tr -d ' \n' < "$INSTALL_DIR/.nvmrc")"
+  local want=""
+  [ -f "$INSTALL_DIR/.nvmrc" ] && want="$(tr -d ' \n' < "$INSTALL_DIR/.nvmrc")"
+  if [ -n "$want" ] && [ -s "$HOME/.nvm/nvm.sh" ]; then
+    local cand
     cand="$(ls -d "$HOME"/.nvm/versions/node/v"$want"* 2>/dev/null | sort -V | tail -n1)"
     [ -n "$cand" ] && [ -x "$cand/bin/node" ] && { echo "$cand/bin"; return 0; }
+  fi
+  # Homebrew keg-only node@N. Without this, a Mac that installs node via brew
+  # (no ~/.nvm at all) has no way to reach the pinned major while the service
+  # is stopped -- the one moment an update most needs the pin.
+  if [ -n "$want" ]; then
+    local brew_dir
+    for brew_dir in /opt/homebrew/opt/node@"$want"/bin /usr/local/opt/node@"$want"/bin; do
+      [ -x "$brew_dir/node" ] && { echo "$brew_dir"; return 0; }
+    done
   fi
   return 1
 }


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

**HU.** Az `update.sh`-ban a `resolve_service_node_dir()` azt hivatott megtalálni, milyen Node-dal fut a dashboard, hogy a `better-sqlite3` a helyes ABI-ra forduljon. Egy Homebrew-Node-os macOS gépen **mind a három ága eltéved**, és a függvény `return 1`-gyel kiszáll:

1. `command -v lsof` nemleges. Az `lsof` **fel van telepítve**, `/usr/sbin/lsof` alatt, de a `/usr/sbin` nincs a login shell `PATH`-ján, így a keresés úgy látja, mintha nem is létezne, és az ág kimarad.
2. `/proc` nincs macOS-en, tehát a `readlink` tartalék nem tud lefutni.
3. `~/.nvm` nem létezik, ha a Node Homebrew-ból jött, tehát a `.nvmrc`-ág is kimarad.

Pin nélkül a build azzal a `node`-dal megy, ami épp elöl van a `PATH`-on. Ezen a gépen mérve: `PATH` node **v26.6.0**, miközben a szolgáltatás `/opt/homebrew/opt/node@22/bin/node`-on fut. A `better-sqlite3` így rossz `NODE_MODULE_VERSION`-re fordul, az `npm ci` menet közben elszáll, és a telepítés félig alkalmazott állapotban marad. Pontosan az az ABI-ütközés, aminek a megelőzésére a függvény készült. A hiba **néma**: a `Node pin:` sor egyszerűen nem íródik ki, semmi nem jelzi, hogy tartalék ágra estünk.

A javítás két része:

* **`ps -o comm= -p <pid>` lesz az elsődleges módszer.** Nem igényel külön binárist, macOS-en és Linuxon egyaránt megy, és közvetlenül az abszolút exe-útvonalat adja. Az `lsof` megmarad tartaléknak, de mostantól a `/usr/sbin` és `/usr/bin` alatt is próbáljuk, nem csak a `PATH`-on.
* **Homebrew keg-only tartalék** (`/opt/homebrew/opt/node@N/bin`, illetve az Intel-es `/usr/local` párja, `N` a `.nvmrc`-ből). Ez azt az esetet fedi le, amikor a szolgáltatás **áll**: pont akkor van a frissítésnek a legnagyobb szüksége a pinre, és pont akkor nem működhet a pid-alapú keresés.

Ahol a régi kód eddig is talált pint, ott nincs viselkedésváltozás: az `lsof`- és az `nvm`-ág tartalmilag változatlan, csak a `ps` mögé került sorrendben.

**EN.** `resolve_service_node_dir()` in `update.sh` finds the Node the running dashboard uses, so the `better-sqlite3` rebuild targets the right ABI. On a macOS box with Homebrew Node all three branches miss: `command -v lsof` reports absent because `lsof` lives in `/usr/sbin`, which is not on the login-shell `PATH`; `/proc` does not exist on macOS; and `~/.nvm` is absent when Node came from Homebrew. The function returns 1, no pin is exported, and the build runs against whatever `node` is first on `PATH` — a different major than the service, which is the exact ABI mismatch the function exists to prevent. The failure is silent. This PR makes `ps -o comm=` the primary method (no extra binary, works on both platforms), probes `lsof` at absolute paths as a fallback, and adds a Homebrew keg-only fallback for the case where the service is stopped.

### Mérés / Measurement

macOS 15 (arm64), Homebrew `node@22`, nincs `~/.nvm` / no `~/.nvm`:

| helyzet / case | pin |
|---|---|
| jelenlegi kód, szolgáltatás fut / current code, service running | *(nincs pin / no pin)* → build with `v26.6.0` |
| javított, szolgáltatás fut / patched, service running | `/opt/homebrew/opt/node@22/bin` (`v22.23.2`) |
| javított, szolgáltatás áll / patched, service stopped | `/opt/homebrew/opt/node@22/bin` (`v22.23.2`) |

A szolgáltatás tényleges Node-ja ugyanezen a gépen / the service's actual Node on the same box: `ps -o comm=` → `/opt/homebrew/opt/node@22/bin/node`.

## Kapcsolódó issue / Related issue

Nincs külön issue; a hiba egy valós, félbeszakadt frissítésből jött elő (1.29.0 → 1.32.1 egy macOS gépen). / No separate issue; found during a real, half-failed update (1.29.0 → 1.32.1 on a macOS box).

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [ ] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).

**Megjegyzés a két ponthoz / Notes on two boxes.**

*Teszt:* a `resolve_service_node_dir()` mindkét ágát a fenti táblázat szerint futtattam a valódi gépen, a dashboard és az ágensek a javítás alatt végig futottak. Amit **nem** futtattam: egy teljes `update.sh` menetet a javított szkripttel, mert a gép időközben már felfrissült (a félbemaradt telepítést kézzel állítottam helyre). A függvény kimenete viszont pontosan az a `NODE_PIN_DIR`, amit a szkript a `PATH` elejére tesz, tehát a javítás hatása ezen az egy értéken múlik. / The function was exercised on the real box both ways; a full `update.sh` run with the patched script was not performed, since the machine had already been updated and repaired by hand.

*`docs/`:* nem nyúltam hozzá, mert a PR nem változtat sem a telepítés menetén, sem az architektúrán. Ugyanazt csinálja, amit a jelenlegi kód szándéka szerint eddig is kellett volna. / Left untouched: this changes neither the install flow nor the architecture, it only makes the existing intent actually work.
