### PR TITLE
feat(bridge): the service-port allowlist is enforced in permitopen, managed server-side (BRIDGEPORT817)

### DIFF
--- a/src/__tests__/bridge-service-ports.test.ts
+++ b/src/__tests__/bridge-service-ports.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from 'vitest'
+import { mkdtempSync, readFileSync, writeFileSync, statSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import {
+  validateBridgeServicePorts,
+  restrictOptionsWithServices,
+  extractServicePorts,
+  rewriteServicePorts,
+  restrictOptions,
+  MAX_BRIDGE_SERVICE_PORTS,
+} from '../remote-enroll-core.js'
+import { updateEnrolledServicePorts } from '../remote-enroll-fs.js'
+
+// BRIDGEPORT817. The permitopen list in authorized_keys is the REAL boundary
+// of the Bridge's service-tab feature; these tests pin the policy (validate),
+// the grant shape (options builder), and the rewrite (only our line, options
+// rebuilt from scratch). The live-sshd red probe -- a direct forward attempt
+// with the key, no Bridge involved -- runs in the PR's verification, not here.
+
+const WEB = 3420
+const ID = '0f81a9a2-08d6-4f4c-9a09-93e35ad27182'
+const B64 = 'AAAAC3NzaC1lZDI1NTE5AAAAIFakefakefakefakefakefakefakefakefakefake'
+const OUR_LINE = `${restrictOptions(WEB)} ssh-ed25519 ${B64} marveen-remote:${ID}`
+const FOREIGN_LINE = 'ssh-rsa AAAAB3Nza... someone@laptop'
+
+describe('validateBridgeServicePorts (policy -- decided server-side)', () => {
+  it('accepts a plain list, sorted and deduplicated, webPort implicit', () => {
+    const v = validateBridgeServicePorts([8443, 4007, 4007, WEB], WEB)
+    expect(v).toEqual({ ok: true, ports: [4007, 8443] })
+  })
+
+  it('refuses privileged ports on both sides of the boundary (22 included)', () => {
+    expect(validateBridgeServicePorts([1023], WEB).ok).toBe(false)
+    expect(validateBridgeServicePorts([1024], WEB)).toEqual({ ok: true, ports: [1024] })
+    expect(validateBridgeServicePorts([22], WEB).ok).toBe(false)
+    expect(validateBridgeServicePorts([65535], WEB)).toEqual({ ok: true, ports: [65535] })
+    expect(validateBridgeServicePorts([65536], WEB).ok).toBe(false)
+  })
+
+  it('refuses non-integers and non-arrays', () => {
+    expect(validateBridgeServicePorts([40.7], WEB).ok).toBe(false)
+    expect(validateBridgeServicePorts(['4007' as unknown as number], WEB).ok).toBe(false)
+    expect(validateBridgeServicePorts('4007', WEB).ok).toBe(false)
+    expect(validateBridgeServicePorts(undefined, WEB).ok).toBe(false)
+  })
+
+  it('caps the list so an allowlist can never approximate a wildcard', () => {
+    const max = Array.from({ length: MAX_BRIDGE_SERVICE_PORTS }, (_, i) => 5000 + i)
+    expect(validateBridgeServicePorts(max, WEB).ok).toBe(true)
+    expect(validateBridgeServicePorts([...max, 6000], WEB).ok).toBe(false)
+  })
+})
+
+describe('restrictOptionsWithServices (the grant shape)', () => {
+  it('keeps restrict + forced command, webPort first, explicit ports only', () => {
+    expect(restrictOptionsWithServices(WEB, [4007, 8443])).toBe(
+      'restrict,port-forwarding,permitopen="127.0.0.1:3420",permitopen="127.0.0.1:4007",permitopen="127.0.0.1:8443",command="/bin/false"',
+    )
+  })
+
+  it('with no service ports it equals the enrollment default exactly', () => {
+    expect(restrictOptionsWithServices(WEB, [])).toBe(restrictOptions(WEB))
+  })
+
+  it('never emits a wildcard, whatever the input', () => {
+    const line = restrictOptionsWithServices(WEB, [4007])
+    expect(line).not.toContain('*')
+    expect(line.match(/permitopen="127\.0\.0\.1:\d+"/g)?.length).toBe(2)
+  })
+})
+
+describe('extractServicePorts', () => {
+  it('legacy single-port line yields no service ports', () => {
+    expect(extractServicePorts(restrictOptions(WEB), WEB)).toEqual([])
+  })
+  it('multi-port options yield the sorted service set minus webPort', () => {
+    expect(extractServicePorts(restrictOptionsWithServices(WEB, [8443, 4007]), WEB)).toEqual([4007, 8443])
+  })
+})
+
+describe('rewriteServicePorts (only our line, options rebuilt from scratch)', () => {
+  const FILE = `${FOREIGN_LINE}\n${OUR_LINE}\n`
+
+  it('rewrites the target line, preserves every other byte, reports before/after', () => {
+    const r = rewriteServicePorts(FILE, ID, WEB, [4007])
+    expect(r.found).toBe(true)
+    expect(r.before).toEqual([])
+    expect(r.after).toEqual([4007])
+    const lines = r.content.split('\n')
+    expect(lines[0]).toBe(FOREIGN_LINE)
+    expect(lines[1]).toBe(`${restrictOptionsWithServices(WEB, [4007])} ssh-ed25519 ${B64} marveen-remote:${ID}`)
+    expect(r.content.endsWith('\n')).toBe(true)
+  })
+
+  it('narrowing back to [] restores the exact enrollment-default line', () => {
+    const widened = rewriteServicePorts(FILE, ID, WEB, [4007]).content
+    const narrowed = rewriteServicePorts(widened, ID, WEB, [])
+    expect(narrowed.before).toEqual([4007])
+    expect(narrowed.after).toEqual([])
+    expect(narrowed.content).toBe(FILE)
+  })
+
+  it('a hand-edited options field cannot smuggle a grant through a rewrite', () => {
+    // Someone edited OUR line to also permit 6666; the rewrite rebuilds the
+    // options from scratch, so the smuggled grant does not survive.
+    const tampered = FILE.replace(
+      restrictOptions(WEB),
+      `restrict,port-forwarding,permitopen="127.0.0.1:${WEB}",permitopen="127.0.0.1:6666",command="/bin/false"`,
+    )
+    const r = rewriteServicePorts(tampered, ID, WEB, [4007])
+    expect(r.before).toEqual([6666])
+    expect(r.content).not.toContain('6666')
+  })
+
+  it('unknown install id: found:false, content unchanged shape', () => {
+    const r = rewriteServicePorts(FILE, 'f0000000-0000-4000-8000-000000000000', WEB, [4007])
+    expect(r.found).toBe(false)
+    expect(r.content).toBe(FILE)
+  })
+
+  it('a line carrying our comment but a foreign shape is not ours to rewrite', () => {
+    const odd = `command="uptime" ssh-rsa ${B64} extra marveen-remote:${ID}\n`
+    const r = rewriteServicePorts(odd, ID, WEB, [4007])
+    expect(r.found).toBe(false)
+    expect(r.content).toBe(odd)
+  })
+})
+
+describe('updateEnrolledServicePorts (fs, temp dir)', () => {
+  it('rewrites under lock, keeps 0600, reports before/after', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'mv-svc-ports-'))
+    const authPath = join(dir, 'authorized_keys')
+    writeFileSync(authPath, `${FOREIGN_LINE}\n${OUR_LINE}\n`, { mode: 0o600 })
+    const r = await updateEnrolledServicePorts({ sshDir: dir, installId: ID, webPort: WEB, ports: [4007, 8443] })
+    expect(r.found).toBe(true)
+    expect(r.after).toEqual([4007, 8443])
+    const content = readFileSync(authPath, 'utf8')
+    expect(content).toContain('permitopen="127.0.0.1:4007"')
+    expect(content.split('\n')[0]).toBe(FOREIGN_LINE)
+    expect(statSync(authPath).mode & 0o777).toBe(0o600)
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('missing file or missing line: found:false, nothing written', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'mv-svc-ports-'))
+    const none = await updateEnrolledServicePorts({ sshDir: dir, installId: ID, webPort: WEB, ports: [4007] })
+    expect(none.found).toBe(false)
+    writeFileSync(join(dir, 'authorized_keys'), `${FOREIGN_LINE}\n`, { mode: 0o600 })
+    const miss = await updateEnrolledServicePorts({ sshDir: dir, installId: ID, webPort: WEB, ports: [4007] })
+    expect(miss.found).toBe(false)
+    expect(readFileSync(join(dir, 'authorized_keys'), 'utf8')).toBe(`${FOREIGN_LINE}\n`)
+    rmSync(dir, { recursive: true, force: true })
+  })
+})

