### PR TITLE
feat(quota): hold back background heartbeats when the shared window runs dry

### DIFF
--- a/src/__tests__/quota-gate-wiring.test.ts
+++ b/src/__tests__/quota-gate-wiring.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { quotaWorkClass } from '../web/schedule-runner.js'
+import { parseQuotaSnapshot } from '../quota-snapshot.js'
+
+// The gate itself is covered in quota-gate.test.ts. This file covers the two
+// seams around it: how a scheduled task is classified, and how the collector's
+// on-disk JSON becomes the gate's input.
+
+const RUNNER_SRC = readFileSync(join(__dirname, '../web/schedule-runner.ts'), 'utf-8')
+
+describe('quotaWorkClass', () => {
+  it('exempts shell-command tasks -- they never call a model', () => {
+    expect(quotaWorkClass({ type: 'command' })).toBe('free')
+  })
+
+  it('classifies heartbeats as background', () => {
+    expect(quotaWorkClass({ type: 'heartbeat' })).toBe('background')
+  })
+
+  it('treats owner-visible and unknown future types as owner-facing', () => {
+    expect(quotaWorkClass({ type: 'task' })).toBe('owner-facing')
+    expect(quotaWorkClass({ type: 'dream-engine' } as never)).toBe('owner-facing')
+    expect(quotaWorkClass({} as never)).toBe('owner-facing')
+  })
+})
+
+describe('schedule-runner wiring', () => {
+  it('reads the snapshot once per tick, not once per task', () => {
+    // A per-task read would re-parse the same file N times every 60s tick.
+    expect(RUNNER_SRC).toContain('const quotaSnapshot = readQuotaSnapshot()')
+    expect(RUNNER_SRC.match(/readQuotaSnapshot\(\)/g)?.length).toBe(1)
+  })
+
+  it('records a held-back occurrence so the catch-up window cannot re-fire it', () => {
+    // Mirrors the pre-check skip: mark the tick as run, log a task-run row.
+    const gate = RUNNER_SRC.slice(RUNNER_SRC.indexOf("if (quota.action === 'defer')"))
+    const block = gate.slice(0, gate.indexOf('const cronPc'))
+    expect(block).toContain('scheduleLastRun.set(task.name, now)')
+    expect(block).toContain('persistScheduleLastRun()')
+    expect(block).toContain("appendTaskRun(task.name, agentName, 'skipped')")
+  })
+
+  it('gates before the pre-check, so a deferred task never spawns its script', () => {
+    expect(RUNNER_SRC.indexOf("if (quota.action === 'defer')")).toBeLessThan(
+      RUNNER_SRC.indexOf('const cronPc = runPreCheck(task)'),
+    )
+  })
+})
+
+describe('parseQuotaSnapshot', () => {
+  const onDisk = {
+    generated_at: '2026-08-17T14:53:57.362898+00:00',
+    generated_at_local: '2026-08-17 16:53:57 CEST',
+    codex: { ok: false },
+    claude: {
+      provider: 'claude',
+      source: 'authoritative',
+      ok: true,
+      windows: {
+        five_hour: { used_percent: 10.0, resets_at: 1786990200.146628 },
+        seven_day: { used_percent: 13.0, resets_at: 1787205600.146654 },
+      },
+    },
+  }
+
+  it('maps the collector output onto the gate input', () => {
+    const s = parseQuotaSnapshot(onDisk)
+    expect(s?.source).toBe('authoritative')
+    expect(s?.generatedAtMs).toBe(Date.parse('2026-08-17T14:53:57.362898+00:00'))
+    expect(s?.windows?.five_hour?.used_percent).toBe(10)
+  })
+
+  it('returns null for anything that is not a collector snapshot', () => {
+    expect(parseQuotaSnapshot(null)).toBeNull()
+    expect(parseQuotaSnapshot('nope')).toBeNull()
+    expect(parseQuotaSnapshot({})).toBeNull()
+    expect(parseQuotaSnapshot({ claude: 'not-an-object' })).toBeNull()
+  })
+
+  it('survives a snapshot with an unparseable timestamp', () => {
+    const s = parseQuotaSnapshot({ ...onDisk, generated_at: 'yesterday-ish' })
+    // Null timestamp -> the gate fails open rather than trusting stale numbers.
+    expect(s?.generatedAtMs).toBeNull()
+    expect(s?.source).toBe('authoritative')
+  })
+})

