### PR TITLE
fix(usage-collect): read the Claude session token from the macOS Keychain

### DIFF
--- a/scripts/__tests__/usage-collect.test.py
+++ b/scripts/__tests__/usage-collect.test.py
@@ -9,6 +9,8 @@ synthetic snapshots -- no real network calls, no real ~/.codex or
 import importlib.util
 import json
 import os
+import subprocess
+import sys
 import tempfile
 import unittest
 import urllib.error
@@ -789,6 +791,90 @@ class TestComputeAlerts(unittest.TestCase):
         later = self.NOW + timedelta(minutes=50)
         third = uc.compute_alerts(self._snapshot(claude_windows=window), state, now_utc=later)
         self.assertTrue(any("nearly exhausted" in a for a in third))
+
+
+class TestClaudeTokenSources(unittest.TestCase):
+    """Token source resolution. The regression this guards: on macOS there is
+    no ~/.claude/.credentials.json (Claude Code stores the session token in
+    the login Keychain), so the collector fell through to the long-lived
+    `claude setup-token` value in .env -- which the oauth/usage endpoint
+    rejects with 403. Result: authoritative usage silently degraded to a
+    token-count estimate with no percentages and no reset times."""
+
+    KEYCHAIN_PAYLOAD = json.dumps({"claudeAiOauth": {"accessToken": "keychain-tok"}})
+
+    def setUp(self):
+        self._tmp = tempfile.NamedTemporaryFile("w", suffix=".env", delete=False)
+        self._tmp.write("CLAUDE_CODE_OAUTH_TOKEN=env-tok\n")
+        self._tmp.close()
+        self.addCleanup(os.unlink, self._tmp.name)
+
+    def _security_ok(self, stdout=None):
+        return MagicMock(returncode=0, stdout=stdout if stdout is not None else self.KEYCHAIN_PAYLOAD)
+
+    def test_keychain_used_when_credentials_file_absent(self):
+        with patch.object(uc.sys, "platform", "darwin"), \
+             patch.object(uc.os.path, "exists", side_effect=lambda p: p == self._tmp.name), \
+             patch.object(uc, "ENV_PATH", self._tmp.name), \
+             patch.object(uc.subprocess, "run", return_value=self._security_ok()):
+            token, source = uc._read_claude_token()
+        self.assertEqual(token, "keychain-tok")
+        self.assertEqual(source, "keychain")
+
+    def test_keychain_beats_env_file(self):
+        """The .env token answers 403, so it must never win over the keychain."""
+        with patch.object(uc.sys, "platform", "darwin"), \
+             patch.object(uc.os.path, "exists", return_value=True), \
+             patch.object(uc, "ENV_PATH", self._tmp.name), \
+             patch.object(uc.subprocess, "run", return_value=self._security_ok()):
+            token, source = uc._read_claude_token()
+        self.assertEqual(token, "keychain-tok")
+        self.assertEqual(source, "keychain")
+
+    def test_credentials_file_still_wins_over_keychain(self):
+        cred = tempfile.NamedTemporaryFile("w", suffix=".json", delete=False)
+        cred.write(json.dumps({"claudeAiOauth": {"accessToken": "file-tok"}}))
+        cred.close()
+        self.addCleanup(os.unlink, cred.name)
+        with patch.object(uc.sys, "platform", "darwin"), \
+             patch.object(uc.os.path, "expanduser", return_value=cred.name), \
+             patch.object(uc.subprocess, "run", return_value=self._security_ok()) as run:
+            token, source = uc._read_claude_token()
+        self.assertEqual(token, "file-tok")
+        self.assertEqual(source, "credentials_file")
+        run.assert_not_called()
+
+    def test_non_darwin_never_shells_out_to_security(self):
+        with patch.object(uc.sys, "platform", "linux"), \
+             patch.object(uc.subprocess, "run") as run:
+            self.assertIsNone(uc._read_keychain_token())
+        run.assert_not_called()
+
+    def test_security_failure_falls_through_to_env_file(self):
+        with patch.object(uc.sys, "platform", "darwin"), \
+             patch.object(uc.os.path, "exists", side_effect=lambda p: p == self._tmp.name), \
+             patch.object(uc, "ENV_PATH", self._tmp.name), \
+             patch.object(uc.subprocess, "run", return_value=MagicMock(returncode=1, stdout="")):
+            token, source = uc._read_claude_token()
+        self.assertEqual(token, "env-tok")
+        self.assertEqual(source, "env_file")
+
+    def test_unparseable_keychain_payload_is_silent(self):
+        with patch.object(uc.sys, "platform", "darwin"), \
+             patch.object(uc.subprocess, "run", return_value=MagicMock(returncode=0, stdout="not json")):
+            self.assertIsNone(uc._read_keychain_token())
+
+    def test_keychain_prompt_timeout_does_not_raise(self):
+        """A headless/launchd run can hit a blocking GUI prompt; the bounded
+        subprocess must degrade to None, never crash the monitor."""
+        with patch.object(uc.sys, "platform", "darwin"), \
+             patch.object(uc.subprocess, "run", side_effect=subprocess.TimeoutExpired("security", 10)):
+            self.assertIsNone(uc._read_keychain_token())
+
+    def test_no_source_at_all_returns_none_pair(self):
+        with patch.object(uc.sys, "platform", "linux"), \
+             patch.object(uc.os.path, "exists", return_value=False):
+            self.assertEqual(uc._read_claude_token(), (None, None))
 
 
 if __name__ == "__main__":

