### PR TITLE
feat(router): two-stage escalation for a parked MAIN box (MAINBOXPARK816)

### DIFF
--- a/src/__tests__/main-parked-escalation.test.ts
+++ b/src/__tests__/main-parked-escalation.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest'
+
+// MAINBOXPARK816: two-stage escalation for a REAL parked line on the MAIN box.
+// The absolute rule stays: the main box is NEVER auto-cleared. What changed:
+// the 2026-06-30 total mute aged out (its premise -- dim ghost noise -- is
+// handled by the dim-guard BEFORE this branch), so a persistent real parked
+// line now (1) becomes visible to the heartbeat round via getMainParkedState,
+// and (2) after double the first threshold notifies the OWNER once, with the
+// concrete manual fix. The alert deliberately does NOT travel the inter-agent
+// queue: a message queued to the main agent would strand behind the very text
+// it reports.
+
+const h = vi.hoisted(() => {
+  const SEP = '─'.repeat(80)
+  const FOOTER = '  ⏵⏵ bypass permissions on (shift+tab to cycle)'
+  const LINE = '❯ Igen, írd meg Baloghnak a választ'
+  const PARKED = ['', SEP, LINE, SEP, FOOTER].join('\n')
+  return { PARKED, calls: [] as string[][] }
+})
+
+vi.mock('node:child_process', async (orig) => ({
+  ...(await orig() as object),
+  execFileSync: vi.fn((_file: string, args?: string[]) => {
+    if (Array.isArray(args)) {
+      h.calls.push(args)
+      if (args.includes('capture-pane')) return h.PARKED
+    }
+    return ''
+  }),
+}))
+vi.mock('../notify.js', () => ({ notifyChannel: vi.fn(async () => {}), notifyTelegram: vi.fn(async () => {}) }))
+
+import {
+  clearStaleParkedInput,
+  decideMainParkedEscalation,
+  getMainParkedState,
+  MAIN_PARKED_HEARTBEAT_AFTER,
+  MAIN_PARKED_OWNER_AFTER,
+} from '../web/agent-process.js'
+import { notifyChannel } from '../notify.js'
+import { MAIN_CHANNELS_SESSION } from '../web/main-agent.js'
+
+let clock = 1_000_000
+const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => clock)
+const COOLDOWN = 31_000 // > UNWEDGE_COOLDOWN_MS so each call is a fresh round
+
+function clearKeystrokes(): string[][] {
+  return h.calls.filter(a => a.includes('send-keys') && (a.includes('C-u') || a.includes('C-k')))
+}
+
+beforeEach(() => {
+  h.calls.length = 0
+  vi.mocked(notifyChannel).mockClear()
+})
+afterAll(() => { nowSpy.mockRestore() })
+
+describe('decideMainParkedEscalation (pure)', () => {
+  it('below the heartbeat threshold: none', () => {
+    expect(decideMainParkedEscalation(MAIN_PARKED_HEARTBEAT_AFTER - 1, false)).toBe('none')
+  })
+  it('at the heartbeat threshold: heartbeat', () => {
+    expect(decideMainParkedEscalation(MAIN_PARKED_HEARTBEAT_AFTER, false)).toBe('heartbeat')
+  })
+  it('the owner threshold is DOUBLE the heartbeat one (the spec ladder)', () => {
+    expect(MAIN_PARKED_OWNER_AFTER).toBe(2 * MAIN_PARKED_HEARTBEAT_AFTER)
+  })
+  it('at the owner threshold, not yet notified: owner (one-shot latch)', () => {
+    expect(decideMainParkedEscalation(MAIN_PARKED_OWNER_AFTER, false)).toBe('owner')
+    expect(decideMainParkedEscalation(MAIN_PARKED_OWNER_AFTER, true)).toBe('heartbeat')
+    expect(decideMainParkedEscalation(MAIN_PARKED_OWNER_AFTER + 5, true)).toBe('heartbeat')
+  })
+})
+
+describe('main box escalation through clearStaleParkedInput (call-site behavior)', () => {
+  it('never clears, notifies the owner ONCE past the owner threshold, with the concrete fix', async () => {
+    for (let i = 0; i < MAIN_PARKED_OWNER_AFTER + 3; i++) {
+      await clearStaleParkedInput(MAIN_CHANNELS_SESSION)
+      clock += COOLDOWN
+    }
+    // The absolute rule: not a single clearing keystroke reached the main box.
+    expect(clearKeystrokes()).toHaveLength(0)
+    // Owner notified exactly once per episode, and the message is actionable:
+    // names the session and the exact keys (three-second manual fix).
+    expect(notifyChannel).toHaveBeenCalledTimes(1)
+    const msg = vi.mocked(notifyChannel).mock.calls[0]![0]
+    expect(msg).toContain(`tmux attach -t ${MAIN_CHANNELS_SESSION}`)
+    expect(msg).toContain('Ctrl-C')
+    expect(msg).toContain('Ctrl-U')
+  }, 60_000) // 15 sequential real 2s stable-confirm delays (same pattern as parked-input-escalation)
+
+  it('exposes the state to the heartbeat surface past the first threshold, and goes stale after the box clears', async () => {
+    for (let i = 0; i < MAIN_PARKED_HEARTBEAT_AFTER; i++) {
+      await clearStaleParkedInput(MAIN_CHANNELS_SESSION)
+      clock += COOLDOWN
+    }
+    const state = getMainParkedState(clock)
+    expect(state).not.toBeNull()
+    expect(state!.fails).toBeGreaterThanOrEqual(MAIN_PARKED_HEARTBEAT_AFTER)
+    expect(state!.preview.length).toBeGreaterThan(0)
+    // Once the router stops observing the episode (box cleared / text gone),
+    // the state must go stale on its own -- a live-looking alert about a
+    // resolved wedge would be the false-heartbeat class.
+    clock += 10 * COOLDOWN
+    expect(getMainParkedState(clock)).toBeNull()
+  }, 30_000) // 6 sequential real 2s stable-confirm delays
+})
+
+import { formatMainParkedSection } from '../heartbeat.js'
+
+describe('formatMainParkedSection (heartbeat stage-1 surface)', () => {
+  it('empty string when nothing to report -- the normal prompt stays byte-identical', () => {
+    expect(formatMainParkedSection(null)).toBe('')
+  })
+  it('names the duration and wraps the parked preview as untrusted', () => {
+    const s = formatMainParkedSection({ preview: 'valami parkolt sor', fails: 7, approxMinutes: 4 })
+    expect(s).toContain('FO-AGENS INPUT-BOX PARKOLT')
+    expect(s).toContain('~4 perce')
+    expect(s).toContain('valami parkolt sor')
+    expect(s).toContain('NEM szabad nyulni')
+  })
+})

