### PR TITLE
fix(messages): no reverse notification to non-agent senders

### DIFF
--- a/src/__tests__/completion-notification.test.ts
+++ b/src/__tests__/completion-notification.test.ts
@@ -2,7 +2,10 @@ import { describe, it, expect, beforeAll } from 'vitest'
 import {
   initDatabase, createAgentMessage,
   markMessageDone, markMessageFailed, getAgentMessage, listAgentMessages,
+  COMPLETION_REPORT_PREFIX,
 } from '../db.js'
+import { shouldNotifyDelegator } from '../web/routes/messages.js'
+import { MAIN_AGENT_ID } from '../config.js'
 
 // Contract tests for the completion-notification feature.
 //
@@ -78,5 +81,41 @@ describe('completion-notification contract', () => {
     // Only the original message was created; route handler would NOT add a notification
     const after = listAgentMessages(200).length
     expect(after - before).toBe(1)
+  })
+})
+
+// The tests above simulate the route's decision by re-implementing it. These call the
+// exported predicate the route actually uses, so a change to the condition shows up here.
+//
+// Sender identities are deliberately MAIN_AGENT_ID and 'system' rather than invented
+// names: `isKnownAgent` resolves real agent directories, and a CI checkout has none, so
+// a made-up sender would be "unknown" there and the positive case would fail for the
+// wrong reason.
+describe('shouldNotifyDelegator', () => {
+  it('notifies a real agent delegator', () => {
+    expect(shouldNotifyDelegator(MAIN_AGENT_ID, 'dex', 'Research something')).toBe(true)
+  })
+
+  it('does not notify the `system` pseudo-sender', () => {
+    // system posts [session-stuck]/[handoff-failure] but has no session to receive a
+    // reply. Before this guard, the undeliverable reply produced another
+    // [handoff-failure], which produced another reply when closed.
+    expect(
+      shouldNotifyDelegator('system', MAIN_AGENT_ID, "[session-stuck] Agent 'polip' ..."),
+    ).toBe(false)
+  })
+
+  it('does not notify on a self-message', () => {
+    expect(shouldNotifyDelegator(MAIN_AGENT_ID, MAIN_AGENT_ID, 'Send to self')).toBe(false)
+  })
+
+  it('does not notify when the content is already a completion report', () => {
+    expect(
+      shouldNotifyDelegator(MAIN_AGENT_ID, 'dex', `${COMPLETION_REPORT_PREFIX} msg_id:1 status:done`),
+    ).toBe(false)
+  })
+
+  it('rejects an empty sender rather than treating it as an agent', () => {
+    expect(shouldNotifyDelegator('', 'dex', 'orphan')).toBe(false)
   })
 })

--- a/src/web/routes/messages.ts
+++ b/src/web/routes/messages.ts
@@ -19,6 +19,30 @@ import { parseQualifiedId, formatQualifiedId } from '../federation/address.js'
 import { getFederationConfig } from '../federation/config.js'
 import type { RouteContext } from './types.js'
 