--- a/src/remote-enroll-core.ts
+++ b/src/remote-enroll-core.ts
@@ -251,6 +251,118 @@ export function restrictOptions(webPort: number = REMOTE_PORT): string {
  * the default shape; port-aware callers use restrictOptions(webPort). */
 export const RESTRICT_OPTIONS = restrictOptions(REMOTE_PORT)
 
+// ---------------------------------------------------------------------------
+// Bridge service-port allowlist (BRIDGEPORT817).
+//
+// The Bridge can open ADDITIONAL host loopback services on separate tabs; the
+// real enforcement is HERE, in the enrolled key's permitopen list -- the
+// Bridge-side allowlist is UX, this is the boundary. The policy therefore
+// lives server-side (the Bridge REQUESTS, this module VALIDATES):
+//   - explicit ports only, NEVER a wildcard or a range;
+//   - the dashboard webPort is always included and cannot be removed;
+//   - privileged ports (<1024, which covers sshd's canonical 22) are refused
+//     outright -- if such a forward is ever legitimately needed, that is a
+//     separate owner decision, not an allowlist entry's side effect;
+//   - the list is capped, so an allowlist can never quietly approximate "*".
+// Every change is written to the config-change ledger by the route layer.
+// ---------------------------------------------------------------------------
+
+export const BRIDGE_SERVICE_PORT_MIN = 1024
+export const BRIDGE_SERVICE_PORT_MAX = 65535
+export const MAX_BRIDGE_SERVICE_PORTS = 12
+
+export type ServicePortListVerdict =
+  | { ok: true; ports: number[] }
+  | { ok: false; error: string }
+
+/** Validate a requested service-port list. Returns a sorted, deduplicated
+ * list (webPort excluded -- it is implicit and always present). */
+export function validateBridgeServicePorts(raw: unknown, webPort: number): ServicePortListVerdict {
+  if (!Array.isArray(raw)) return { ok: false, error: 'ports must be an array' }
+  const out: number[] = []
+  for (const item of raw) {
+    const port = typeof item === 'number' ? item : NaN
+    if (!Number.isInteger(port)) return { ok: false, error: 'every port must be an integer' }
+    if (port < BRIDGE_SERVICE_PORT_MIN || port > BRIDGE_SERVICE_PORT_MAX) {
+      return { ok: false, error: `port ${port} out of range (${BRIDGE_SERVICE_PORT_MIN}-${BRIDGE_SERVICE_PORT_MAX}; privileged ports are refused)` }
+    }
+    if (port === webPort) continue // implicit, never refused, never duplicated
+    if (!out.includes(port)) out.push(port)
+  }
+  if (out.length > MAX_BRIDGE_SERVICE_PORTS) {
+    return { ok: false, error: `too many ports (max ${MAX_BRIDGE_SERVICE_PORTS})` }
+  }
+  out.sort((a, b) => a - b)
+  return { ok: true, ports: out }
+}
+
+/** Restriction options with the webPort plus explicit service ports. The
+ * single-port restrictOptions() stays the enrollment default: a fresh device
+ * starts with NO service ports. */
+export function restrictOptionsWithServices(webPort: number, servicePorts: number[]): string {
+  const permits = [webPort, ...servicePorts.filter((p) => p !== webPort)]
+    .map((p) => `permitopen="127.0.0.1:${p}"`)
+    .join(',')
+  return `restrict,port-forwarding,${permits},command="/bin/false"`
+}
+
+const PERMITOPEN_RE = /permitopen="127\.0\.0\.1:(\d{1,5})"/g
+
+/** The service ports (webPort excluded) currently granted by an options
+ * field. Tolerates the single-port legacy shape. */
+export function extractServicePorts(optionsField: string, webPort: number): number[] {
+  const ports: number[] = []
+  for (const m of optionsField.matchAll(PERMITOPEN_RE)) {
+    const p = Number(m[1])
+    if (p !== webPort && !ports.includes(p)) ports.push(p)
+  }
+  ports.sort((a, b) => a - b)
+  return ports
+}
+
+export interface ServicePortsRewrite {
+  content: string
+  found: boolean
+  before: number[]
+  after: number[]
+}
+
+/**
+ * Rewrite the permitopen set of the line carrying marveen-remote:<installId>.
+ * Only lines this codebase authored are touched (found by our comment, shape
+ * re-verified before rewrite); every other line is preserved byte-for-byte.
+ * The key material and comment are reproduced verbatim -- only the options
+ * field is rebuilt, from scratch, via restrictOptionsWithServices, so a
+ * hand-edited options field cannot smuggle anything through a rewrite.
+ */
+export function rewriteServicePorts(
+  existing: string,
+  installId: string,
+  webPort: number,
+  ports: number[],
+): ServicePortsRewrite {
+  const target = `${COMMENT_PREFIX}${installId}`
+  const lines = existing.length ? existing.split('\n') : []
+  if (lines.length > 0 && lines[lines.length - 1] === '') lines.pop()
+  let found = false
+  let before: number[] = []
+  const out = lines.map((line) => {
+    const trimmed = line.trim()
+    const fields = trimmed.split(/\s+/)
+    if (fields.length < 4 || fields[fields.length - 1] !== target) return line
+    // Our lines are exactly: <options> ssh-ed25519 <base64> marveen-remote:<uuid>
+    // (no spaces inside the options we author). Anything else with our comment
+    // is not ours to rewrite.
+    if (fields.length !== 4 || fields[1] !== ACCEPTED_KEY_TYPE) return line
+    found = true
+    before = extractServicePorts(fields[0], webPort)
+    return `${restrictOptionsWithServices(webPort, ports)} ${fields[1]} ${fields[2]} ${fields[3]}`
+  })
+  let content = out.join('\n')
+  if (content.length > 0 && !content.endsWith('\n')) content += '\n'
+  return { content, found, before, after: found ? [...ports].sort((a, b) => a - b) : [] }
+}
+
 /**
  * Build the exact restricted authorized_keys line for a validated key.
  * The key material and comment are reproduced verbatim. `webPort` is the actual

--- a/src/remote-enroll-fs.ts
+++ b/src/remote-enroll-fs.ts
@@ -18,7 +18,7 @@ import {
   chmodSync,
 } from 'node:fs'
 import { join } from 'node:path'
-import { mergeAuthorizedKeys, removeAuthorizedKey, type MergeAction } from './remote-enroll-core.js'
+import { mergeAuthorizedKeys, removeAuthorizedKey, rewriteServicePorts, type MergeAction } from './remote-enroll-core.js'
 
 const SSH_DIR_MODE = 0o700
 const AUTH_KEYS_MODE = 0o600
@@ -204,6 +204,62 @@ function writeAtomic(sshDir: string, authPath: string, content: string): void {
       /* ignore */
     }
     throw err