--- a/src/__tests__/quota-gate.test.ts
+++ b/src/__tests__/quota-gate.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest'
+import {
+  decideQuotaAction,
+  quotaPressure,
+  QUOTA_GATE,
+  type QuotaSnapshot,
+} from '../quota-gate.js'
+
+const NOW = Date.UTC(2026, 7, 17, 20, 0, 0) // 2026-08-17T20:00:00Z
+
+/** Build a snapshot; percentages in, epoch-seconds resets derived from NOW. */
+function snap(
+  windows: Record<string, { used: number; resetsInMin?: number }>,
+  opts: { source?: string; ageMs?: number } = {},
+): QuotaSnapshot & { windows: Record<string, { used_percent: number | null; resets_at: number | null }> } {
+  return {
+    source: opts.source ?? 'authoritative',
+    generatedAtMs: NOW - (opts.ageMs ?? 60_000),
+    windows: Object.fromEntries(
+      Object.entries(windows).map(([k, v]) => [
+        k,
+        {
+          used_percent: v.used,
+          resets_at: v.resetsInMin == null ? null : (NOW + v.resetsInMin * 60_000) / 1000,
+        },
+      ]),
+    ),
+  }
+}
+
+const background = (snapshot: unknown) =>
+  decideQuotaAction({ snapshot: snapshot as never, nowMs: NOW, workClass: 'background' })
+
+describe('quotaPressure', () => {
+  it('takes the highest utilization across windows', () => {
+    expect(quotaPressure(snap({ five_hour: { used: 10 }, seven_day: { used: 62 } }))).toBe(62)
+  })
+
+  it('ignores windows without a numeric percentage', () => {
+    const s = snap({ five_hour: { used: 10 } })
+    s.windows.seven_day = { used_percent: null, resets_at: null }
+    expect(quotaPressure(s)).toBe(10)
+  })
+
+  it('returns null when nothing reports a percentage', () => {
+    expect(quotaPressure({ source: 'authoritative', windows: {} })).toBeNull()
+    expect(quotaPressure(null)).toBeNull()
+  })
+})
+
+describe('decideQuotaAction -- fail open', () => {
+  it('runs shell-only work without even looking at the snapshot', () => {
+    const d = decideQuotaAction({
+      snapshot: snap({ five_hour: { used: 99 } }),
+      nowMs: NOW,
+      workClass: 'free',
+    })
+    expect(d.action).toBe('run')
+    expect(d.reason).toBe('no-model-cost')
+  })
+
+  it('runs when there is no snapshot at all', () => {
+    expect(background(null).action).toBe('run')
+    expect(background(undefined).reason).toBe('no-snapshot')
+  })
+
+  it('runs on an estimate-only snapshot, however alarming its numbers look', () => {
+    const d = background(snap({ five_hour: { used: 99 } }, { source: 'estimate' }))
+    expect(d.action).toBe('run')
+    expect(d.reason).toContain('untrusted-source')
+  })
+
+  it('accepts a cached authoritative snapshot as evidence', () => {
+    const d = background(snap({ five_hour: { used: 95 } }, { source: 'authoritative_cached' }))
+    expect(d.action).toBe('defer')
+  })
+
+  it('runs when the snapshot is too old to describe now', () => {
+    const d = background(
+      snap({ five_hour: { used: 99 } }, { ageMs: QUOTA_GATE.staleAfterMs + 60_000 }),
+    )
+    expect(d.action).toBe('run')
+    expect(d.reason).toContain('stale-snapshot')
+  })
+
+  it('runs when the snapshot has no usable window', () => {
+    const d = background({ source: 'authoritative', generatedAtMs: NOW - 1000, windows: {} })
+    expect(d.action).toBe('run')
+    expect(d.reason).toBe('no-usable-window')
+  })
+})
+
+describe('decideQuotaAction -- the brake', () => {
+  it('defers background work under high pressure', () => {
+    const d = background(snap({ five_hour: { used: 90, resetsInMin: 180 } }))
+    expect(d.action).toBe('defer')
+    expect(d.reason).toBe('pressure:90%')
+    expect(d.pressure).toBe(90)
+  })
+
+  it('runs background work when there is plenty left', () => {
+    const d = background(snap({ five_hour: { used: 10, resetsInMin: 130 }, seven_day: { used: 13 } }))
+    expect(d.action).toBe('run')
+    expect(d.reason).toBe('ok@13%')
+  })
+
+  it("waits out a window that is over the line and resets shortly (the owner's own example)", () => {
+    // 90% and half an hour to go: spending the tail buys nothing.
+    const d = background(snap({ five_hour: { used: 75, resetsInMin: 25 } }))
+    expect(d.action).toBe('defer')
+    expect(d.reason).toContain('near-reset:five_hour')
+  })
+
+  it('does not wait out a reset that is still far away', () => {
+    const d = background(snap({ five_hour: { used: 75, resetsInMin: 120 } }))
+    expect(d.action).toBe('run')
+  })
+
+  it('does not wait out a nearly-empty window that happens to reset soon', () => {
+    const d = background(snap({ five_hour: { used: 12, resetsInMin: 5 } }))
+    expect(d.action).toBe('run')
+  })
+
+  it('ignores a reset timestamp that has already passed', () => {
+    const d = background(snap({ five_hour: { used: 75, resetsInMin: -10 } }))
+    expect(d.action).toBe('run')
+  })
+})
+
+describe('decideQuotaAction -- the owner is never silenced', () => {
+  it('runs owner-facing work at any pressure', () => {
+    for (const used of [50, 85, 99, 100]) {
+      const d = decideQuotaAction({
+        snapshot: snap({ five_hour: { used, resetsInMin: 5 } }),
+        nowMs: NOW,
+        workClass: 'owner-facing',
+      })
+      expect(d.action).toBe('run')
+      expect(d.reason).toBe(`owner-facing@${used}%`)
+    }
+  })
+
+  it('still reports the pressure it saw, so the caller can log it', () => {
+    const d = decideQuotaAction({
+      snapshot: snap({ five_hour: { used: 97 } }),
+      nowMs: NOW,
+      workClass: 'owner-facing',
+    })
+    expect(d.pressure).toBe(97)
+  })
+})