--- a/src/heartbeat.ts
+++ b/src/heartbeat.ts
@@ -17,6 +17,7 @@ import { runAgent } from './agent.js'
 import { notifyTelegram } from './notify.js'
 import { logger } from './logger.js'
 import { wrapUntrusted, UNTRUSTED_PREAMBLE } from './prompt-safety.js'
+import { getMainParkedState } from './web/agent-process.js'
 import { CHANNEL_PLUGIN_IDS } from './web/plugin-ids.js'
 
 // Isolation cwd for the heartbeat sub-agent. Keep this OUT of PROJECT_ROOT
@@ -388,6 +389,23 @@ function shouldNotify(data: HeartbeatData): boolean {
 
 // --- Agent prompt ---
 
+// MAINBOXPARK816: pure formatter, exported for tests. The parked preview is
+// wrapped as untrusted (it is whatever text sits in the box). Empty string when
+// there is nothing to report, so the prompt stays byte-identical in the normal
+// case.
+export function formatMainParkedSection(
+  state: { preview: string; fails: number; approxMinutes: number } | null,
+): string {
+  if (!state) return ''
+  return (
+    `## ⚠️ FO-AGENS INPUT-BOX PARKOLT (~${state.approxMinutes} perce)\n` +
+    `A fo agens input-mezojeben parkolt sor all, a csatorna emiatt nem dolgoz fel bejovo uzenetet. ` +
+    `A boxhoz NEM szabad nyulni (guard vedi); a te dolgod: jelezd EXPLICIT a gazda fele az osszefoglalod ELEJEN, ` +
+    `es ha ${OWNER_NAME} mar kapott kulon riasztast (owner-fok), eleg roviden megerositeni. ` +
+    `Parkolt sor eleje (untrusted adat): ${wrapUntrusted('main-parked-input', state.preview)}\n\n`
+  )
+}
+
 function buildAgentPrompt(data: HeartbeatData): string {
   const timeStr = data.timestamp.toLocaleString('hu-HU', { timeZone: APP_TZ })
 
@@ -398,6 +416,12 @@ function buildAgentPrompt(data: HeartbeatData): string {
   prompt += `Az alabbi adatokat gyujtottem nativ modon (API/DB). Fogalmazz tomor, emberi osszefoglalot ${OWNER_NAME} szamara.\n`
   prompt += `FONTOS: Nezd meg az emaileket is MCP-n keresztul (search_emails, utolso 2 ora, olvasatlanok).\n`
   prompt += `Hasznald a HEARTBEAT.md formatumot.\n\n`
+
+  // MAINBOXPARK816 stage 1: a parked main-agent input box silences the channel
+  // unsupervised, and the alert cannot travel the inter-agent queue (it would
+  // strand behind the very text it reports) -- so the heartbeat round is the
+  // first escalation surface. Same-process read, no queue involved.
+  prompt += formatMainParkedSection(getMainParkedState())
 
   // Calendar -- event summaries and attendee names come from whoever sent the
   // invite, so every one is wrapped individually as untrusted data.

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -2118,6 +2118,43 @@ const UNWEDGE_COOLDOWN_MS = 30_000
 // so escalation is the only recovery; a sub-agent escalates only after the
 // auto-clear has genuinely failed several times.
 const SUBAGENT_PARKED_ESCALATE_AFTER = 6  // ~3min for a sub-agent whose auto-clear keeps failing
+// MAINBOXPARK816: two-stage escalation for the (never-cleared) main box. Each
+// fails increment costs one UNWEDGE_COOLDOWN_MS round, so 6 = ~3 min visible to
+// the heartbeat, 12 = ~6 min -> the owner's phone as the FINAL stage (double
+// the first threshold, per the spec).
+export const MAIN_PARKED_HEARTBEAT_AFTER = 6
+export const MAIN_PARKED_OWNER_AFTER = 12
+
+// Pure decision, exported for tests: which escalation stage applies. 'owner'
+// fires once per episode (ownerNotified latches via the record's escalated
+// flag); afterwards the state stays 'heartbeat'-visible until the box clears.
+export function decideMainParkedEscalation(
+  fails: number,
+  ownerNotified: boolean,
+): 'none' | 'heartbeat' | 'owner' {
+  if (fails >= MAIN_PARKED_OWNER_AFTER && !ownerNotified) return 'owner'
+  if (fails >= MAIN_PARKED_HEARTBEAT_AFTER) return 'heartbeat'
+  return 'none'
+}
+
+// MAINBOXPARK816 stage-1 surface: the heartbeat round (same process) reads this
+// and puts the fact into its prompt -- deliberately NOT the inter-agent queue,
+// because a message queued to the main agent would strand behind the very
+// parked text it reports. Returns null when there is no FRESH parked episode
+// (last attempt older than two cooldown windows = the box cleared or the
+// router stopped observing it).
+export function getMainParkedState(nowMs: number = Date.now()):
+  | { preview: string; fails: number; approxMinutes: number }
+  | null {
+  const rec = unwedgeAttempts.get('local:' + MAIN_CHANNELS_SESSION)
+  if (!rec || rec.fails < MAIN_PARKED_HEARTBEAT_AFTER) return null
+  if (nowMs - rec.last > 2 * UNWEDGE_COOLDOWN_MS + PARKED_STABLE_CONFIRM_MS) return null
+  return {
+    preview: rec.sig.slice(0, 80),
+    fails: rec.fails,
+    approxMinutes: Math.round((rec.fails * UNWEDGE_COOLDOWN_MS) / 60000),
+  }
+}
 // Per-session record of the last un-wedge attempt: when, on what text, how many
 // consecutive attempts failed to empty the box, and whether we already notified
 // the operator for this exact stuck text (one-shot; resets when sig/clears).
@@ -2163,19 +2200,43 @@ export async function clearStaleParkedInput(session: string, host: string | null
   if (b == null || detectPaneState(b) !== 'typing' || parkedInputText(captureParkedInputView(session, host) ?? b) !== parked) return false
 
   // The main agent's input box is NEVER auto-cleared (a parked line could be a
-  // real reply -- the 2026-06-30 "Balogh" near-miss). The operator escalation is
-  // MUTED (2026-06-30, Szabi): the main box's "parked" lines are overwhelmingly
-  // DIM ghost/placeholder frames (stale capture, not real input -- e.g. a persona
-  // fragment shown for 28 min while the agent was actively turning), so notifying
-  // on each is false-positive noise. The durable fix is the inbox pull-model (no
-  // send-keys delivery -> no parked fragments) + a dim-text guard in pane
-  // detection (a faint SGR line is a ghost, not a parked command). Until those
-  // land: stay silent. Still RECORD the attempt so the cooldown guard backs us off
-  // and we don't re-run the stable-confirm sleep on every router tick.
+  // real reply -- the 2026-06-30 "Balogh" near-miss). That stays absolute.
+  //
+  // MAINBOXPARK816 (2026-08-16): the total MUTE is gone, because its premise
+  // aged out. The 2026-06-30 mute existed for dim ghost-frame noise -- but the
+  // dim-guard above now strips ghosts BEFORE this branch, so a line that gets
+  // here is normal-intensity, 2s-stable, REAL text. And a parked main box is
+  // exactly the state that silences the channel UNSUPERVISED: every sub-agent
+  // gets an auto-heal for this, only the main agent got silence. Two-stage
+  // escalation, never a keystroke:
+  //   stage 1 (fails >= MAIN_PARKED_HEARTBEAT_AFTER, ~3 min): WARN log + the
+  //     state is exposed via getMainParkedState() so the heartbeat round's
+  //     prompt carries it (same process; NOT the inter-agent queue -- an alert
+  //     queued to the main agent would strand BEHIND the very text it reports).
+  //   stage 2 (fails >= MAIN_PARKED_OWNER_AFTER, ~6 min, one-shot/episode):
+  //     notifyChannel direct to the owner (pure HTTP, does not touch the box)
+  //     with the CONCRETE manual fix -- a message actionable in seconds, not
+  //     "something is wrong".
   if (session === MAIN_CHANNELS_SESSION) {
     const fails = (prev && prev.sig === parked ? prev.fails : 0) + 1
-    unwedgeAttempts.set(key, { last: nowMs, sig: parked, fails, escalated: true })
-    logger.debug({ session, parked: parked.slice(0, 60), fails }, 'message-router: main-agent parked input -- left untouched (escalation muted)')
+    let escalated = !!(prev && prev.sig === parked && prev.escalated)
+    const stage = decideMainParkedEscalation(fails, escalated)
+    if (stage === 'owner') {
+      const preview = parked.slice(0, 80).replace(/[<>&]/g, ' ')
+      notifyChannel(
+        `🚨 A fo agens (${session}) input-mezojeben ~${Math.round((fails * UNWEDGE_COOLDOWN_MS) / 60000)} perce all egy parkolt sor, ` +
+        `es emiatt a csatorna nem dolgoz fel bejovo uzenetet. KEZI FELOLDAS (par masodperc): ` +
+        `tmux attach -t ${session}, majd Ctrl-C es utana Ctrl-U (a sor torlese), vegul kilepes: Ctrl-B d. ` +
+        `A parkolt sor eleje: "${preview}"`,
+      ).catch(() => { /* notify is best-effort */ })
+      escalated = true
+      logger.warn({ session, parked: parked.slice(0, 60), fails }, 'message-router: main-agent parked input -- owner notified with manual fix (box untouched)')
+    } else if (stage === 'heartbeat') {
+      logger.warn({ session, parked: parked.slice(0, 60), fails }, 'message-router: main-agent parked input -- persisting; visible to the heartbeat round (box untouched)')
+    } else {
+      logger.debug({ session, parked: parked.slice(0, 60), fails }, 'message-router: main-agent parked input -- left untouched')
+    }
+    unwedgeAttempts.set(key, { last: nowMs, sig: parked, fails, escalated })
     return false
   }
 


### PR DESCRIPTION
Spec: msg 12504 (Marveen GO), built on fresh develop (post-#973).

**The asymmetry being closed:** every sub-agent has an auto-heal for parked input; the main agent had total silence -- while a parked main box is exactly the state that mutes the channel unsupervised. The 2026-06-30 mute premise (dim ghost noise) is obsolete: the dim-guard strips ghosts BEFORE this branch. Measured noise floor: the old escalating build fired twice across the entire retained log.

**Itemized, per file:**
- `src/web/agent-process.ts`: the main-box branch gets the two-stage ladder. NEVER clears (unchanged, test-pinned). Stage 1 (fails>=6, ~3 min): WARN + `getMainParkedState()` export. Stage 2 (fails>=12, double, one-shot/episode): `notifyChannel` direct to the owner with the CONCRETE fix (`tmux attach -t <session>`, Ctrl-C, Ctrl-U). Pure `decideMainParkedEscalation` exported for tests. State self-stales after two unobserved cooldown windows.
- `src/heartbeat.ts`: `formatMainParkedSection` + prompt wiring -- the heartbeat round reads the state IN-PROCESS. Deliberately NOT the inter-agent queue: an alert queued to the main agent would strand behind the very text it reports (this routing insight is the reason the card exists).
- `src/__tests__/main-parked-escalation.test.ts`: 8 tests -- pure ladder (incl. owner=2x heartbeat pin), call-site behavior in both directions (owner notified exactly once WITH the actionable text; zero clearing keystrokes across 15 rounds), state staleness, formatter (empty when nothing to report).

**Timing per the spec: merge AFTER the Tuesday promote.** tsc clean, suite 3623/0 (270 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)