+// Should closing a message produce a reverse "[Eredmény]" notification to its sender?
+//
+// Exported and tested directly, rather than inlined in the PUT handler: the previous
+// tests re-implemented this condition inside the test file, so they passed no matter
+// what the route actually did.
+//
+// Three senders get no notification:
+//   1. self-messages -- the sender already knows;
+//   2. senders that are not addressable agents. `system` posts the [session-stuck] and
+//      [handoff-failure] notices but owns no tmux session, so a reply to it can never be
+//      delivered: it fails, the retry window expires, and the resulting [handoff-failure]
+//      wakes the main agent -- which, once closed, produced the next one. Measured on the
+//      Acrobot install 2026-08-17: 44 of the last 200 rows were `-> system`, all failed.
+//      `isKnownAgent` is the right test here because it accepts MAIN_AGENT_ID as well as
+//      the sub-agent directories; a plain registry lookup would have suppressed every
+//      notification back to the MAIN agent, which is the case this feature exists for.
+//   3. contents that are themselves completion reports -- breaks ping-pong chains.
+export function shouldNotifyDelegator(fromAgent: string, toAgent: string, content: string): boolean {
+  if (fromAgent === toAgent) return false
+  if (!isKnownAgent(fromAgent)) return false
+  if (content.startsWith(COMPLETION_REPORT_PREFIX)) return false
+  return true
+}
+
 export async function tryHandleMessages(ctx: RouteContext): Promise<boolean> {
   const { req, res, path, method, url } = ctx
 
@@ -193,11 +217,9 @@ export async function tryHandleMessages(ctx: RouteContext): Promise<boolean> {
         closeOtelSpan(done.trace_id, done.span_id, Date.now(), newStatus === 'done' ? 'ok' : 'error')
       }
       // Notify the delegator: create a reverse message from executor → delegator so
-      // they learn the result without polling. Use a sentinel prefix to break
-      // ping-pong chains (the delegator might write back, which would trigger
-      // markMessageDone on this notification; we skip creating ANOTHER notification
-      // when the original content is already a completion report).
-      if (done && done.from_agent !== done.to_agent && !done.content.startsWith(COMPLETION_REPORT_PREFIX)) {
+      // they learn the result without polling. See shouldNotifyDelegator for which
+      // senders are skipped and why.
+      if (done && shouldNotifyDelegator(done.from_agent, done.to_agent, done.content)) {
         const summary = result ? result.slice(0, 500) : '(nincs eredmény)'
         createAgentMessage(
           done.to_agent,


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

Closing an inter-agent message creates a reverse `[Eredmény]` notification back to its
sender, so the delegator learns the result without polling. The condition skipped
self-messages and contents that were already completion reports, but it never asked
whether the sender can receive anything at all.

`system` is not an agent. It posts the `[session-stuck]` and `[handoff-failure]` notices
but owns no tmux session, so the notification addressed to it can never be delivered: it
fails, the retry window expires, and the resulting `[handoff-failure]` wakes the main
agent — which, once closed, produced the next one.

**Measured on a live install on 2026-08-17: 44 of the last 200 message rows were
`-> system`, every one of them failed, plus six handoff-failure notices.** Nothing was
lost, but a fifth of the queue could never arrive, and each round cost the main agent a
wake-up.

The guard uses `isKnownAgent`, which is already how this same file authenticates
`POST /api/messages` senders. It accepts `MAIN_AGENT_ID` as well as the `agents/<id>/`
directories. A plain agent-registry lookup would have been wrong: the registry contains
only the sub-agent directories, so guarding on it would have suppressed every
notification back to the **main** agent — the case this feature exists for. That is noted
in the comment so it does not get "simplified" back.

**Tests.** The condition moved into an exported `shouldNotifyDelegator` so the tests can
call it; the existing tests re-implemented the condition inside the test file, so they
passed regardless of what the route did. Five new tests, and I verified they can fail:
with the guard removed two of them fail, with it restored all pass. The senders in the
tests are `MAIN_AGENT_ID` and `system` rather than invented names, because `isKnownAgent`
resolves real directories and a CI checkout has none — a made-up sender would be
"unknown" there and the positive case would pass or fail for the wrong reason.

`tsc --noEmit` clean; `completion-notification.test.ts` green (10 tests). 26 other tests
fail in my checkout (hooks, ports, brand, installer, email gate), but they fail
identically on unmodified `develop` in the same environment — they read files a bare
worktree does not have. Untouched by this change.

## Kapcsolódó issue / Related issue

Nincs kapcsolódó issue. / No related issue — found while operating the fleet.

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [x] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).

Verified live on the Acrobot install after rebuilding and restarting the dashboard:
closing a `system` message creates no reverse row (44 dead rows before, 44 after);
closing a message from a real agent still does create one (control, so the fix does
not simply disable the feature); closing that notification creates nothing further
(ping-pong guard intact); and a live inter-agent message was delivered and answered
on the new build. Channel plugins were not restarted and are unaffected by this change.
Unit tests and typecheck were run in an isolated worktree; the dashboard was
**not** rebuilt and restarted with this change, so I have not observed live agents
communicating on this build. Ticking it would claim an observation I did not make. The
second box is ticked as not-applicable: the change touches neither installation nor
architecture, so `docs/` needed no update.