### PR TITLE
fix(egress): a quarantine_domains grant must reach the rendered reader definition (EGRESSKEY816)

### DIFF
--- a/src/__tests__/quarantine-allowlist-render.test.ts
+++ b/src/__tests__/quarantine-allowlist-render.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { renderQuarantineReader, ownerAllowedDomains, isPublicFetchHost } from '../web/agent-scaffold.js'
+import { renderQuarantineReader, ownerAllowedDomains, quarantineReaderDomains, isPublicFetchHost } from '../web/agent-scaffold.js'
 
 // The quarantine reader may only fetch from an allowlist, and that list used to
 // exist TWICE: once in this template and once in store/egress-allowlist.json,
@@ -104,6 +104,54 @@ describe('ownerAllowedDomains', () => {
   it('a file without a domains key is not an error either', () => {
     writeFileSync(join(dir, 'egress-allowlist.json'), JSON.stringify({ note: 'empty for now' }))
     expect(ownerAllowedDomains(dir)).toEqual([])
+  })
+})
+
+// EGRESSKEY816: a domain granted at the quarantine_domains level is honored by
+// the egress-gate hook (its step 4 applies to the quarantine-reader agent type)
+// but used to be invisible to the rendered reader definition, whose prompt-level
+// list came from the `domains` key alone -- so the reader refused the host
+// before a fetch was ever attempted. The render input must be the union the
+// hook enforces.
+describe('quarantineReaderDomains', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'egress-q-'))
+
+  it('unions domains and quarantine_domains, domains first', () => {
+    writeFileSync(join(dir, 'egress-allowlist.json'),
+      JSON.stringify({ domains: ['a.com'], quarantine_domains: ['q.com'] }))
+    expect(quarantineReaderDomains(dir)).toEqual(['a.com', 'q.com'])
+  })
+
+  it('does not open quarantine_domains for the every-agent list', () => {
+    writeFileSync(join(dir, 'egress-allowlist.json'),
+      JSON.stringify({ domains: ['a.com'], quarantine_domains: ['q.com'] }))
+    expect(ownerAllowedDomains(dir)).toEqual(['a.com'])
+  })
+
+  it('dedupes a host present at both levels, case-insensitively', () => {
+    writeFileSync(join(dir, 'egress-allowlist.json'),
+      JSON.stringify({ domains: ['both.com'], quarantine_domains: ['BOTH.com', 'q.com'] }))
+    expect(quarantineReaderDomains(dir)).toEqual(['both.com', 'q.com'])
+  })
+
+  it('applies the same host vetting as the domains key', () => {
+    writeFileSync(join(dir, 'egress-allowlist.json'),
+      JSON.stringify({ domains: [], quarantine_domains: ['q.com', 'localhost', 'evil.internal', 42, ' spaced.com '] }))
+    expect(quarantineReaderDomains(dir)).toEqual(['q.com', 'spaced.com'])
+  })
+
+  it('a missing quarantine_domains key degrades to the domains list', () => {
+    writeFileSync(join(dir, 'egress-allowlist.json'), JSON.stringify({ domains: ['a.com'] }))
+    expect(quarantineReaderDomains(dir)).toEqual(['a.com'])
+  })
+
+  it('a quarantine_domains-level grant reaches the rendered reader definition', () => {
+    // The regression this whole card exists for: the render must carry the
+    // union, or the hook allows what the reader's own prompt still refuses.
+    writeFileSync(join(dir, 'egress-allowlist.json'),
+      JSON.stringify({ domains: [], quarantine_domains: ['elevenlabs.io'] }))
+    const out = renderQuarantineReader(TEMPLATE, quarantineReaderDomains(dir))
+    expect(out).toContain('- `elevenlabs.io`')
   })
 })
 

--- a/src/web/agent-scaffold.ts
+++ b/src/web/agent-scaffold.ts
@@ -537,6 +537,32 @@ export function ownerAllowedDomains(storeDir = STORE_DIR): string[] {
   }
 }
 