+  }
+}
+
+export interface UpdateServicePortsOptions {
+  sshDir: string
+  installId: string
+  webPort: number
+  /** The DESIRED service-port list (already validated by the caller's policy
+   * layer -- validateBridgeServicePorts). Declarative: the permitopen set
+   * becomes {webPort} + exactly these. */
+  ports: number[]
+  lockRetries?: number
+  lockRetryDelayMs?: number
+  staleLockMs?: number
+  sleep?: (ms: number) => Promise<void>
+}
+
+export interface UpdateServicePortsResult {
+  found: boolean
+  before: number[]
+  after: number[]
+  authorizedKeysPath: string
+}
+
+/**
+ * Rewrite the enrolled key's permitopen set (BRIDGEPORT817) under the same
+ * lock + atomic-replace discipline as enrollment. found:false means no line
+ * carries this installId -- the device is not enrolled (or was revoked).
+ */
+export async function updateEnrolledServicePorts(
+  opts: UpdateServicePortsOptions,
+): Promise<UpdateServicePortsResult> {
+  const {
+    sshDir,
+    installId,
+    webPort,
+    ports,
+    lockRetries = 20,
+    lockRetryDelayMs = 100,
+    staleLockMs = 15000,
+    sleep = defaultSleep,
+  } = opts
+  const authPath = join(sshDir, AUTH_KEYS_NAME)
+  const lockPath = join(sshDir, LOCK_NAME)
+
+  if (!existsSync(authPath)) return { found: false, before: [], after: [], authorizedKeysPath: authPath }
+
+  const fd = await acquireLock(lockPath, lockRetries, lockRetryDelayMs, staleLockMs, sleep)
+  try {
+    if (!existsSync(authPath)) return { found: false, before: [], after: [], authorizedKeysPath: authPath }
+    const existing = readFileSync(authPath, 'utf8')
+    const result = rewriteServicePorts(existing, installId, webPort, ports)
+    if (result.found && result.content !== existing) writeAtomic(sshDir, authPath, result.content)
+    return { found: result.found, before: result.before, after: result.after, authorizedKeysPath: authPath }
+  } finally {
+    releaseLock(fd, lockPath)
   }
 }
 