--- a/src/quota-gate.ts
+++ b/src/quota-gate.ts
@@ -1,0 +1,156 @@
+// Pure decision logic for quota-aware work dispatch.
+//
+// The Claude subscription quota is ONE pool for the whole fleet, not a
+// per-agent budget: every heartbeat, every scheduled task and every agent turn
+// draws from the same 5-hour and 7-day windows. Nothing used to look at that
+// pool before starting work, so the fleet's cheapest, most frequent consumers
+// (background heartbeats, one per agent every 30 minutes) could burn the last
+// percent of a window minutes before the owner needed it for real work.
+//
+// This module answers one question -- "should this piece of work start right
+// now?" -- from the snapshot scripts/usage-collect.py writes to
+// store/usage-latest.json. Kept pure so the thresholds are unit-tested without
+// a network call or a filesystem read; the caller supplies the snapshot.
+//
+// Two design rules, both deliberate:
+//
+//   FAIL OPEN. A missing, stale, unparseable or estimate-only snapshot means we
+//   do not know the quota state, and "unknown" must never silence the fleet.
+//   Every uncertain path returns 'run'. The gate can only ever stop work when
+//   it has fresh, authoritative evidence of real pressure.
+//
+//   ONLY BACKGROUND WORK IS DEFERRED. Anything the owner sees or waits for runs
+//   regardless of pressure -- a quota window that is nearly full is not a
+//   reason to go silent on the person paying for it. Skipping one background
+//   heartbeat costs nothing; skipping the owner's answer costs everything.
+
+/** One quota window as scripts/usage-collect.py records it. */
+export interface QuotaWindow {
+  /** 0..100, or null when the source could not report a percentage. */
+  used_percent?: number | null
+  /** Unix epoch SECONDS (float ok), or null. */
+  resets_at?: number | null
+}
+
+/** The `claude` section of store/usage-latest.json. */
+export interface QuotaSnapshot {
+  /** 'authoritative' | 'authoritative_cached' | 'estimate' | ... */
+  source?: string | null
+  generatedAtMs?: number | null
+  windows?: Record<string, QuotaWindow> | null
+}
+
+// What the work costs us, NOT how important it feels.
+//   free         -- consumes no model tokens at all (type='command' shell tasks)
+//   owner-facing -- the owner sees the result or is waiting for it
+//   background   -- nobody is waiting; skipping one occurrence is invisible
+export type QuotaWorkClass = 'free' | 'owner-facing' | 'background'
+
+export type QuotaAction = 'run' | 'defer'
+
+export interface QuotaDecision {
+  action: QuotaAction
+  /** Short machine-ish reason, safe to log. */
+  reason: string
+  /** Highest used_percent across the windows, or null when unknown. */
+  pressure: number | null
+}
+
+export const QUOTA_GATE = {
+  /** A snapshot older than this tells us nothing about now. */
+  staleAfterMs: 20 * 60_000,
+  /** Background work stops at or above this utilization. */
+  deferAtPercent: 85,
+  /** ... and also stops above this, if the window is about to reset anyway. */
+  nearResetPercent: 70,
+  /** "About to reset": waiting this long is cheaper than spending the tail. */
+  nearResetMs: 30 * 60_000,
+  /** Sources whose numbers are real. Anything else is a guess -- fail open. */
+  trustedSources: ['authoritative', 'authoritative_cached'],
+} as const
+
+/** Highest utilization across all windows, or null when none reports one. */
+export function quotaPressure(snapshot: QuotaSnapshot | null | undefined): number | null {
+  const windows = snapshot?.windows
+  if (!windows) return null
+  let max: number | null = null
+  for (const w of Object.values(windows)) {
+    const used = w?.used_percent
+    if (typeof used !== 'number' || Number.isNaN(used)) continue
+    if (max === null || used > max) max = used
+  }
+  return max
+}
+
+/**
+ * The window we would be waiting for: the one under pressure that resets
+ * soonest. Returns null when nothing is close to a reset.
+ */
+function windowResettingSoon(
+  snapshot: QuotaSnapshot,
+  nowMs: number,
+): { key: string; usedPercent: number; msUntilReset: number } | null {
+  const windows = snapshot.windows ?? {}
+  let best: { key: string; usedPercent: number; msUntilReset: number } | null = null
+  for (const [key, w] of Object.entries(windows)) {
+    const used = w?.used_percent
+    const resets = w?.resets_at
+    if (typeof used !== 'number' || typeof resets !== 'number') continue
+    const msUntilReset = resets * 1000 - nowMs
+    if (msUntilReset <= 0 || msUntilReset > QUOTA_GATE.nearResetMs) continue
+    if (used < QUOTA_GATE.nearResetPercent) continue
+    if (!best || msUntilReset < best.msUntilReset) best = { key, usedPercent: used, msUntilReset }
+  }
+  return best
+}
+
+export function decideQuotaAction(input: {
+  snapshot: QuotaSnapshot | null | undefined
+  nowMs: number
+  workClass: QuotaWorkClass
+}): QuotaDecision {
+  const { snapshot, nowMs, workClass } = input
+
+  // Shell commands cost no tokens -- the gate has no business touching them.
+  if (workClass === 'free') return { action: 'run', reason: 'no-model-cost', pressure: null }
+
+  if (!snapshot) return { action: 'run', reason: 'no-snapshot', pressure: null }
+
+  const source = (snapshot.source ?? '').toLowerCase()
+  if (!(QUOTA_GATE.trustedSources as readonly string[]).includes(source)) {
+    return { action: 'run', reason: `untrusted-source:${source || 'none'}`, pressure: null }
+  }
+
+  const generatedAtMs = snapshot.generatedAtMs
+  if (typeof generatedAtMs !== 'number' || Number.isNaN(generatedAtMs)) {
+    return { action: 'run', reason: 'no-snapshot-timestamp', pressure: null }
+  }
+  const ageMs = nowMs - generatedAtMs
+  if (ageMs > QUOTA_GATE.staleAfterMs) {
+    return { action: 'run', reason: `stale-snapshot:${Math.round(ageMs / 60_000)}m`, pressure: null }
+  }
+
+  const pressure = quotaPressure(snapshot)
+  if (pressure === null) return { action: 'run', reason: 'no-usable-window', pressure: null }
+
+  // The owner is waiting, or will read the result. Pressure is not a reason to
+  // go quiet on them -- report it in the reason and run.
+  if (workClass === 'owner-facing') {
+    return { action: 'run', reason: `owner-facing@${pressure}%`, pressure }
+  }
+
+  if (pressure >= QUOTA_GATE.deferAtPercent) {
+    return { action: 'defer', reason: `pressure:${pressure}%`, pressure }
+  }
+
+  const soon = windowResettingSoon(snapshot, nowMs)
+  if (soon) {
+    return {
+      action: 'defer',
+      reason: `near-reset:${soon.key}@${soon.usedPercent}%/${Math.round(soon.msUntilReset / 60_000)}m`,
+      pressure,
+    }
+  }
+
+  return { action: 'run', reason: `ok@${pressure}%`, pressure }
+}