+// The reader's effective allowlist, matching the egress-gate hook's semantics:
+// `domains` opens a host for every agent type (the hook's step 3), while
+// `quarantine_domains` opens it for the quarantine-reader only (step 4). The
+// rendered definition must carry the union, or a host granted at the
+// quarantine_domains level is honored by the hook but the reader's own prompt
+// still refuses it before a fetch is ever attempted -- which is exactly what
+// stranded a research task on 2026-08-16 (EGRESSKEY816).
+export function quarantineReaderDomains(storeDir = STORE_DIR): string[] {
+  const base = ownerAllowedDomains(storeDir)
+  try {
+    const raw = JSON.parse(readFileSync(join(storeDir, 'egress-allowlist.json'), 'utf-8'))
+    const list = Array.isArray(raw?.quarantine_domains) ? raw.quarantine_domains : []
+    const seen = new Set(base.map((d) => d.toLowerCase()))
+    for (const d of list) {
+      if (typeof d !== 'string') continue
+      const host = d.trim()
+      if (!isPublicFetchHost(host) || seen.has(host.toLowerCase())) continue
+      seen.add(host.toLowerCase())
+      base.push(host)
+    }
+    return base
+  } catch {
+    return base
+  }
+}
+
 // Render the reader definition: the template's shipped feeds, plus the domains
 // the owner allowed on this install. Pure, so the tests drive the same string
 // the deploy writes.
@@ -638,7 +664,7 @@ export function ensureQuarantineReader(name: string): boolean {
   const destPath = join(destDir, 'quarantine-reader.md')
   let rendered: string
   try {
-    rendered = renderQuarantineReader(readFileSync(tplPath, 'utf-8'), ownerAllowedDomains())
+    rendered = renderQuarantineReader(readFileSync(tplPath, 'utf-8'), quarantineReaderDomains())
   } catch {
     return false
   }


### PR DESCRIPTION
## Mi ez

A `store/egress-allowlist.json` két kulcsát két külön réteg olvassa, és nem értettek egyet:

- Az egress-gate **hook** (`scripts/hooks/egress-gate.mjs:159`) a `quarantine_domains` kulcsot a quarantine-reader agent_type-ra érvényesíti (a `domains` minden agent-típusra megy).
- A quarantine-reader **definíció renderje** (`ensureQuarantineReader`) viszont az `ownerAllowedDomains()`-ból táplálkozott, ami KIZÁRÓLAG a `domains` kulcsot olvassa.

Következmény: egy `quarantine_domains` szinten adott grant-et a hook engedne, de a reader saját prompt-listája elutasítja, mielőtt a fetch egyáltalán megtörténne. Élesben mérve 2026-08-16-án: négy frissen engedélyezett kutatási domain, négy reader-agent, **nulla fetch-kísérlet** (0 tool-hívás mind).

## A fix

- Új `quarantineReaderDomains()`: a hook által kikényszerített unió (`domains` ∪ `quarantine_domains`), domains-elemek elöl, case-insensitive dedupe, ugyanaz az `isPublicFetchHost` vetting.
- A render ezt kapja; az `ownerAllowedDomains()` változatlan, tehát a minden-agens lista NEM bővül.

## Fájlok (tételesen)

- `src/web/agent-scaffold.ts`: az új függvény + a render hívóhely átkötése (1 sor).
- `src/__tests__/quarantine-allowlist-render.test.ts`: 6 új teszt, köztük az, ami a kártya lényegét fogja meg: egy csak-`quarantine_domains` grant megjelenik a renderelt definícióban; és a kontroll, hogy az `ownerAllowedDomains` NEM nyílik ki tőle.

## Mérések

- tsc: 0 hiba (worktree, lockfile-azonos node_modules, `./node_modules/.bin/tsc`).
- Suite: 3621/3621 zöld (`WEB_ONLY=true`, lokál runner; develop 3615 + 6 új).

Kártya: EGRESSKEY816. Nem sürgős, a keddi promote-sorba illeszthető a review után.

🤖 Generated with [Claude Code](https://claude.com/claude-code)