--- a/src/web.ts
+++ b/src/web.ts
@@ -34,6 +34,7 @@ import { collectTokenUsage } from './web/token-usage.js'
 import { logger } from './logger.js'
 import { tryHandleAuth } from './web/routes/auth.js'
 import { tryHandleSecurity } from './web/routes/security.js'
+import { tryHandleBridgeServicePorts } from './web/routes/bridge-service-ports.js'
 import { tryHandleProfiles } from './web/routes/profiles.js'
 import { tryHandleMessages } from './web/routes/messages.js'
 import { tryHandleFederation } from './web/routes/federation.js'
@@ -155,7 +156,7 @@ export function startWebServer(port = 3420): http.Server {
     const fedPeerForCtx: string | null = auth.kind === 'federation' ? auth.peer : null
     const ctxAuth =
       auth.kind === 'token' ? { kind: 'token' as const }
-      : auth.kind === 'device' ? { kind: 'device' as const, device: auth.device }
+      : auth.kind === 'device' ? { kind: 'device' as const, device: auth.device, deviceId: auth.deviceId }
       : auth.kind === 'session' ? { kind: 'session' as const, user: auth.user }
       : auth.kind === 'federation' ? { kind: 'federation' as const, peer: auth.peer }
       : undefined
@@ -174,6 +175,7 @@ export function startWebServer(port = 3420): http.Server {
 
       if (await tryHandleAuth(routeCtx)) return
       if (await tryHandleSecurity(routeCtx)) return
+      if (await tryHandleBridgeServicePorts(routeCtx)) return
       if (await tryHandleProfiles(routeCtx)) return
       if (await tryHandleMessages(routeCtx)) return
       if (await tryHandleFederation(routeCtx)) return

--- a/src/web/routes/bridge-service-ports.ts
+++ b/src/web/routes/bridge-service-ports.ts
@@ -1,0 +1,208 @@
+// Bridge service-port allowlist endpoints (BRIDGEPORT817).
+//
+// The Bridge lets the owner open additional host loopback services on
+// separate tabs, but the REAL boundary is the enrolled key's permitopen list
+// in authorized_keys -- and that list is managed here, never client-side. The
+// Bridge REQUESTS a desired port list; this route VALIDATES it (explicit
+// ports only, never a wildcard, privileged ports refused, capped), rewrites
+// the key's options field, writes the change to the config-change ledger and
+// notifies the owner. A rule that only exists in the client is not a rule.
+//
+// Principal discipline:
+//   - device key WITH install_id: self-scoped -- a Bridge can only manage the
+//     permitopen set of ITS OWN enrolled key. This is the normal caller.
+//   - dashboard token / session: owner tooling; must name the install_id
+//     explicitly. A device key can never widen another device's grant.
+//
+// PUT is DECLARATIVE (the full desired list), not add/remove deltas: the
+// permitopen set becomes {webPort} + exactly the validated list, so client
+// and server can never drift apart entry-by-entry.
+//
+// The change applies to NEW ssh connections only (sshd evaluates
+// authorized_keys options at auth time); the Bridge reconnects after a
+// successful PUT. Narrowing therefore also requires the Bridge-side
+// reconnect -- stated in the response so the caller cannot miss it.
+
+import { readBody, json } from '../http-helpers.js'
+import { logger } from '../../logger.js'
+import { logConfigChange } from '../../db.js'
+import { notifySecurityEvent } from '../../notify.js'
+import { WEB_PORT } from '../../config.js'
+import { validateBridgeServicePorts, extractServicePorts, COMMENT_PREFIX, ACCEPTED_KEY_TYPE } from '../../remote-enroll-core.js'
+import { updateEnrolledServicePorts } from '../../remote-enroll-fs.js'
+import { getDeviceKey } from '../auth-device-keys.js'
+import { sshDirOverride } from '../bridge-enroll.js'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { readFileSync } from 'node:fs'
+import type { RouteContext } from './types.js'
+
+const BODY_MAX_BYTES = 8 * 1024
+const PATH = '/api/bridge/service-ports'
+
+function resolveSshDir(): string {
+  const override = sshDirOverride()
+  if (override) {
+    logger.warn({ sshDir: override }, 'MARVEEN_SSH_DIR override active for service-port update (test seam; must be unset in production)')
+    return override
+  }
+  return join(homedir(), '.ssh')
+}
+
+/** The caller's install scope, or null with the response already written. */
+function resolveInstallId(ctx: RouteContext, explicit: string | undefined): string | null {
+  const { res, auth } = ctx
+  if (auth?.kind === 'device') {
+    if (auth.deviceId === undefined) {
+      json(res, { error: 'Device principal without id' }, 500)
+      return null
+    }
+    const info = getDeviceKey(auth.deviceId)
+    if (!info || !info.installId) {
+      // Pre-per-device-key bundles (shared token) and non-bridge device keys
+      // have no install binding; they cannot manage permitopen. Re-pairing
+      // mints a bound key.
+      json(res, { error: 'This device key is not bound to a Bridge enrollment. Re-pair the device.' }, 403)
+      return null
+    }
+    if (explicit && explicit !== info.installId) {
+      // Self-scope is not negotiable for device callers.
+      json(res, { error: 'A device may only manage its own service ports' }, 403)
+      return null
+    }
+    return info.installId
+  }
+  if (auth?.kind === 'token' || auth?.kind === 'session') {
+    if (!explicit) {
+      json(res, { error: 'install_id is required for token/session callers' }, 400)
+      return null
+    }
+    return explicit
+  }
+  json(res, { error: 'Forbidden for this credential type' }, 403)
+  return null
+}
+
+/** Current service ports straight from authorized_keys (the ground truth). */
+function readCurrentPorts(installId: string): { found: boolean; ports: number[] } {
+  try {
+    const content = readFileSync(join(resolveSshDir(), 'authorized_keys'), 'utf8')
+    const target = `${COMMENT_PREFIX}${installId}`
+    for (const line of content.split('\n')) {
+      const fields = line.trim().split(/\s+/)
+      if (fields.length === 4 && fields[3] === target && fields[1] === ACCEPTED_KEY_TYPE) {
+        return { found: true, ports: extractServicePorts(fields[0], WEB_PORT) }
+      }
+    }
+  } catch {
+    /* missing file = not enrolled */
+  }
+  return { found: false, ports: [] }
+}
+
+export async function tryHandleBridgeServicePorts(ctx: RouteContext): Promise<boolean> {
+  const { req, res, path, method, url, auth } = ctx
+  if (path !== PATH) return false
+
+  if (method === 'GET') {
+    const installId = resolveInstallId(ctx, url.searchParams.get('install_id') || undefined)
+    if (installId === null) return true
+    const current = readCurrentPorts(installId)
+    if (!current.found) {
+      json(res, { error: 'No enrollment found for this install id' }, 404)
+      return true
+    }
+    json(res, { ok: true, install_id: installId, web_port: WEB_PORT, ports: current.ports })
+    return true
+  }
+
+  if (method !== 'PUT') return false
+
+  let body: Record<string, unknown>
+  try {
+    const raw = (await readBody(req, { maxBytes: BODY_MAX_BYTES })).toString().trim()
+    const parsed = raw ? JSON.parse(raw) : {}
+    body = parsed && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : {}
+  } catch {
+    json(res, { error: 'Invalid JSON' }, 400)
+    return true
+  }
+
+  const installId = resolveInstallId(ctx, typeof body.install_id === 'string' ? body.install_id : undefined)
+  if (installId === null) return true
+
+  // Accept [{name, port}] (the Bridge's shape -- names enrich the ledger) or
+  // bare numbers. POLICY runs on the ports alone, server-side, always.
+  const rawList = Array.isArray(body.ports) ? body.ports : null
+  if (!rawList) {
+    json(res, { error: 'ports must be an array' }, 400)
+    return true
+  }
+  const portNumbers = rawList.map((e) =>
+    typeof e === 'number' ? e : e && typeof e === 'object' ? (e as { port?: unknown }).port : undefined,
+  )
+  const verdict = validateBridgeServicePorts(portNumbers, WEB_PORT)
+  if (!verdict.ok) {
+    json(res, { error: verdict.error }, 400)
+    return true
+  }
+  const names = new Map<number, string>()
+  for (const e of rawList) {
+    if (e && typeof e === 'object') {
+      const { name, port } = e as { name?: unknown; port?: unknown }
+      if (typeof name === 'string' && typeof port === 'number' && name.trim()) {
+        names.set(port, name.trim().slice(0, 32))
+      }
+    }
+  }
+
+  try {
+    const result = await updateEnrolledServicePorts({
+      sshDir: resolveSshDir(),
+      installId,
+      webPort: WEB_PORT,
+      ports: verdict.ports,
+    })
+    if (!result.found) {
+      json(res, { error: 'No enrollment found for this install id' }, 404)
+      return true
+    }
+
+    const label = (p: number) => (names.has(p) ? `${names.get(p)}:${p}` : String(p))
+    const added = result.after.filter((p) => !result.before.includes(p))
+    const removed = result.before.filter((p) => !result.after.includes(p))
+    if (added.length || removed.length) {
+      // Ledger row: who, what changed, from what to what. A quiet widening of
+      // an SSH grant must be reconstructable from the trail alone.
+      logConfigChange(
+        'security.bridge_service_ports',
+        `[${result.before.join(',')}]`,
+        `[${result.after.map(label).join(',')}] (install ${installId})` +
+          (added.length ? ` added=[${added.map(label).join(',')}]` : '') +
+          (removed.length ? ` removed=[${removed.join(',')}]` : '') +
+          (sshDirOverride() ? ' sshdir_override=1' : ''),
+        auth!.kind,
+      )
+      logger.info({ installId, before: result.before, after: result.after, actor: auth!.kind }, 'bridge service ports updated')
+      void notifySecurityEvent(
+        `🔌 Bridge port-lista változott (${auth!.kind === 'device' ? 'a Bridge-ből' : 'a dashboardról'}): ` +
+          (added.length ? `+ ${added.map(label).join(', ')} ` : '') +
+          (removed.length ? `- ${removed.join(', ')} ` : '') +
+          `-- az eszköz SSH-kulcsa mostantól ezekre a helyi portokra forwardolhat. Ha nem te voltál, vond vissza a Biztonság fülön.`,
+      )
+    }
+
+    json(res, {
+      ok: true,
+      install_id: installId,
+      web_port: WEB_PORT,
+      ports: result.after,
+      // sshd applies authorized_keys options at AUTH time.
+      reconnect_required: true,
+    })
+  } catch (err) {
+    logger.error({ err, installId }, 'bridge service-port update failed')
+    json(res, { error: 'Update failed' }, 500)
+  }
+  return true
+}

--- a/src/web/routes/bridge-service-ports.ts
+++ b/src/web/routes/bridge-service-ports.ts
@@ -184,11 +184,22 @@ export async function tryHandleBridgeServicePorts(ctx: RouteContext): Promise<bo
         auth!.kind,
       )
       logger.info({ installId, before: result.before, after: result.after, actor: auth!.kind }, 'bridge service ports updated')
+      // Narrowing latency, said out loud: sshd applies authorized_keys options
+      // at AUTH time. A device-initiated change is followed by the Bridge's
+      // own reconnect, but a dashboard/token-side narrowing has no Bridge to
+      // reconnect -- the live session keeps the old grant until the device
+      // next reconnects. The notification must not imply immediacy it does
+      // not have.
+      const narrowingLatency =
+        removed.length && auth!.kind !== 'device'
+          ? ' FIGYELEM: a szűkítés az eszköz KÖVETKEZŐ újrakapcsolódásakor lép életbe -- az élő kapcsolat addig a régi listát használja. Azonnali hatályhoz vond vissza a párosítást a Biztonság fülön.'
+          : ''
       void notifySecurityEvent(
         `🔌 Bridge port-lista változott (${auth!.kind === 'device' ? 'a Bridge-ből' : 'a dashboardról'}): ` +
           (added.length ? `+ ${added.map(label).join(', ')} ` : '') +
           (removed.length ? `- ${removed.join(', ')} ` : '') +
-          `-- az eszköz SSH-kulcsa mostantól ezekre a helyi portokra forwardolhat. Ha nem te voltál, vond vissza a Biztonság fülön.`,
+          `-- az eszköz SSH-kulcsa mostantól ezekre a helyi portokra forwardolhat. Ha nem te voltál, vond vissza a Biztonság fülön.` +
+          narrowingLatency,
       )
     }
 

