### PR TITLE
fix(messages): a completion report that drops half the result must say so

### DIFF
--- a/src/__tests__/completion-report-truncation.test.ts
+++ b/src/__tests__/completion-report-truncation.test.ts
@@ -1,0 +1,58 @@
+// A completion report carries at most 500 characters of the close's `result`.
+// The cap is fine -- that field is a status summary, not a channel. What was
+// not fine is that it cut SILENTLY: the receiver got a sentence that stopped
+// mid-word and read as carelessness, and the sender learned nothing at all.
+//
+// Measured 2026-08-16: 24 completion reports in one evening, every one of them
+// exactly 535 characters in the database, and the instructions written into
+// them never arrived. An agent noticed the cut-off sentence; the sender spent
+// the evening suspecting the agents instead.
+import { describe, it, expect } from 'vitest'
+import { buildCompletionSummary } from '../web/routes/messages.js'
+
+const CAP = 500
+
+describe('buildCompletionSummary', () => {
+  it('passes a short result through untouched and reports no loss', () => {
+    const r = buildCompletionSummary('done, nothing to add')
+    expect(r.summary).toBe('done, nothing to add')
+    expect(r.dropped).toBe(0)
+  })
+
+  it('keeps the placeholder when there is no result', () => {
+    expect(buildCompletionSummary(undefined)).toEqual({ summary: '(nincs eredmény)', dropped: 0 })
+    expect(buildCompletionSummary('')).toEqual({ summary: '(nincs eredmény)', dropped: 0 })
+  })
+
+  it('does not touch a result sitting exactly on the cap', () => {
+    const exact = 'x'.repeat(CAP)
+    const r = buildCompletionSummary(exact)
+    expect(r.summary).toBe(exact)
+    expect(r.dropped).toBe(0)
+  })
+
+  // The regression this exists for: one character over the cap must already
+  // announce itself, not wait for a suspiciously round number.
+  it('announces the loss one character over the cap', () => {
+    const r = buildCompletionSummary('x'.repeat(CAP + 1))
+    expect(r.dropped).toBe(1)
+    expect(r.summary).toContain('levágva')
+  })
+
+  it('keeps the first CAP characters and states exactly how many were dropped', () => {
+    const body = 'A'.repeat(CAP) + 'B'.repeat(140)
+    const r = buildCompletionSummary(body)
+    expect(r.dropped).toBe(140)
+    expect(r.summary.startsWith('A'.repeat(CAP))).toBe(true)
+    expect(r.summary).not.toContain('B')
+    expect(r.summary).toContain('még 140 karakter')
+  })
+
+  // The marker has to be findable by a reader who does not know the cap, so it
+  // names the number rather than gesturing at "some text was removed".
+  it('names the cap in the marker so the reader can act on it', () => {
+    const r = buildCompletionSummary('y'.repeat(CAP + 50))
+    expect(r.summary).toContain(String(CAP))
+    expect(r.summary).toContain('külön üzenetbe')
+  })
+})

--- a/src/web/routes/messages.ts
+++ b/src/web/routes/messages.ts
@@ -19,6 +19,33 @@ import { parseQualifiedId, formatQualifiedId } from '../federation/address.js'
 import { getFederationConfig } from '../federation/config.js'
 import type { RouteContext } from './types.js'
 