--- a/src/quota-snapshot.ts
+++ b/src/quota-snapshot.ts
@@ -1,0 +1,50 @@
+// Reads the quota snapshot scripts/usage-collect.py writes to
+// store/usage-latest.json and hands it to the pure gate in quota-gate.ts.
+//
+// Everything here degrades to null: a missing file, a half-written file, a
+// shape we do not recognise. Null means "we do not know", and the gate treats
+// not-knowing as permission to run (see quota-gate.ts, FAIL OPEN).
+
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { STORE_DIR } from './config.js'
+import type { QuotaSnapshot } from './quota-gate.js'
+
+export const USAGE_SNAPSHOT_PATH = join(STORE_DIR, 'usage-latest.json')
+
+/**
+ * Map the collector's on-disk JSON onto the gate's input shape.
+ * Exported separately from the file read so the mapping is unit-testable.
+ */
+export function parseQuotaSnapshot(raw: unknown): QuotaSnapshot | null {
+  if (!raw || typeof raw !== 'object') return null
+  const root = raw as Record<string, unknown>
+  const claude = root.claude
+  if (!claude || typeof claude !== 'object') return null
+  const c = claude as Record<string, unknown>
+
+  // generated_at is an ISO-8601 string on disk; the gate wants epoch ms.
+  let generatedAtMs: number | null = null
+  if (typeof root.generated_at === 'string') {
+    const parsed = Date.parse(root.generated_at)
+    if (!Number.isNaN(parsed)) generatedAtMs = parsed
+  }
+
+  const windows = c.windows && typeof c.windows === 'object'
+    ? (c.windows as QuotaSnapshot['windows'])
+    : null
+
+  return {
+    source: typeof c.source === 'string' ? c.source : null,
+    generatedAtMs,
+    windows,
+  }
+}
+
+export function readQuotaSnapshot(path: string = USAGE_SNAPSHOT_PATH): QuotaSnapshot | null {
+  try {
+    return parseQuotaSnapshot(JSON.parse(readFileSync(path, 'utf-8')))
+  } catch {
+    return null
+  }
+}

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -49,6 +49,8 @@ import {
 import { MAIN_CHANNELS_SESSION } from './main-agent.js'
 import { sendTelegramMessage } from './telegram.js'
 import { runCommandTask } from './command-task.js'
+import { decideQuotaAction, type QuotaWorkClass } from '../quota-gate.js'
+import { readQuotaSnapshot } from '../quota-snapshot.js'
 import { paneShowsContextSaturation, detectsFirstRunGate, detectPaneState, type PaneState } from '../pane-state.js'
 import { withSessionSendLock } from './session-send-lock.js'
 
@@ -429,6 +431,17 @@ export function resolveBoundChatId(agentName: string): string | null {
     }
     return chosen
   } catch { return null }