--- a/src/web/routes/bridge-service-ports.ts
+++ b/src/web/routes/bridge-service-ports.ts
@@ -184,21 +184,24 @@ export async function tryHandleBridgeServicePorts(ctx: RouteContext): Promise<bo
         auth!.kind,
       )
       logger.info({ installId, before: result.before, after: result.after, actor: auth!.kind }, 'bridge service ports updated')
-      // Narrowing latency, said out loud: sshd applies authorized_keys options
-      // at AUTH time. A device-initiated change is followed by the Bridge's
-      // own reconnect, but a dashboard/token-side narrowing has no Bridge to
-      // reconnect -- the live session keeps the old grant until the device
-      // next reconnects. The notification must not imply immediacy it does
-      // not have.
+      // Latency, said out loud -- and ONLY what the system can actually do:
+      // sshd applies authorized_keys options at AUTH time, so neither a
+      // narrowing nor a pairing revocation touches an already-established
+      // session (removeBridgeSshAccess only deletes the line; nothing kills
+      // the live tunnel). A device-initiated change is followed by the
+      // Bridge's own reconnect; a dashboard/token-side narrowing is not.
+      // This is a security notification the owner reads MID-INCIDENT: it
+      // must not promise an immediate cut that does not exist. Killing the
+      // live session on revoke would be real work, tracked separately.
       const narrowingLatency =
         removed.length && auth!.kind !== 'device'