--- a/scripts/usage-collect.py
+++ b/scripts/usage-collect.py
@@ -6,7 +6,10 @@ Reads current usage/quota status for two providers:
   - Codex (OpenAI Codex CLI): authoritative, parsed from the newest
     ~/.codex/sessions/*/*/*/rollout-*.jsonl rate_limits event.
   - Claude (Claude Code subscription): tries the authoritative
-    api.anthropic.com/api/oauth/usage endpoint first. On a transient
+    api.anthropic.com/api/oauth/usage endpoint first, authenticating with
+    the session OAuth token (~/.claude/.credentials.json, or the macOS
+    login Keychain entry "Claude Code-credentials" -- on darwin the file
+    does not exist). On a transient
     failure (429/5xx/timeout) it reuses the last authoritative snapshot
     from store/usage-latest.json if it's fresh enough (source becomes
     "authoritative_cached") instead of losing real numbers. Only falls
@@ -305,8 +308,42 @@ def collect_codex():
 # Claude collector -- authoritative endpoint, else local-transcript estimate
 # --------------------------------------------------------------------------
 
+def _read_keychain_token():
+    """macOS only: Claude Code keeps its OAuth credentials in the login
+    Keychain, NOT in ~/.claude/.credentials.json (that file simply does not
+    exist on darwin). Returns the access token or None. Never logs the value.
+
+    Failures are silent by design: on a headless/launchd run the `security`
+    call can be denied or block on a GUI prompt, so it is bounded by a
+    timeout and falls through to the next source instead of raising."""
+    if sys.platform != "darwin":
+        return None
+    try:
+        proc = subprocess.run(
+            ["security", "find-generic-password", "-s", "Claude Code-credentials", "-w"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except Exception:
+        return None
+    if proc.returncode != 0 or not proc.stdout.strip():
+        return None
+    try:
+        data = json.loads(proc.stdout.strip())
+    except Exception:
+        return None
+    oauth = data.get("claudeAiOauth") or {}
+    return oauth.get("accessToken") or data.get("accessToken") or None
+
+
 def _read_claude_token():
-    """Return (token, token_source) or (None, None). Never logs the value."""
+    """Return (token, token_source) or (None, None). Never logs the value.
+
+    Source order matters: the long-lived `claude setup-token` value that
+    typically lands in the .env file is NOT accepted by the oauth/usage
+    endpoint (it answers 403), while the session token from the Keychain /
+    credentials file is. Cheapest authoritative source first, .env last."""
     cred_path = os.path.expanduser("~/.claude/.credentials.json")
     if os.path.exists(cred_path):
         try:
@@ -318,6 +355,10 @@ def _read_claude_token():
                 return token, "credentials_file"
         except Exception:
             pass
+
+    keychain_token = _read_keychain_token()
+    if keychain_token:
+        return keychain_token, "keychain"
 
     if os.path.exists(ENV_PATH):
         try:
@@ -354,7 +395,7 @@ def _collect_claude_authoritative():
     """
     token, token_source = _read_claude_token()
     if not token:
-        return None, "no oauth token available (no credentials.json, no .env token)", "no_token"
+        return None, "no oauth token available (no credentials.json, no keychain entry, no .env token)", "no_token"
 
     version = _claude_cli_version()
     req = urllib.request.Request(


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

**HU.** A `scripts/usage-collect.py` a kvóta-végpontot (`api/oauth/usage`) azzal a tokennel hívja, amit a `_read_claude_token()` először talál: `~/.claude/.credentials.json`, utána a `.env`-beli `CLAUDE_CODE_OAUTH_TOKEN`. macOS-en az a fájl **nem létezik** (a Claude Code a login Keychainben tárolja a session tokent), így minden futás a `.env`-ben lévő, `claude setup-token`-nel készült hosszú életű tokenre esik vissza -- amit a usage végpont **403-mal utasít vissza**. A 403 „permanent" besorolású, tehát a cache sem menti meg: a mérő csendben lokális transzkript-becslésre vált, százalék és nullázási időpont nélkül. Pontosan az az adat tűnik el, amire a kvóta-riasztások épülnek, és semmi nem jelzi, csak a `(source: estimate)` sor.

A javítás egy Keychain-forrást tesz a credentials fájl és a `.env` közé. `sys.platform !== 'darwin'` esetén meg sem próbálja. A `security` hívás 10 másodperces időkorláttal fut és minden hibán csendben a következő forrásra lép, hogy egy headless/launchd futásban egy megtagadott vagy blokkoló Keychain-prompt se állítsa meg a monitort (a szkript szerződése: soha nem dob, mindig 0-val tér vissza).

Élő futás a javítás után újra autoritatív ablakokat ad: 5 órás 10%, heti 13%, Fable-heti 12%.

**EN.** `scripts/usage-collect.py` authenticates against `api/oauth/usage` with whatever `_read_claude_token()` finds first: `~/.claude/.credentials.json`, then the `.env` `CLAUDE_CODE_OAUTH_TOKEN`. On macOS that file **does not exist** -- Claude Code keeps the session token in the login Keychain -- so every run falls through to the long-lived `claude setup-token` value, which the usage endpoint **rejects with 403**. That 403 is classified `permanent`, so the cache cannot rescue it either: the collector silently degrades to a local-transcript token-count estimate with no utilization percentages and no reset times. Exactly the data the quota alerts are built on disappears, and the only tell is the `(source: estimate)` line.

The fix adds a Keychain source between the credentials file and `.env`. It is skipped outright when `sys.platform != 'darwin'`. The `security` call is bounded by a 10s timeout and silent on any failure, so a headless/launchd run that hits a denied or blocking Keychain prompt degrades to the next source instead of crashing the monitor (the script's contract: never raise, always exit 0).

A live run after the fix reports authoritative windows again: 5-hour 10%, weekly 13%, Fable-tier weekly 12%.

## Kapcsolódó issue / Related issue

Closes #

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [ ] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).

### Teszt / Tests

8 új unit teszt (`scripts/__tests__/usage-collect.test.py`, `TestClaudeTokenSources`): forrás-sorrend (credentials fájl > Keychain > `.env`), a `.env` token soha nem előzi meg a Keychaint, nem-darwin platformon nincs `security` hívás, `security` hiba esetén továbbesés a `.env`-re, olvashatatlan Keychain-payload, és a blokkoló prompt időtúllépése nem dob. A teljes fájl 82 tesztje zöld.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