+}
+
+// What a scheduled task costs the shared quota pool, for the gate in
+// quota-gate.ts. `command` tasks run a raw shell command with no model call at
+// all; heartbeats are background checks nobody is waiting for; everything else
+// (task, dream-engine, unknown future types) reports to the owner and is never
+// held back.
+export function quotaWorkClass(task: Pick<ScheduledTask, 'type'>): QuotaWorkClass {
+  if (task.type === 'command') return 'free'
+  if (task.type === 'heartbeat') return 'background'
+  return 'owner-facing'
 }
 
 export function runPreCheck(task: ScheduledTask): { skip: boolean; prefix?: string } {
@@ -1219,6 +1232,12 @@ export function startScheduleRunner(): NodeJS.Timeout {
     // routine heartbeats (see taskInjectionRank). listScheduledTasks() builds
     // a fresh array every tick, so the in-place sort leaks nowhere.
     tasks.sort((a, b) => taskInjectionRank(a) - taskInjectionRank(b))
+
+    // One read per tick, shared by every task the loop considers: the whole
+    // fleet draws on ONE subscription quota pool, so the gate below asks the
+    // same snapshot about all of them.
+    const quotaSnapshot = readQuotaSnapshot()
+
     for (const task of tasks) {
       if (!task.enabled) continue
       const occurrenceMs = cronPrevOccurrence(task.schedule, fromMs, now)
@@ -1273,6 +1292,30 @@ export function startScheduleRunner(): NodeJS.Timeout {
         targetAgents = [MAIN_AGENT_ID, ...running]
       } else {
         targetAgents = [task.agent || MAIN_AGENT_ID]
+      }
+
+      // Quota gate. Every heartbeat across the fleet spends from the same
+      // subscription pool as the owner's own turns, so a routine background
+      // check must not burn the tail of a window minutes before real work
+      // needs it. Only background work is ever held back, and only on fresh
+      // authoritative evidence -- an unknown quota state runs (quota-gate.ts).
+      // A held-back occurrence is recorded like a pre-check skip: the tick is
+      // marked as run so the catch-up window does not fire it later, and the
+      // next scheduled occurrence is evaluated on its own merits.
+      const quota = decideQuotaAction({
+        snapshot: quotaSnapshot,
+        nowMs: now,
+        workClass: quotaWorkClass(task),
+      })
+      if (quota.action === 'defer') {
+        logger.info(
+          { task: task.name, reason: quota.reason, pressure: quota.pressure },
+          'Quota gate: holding back a background task until the window recovers',
+        )
+        scheduleLastRun.set(task.name, now)
+        persistScheduleLastRun()
+        for (const agentName of targetAgents) appendTaskRun(task.name, agentName, 'skipped')
+        continue
       }
 
       // Run pre-check once per task (not per agent) since it queries shared


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [ ] Bug fix (hibajavítás / bug fix)
- [x] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

**HU.** Az előfizetés kvótája **egyetlen közös készlet** az egész flottának: minden heartbeat, minden ütemezett feladat és a gazda saját fordulói is ugyanabból az 5 órás és 7 napos ablakból fogyasztanak. Eddig semmi nem nézte meg ezt a készletet munkakezdés előtt, így a leggyakoribb fogyasztók -- ágensenként egy háttér-heartbeat félóránként -- percekkel az előtt éghették el egy ablak maradékát, hogy a gazdának valódi munkára kellett volna. A tünet nem hibaüzenet, hanem az, hogy a gazda limitbe ütközik, miközben egy felügyelet nélküli háttér-ellenőrzés dolgozik.

A PR egy **tiszta döntési modult** ad (`src/quota-gate.ts`), amit a collector pillanatképe táplál (`src/quota-snapshot.ts`, a `store/usage-latest.json`-ból), és beköti a schedule runnerbe a kiosztás határán -- a pre-check **elé**, hogy egy visszatartott feladat még a saját scriptjét se indítsa el. A visszatartott előfordulás pontosan úgy rögzül, mint egy pre-check skip (a tick lefutottnak számít), így a catch-up ablak nem tüzeli el később.

Két szabály, tesztekkel rögzítve:

- **Fail open.** Hiányzó, 20 percnél régebbi, `estimate`-forrású vagy olvashatatlan pillanatkép azt jelenti, hogy nem tudjuk a kvóta állapotát, és a nem-tudás soha nem némíthatja el a flottát. Csak friss, autoritatív bizonyíték állíthat meg munkát.
- **Csak a háttérmunka áll le.** Amit a gazda lát vagy amire vár, az bármilyen nyomáson fut. Egy tele ablak nem ok arra, hogy elhallgassunk az előtt, aki fizeti.

A fék 85% felett húz, illetve 70% felett, ha az ablak 30 percen belül nullázódik (az utolsó félóra kivárása többet ér, mint a maradék elégetése). A `type: "command"` feladatok modellt nem hívnak, ezért eleve kivételek.

Mellékelve egy `usage-snapshot` command task (10 perces frissítés, nulla model-költség), ami a pillanatképet a frissességi ablakon belül tartja. Enélkül a kapu néhány perc után magától fail-openbe megy.

**EN.** The subscription quota is **one shared pool** for the whole fleet: every heartbeat, every scheduled task and the owner's own turns draw from the same 5-hour and 7-day windows. Nothing looked at that pool before starting work, so the most frequent consumers -- one background heartbeat per agent every 30 minutes -- could spend the tail of a window minutes before the owner needed it. The symptom is not an error message; it is the owner hitting a limit while an unattended background check runs.

This adds a **pure decision module** (`src/quota-gate.ts`) fed by the collector's snapshot (`src/quota-snapshot.ts`, from `store/usage-latest.json`), wired into the schedule runner at the dispatch boundary -- **before** the pre-check, so a deferred task never even spawns its script. A held-back occurrence is recorded exactly like a pre-check skip, so the catch-up window cannot re-fire it later.

Two rules, pinned by tests:

- **Fail open.** A missing, >20 min old, `estimate`-sourced or unparseable snapshot means we do not know the quota state, and not-knowing must never silence the fleet. Only fresh authoritative evidence can stop work.
- **Only background work is deferred.** Anything the owner sees or waits for runs at any pressure -- a full window is not a reason to go quiet on the person paying for it.

The brake trips above 85% utilization, or above 70% when the window resets within 30 minutes (waiting out the last half hour beats spending the tail). `type: "command"` tasks call no model and are exempt outright.

Includes a `usage-snapshot` command task (10-minute refresh, zero model cost) that keeps the snapshot inside the freshness window; without it the gate fails open on its own after a few minutes.

## Kapcsolódó issue / Related issue

Closes #

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [ ] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).

### Teszt / Tests

26 új teszt: `src/__tests__/quota-gate.test.ts` (17 -- fail-open ágak, a fék két küszöbe, a gazda-látható munka soha nem áll le) és `src/__tests__/quota-gate-wiring.test.ts` (9 -- feladat-osztályozás, a pillanatkép tick-enként egyszer olvasódik, a visszatartás a catch-up ablakot is lezárja, a kapu a pre-check előtt fut). A meglévő négy schedule-runner suite (57 teszt) változatlanul zöld. `npx tsc --noEmit` tiszta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