-          ? ' FIGYELEM: a szűkítés az eszköz KÖVETKEZŐ újrakapcsolódásakor lép életbe -- az élő kapcsolat addig a régi listát használja. Azonnali hatályhoz vond vissza a párosítást a Biztonság fülön.'
+          ? ' FIGYELEM: a szűkítés az eszköz KÖVETKEZŐ újrakapcsolódásakor lép életbe -- az élő kapcsolat addig a régi listát használja.'
           : ''
       void notifySecurityEvent(
         `🔌 Bridge port-lista változott (${auth!.kind === 'device' ? 'a Bridge-ből' : 'a dashboardról'}): ` +
           (added.length ? `+ ${added.map(label).join(', ')} ` : '') +
           (removed.length ? `- ${removed.join(', ')} ` : '') +
-          `-- az eszköz SSH-kulcsa mostantól ezekre a helyi portokra forwardolhat. Ha nem te voltál, vond vissza a Biztonság fülön.` +
+          `-- az eszköz SSH-kulcsa mostantól ezekre a helyi portokra forwardolhat. Ha nem te voltál, vond vissza a párosítást a Biztonság fülön -- ez minden TOVÁBBI kapcsolódást megakadályoz; a már élő kapcsolat a saját megszakadásáig él.` +
           narrowingLatency,
       )
     }

