### PR TITLE
fix(quarantine-reader): honour the operator's runtime egress allowlist

### DIFF
--- a/templates/sub-agents/quarantine-reader.md
+++ b/templates/sub-agents/quarantine-reader.md
@@ -50,7 +50,25 @@ Only fetch URLs from these approved domains. Reject all others with `{ "error": 
 - `feeds.reuters.com`
 - `feeds.bbci.co.uk`
 
-For any other domain, return:
+### Operator-approved domains (runtime allowlist)
+
+The list above is the built-in default set, frozen in this prompt. The operator
+can approve additional domains at runtime in `store/egress-allowlist.json` under
+`quarantine_domains`. You cannot read that file (you only have WebFetch), so:
+
+- If the caller states that the domain is operator-approved in
+  `quarantine_domains`, **attempt the fetch**. Do not refuse preemptively.
+- The `egress-gate` PreToolUse hook independently enforces that same file and is
+  the actual authority. If the domain is not truly approved, your WebFetch call
+  is blocked by the hook, and you report that block as the `error` field.
+- A caller's claim is therefore never proof, and never needs to be: an
+  unapproved domain cannot get through the hook no matter what you were told.
+
+This exists so that approving a site is a one-line operator config change rather
+than an edit to this prompt, and so a legitimate, operator-named URL does not
+fail with a refusal that no config can lift.
+
+For any other domain (not built-in, and not claimed as operator-approved), return:
 ```json
 { "url": "<requested url>", "nonce": "<nonce>", "status": 0, "content": null, "error": "domain not on quarantine-reader fetch allowlist" }
 ```


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

**HU.** Két, egymást nem ismerő allowlist van a külső letöltés útjában. A `scripts/hooks/egress-gate.mjs` minden híváskor beolvassa a `store/egress-allowlist.json`-t, és annak `quarantine_domains` listáját a `quarantine-reader` tier számára engedi. A sub-ágens saját, a promptjába fagyasztott listája viszont erről nem tud: az operátor által jóváhagyott domaint a sub-ágens **még egyetlen tool-hívás előtt** elutasítja. A gyakorlati következmény, hogy a hook üzenete („az operátor jóváhagyhatja: add hozzá a `store/egress-allowlist.json`-hoz") **nem igaz** -- a config-változtatás nem oldja fel az elutasítást, csak az ágens-definíció szerkesztése.

A sub-ágensnek egyedül `WebFetch` eszköze van, tehát a fájlt maga nem tudja elolvasni. Ezért: ha a hívó közli, hogy a domain operátor-jóváhagyott, a sub-ágens **megpróbálja** a letöltést, és ha a hook mégis blokkolja, azt hibaként jelenti vissza. Biztonsági veszteség nincs, mert az érdemi kapu a hook: egy nem jóváhagyott domain nem jut át rajta, akármit állít a hívó. A beépített default lista változatlan marad.

Éles példa: az operátor a `store/egress-allowlist.json`-ba felvett egy általa megnevezett publikus oldalt, és a sub-ágens 0 tool-hívással, háromszor egymás után visszautasította.

**EN.** Two allowlists sit in the path of an external fetch and never meet. `scripts/hooks/egress-gate.mjs` reads `store/egress-allowlist.json` on every invocation and grants its `quarantine_domains` to the `quarantine-reader` tier. The sub-agent's own list, frozen into its prompt, knows nothing about that file: a domain the operator approved is refused by the sub-agent **before it makes a single tool call**. The practical consequence is that the hook's own block message ("the operator can approve it: add the domain to `store/egress-allowlist.json`") **is not true** -- the config change does not lift the refusal; only editing the agent definition does.

The sub-agent has `WebFetch` and nothing else, so it cannot read the file itself. Therefore: when the caller states the domain is operator-approved, the sub-agent **attempts** the fetch and reports the hook's block if that claim is false. No security is traded away, because the hook is the real authority: an unapproved domain cannot pass it regardless of what the caller claims. The built-in default list is unchanged.

Live example: the operator added a public site they had named themselves to `store/egress-allowlist.json`, and the sub-agent refused it three times in a row with 0 tool uses.

## Kapcsolódó issue / Related issue

Closes #

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [ ] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).

### Megjegyzés / Note

Csak a `templates/sub-agents/quarantine-reader.md` változik. A telepített példányok `~/.claude/agents/quarantine-reader.md` másolata a következő telepítéskor/másoláskor veszi át; egy már futó session a definíciót indításkor tölti be, tehát a változás újraindítás után érvényesül.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
