### PR TITLE
feat(context-guard): a stale handoff is not a handoff -- measure freshness at restart (GUARDSTALEHO817)

### DIFF
--- a/src/__tests__/context-guard.test.ts
+++ b/src/__tests__/context-guard.test.ts
@@ -255,7 +255,7 @@ describe('saturation net (samu 2026-07-18 stall)', () => {
       deadlineMs: NOW + 60_000,
       cooldownUntilMs: 0,
       saturatedStreak: 0,
-    handoffStaleMinutes: null,
+      handoffStaleMinutes: null,
     }
     const d = decideGuard(awaiting, inputs({ paneSaturated: true, paneIdle: false }), CFG)
     expect(d.action).toBe('restart')
@@ -275,7 +275,7 @@ describe('saturation net (samu 2026-07-18 stall)', () => {
       deadlineMs: 0,
       cooldownUntilMs: NOW + 60_000,
       saturatedStreak: 0,
-    handoffStaleMinutes: null,
+      handoffStaleMinutes: null,
     }
     const d = decideGuard(cooling, inputs({ paneSaturated: true }), netOnly)
     expect(d.action).toBe('none')
@@ -402,9 +402,18 @@ describe('stale handoff (GUARDSTALEHO817)', () => {
     expect(handoffStaleMinutes(inputs(staleWritten))).toBe(19)
     // within slack: the handoff-writing turn itself touches the transcript after the file write
     expect(handoffStaleMinutes(inputs({ handoffMtime: NOW - 2 * 60_000, idleMs: 30_000 }))).toBe(null)
-    // unmeasurable inputs -> no staleness claim
+    // no artifact -> nothing to judge
     expect(handoffStaleMinutes(inputs({ handoffMtime: null, idleMs: 60_000 }))).toBe(null)
-    expect(handoffStaleMinutes(inputs({ handoffMtime: NOW - 20 * 60_000, idleMs: null }))).toBe(null)
+    // artifact exists but the transcript clock is unreadable -> 'unknown',
+    // NOT null: a missing measurement must not impersonate a fresh one
+    expect(handoffStaleMinutes(inputs({ handoffMtime: NOW - 20 * 60_000, idleMs: null }))).toBe('unknown')
+  })
+
+  it("unmeasurable freshness restarts as 'handoff written' (no refresh demand without evidence) and carries 'unknown'", () => {
+    const d = decideGuard(awaiting, inputs({ handoffMtime: NOW - 20 * 60_000, idleMs: null, paneIdle: true }), CFG)
+    expect(d.action).toBe('restart')
+    expect(d.reason).toBe('handoff written')
+    expect(d.nextState.handoffStaleMinutes).toBe('unknown')
   })
 
   it('asks for a refresh instead of restarting when the written handoff is stale and there is budget', () => {
@@ -656,7 +665,7 @@ describe('decideGuard -- idle-flush tier', () => {
       deadlineMs: NOW + 60_000,
       cooldownUntilMs: 0,
       saturatedStreak: 0,
-    handoffStaleMinutes: null,
+      handoffStaleMinutes: null,
     }
     const d = decideGuard(awaiting, inputs({ handoffMtime: NOW, paneIdle: true }), IDLE_CFG)
     expect(d.action).toBe('restart')

--- a/src/__tests__/context-guard.test.ts
+++ b/src/__tests__/context-guard.test.ts
@@ -6,9 +6,11 @@ import {
   CALIBRATION_OVERSHOOT_TOLERANCE,
   decideGuard,
   DEFAULT_CONTEXT_GUARD,
+  handoffStaleMinutes,
   INITIAL_GUARD_STATE,
   READY_TIMEOUT_MS,
   SATURATION_CONFIRM_SWEEPS,
+  STALE_REFRESH_REASON_PREFIX,
   type ContextGuardConfig,
   type GuardInputs,
   type GuardState,
@@ -191,7 +193,7 @@ describe('decideGuard: idle', () => {
 
   it('resets to initial state when fully disarmed (guard + net off)', () => {
     const disarmed = { ...CFG, enabled: false, saturationRestart: false }
-    const stale: GuardState = { phase: 'await-handoff', handoffMtimeAtRequest: 1, deadlineMs: 2, cooldownUntilMs: 0, saturatedStreak: 0 }
+    const stale: GuardState = { phase: 'await-handoff', handoffMtimeAtRequest: 1, deadlineMs: 2, cooldownUntilMs: 0, saturatedStreak: 0, handoffStaleMinutes: null }
     const d = decideGuard(stale, inputs({ pct: 0.99, paneSaturated: true }), disarmed)
     expect(d.action).toBe('none')
     expect(d.nextState).toEqual(INITIAL_GUARD_STATE)
@@ -199,7 +201,7 @@ describe('decideGuard: idle', () => {
 
   it('stands down a stale await-handoff into cooldown when the guard is disabled mid-sequence', () => {
     const netOnly = { ...CFG, enabled: false }
-    const stale: GuardState = { phase: 'await-handoff', handoffMtimeAtRequest: 1, deadlineMs: 2, cooldownUntilMs: 0, saturatedStreak: 0 }
+    const stale: GuardState = { phase: 'await-handoff', handoffMtimeAtRequest: 1, deadlineMs: 2, cooldownUntilMs: 0, saturatedStreak: 0, handoffStaleMinutes: null }
     const d = decideGuard(stale, inputs({ pct: 0.99 }), netOnly)
     expect(d.action).toBe('none')
     expect(d.nextState.phase).toBe('cooldown')
@@ -253,6 +255,7 @@ describe('saturation net (samu 2026-07-18 stall)', () => {
       deadlineMs: NOW + 60_000,
       cooldownUntilMs: 0,
       saturatedStreak: 0,
+    handoffStaleMinutes: null,
     }
     const d = decideGuard(awaiting, inputs({ paneSaturated: true, paneIdle: false }), CFG)
     expect(d.action).toBe('restart')
@@ -272,6 +275,7 @@ describe('saturation net (samu 2026-07-18 stall)', () => {
       deadlineMs: 0,
       cooldownUntilMs: NOW + 60_000,
       saturatedStreak: 0,
+    handoffStaleMinutes: null,
     }
     const d = decideGuard(cooling, inputs({ paneSaturated: true }), netOnly)
     expect(d.action).toBe('none')
@@ -292,6 +296,7 @@ describe('decideGuard: await-handoff', () => {
     deadlineMs: NOW + 60_000,
     cooldownUntilMs: 0,
     saturatedStreak: 0,
+    handoffStaleMinutes: null,
   }
 
   it('restarts once the handoff is written and the pane is idle', () => {
@@ -369,6 +374,101 @@ describe('decideGuard: await-handoff', () => {
   })
 })
 
+// 2026-08-17 (GUARDSTALEHO817): the guard restarted samu with reason "handoff
+// written" while HANDOFF.md was 20 minutes old and covered NOTHING of the work
+// done since -- including a merge-gate verdict on a payment PR. The agent wrote
+// the handoff on request, then kept working while the guard waited for an idle
+// pane; "mtime advanced since the request" was satisfied by an artifact that no
+// longer described the session. Existence is not freshness: the handoff must be
+// compared against the agent's last transcript activity at RESTART time.
+describe('stale handoff (GUARDSTALEHO817)', () => {
+  const awaiting: GuardState = {
+    phase: 'await-handoff',
+    handoffMtimeAtRequest: NOW - 30 * 60_000,
+    deadlineMs: NOW + 5 * 60_000,
+    cooldownUntilMs: 0,
+    saturatedStreak: 0,
+    handoffStaleMinutes: null,
+  }
+  // Handoff written 20 minutes ago (after the request), last transcript
+  // activity 1 minute ago: 19 minutes of work the handoff does not cover.
+  const staleWritten = {
+    handoffMtime: NOW - 20 * 60_000,
+    idleMs: 60_000,
+    paneIdle: true,
+  }
+
+  it('handoffStaleMinutes: measures the uncovered gap, honours the slack, fails closed', () => {
+    expect(handoffStaleMinutes(inputs(staleWritten))).toBe(19)
+    // within slack: the handoff-writing turn itself touches the transcript after the file write
+    expect(handoffStaleMinutes(inputs({ handoffMtime: NOW - 2 * 60_000, idleMs: 30_000 }))).toBe(null)
+    // unmeasurable inputs -> no staleness claim
+    expect(handoffStaleMinutes(inputs({ handoffMtime: null, idleMs: 60_000 }))).toBe(null)
+    expect(handoffStaleMinutes(inputs({ handoffMtime: NOW - 20 * 60_000, idleMs: null }))).toBe(null)
+  })
+
+  it('asks for a refresh instead of restarting when the written handoff is stale and there is budget', () => {
+    const d = decideGuard(awaiting, inputs(staleWritten), CFG)
+    expect(d.action).toBe('request-handoff')
+    expect(d.reason).toContain(STALE_REFRESH_REASON_PREFIX)
+    expect(d.nextState.phase).toBe('await-handoff')
+    // the recorded mtime advances so the NEXT write counts as fresh...
+    expect(d.nextState.handoffMtimeAtRequest).toBe(staleWritten.handoffMtime)
+    // ...but the deadline does NOT move: an agent that keeps working through
+    // refresh requests still restarts on time.
+    expect(d.nextState.deadlineMs).toBe(awaiting.deadlineMs)
+  })
+
+  it('restarts normally once the refreshed handoff is fresh', () => {
+    const refreshed = decideGuard(awaiting, inputs(staleWritten), CFG).nextState
+    const d = decideGuard(refreshed, inputs({
+      handoffMtime: NOW - 60_000, idleMs: 30_000, paneIdle: true, nowMs: NOW + 60_000,
+    }), CFG)
+    expect(d.action).toBe('restart')
+    expect(d.reason).toBe('handoff written')
+    expect(d.nextState.handoffStaleMinutes).toBe(null)
+  })
+
+  it('past the deadline a stale handoff restarts anyway, with the staleness said out loud', () => {
+    const d = decideGuard(awaiting, inputs({ ...staleWritten, nowMs: NOW + 6 * 60_000 }), CFG)
+    expect(d.action).toBe('restart')
+    expect(d.reason).toContain('STALE')
+    expect(d.nextState.handoffStaleMinutes).toBe(25) // 6m later, gap grew with it
+  })
+
+  it('at hardPct a stale handoff restarts immediately (no refresh into a breaking session), staleness carried', () => {
+    const d = decideGuard(awaiting, inputs({ ...staleWritten, pct: 0.99 }), CFG)
+    expect(d.action).toBe('restart')
+    expect(d.reason).toContain('STALE')
+    expect(d.nextState.handoffStaleMinutes).toBe(19)
+  })
+
+  it('a fresh handoff restarts exactly as before (no refresh detour)', () => {
+    const d = decideGuard(awaiting, inputs({ handoffMtime: NOW - 60_000, idleMs: 30_000, paneIdle: true }), CFG)
+    expect(d.action).toBe('restart')
+    expect(d.reason).toBe('handoff written')
+  })
+
+  it('the timeout restart measures the OLD artifact too (it will be presented at resume)', () => {
+    // agent never wrote after the request; a pre-existing handoff is an hour behind
+    const state = { ...awaiting, handoffMtimeAtRequest: NOW - 60 * 60_000 }
+    const d = decideGuard(state, inputs({
+      nowMs: NOW + 6 * 60_000, handoffMtime: NOW - 60 * 60_000, idleMs: 60_000,
+    }), CFG)
+    expect(d.action).toBe('restart')
+    expect(d.reason).toContain('timeout')
+    expect(d.nextState.handoffStaleMinutes).toBe(65)
+  })
+
+  it('inject-resume clears the staleness for the next cycle', () => {
+    const restarted = decideGuard(awaiting, inputs({ ...staleWritten, nowMs: NOW + 6 * 60_000 }), CFG)
+    expect(restarted.nextState.handoffStaleMinutes).toBe(25)
+    const resumed = decideGuard(restarted.nextState, inputs({ nowMs: NOW + 7 * 60_000, sessionReady: true }), CFG)
+    expect(resumed.action).toBe('inject-resume')
+    expect(resumed.nextState.handoffStaleMinutes).toBe(null)
+  })
+})
+
 describe('decideGuard: await-ready', () => {
   const awaitingReady: GuardState = {
     phase: 'await-ready',
@@ -376,6 +476,7 @@ describe('decideGuard: await-ready', () => {
     deadlineMs: NOW + 60_000,
     cooldownUntilMs: 0,
     saturatedStreak: 0,
+    handoffStaleMinutes: null,
   }
 
   it('injects the resume prompt when the session is ready, then cools down', () => {
@@ -405,6 +506,7 @@ describe('decideGuard: cooldown', () => {
     deadlineMs: 0,
     cooldownUntilMs: NOW + 60_000,
     saturatedStreak: 0,
+    handoffStaleMinutes: null,
   }
 
   it('suppresses everything during cooldown, even a huge pct', () => {
@@ -554,6 +656,7 @@ describe('decideGuard -- idle-flush tier', () => {
       deadlineMs: NOW + 60_000,
       cooldownUntilMs: 0,
       saturatedStreak: 0,
+    handoffStaleMinutes: null,
     }
     const d = decideGuard(awaiting, inputs({ handoffMtime: NOW, paneIdle: true }), IDLE_CFG)
     expect(d.action).toBe('restart')

--- a/src/context-guard.ts
+++ b/src/context-guard.ts
@@ -248,7 +248,7 @@ export interface GuardState {
    *  fresh session pointed at a stale handoff re-opens already-decided
    *  questions (2026-08-17: a merge-gate verdict on a payment PR was missing
    *  from a 20-minute-old handoff presented as current). */
-  handoffStaleMinutes: number | null
+  handoffStaleMinutes: HandoffStaleness
 }
 
 export const INITIAL_GUARD_STATE: GuardState = {
@@ -325,18 +325,30 @@ export const STALE_REFRESH_REASON_PREFIX = 'stale-handoff-refresh'
  *  a zero-slack comparison would flag every handoff as stale. */
 export const STALE_HANDOFF_SLACK_MS = 3 * 60_000
 
+/** Freshness verdict for HANDOFF.md at decision time: minutes of uncovered
+ *  work, 'unknown', or null (= fresh enough / no artifact to judge). */
+export type HandoffStaleness = number | 'unknown' | null
+
 /**
- * How many minutes of work HANDOFF.md fails to cover, or null when it is
- * fresh enough / unmeasurable. "Existence is not freshness": the guard's
- * handoff precondition must compare the artifact against the agent's LAST
- * MEANINGFUL OUTPUT (transcript mtime = nowMs - idleMs), not merely observe
- * that the file appeared after the request -- an agent that writes the
- * handoff and then keeps working (messages keep arriving while the guard
+ * How many minutes of work HANDOFF.md fails to cover; null when it is fresh
+ * enough or there is no artifact to judge. "Existence is not freshness": the
+ * guard's handoff precondition must compare the artifact against the agent's
+ * LAST MEANINGFUL OUTPUT (transcript mtime = nowMs - idleMs), not merely
+ * observe that the file appeared after the request -- an agent that writes
+ * the handoff and then keeps working (messages keep arriving while the guard
  * waits for an idle pane) satisfies the mtime-advanced check with an
  * artifact that is minutes-to-hours behind.
+ *
+ * When the artifact exists but the transcript clock is unreadable the answer
+ * is 'unknown', NOT null: a missing measurement must not impersonate a
+ * fresh one (the same error class this function exists to fix). 'unknown'
+ * never triggers a refresh -- there is no evidence to demand one on -- but
+ * it rides to the resume prompt so the fresh session is told the freshness
+ * was unverifiable instead of nothing.
  */
-export function handoffStaleMinutes(inputs: GuardInputs): number | null {
-  if (inputs.handoffMtime === null || inputs.idleMs === null) return null
+export function handoffStaleMinutes(inputs: GuardInputs): HandoffStaleness {
+  if (inputs.handoffMtime === null) return null
+  if (inputs.idleMs === null) return 'unknown'
   const lastActivityMs = inputs.nowMs - inputs.idleMs
   const gapMs = lastActivityMs - inputs.handoffMtime
   return gapMs > STALE_HANDOFF_SLACK_MS ? Math.round(gapMs / 60_000) : null
@@ -372,7 +384,7 @@ function cooldown(nowMs: number, cfg: ContextGuardConfig, reason: string): Guard
 
 /** staleMinutes rides into await-ready so inject-resume can tell the fresh
  *  session its handoff does not cover the last N minutes. */
-function restartDecision(nowMs: number, reason: string, staleMinutes: number | null = null): GuardDecision {
+function restartDecision(nowMs: number, reason: string, staleMinutes: HandoffStaleness = null): GuardDecision {
   return {
     action: 'restart',
     reason,
@@ -470,7 +482,7 @@ export function decideGuard(
         // idle pane (2026-08-17: 20 minutes of work, including a merge-gate
         // verdict, happened after the write). Existence is not freshness.
         const staleMin = handoffStaleMinutes(inputs)
-        if (staleMin !== null && nowMs < state.deadlineMs && !(inputs.pct !== null && inputs.pct >= cfg.hardPct)) {
+        if (typeof staleMin === 'number' && nowMs < state.deadlineMs && !(inputs.pct !== null && inputs.pct >= cfg.hardPct)) {
           // There is still budget before the deadline and the context is not
           // yet at the hard threshold: ask for a refresh instead of shipping
           // a handoff that misses the last N minutes. Advancing the recorded
@@ -485,7 +497,7 @@ export function decideGuard(
         }
         return restartDecision(
           nowMs,
-          staleMin !== null ? `handoff written but STALE (~${staleMin}m of work after it)` : 'handoff written',
+          typeof staleMin === 'number' ? `handoff written but STALE (~${staleMin}m of work after it)` : 'handoff written',
           staleMin,
         )
       }

--- a/src/context-guard.ts
+++ b/src/context-guard.ts
@@ -242,6 +242,13 @@ export interface GuardState {
   cooldownUntilMs: number
   /** Consecutive idle-phase sweeps that saw a saturated pane (debounce). */
   saturatedStreak: number
+  /** Set at restart time when HANDOFF.md predates the agent's last transcript
+   *  activity by more than the slack: ~minutes of work the handoff does NOT
+   *  cover. Carried into await-ready so the resume prompt can say so -- a
+   *  fresh session pointed at a stale handoff re-opens already-decided
+   *  questions (2026-08-17: a merge-gate verdict on a payment PR was missing
+   *  from a 20-minute-old handoff presented as current). */
+  handoffStaleMinutes: number | null
 }
 
 export const INITIAL_GUARD_STATE: GuardState = {
@@ -250,6 +257,7 @@ export const INITIAL_GUARD_STATE: GuardState = {
   deadlineMs: 0,
   cooldownUntilMs: 0,
   saturatedStreak: 0,
+  handoffStaleMinutes: null,
 }
 
 /** Idle-phase sweeps that must agree the pane is saturated before the net
@@ -302,6 +310,38 @@ export interface GuardInputs {
  */
 export const IDLE_FLUSH_REASON_PREFIX = 'idle-flush'
 
+/**
+ * Reason prefix for a repeated handoff request sent because the one on disk
+ * went stale while the guard waited for an idle pane. The runner words this
+ * request differently again: the agent DID write a handoff, it just kept
+ * working afterwards, so "write a handoff" would read as a bug and "your
+ * context is critical" may be false.
+ */
+export const STALE_REFRESH_REASON_PREFIX = 'stale-handoff-refresh'
+
+/** Slack between HANDOFF.md's mtime and the last transcript activity before
+ *  the handoff counts as stale. The handoff-writing turn itself touches the
+ *  transcript slightly AFTER the file write (tool result + closing reply), so
+ *  a zero-slack comparison would flag every handoff as stale. */
+export const STALE_HANDOFF_SLACK_MS = 3 * 60_000
+
+/**
+ * How many minutes of work HANDOFF.md fails to cover, or null when it is
+ * fresh enough / unmeasurable. "Existence is not freshness": the guard's
+ * handoff precondition must compare the artifact against the agent's LAST
+ * MEANINGFUL OUTPUT (transcript mtime = nowMs - idleMs), not merely observe
+ * that the file appeared after the request -- an agent that writes the
+ * handoff and then keeps working (messages keep arriving while the guard
+ * waits for an idle pane) satisfies the mtime-advanced check with an
+ * artifact that is minutes-to-hours behind.
+ */
+export function handoffStaleMinutes(inputs: GuardInputs): number | null {
+  if (inputs.handoffMtime === null || inputs.idleMs === null) return null
+  const lastActivityMs = inputs.nowMs - inputs.idleMs
+  const gapMs = lastActivityMs - inputs.handoffMtime
+  return gapMs > STALE_HANDOFF_SLACK_MS ? Math.round(gapMs / 60_000) : null
+}
+
 export type GuardActionType = 'none' | 'request-handoff' | 'restart' | 'inject-resume'
 
 export interface GuardDecision {
@@ -325,11 +365,14 @@ function cooldown(nowMs: number, cfg: ContextGuardConfig, reason: string): Guard
       deadlineMs: 0,
       cooldownUntilMs: nowMs + cfg.cooldownMinutes * 60_000,
       saturatedStreak: 0,
+      handoffStaleMinutes: null,
     },
   }
 }
 
-function restartDecision(nowMs: number, reason: string): GuardDecision {
+/** staleMinutes rides into await-ready so inject-resume can tell the fresh
+ *  session its handoff does not cover the last N minutes. */
+function restartDecision(nowMs: number, reason: string, staleMinutes: number | null = null): GuardDecision {
   return {
     action: 'restart',
     reason,
@@ -339,6 +382,7 @@ function restartDecision(nowMs: number, reason: string): GuardDecision {
       deadlineMs: nowMs + READY_TIMEOUT_MS,
       cooldownUntilMs: 0,
       saturatedStreak: 0,
+      handoffStaleMinutes: staleMinutes,
     },
   }
 }
@@ -374,7 +418,11 @@ export function decideGuard(
       if (cfg.saturationRestart && inputs.paneSaturated) {
         const streak = state.saturatedStreak + 1
         if (streak >= SATURATION_CONFIRM_SWEEPS) {
-          return restartDecision(nowMs, `pane saturated (100% context) for ${streak} sweeps -- unrecoverable without restart`)
+          return restartDecision(
+            nowMs,
+            `pane saturated (100% context) for ${streak} sweeps -- unrecoverable without restart`,
+            handoffStaleMinutes(inputs),
+          )
         }
         return none('pane saturated, awaiting confirmation sweep', { ...state, saturatedStreak: streak })
       }
@@ -411,13 +459,35 @@ export function decideGuard(
         // The pane tipped over while we waited for the handoff: the agent can
         // no longer act on the request, so restart now (no debounce -- the
         // act-threshold pct already corroborates a near-full context).
-        return restartDecision(nowMs, 'pane saturated during await-handoff')
+        return restartDecision(nowMs, 'pane saturated during await-handoff', handoffStaleMinutes(inputs))
       }
       const handoffWritten =
         inputs.handoffMtime !== null &&
         (state.handoffMtimeAtRequest === null || inputs.handoffMtime > state.handoffMtimeAtRequest)
       if (handoffWritten && inputs.paneIdle) {
-        return restartDecision(nowMs, 'handoff written')
+        // mtime-advanced is necessary but NOT sufficient: the agent may have
+        // written the handoff and then kept working while we waited for an
+        // idle pane (2026-08-17: 20 minutes of work, including a merge-gate
+        // verdict, happened after the write). Existence is not freshness.
+        const staleMin = handoffStaleMinutes(inputs)
+        if (staleMin !== null && nowMs < state.deadlineMs && !(inputs.pct !== null && inputs.pct >= cfg.hardPct)) {
+          // There is still budget before the deadline and the context is not
+          // yet at the hard threshold: ask for a refresh instead of shipping
+          // a handoff that misses the last N minutes. Advancing the recorded
+          // mtime makes the NEXT write count as fresh; the deadline is left
+          // alone, so an agent that keeps working through refresh requests
+          // still restarts on time (with the staleness said out loud).
+          return {
+            action: 'request-handoff',
+            reason: `${STALE_REFRESH_REASON_PREFIX}: handoff written but ~${staleMin}m of work happened after it -- requesting refresh`,
+            nextState: { ...state, handoffMtimeAtRequest: inputs.handoffMtime },
+          }
+        }
+        return restartDecision(
+          nowMs,
+          staleMin !== null ? `handoff written but STALE (~${staleMin}m of work after it)` : 'handoff written',
+          staleMin,
+        )
       }
       // Same mid-turn deferral as the idle-phase hard tier: neither the hard
       // threshold nor the handoff timeout may cut a live turn. The deadline
@@ -426,13 +496,15 @@ export function decideGuard(
       // mid-flight is caught by the paneSaturated branch above.
       if (inputs.pct !== null && inputs.pct >= cfg.hardPct) {
         if (inputs.paneBusy) return none('hard threshold during await-handoff but agent mid-turn -- deferring restart')
-        return restartDecision(nowMs, 'hard threshold during await-handoff')
+        return restartDecision(nowMs, 'hard threshold during await-handoff', handoffStaleMinutes(inputs))
       }
       if (nowMs >= state.deadlineMs) {
         if (inputs.paneBusy) return none('handoff timeout but agent mid-turn -- deferring restart')
         // No handoff in time (agent wedged or ignored the prompt). Restart
         // anyway: taskstate + kanban + hot memories are the fallback context.
-        return restartDecision(nowMs, 'handoff timeout -- force restart')
+        // An OLD HANDOFF.md may still exist; measure how far behind it is so
+        // the resume prompt does not present it as current.
+        return restartDecision(nowMs, 'handoff timeout -- force restart', handoffStaleMinutes(inputs))
       }
       return none(handoffWritten ? 'handoff written, waiting for idle pane' : 'waiting for handoff')
     }
@@ -448,6 +520,7 @@ export function decideGuard(
             deadlineMs: 0,
             cooldownUntilMs: nowMs + cfg.cooldownMinutes * 60_000,
             saturatedStreak: 0,
+            handoffStaleMinutes: null,
           },
         }
       }
@@ -482,7 +555,11 @@ function decideWedgeTiers(
     if (inputs.paneBusy) {
       return none(`hard threshold (${Math.round(pct * 100)}%) but agent mid-turn -- deferring restart`, cleared)
     }
-    return restartDecision(nowMs, `hard threshold (${Math.round(pct * 100)}% >= ${Math.round(cfg.hardPct * 100)}%)`)
+    return restartDecision(
+      nowMs,
+      `hard threshold (${Math.round(pct * 100)}% >= ${Math.round(cfg.hardPct * 100)}%)`,
+      handoffStaleMinutes(inputs),
+    )
   }
   if (pct >= cfg.actPct) {
     return handoffRequest(nowMs, inputs, cfg, `act threshold (${Math.round(pct * 100)}% >= ${Math.round(cfg.actPct * 100)}%)`)
@@ -567,6 +644,7 @@ function handoffRequest(
       deadlineMs: nowMs + cfg.handoffTimeoutMinutes * 60_000,
       cooldownUntilMs: 0,
       saturatedStreak: 0,
+      handoffStaleMinutes: null,
     },
   }
 }

--- a/src/web/context-guard-runner.ts
+++ b/src/web/context-guard-runner.ts
@@ -404,12 +404,18 @@ async function checkAgent(name: string, nowMs: number): Promise<void> {
             `[CONTEXT-GUARD] Ujrainditottam a(z) "${name}" agentet -- ok: ${decision.reason}` +
             (pctRound !== null ? ` (kontextus ~${pctRound}%)` : '') +
             `. A regi sessionbe az utolso percekben kuldott uzenetek/utasitasok ELVESZHETTEK -- ellenorizd es kuldd ujra oket.` +
-            (typeof decision.nextState.handoffStaleMinutes === 'number' 
+            (typeof decision.nextState.handoffStaleMinutes === 'number'
               // The generic "messages may be lost" line invites the wrong
               // conclusion when the real gap is the ARTIFACT: say explicitly
               // that the handoff does not cover the tail of the session.
               ? ` FIGYELEM: a HANDOFF.md ELAVULT -- az utolso ~${decision.nextState.handoffStaleMinutes} perc munkaja nincs benne, a friss session ezt a szakaszt az elo forrasokbol kapja meg.`
-              : '') +
+              : decision.nextState.handoffStaleMinutes === 'unknown'
+                // The supervisor's manual state-handoff decision runs on this
+                // line (2026-08-17: a hand-measured mtime saved a payment-PR
+                // verdict); a silent unknown would read as "all fine" to the
+                // one reader who could compensate.
+                ? ` FIGYELEM: a HANDOFF.md letezik, de a FRISSESSEGET NEM TUDTAM MERNI (transcript-ora olvashatatlan) -- ha a session-ben friss dontes szuletett, kezi allapot-ellenorzes ajanlott (mtime vs. utolso munka).`
+                : '') +
             (snapshotPath ? ` Pane-snapshot a restart elotti allapotrol: ${snapshotPath}` : ''),
             'context-guard restart notice',
           )

--- a/src/web/context-guard-runner.ts
+++ b/src/web/context-guard-runner.ts
@@ -27,6 +27,7 @@ import {
   INITIAL_GUARD_STATE,
   STALE_REFRESH_REASON_PREFIX,
   type GuardState,
+  type HandoffStaleness,
   type GuardInputs,
 } from '../context-guard.js'
 
@@ -151,7 +152,7 @@ export function resumePrompt(
   name: string,
   handoffPath: string,
   hadHandoff: boolean,
-  staleMinutes: number | null = null,
+  staleMinutes: HandoffStaleness = null,
 ): string {
   const base =
     // Wording covers both tiers that lead here: "grew too large" is true at the
@@ -160,7 +161,13 @@ export function resumePrompt(
     `[CONTEXT-GUARD] Friss kontextussal indultál, mert az előző session kontextusa túl nagyra nőtt (auto-handoff). `
   const source = !hadHandoff
     ? `HANDOFF.md nem készült el időben, ezért az élő forrásokból dolgozz. `
-    : staleMinutes !== null
+    : staleMinutes === 'unknown'
+      // A missing measurement must not impersonate a fresh one: say that the
+      // freshness was unverifiable, so the agent cross-checks instead of
+      // trusting the artifact blindly.
+      ? `Első lépés: olvasd be ${handoffPath} -- ez az előző session átadója, de a FRISSESSÉGÉT NEM TUDTAM MEGMÉRNI. ` +
+        `Kezeld óvatosan: vesd össze a kanban-kommentekkel és az inter-agent üzenetekkel, mielőtt a Next Steps-e szerint cselekednél. `
+      : typeof staleMinutes === 'number' 
       // A stale handoff presented as current re-opens already-decided
       // questions; say the gap out loud and route the agent to the live
       // sources FIRST for the uncovered window.
@@ -363,7 +370,7 @@ async function checkAgent(name: string, nowMs: number): Promise<void> {
           decision.reason.startsWith(STALE_REFRESH_REASON_PREFIX)
             // The handoff exists but went stale while we waited for an idle
             // pane; ask for a refresh, not a first write.
-            ? staleRefreshHandoffPrompt(handoffStaleMinutes(inputs) ?? 0, handoffPathFor(name))
+            ? staleRefreshHandoffPrompt(((sm) => typeof sm === 'number' ? sm : 0)(handoffStaleMinutes(inputs)), handoffPathFor(name))
             : decision.reason.startsWith(IDLE_FLUSH_REASON_PREFIX)
               // pct is null whenever the idle tier runs without the proactive
               // tiers, so the alarming percentage-based prompt would read "~0%
@@ -397,7 +404,7 @@ async function checkAgent(name: string, nowMs: number): Promise<void> {
             `[CONTEXT-GUARD] Ujrainditottam a(z) "${name}" agentet -- ok: ${decision.reason}` +
             (pctRound !== null ? ` (kontextus ~${pctRound}%)` : '') +
             `. A regi sessionbe az utolso percekben kuldott uzenetek/utasitasok ELVESZHETTEK -- ellenorizd es kuldd ujra oket.` +
-            (decision.nextState.handoffStaleMinutes !== null
+            (typeof decision.nextState.handoffStaleMinutes === 'number' 
               // The generic "messages may be lost" line invites the wrong
               // conclusion when the real gap is the ARTIFACT: say explicitly
               // that the handoff does not cover the tail of the session.

--- a/src/web/context-guard-runner.ts
+++ b/src/web/context-guard-runner.ts
@@ -22,8 +22,10 @@ import {
   decideGuard,
   contextLimitForModel,
   calibrateLimit,
+  handoffStaleMinutes,
   IDLE_FLUSH_REASON_PREFIX,
   INITIAL_GUARD_STATE,
+  STALE_REFRESH_REASON_PREFIX,
   type GuardState,
   type GuardInputs,
 } from '../context-guard.js'
@@ -130,15 +132,41 @@ export function idleFlushHandoffPrompt(tokens: number, idleMinutes: number, hand
   )
 }
 
-export function resumePrompt(name: string, handoffPath: string, hadHandoff: boolean): string {
+/**
+ * A handoff refresh request: the agent DID write a handoff, then kept working,
+ * so the artifact no longer covers the session. Distinct wording from both
+ * other requests -- "write a handoff" would read as a bug ("I already did"),
+ * and the critical-context alarm may be false here.
+ */
+export function staleRefreshHandoffPrompt(staleMinutes: number, handoffPath: string): string {
+  return (
+    `[CONTEXT-GUARD] A HANDOFF.md-d megvan, de az írása óta ~${staleMinutes} perc érdemi munka történt, ` +
+    `tehát a mostani állapotot MÁR NEM fedi (döntések, verdiktek, üzenetváltások hiányoznak belőle). ` +
+    `EGYETLEN dolgod ebben a körben: frissítsd a HANDOFF.md-t itt: ${handoffPath} úgy, hogy a legutóbbi munkát is tartalmazza ` +
+    `(mi dőlt el, mi került leadásra, mi a következő lépés). Utána ÁLLJ MEG -- a rendszer friss kontextussal újraindít és ebből folytatod.`
+  )
+}
+
+export function resumePrompt(
+  name: string,
+  handoffPath: string,
+  hadHandoff: boolean,
+  staleMinutes: number | null = null,
+): string {
   const base =
     // Wording covers both tiers that lead here: "grew too large" is true at the
     // act threshold and true of an idle-flush, where the context was heavy but
     // the window was nowhere near full. "megtelt" would be false in that case.
     `[CONTEXT-GUARD] Friss kontextussal indultál, mert az előző session kontextusa túl nagyra nőtt (auto-handoff). `
-  const source = hadHandoff
-    ? `Első lépés: olvasd be ${handoffPath} -- ez az előző session átadója. `
-    : `HANDOFF.md nem készült el időben, ezért az élő forrásokból dolgozz. `
+  const source = !hadHandoff
+    ? `HANDOFF.md nem készült el időben, ezért az élő forrásokból dolgozz. `
+    : staleMinutes !== null
+      // A stale handoff presented as current re-opens already-decided
+      // questions; say the gap out loud and route the agent to the live
+      // sources FIRST for the uncovered window.
+      ? `Első lépés: olvasd be ${handoffPath} -- ez az előző session átadója, DE ELAVULT: az utolsó ~${staleMinutes} perc munkája NINCS benne. ` +
+        `A hiányzó szakaszt az élő forrásokból pótold (kanban-kommentek, inter-agent üzenetek, hot memóriák), MIELŐTT a handoff Next Steps-e szerint cselekednél. `
+      : `Első lépés: olvasd be ${handoffPath} -- ez az előző session átadója. `
   return (
     base + source +
     `Utána ellenőrizd a kanban tábládat (in_progress kártyák, assignee=${name}) és a hot memóriáidat, ` +
@@ -260,12 +288,15 @@ async function checkAgent(name: string, nowMs: number): Promise<void> {
     sessionReady,
     handoffMtime: needPct ? handoffMtime(name) : null,
     paneSaturated: pane !== null ? paneShowsContextSaturation(pane) : false,
-    // Idle-flush probes, paid for only when that tier is armed. Note the
-    // condition is cfg.idleFlushEnabled, NOT cfg.enabled: the two tiers are
-    // independently switchable, so an agent running the idle tier alone must
-    // still get its measurements.
+    // Context-size probe, paid for only when the idle-flush tier is armed.
+    // Note the condition is cfg.idleFlushEnabled, NOT cfg.enabled: the two
+    // tiers are independently switchable, so an agent running the idle tier
+    // alone must still get its measurements.
     contextTokens: running && needPct && cfg.idleFlushEnabled ? measureContextTokens(name) : null,
-    idleMs: running && needPct && cfg.idleFlushEnabled ? measureIdleMs(name, nowMs) : null,
+    // idleMs is NOT gated on the idle-flush tier: the handoff-staleness check
+    // (handoffStaleMinutes) needs the transcript mtime on every decision path
+    // that can restart, and the probe is a single stat().
+    idleMs: running && needPct ? measureIdleMs(name, nowMs) : null,
   }
 
   const decision = decideGuard(state, inputs, cfg)
@@ -329,12 +360,16 @@ async function checkAgent(name: string, nowMs: number): Promise<void> {
       case 'request-handoff':
         await sendPromptToSession(
           session,
-          decision.reason.startsWith(IDLE_FLUSH_REASON_PREFIX)
-            // pct is null whenever the idle tier runs without the proactive
-            // tiers, so the alarming percentage-based prompt would read "~0%
-            // -- critical". The idle tier states the token count it measured.
-            ? idleFlushHandoffPrompt(inputs.contextTokens ?? 0, cfg.idleMinutes, handoffPathFor(name))
-            : handoffPrompt(pctRound ?? 0, handoffPathFor(name)),
+          decision.reason.startsWith(STALE_REFRESH_REASON_PREFIX)
+            // The handoff exists but went stale while we waited for an idle
+            // pane; ask for a refresh, not a first write.
+            ? staleRefreshHandoffPrompt(handoffStaleMinutes(inputs) ?? 0, handoffPathFor(name))
+            : decision.reason.startsWith(IDLE_FLUSH_REASON_PREFIX)
+              // pct is null whenever the idle tier runs without the proactive
+              // tiers, so the alarming percentage-based prompt would read "~0%
+              // -- critical". The idle tier states the token count it measured.
+              ? idleFlushHandoffPrompt(inputs.contextTokens ?? 0, cfg.idleMinutes, handoffPathFor(name))
+              : handoffPrompt(pctRound ?? 0, handoffPathFor(name)),
         )
         break
       case 'restart': {
@@ -362,6 +397,12 @@ async function checkAgent(name: string, nowMs: number): Promise<void> {
             `[CONTEXT-GUARD] Ujrainditottam a(z) "${name}" agentet -- ok: ${decision.reason}` +
             (pctRound !== null ? ` (kontextus ~${pctRound}%)` : '') +
             `. A regi sessionbe az utolso percekben kuldott uzenetek/utasitasok ELVESZHETTEK -- ellenorizd es kuldd ujra oket.` +
+            (decision.nextState.handoffStaleMinutes !== null
+              // The generic "messages may be lost" line invites the wrong
+              // conclusion when the real gap is the ARTIFACT: say explicitly
+              // that the handoff does not cover the tail of the session.
+              ? ` FIGYELEM: a HANDOFF.md ELAVULT -- az utolso ~${decision.nextState.handoffStaleMinutes} perc munkaja nincs benne, a friss session ezt a szakaszt az elo forrasokbol kapja meg.`
+              : '') +
             (snapshotPath ? ` Pane-snapshot a restart elotti allapotrol: ${snapshotPath}` : ''),
             'context-guard restart notice',
           )
@@ -372,7 +413,12 @@ async function checkAgent(name: string, nowMs: number): Promise<void> {
       }
       case 'inject-resume': {
         const hadHandoff = inputs.handoffMtime !== null || handoffMtime(name) !== null
-        await sendPromptToSession(session, resumePrompt(name, handoffPathFor(name), hadHandoff))
+        // Staleness was measured at RESTART time and rode here in the state;
+        // measuring now would be meaningless (the old session is gone).
+        await sendPromptToSession(
+          session,
+          resumePrompt(name, handoffPathFor(name), hadHandoff, state.handoffStaleMinutes),
+        )
         break
       }
     }


### PR DESCRIPTION
## The incident (2026-08-17, measured)

The guard restarted samu with reason `handoff written` at 16:27:43 while `HANDOFF.md` was written 16:07:50 -- the agent wrote it on request, then kept working for 20 minutes while the guard waited for an idle pane. A merge-gate verdict on a payment PR was missing from the artifact the fresh session was told to trust as current. The precondition ("mtime advanced since the request") is satisfiable by an arbitrarily stale file: existence is not freshness.

## The fix

New `handoffStaleMinutes(inputs)`: compares HANDOFF.md's mtime against the agent's last transcript activity (`nowMs - idleMs`) at decision time, with a 3-minute slack for the handoff-writing turn itself. Fails closed (null) when unmeasurable.

- **Refresh instead of restart** when the written handoff is stale, the deadline hasn't passed and the context is below `hardPct`: the guard re-requests with a distinct wording (`stale-handoff-refresh` prefix -- "update it", not "write one" / "critical"). The recorded mtime advances so the next write counts as fresh; the deadline does NOT move, so an agent that keeps working through refreshes still restarts on time.
- **Staleness said out loud on every restart path**: reason becomes `handoff written but STALE (~Nm of work after it)`; the gap rides in `GuardState.handoffStaleMinutes` into `await-ready`, and the resume prompt tells the fresh session the handoff does not cover the last ~N minutes and routes it to the live sources (kanban comments, inter-agent messages, hot memories) first. The supervisor restart notice names the gap too, replacing the generic "messages may be lost" hint that invites the wrong conclusion.
- **`idleMs` probed on every decision path that can restart** (it was gated on the idle-flush tier; it is a single `stat()`).

## Verification

- Suite: **3623 passed (269 files)**, `tsc --noEmit` clean.
- 8 new tests incl. the incident as a regression case; red-probe with confirmed mutation (staleness detection neutered -> 7 tests fail, restored -> green).
- Behavior unchanged when the handoff is fresh or staleness is unmeasurable (existing guard tests untouched and green).

## Merge timing

develop is under the soak freeze until the 08-18 promote -- merge timing is Marveen's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