--- a/src/web/routes/types.ts
+++ b/src/web/routes/types.ts
@@ -21,7 +21,7 @@ export interface RouteContext {
    *  'session' kind; `peer` mirrors fedPeer for the 'federation' kind;
    *  `device` is the key name for the 'device' kind. Lets routes distinguish
    *  a human session from a token/fleet caller or an enrolled device. */
-  auth?: { kind: 'token' | 'session' | 'federation' | 'device'; user?: string; peer?: string; device?: string }
+  auth?: { kind: 'token' | 'session' | 'federation' | 'device'; user?: string; peer?: string; device?: string; deviceId?: number }
 }
 
 export type RouteHandler = (ctx: RouteContext) => Promise<boolean>


### PR DESCRIPTION
## What (BRIDGEPORT817 server half -- pairs with marveen-bridge #10)

The Bridge's service tabs forward additional host loopback ports through the enrolled key, but that key's `permitopen` only admits the dashboard port and sshd correctly refuses everything else. This PR adds the server-side policy + rewrite: `PUT/GET /api/bridge/service-ports`.

## Marveen's five conditions, item by item

1. **Policy decided server-side.** The Bridge REQUESTS a desired list; `validateBridgeServicePorts` runs here, always, on the ports alone. A rule that only exists in the client is not a rule.
2. **Never a wildcard; privileged refused.** Options are rebuilt from scratch via `restrictOptionsWithServices` (explicit `permitopen="127.0.0.1:<port>"` entries only); the dashboard `webPort` is always included and cannot be removed; ports `<1024` (which covers sshd's canonical 22) are refused outright; capped at 12 so a list can never approximate `*`. A hand-edited extra grant does not survive a rewrite (tamper-wipe test).
3. **Ledger.** Every change writes a config-change row (`security.bridge_service_ports`): before/after, added/removed with names, actor kind, sshdir-override flag -- plus a security notification to the owner. A quiet widening of an SSH grant is reconstructable from the trail alone.
4. **Red probe WITHOUT the Bridge.** Direct ssh client (standalone ssh2 script, no Bridge code) against a throwaway sshd, authorized_keys written by THIS code path end to end:
   - default line -> service port refused: `ADMINISTRATIVELY_PROHIBITED` (RED)
   - widen via `updateEnrolledServicePorts` -> service port forwards (GREEN)
   - narrow back -> refused again (RED)
   - dashboard port forwards throughout (positive control)
5. **develop, merge after the promote** -- same as #988.

## Scoping

- **Device-key callers are self-scoped** through their install binding: a Bridge manages only its own key's grant. Pre-binding (shared-token) bundles get a 403 with a re-pair hint.
- Token/session callers (owner tooling) must name `install_id` explicitly.
- `PUT` is declarative (full desired list), and the response carries `reconnect_required: true` -- sshd applies authorized_keys options at auth time; the Bridge reconnects after a successful sync (already wired in #10's second commit).

## Verification

- Suite: **3631 passed (270 files)**, `tsc --noEmit` clean.
- 16 new unit tests: policy boundaries (both sides of every limit), grant shape, extract/rewrite roundtrip, tamper-wipe, unknown-id and foreign-shape refusal, fs lock/0600/atomic behavior.
- Live probe cycle above (A-G), instrument pitfalls documented in the card.

## Trade-off stated (from Marveen's review of the plan)

With this endpoint the Bridge can widen its own SSH reach. Mitigations: self-scope, server-side validation, no wildcard, privileged refusal, cap, ledger row + owner notification on every change. The residual is accepted and recorded on the card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