+/** How much of a close's `result` rides along in the completion report. */
+const RESULT_SUMMARY_MAX = 500
+
+/**
+ * Build the completion-report body from a close's `result`, and say how much
+ * did not fit.
+ *
+ * The cap itself is fine -- this field is a status summary, not a channel.
+ * Truncating SILENTLY is not: the receiver gets a sentence that stops mid-word
+ * and reads as carelessness rather than as data loss, and the sender sees
+ * nothing at all. Measured 2026-08-16: 24 completion reports in one evening,
+ * every one of them cut at the same byte, and the instructions written into
+ * them never arrived. An agent noticed the cut-off sentence; the sender did
+ * not. So the cap stays, and the loss is stated at both ends -- in the report
+ * for the receiver, in the PUT response for the sender.
+ *
+ * Exported for unit tests.
+ */
+export function buildCompletionSummary(result?: string): { summary: string; dropped: number } {
+  if (!result) return { summary: '(nincs eredmény)', dropped: 0 }
+  if (result.length <= RESULT_SUMMARY_MAX) return { summary: result, dropped: 0 }
+  const dropped = result.length - RESULT_SUMMARY_MAX
+  const notice = `[...levágva: még ${dropped} karakter. A lezárás eredmény-mezője `
+    + `${RESULT_SUMMARY_MAX} karakternél vágódik. Érdemi utasítást ne ide írj, hanem külön üzenetbe.]`
+  return { summary: `${result.slice(0, RESULT_SUMMARY_MAX)}\n\n${notice}`, dropped }
+}
+
 export async function tryHandleMessages(ctx: RouteContext): Promise<boolean> {
   const { req, res, path, method, url } = ctx
 
@@ -197,15 +224,19 @@ export async function tryHandleMessages(ctx: RouteContext): Promise<boolean> {
       // ping-pong chains (the delegator might write back, which would trigger
       // markMessageDone on this notification; we skip creating ANOTHER notification
       // when the original content is already a completion report).
+      let dropped = 0
       if (done && done.from_agent !== done.to_agent && !done.content.startsWith(COMPLETION_REPORT_PREFIX)) {
-        const summary = result ? result.slice(0, 500) : '(nincs eredmény)'
+        const built = buildCompletionSummary(result)
+        dropped = built.dropped
         createAgentMessage(
           done.to_agent,
           done.from_agent,
-          `${COMPLETION_REPORT_PREFIX} msg_id:${id} status:${newStatus}\n\n${summary}`,
+          `${COMPLETION_REPORT_PREFIX} msg_id:${id} status:${newStatus}\n\n${built.summary}`,
         )
       }
-      json(res, { ok: true }); return true
+      // Tell the CALLER too. The receiver now sees the marker in the report, but
+      // the sender is the one who can still resend what was lost.
+      json(res, dropped > 0 ? { ok: true, resultTruncated: dropped } : { ok: true }); return true
     }
     json(res, { error: 'Message not found or invalid status' }, 404)
     return true


### PR DESCRIPTION
## What breaks

`PUT /api/messages/<id>` copies at most 500 characters of `result` into the completion report it sends back to the delegator. The cap is right: that field is a status summary, not a channel. Cutting **silently** is not.

The receiver gets a sentence that stops mid-word. That reads as carelessness, not as data loss. The sender is told nothing at all -- the response is `{ok: true}` whether everything arrived or half of it went in the bin.

## Evidence

Measured 2026-08-16 on one host: 24 completion reports sent in a single evening, and every one of them sits at exactly 535 characters in `agent_messages` (500 of `result` plus the `[Eredmény] msg_id:N status:done` prefix). Every instruction, correction and piece of reasoning written into those closes was gone.

One of them mattered: a measurement request cut off inside the enumeration, so the receiving agent could not have known what was being asked. When the answer did not come, the obvious suspicion was the agent. The agent was fine. It was this line.

What actually surfaced it: the agent on the other end mentioned that a message ended mid-word. Nothing in the system reported the loss, at either end.

## The fix

The cap stays. The loss is stated:

- **In the report**, for the receiver: a marker naming exactly how many characters were dropped, and where substantive text belongs instead.
- **In the PUT response**, for the sender: `resultTruncated: <n>`. The sender is the one who can still resend what was lost, so telling only the receiver would fix the smaller half.

Summary building moves into `buildCompletionSummary` so the boundary is unit-testable rather than inline.

## Tests

`src/__tests__/completion-report-truncation.test.ts`, 6 cases: short result untouched; missing result keeps the existing placeholder; **exactly** on the cap untouched; **one character over** already announces itself (a round-number-only guard would have missed the real incident by a hair); the kept prefix is the first 500 characters and the count is exact; the marker names the cap so a reader who does not know it can act.

## Verification

- `npm run build` clean
- `completion-report-truncation` + `message-router-tick-cap` + `queued-messages-not-idle` + `messages-view-display-name`: 16 pass
- Live check on a running dashboard: a 640-character result produced a 670-character report ending in `[...levágva: még 140 karakter...]`, and the PUT returned `resultTruncated: 140`

## Compatibility

`{ok: true}` is unchanged for the untruncated case; `resultTruncated` only appears when something was actually dropped, so existing callers see no difference until the day they lose data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)