### PR TITLE
feat(hooks): missing name-rules file -- email fail-closed, telegram loud systemMessage (GATEPERSIST816/2)

### DIFF
--- a/scripts/hooks/outgoing-copy-gate.py
+++ b/scripts/hooks/outgoing-copy-gate.py
@@ -360,6 +360,15 @@ def telegram_gate(tool_input: dict) -> None:
               "az ellenorzes elott feloldja, azok nem szamitanak hibanak).\n"
         )
         sys.exit(2)
+    # GATEPERSIST816(2): a hianyzo nev-szabaly a telegram-agon fail-open marad,
+    # de a figyelmeztetes ODA megy, ahol a session tenyleg latja -- a hook
+    # stdout systemMessage mezoje a futo sessionben jelenik meg, nem egy
+    # logfajlban, amit senki nem olvas.
+    if BAD_NAME is None:
+        print(json.dumps({"systemMessage":
+            "outgoing-copy-gate: a NEV-SZABALY fajl hianyzik/ures "
+            f"({_LOCAL_RULES}) -- a nev-ellenorzes NEM fut a kimeno uzeneteken. "
+            "Potold a store/outgoing-copy-gate-rules.json-t."}))
     sys.exit(0)
 
 
@@ -453,6 +462,20 @@ def main():
             "Ez szandekosan fail-closed: egy vizsgalhatatlan kuldes pont a kaput utne ki.\n"
             "Tedd vizsgalhatova, aztan kuldd ujra -- ABSZOLUT utvonalu stdin-atiranyitas "
             "(< /teljes/ut/body.txt, shell-valtozo NELKUL), vagy --body-ban atadott szoveg.\n"
+        )
+        sys.exit(2)
+
+    # GATEPERSIST816(2): az EMAIL ut a hianyzo nev-szabalyra FAIL-CLOSED. A
+    # level halaszthato, es pont a vevo fele a legdragabb a rossz nev -- egy
+    # csendben lealit nev-ellenorzes mellett kuldeni rosszabb, mint megvarni a
+    # szabaly-fajl potlasat. (A telegram-ag fail-open marad systemMessage
+    # figyelmeztetessel: az a felugyeleti csatorna, ott a nemulas a dragabb.)
+    if BAD_NAME is None:
+        sys.stderr.write(
+            "KIMENO-SZOVEG KAPU: TILTVA -- a NEV-SZABALY fajl hianyzik/ures "
+            f"({_LOCAL_RULES}), igy a nev-ellenorzes nem tud lefutni.\n"
+            "Email fail-closed: potold a store/outgoing-copy-gate-rules.json-t "
+            "(bad_name_patterns + correction), aztan kuldd ujra.\n"
         )
         sys.exit(2)
 


### PR DESCRIPTION
Part (2) of GATEPERSIST816 (msg 12491): the #983 split reproduced on the NAME rule the exact invisibility the card was about -- a vanished rules file silently disabled the name check, traced only by a log line nobody reads.

**Itemized (one file):** `scripts/hooks/outgoing-copy-gate.py`
- EMAIL path: missing/empty `store/outgoing-copy-gate-rules.json` -> **FAIL-CLOSED** (exit 2, actionable message naming the file). A letter is deferrable; the customer-facing send is where a wrong name costs the most.
- TELEGRAM path: stays **fail-open** (the supervision channel must not go mute), but the warning moves to where the session actually sees it -- a hook `systemMessage` on stdout on every affected send, instead of a log file.

**Verified:** 4 new tests (email+missing -> exit 2; telegram+missing -> exit 0 WITH systemMessage; both paths clean with the live rules file present, no spurious systemMessage) + all 29 earlier gate cases green against this script version. The live host has the rules file, so the new branches are dormant there until needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)