### PR TITLE
feat(security): fail-closed secret gate, so captured output cannot carry a key into a public repo (EVIDGUARD818)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,3 +25,13 @@ Closes #
 - [ ] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
 - [ ] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
 - [ ] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).
+
+## Titok-kapu / Secret gate
+
+A `secret-gate` CI-job a valodi kapu. A lokalis pre-commit hook csak gyors
+elorejelzes, es `--no-verify`-jal megkerulheto -- ne tekintsd elegnek.
+The `secret-gate` CI job is the real gate; the local pre-commit hook is a fast
+preview and can be skipped with `--no-verify`, so it is not sufficient on its own.
+
+- [ ] Nincs a valtoztatasban bizonyitek-/artefaktum-mappa, titok-alaku string vagy idezett csatorna-uzenet.
+      / No evidence or artifact directory, secret-shaped string, or quoted channel message in this change.

--- a/.github/workflows/secret-gate.yml
+++ b/.github/workflows/secret-gate.yml
@@ -1,0 +1,44 @@
+# EVIDGUARD818 -- THE gate. The pre-commit hook is a convenience and is skippable
+# with --no-verify; this job is not. Both run scripts/secret-gate.ts.
+name: secret-gate
+
+on:
+  pull_request:
+  push:
+    branches: [develop, main]
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history: the gate diffs against the merge base, and a shallow
+          # clone would silently shrink the file set -- the exact fail-open this
+          # job exists to prevent.
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - run: npm ci --ignore-scripts
+
+      - name: Scan the change set
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+            HEAD="${{ github.event.pull_request.head.sha }}"
+            if [ -z "$BASE" ] || [ -z "$HEAD" ]; then
+              echo "secret-gate: could not resolve the PR range -- failing closed."
+              exit 2
+            fi
+            npx tsx scripts/secret-gate.ts --range "$BASE..$HEAD"
+          else
+            npx tsx scripts/secret-gate.ts --range "${{ github.event.before }}..${{ github.sha }}" \
+              || npx tsx scripts/secret-gate.ts --all
+          fi
+
+      - name: Gate's own tests must pass (a disabled detector is a red test)
+        run: npx vitest run src/__tests__/secret-gate.test.ts

--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,13 @@ __pycache__/
 # Claude Code Channels runtime config/session dir (sessions, history, tokens,
 # plugins, skills). Per-install runtime state -- never source, never commit.
 .channels-config/
+
+# EVIDGUARD818: captured output never belongs in the repo (a key leaked from
+# .pre-ship-evidence in 2026-07). The secret gate blocks these paths too; this
+# rule keeps them from being staged by accident in the first place.
+.pre-ship-evidence/
+.pre-ship-evidence*
+evidence/
+.evidence/
+transcripts/
+.session-capture/

--- a/scripts/install-secret-gate-hook.sh
+++ b/scripts/install-secret-gate-hook.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# EVIDGUARD818 -- idempotent installer: run the secret gate before every commit.
+# Auto-run by scripts/sync-hooks.sh on update, same as install-git-guard-hook.sh.
+#
+# THIS HOOK IS THE FAST LANE, NOT THE GATE. It is skippable with
+# `git commit --no-verify`, so the authoritative check is the CI job on the PR
+# (.github/workflows/secret-gate.yml). Both call the same scanner.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+HOOK_DIR="$(cd "$(git -C "$ROOT" rev-parse --git-common-dir)" && pwd)/hooks"
+DISPATCH="$HOOK_DIR/pre-commit"
+GUARD="$HOOK_DIR/pre-commit.d/10-secret-gate"
+MARK="marveen-pre-commit-dispatcher"
+mkdir -p "$HOOK_DIR/pre-commit.d"
+
+# 1. The sub-hook: scan what is staged.
+cat > "$GUARD" <<'EOF'
+#!/usr/bin/env bash
+# EVIDGUARD818: block a commit that stages an evidence/artifact path, a known
+# secret shape, or quoted channel material. Override (CI still checks):
+#   SKIP_SECRET_GATE=1 git commit ...
+set -euo pipefail
+[ "${SKIP_SECRET_GATE:-0}" = "1" ] && { echo "pre-commit: SKIP_SECRET_GATE=1 -- the CI job still runs." >&2; exit 0; }
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+if ! command -v npx >/dev/null 2>&1; then
+  echo "pre-commit: npx not found, cannot run the secret gate -- BLOCKING (fail-closed)." >&2
+  echo "Install Node, or bypass knowingly with SKIP_SECRET_GATE=1 (the CI job will still catch it)." >&2
+  exit 1
+fi
+npx --no-install tsx scripts/secret-gate.ts --staged
+EOF
+chmod +x "$GUARD"
+
+# 2. Dispatcher: run every executable in pre-commit.d/ (mirrors the pre-push one).
+if [ -f "$DISPATCH" ] && ! grep -q "$MARK" "$DISPATCH" 2>/dev/null; then
+  mv "$DISPATCH" "$HOOK_DIR/pre-commit.d/00-existing-precommit"
+  chmod +x "$HOOK_DIR/pre-commit.d/00-existing-precommit"
+  echo "  (preserved existing pre-commit as pre-commit.d/00-existing-precommit)"
+fi
+cat > "$DISPATCH" <<EOF
+#!/usr/bin/env bash
+# $MARK : run every executable in pre-commit.d/.
+set -euo pipefail
+HOOK_DIR="\$(cd "\$(dirname "\$0")" && pwd)"
+status=0
+for h in "\$HOOK_DIR"/pre-commit.d/*; do
+  [ -x "\$h" ] || continue
+  "\$h" "\$@" || status=1
+done
+exit \$status
+EOF
+chmod +x "$DISPATCH"
+
+echo "  secret gate pre-commit hook installed (bypass: SKIP_SECRET_GATE=1; the CI job is the real gate)"

--- a/scripts/secret-gate.ts
+++ b/scripts/secret-gate.ts
@@ -1,0 +1,125 @@
+#!/usr/bin/env tsx
+/**
+ * EVIDGUARD818: the secret gate's runner. Two callers, one core.
+ *
+ *   scripts/secret-gate.ts --staged            (pre-commit hook: what is about to be committed)
+ *   scripts/secret-gate.ts --range <base>..<head>   (CI: what the PR adds)
+ *   scripts/secret-gate.ts --all               (audit: every tracked file)
+ *
+ * The hook is the fast lane and can be skipped with `git commit --no-verify`.
+ * The CI run is the actual gate. That is stated here and in the PR template so
+ * nobody mistakes the convenience for the control.
+ *
+ * Everything this runner cannot scan is REPORTED and FAILS. Size limits, binary
+ * files, read errors: each is named. A silent skip would read as "clean".
+ */
+import { execFileSync } from 'node:child_process';
+import { readFileSync, statSync } from 'node:fs';
+import { runGate, type ScanInput, type GateResult } from '../src/security/secret-gate.js';
+
+/** Beyond this the file is not scanned -- and therefore not cleared. */
+const MAX_BYTES = 5 * 1024 * 1024;
+
+function git(args: string[]): string {
+  return execFileSync('git', args, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+}
+
+function fileList(mode: string, range?: string): string[] {
+  if (mode === '--staged') {
+    return git(['diff', '--cached', '--name-only', '--diff-filter=ACMR']).split('\n').filter(Boolean);
+  }
+  if (mode === '--range') {
+    if (!range || !range.includes('..')) throw new Error(`--range needs <base>..<head>, got: ${range ?? '(nothing)'}`);
+    return git(['diff', '--name-only', '--diff-filter=ACMR', range]).split('\n').filter(Boolean);
+  }
+  if (mode === '--all') return git(['ls-files']).split('\n').filter(Boolean);
+  throw new Error(`unknown mode: ${mode}`);
+}
+
+/** Binary sniff: a NUL byte in the first 8k. Binary files are still scanned as
+ *  latin1 text -- an embedded ASCII key is exactly the case we care about. */
+function readForScan(path: string): ScanInput {
+  let size: number;
+  try {
+    size = statSync(path).size;
+  } catch (e) {
+    return { path, unreadable: { reason: `stat failed (${(e as Error).message})` } };
+  }
+  if (size > MAX_BYTES) {
+    return { path, unreadable: { reason: `file is ${(size / 1048576).toFixed(1)} MB, above the ${MAX_BYTES / 1048576} MB scan limit` } };
+  }
+  try {
+    return { path, content: readFileSync(path, 'latin1') };
+  } catch (e) {
+    return { path, unreadable: { reason: `read failed (${(e as Error).message})` } };
+  }
+}
+
+function report(result: GateResult, mode: string, files: string[]): void {
+  const line = (s = '') => process.stdout.write(`${s}\n`);
+  line();
+  line(`secret-gate (EVIDGUARD818) -- mode ${mode}, ${result.scannedCount} file(s) in scope`);
+
+  if (result.allowlisted.length) {
+    line();
+    line('Allowlisted by path (NOT scanned, on purpose):');
+    for (const a of result.allowlisted) line(`  - ${a.file}  <- ${a.reason}`);
+  }
+
+  if (result.ok) {
+    line();
+    line(`PASS: no denied path, no secret shape, no channel material in ${result.scannedCount} file(s).`);
+    return;
+  }
+
+  const blocked = result.findings.filter((f) => f.severity === 'blocked');
+  const unscannable = result.findings.filter((f) => f.severity === 'unscannable');
+
+  if (blocked.length) {
+    line();
+    line(`BLOCKED (${blocked.length}):`);
+    for (const f of blocked) line(`  ${f.file}${f.line ? `:${f.line}` : ''}  [${f.detector}]  ${f.reason}`);
+  }
+  if (unscannable.length) {
+    line();
+    line(`NOT SCANNED, therefore NOT CLEARED (${unscannable.length}):`);
+    for (const f of unscannable) line(`  ${f.file}  ${f.reason}`);
+  }
+  line();
+  line('The matched text is deliberately not printed: echoing a secret into CI logs');
+  line('would leak it a second time. Look at the file and line above.');
+  line();
+  line('If a hit is an intentional fixture, add the PATH to ALLOWLISTED_PATHS in');
+  line('src/security/secret-gate.ts. Do NOT loosen the pattern: a pattern exception');
+  line('opens the same hole in every file in the repository.');
+  if (files.length !== result.scannedCount) {
+    line();
+    line(`NOTE: ${files.length} file(s) were listed but ${result.scannedCount} reached the scanner.`);
+  }
+}
+
+function main(): void {
+  const [, , mode = '--staged', range] = process.argv;
+  let files: string[];
+  try {
+    files = fileList(mode, range);
+  } catch (e) {
+    // Fail-closed: if we cannot even determine the set, we do not pass it.
+    process.stdout.write(`\nsecret-gate: FAILED to determine the file set: ${(e as Error).message}\n`);
+    process.stdout.write('Fail-closed by design (EVIDGUARD818): an undeterminable set is a failure, not a pass.\n');
+    process.exit(2);
+  }
+
+  // --staged with nothing staged is a no-op commit, which git blocks anyway;
+  // any other mode with an empty set means the computation broke.
+  if (files.length === 0 && mode === '--staged') {
+    process.stdout.write('\nsecret-gate: nothing staged, nothing to check.\n');
+    process.exit(0);
+  }
+
+  const result = runGate(files.map(readForScan));
+  report(result, mode, files);
+  process.exit(result.ok ? 0 : 1);
+}
+
+main();

--- a/src/__tests__/secret-gate.test.ts
+++ b/src/__tests__/secret-gate.test.ts
@@ -10,6 +10,7 @@
  * gate ripped out proves nothing.
  */
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
 import {
   runGate,
   scanFile,
@@ -165,6 +166,21 @@ describe('allowlist is PATH-based, and visible', () => {
     expect(r.allowlisted).toEqual([
       { file: 'src/__tests__/auth-gate.test.ts', reason: expect.stringMatching(/fixture/i) },
     ]);
+  });
+
+  it('the gate is NOT exempt from itself: its own source passes the gate unaided', () => {
+    // Two assertions on purpose, and the first is the one that matters.
+    // (a) The exemption must be ABSENT. If anyone re-adds the allowlist entry
+    //     for this module, this line fails -- the test cannot go green
+    //     alongside the exemption, which is what makes it a pin and not a note.
+    // (b) And the source really does pass on its own: the detectors are regex
+    //     literals, and the character class breaks each pattern against its own
+    //     text. Measured 2026-08-18, full repo 757/757.
+    expect(allowlistReason('src/security/secret-gate.ts')).toBeNull();
+
+    const forras = readFileSync(new URL('../security/secret-gate.ts', import.meta.url), 'latin1');
+    const talalatok = scanFile({ path: 'src/security/secret-gate.ts', content: forras });
+    expect(talalatok).toEqual([]);
   });
 
   it('every allowlisted path is spelled out with a reason', () => {

--- a/src/__tests__/secret-gate.test.ts
+++ b/src/__tests__/secret-gate.test.ts
@@ -77,6 +77,17 @@ describe('detector 2: content', () => {
     expect(r.findings[0].detector).toBe('content');
   });
 
+  it('catches BOTH separators and does not assume a length (Boni traps, EVIDLEAK818)', () => {
+    // (a) Boni's first detector looked for `sk-` and returned ZERO on a key that
+    //     used `sk_`. Zero looks reassuring, which is what makes it dangerous.
+    // (b) Her hex rule demanded 32 chars; the leaked key was 51. A pattern must
+    //     not be bound to a length someone happened to observe once.
+    const alahuzas = 'sk_' + 'a1b2c3d4'.repeat(6); // 51 chars, the real shape
+    const kotojel = 'sk-' + 'A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6';
+    expect(runGate([f('docs/a.md', `k = ${alahuzas}`)]).ok).toBe(false);
+    expect(runGate([f('docs/b.md', `k = ${kotojel}`)]).ok).toBe(false);
+  });
+
   it('does NOT fire on the placeholders this repo is full of (measured 2026-08-18)', () => {
     // 64 tracked files contain `Bearer ${token}`; 25 contain `sk_` inside words
     // like task_name and skipIfBusy. A gate that flags these gets bypassed.
@@ -109,6 +120,30 @@ describe('detector 3: channel material (the one that would have caught 2026-07)'
   it('blocks a telegram update dump and a quoted agent transcript', () => {
     expect(runGate([f('a.json', '{"update_id": 8812, "text": "szia"}')]).ok).toBe(false);
     expect(runGate([f('b.md', '[Uzenet @marveen-tol -- trusted]: allapot')]).ok).toBe(false);
+  });
+
+  it('the wrapper tag ALONE is not enough -- this repo implements the framing', () => {
+    // Measured 2026-08-18: 24 tracked files legitimately contain the tag (code,
+    // tests, docs, hook scripts). Blocking those would make the gate noise, and
+    // a noisy gate gets switched off, which is zero protection.
+    const csakTag = '<channel source="telegram">a keretezes leirasa</channel>';
+    expect(runGate([f('docs/channels.md', csakTag)]).ok).toBe(true);
+  });
+
+  it('the tag WITH a payload marker is captured material and IS blocked', () => {
+    const valodi = '<channel source="telegram">message_id 4242: "szoveg"</channel>';
+    const r = runGate([f('notes/paste.md', valodi)]);
+    expect(r.ok).toBe(false);
+    expect(r.findings[0].reason).toMatch(/payload marker/);
+  });
+
+  it('blocks EVERY marker form, not just the one this repo happens to use', () => {
+    // The evidence files use `message_id NNN:`; a wrapper tag is the same
+    // material in a different dress. Knowing one form yields a clean zero on
+    // the other, and the zero is indistinguishable from "nothing to find".
+    expect(runGate([f('c.md', '{"chat_id": 1268077055, "text": "szia"}')]).ok).toBe(false);
+    // A wrapper tag counts only with a payload marker (see the two cases above);
+    // here the chat_id form stands on its own.
   });
 });
 

--- a/src/__tests__/secret-gate.test.ts
+++ b/src/__tests__/secret-gate.test.ts
@@ -1,0 +1,141 @@
+/**
+ * EVIDGUARD818. The gate's own tests.
+ *
+ * The synthetic secrets below are FAKE and this file is allowlisted by path --
+ * which is itself part of what is under test: the allowlist must be path-based,
+ * because a pattern-level exception would open the same hole everywhere.
+ *
+ * Every assertion here has a red probe behind it (documented in the PR): remove
+ * the detector and these go red. A green test that would stay green with the
+ * gate ripped out proves nothing.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  runGate,
+  scanFile,
+  allowlistReason,
+  ALLOWLISTED_PATHS,
+  type ScanInput,
+} from '../security/secret-gate.js';
+
+const f = (path: string, content: string): ScanInput => ({ path, content });
+
+/**
+ * Assembled at runtime on purpose. Written out as a literal, GitHub's own push
+ * protection rejects this file (measured 2026-08-18: "Stripe API Key", push
+ * declined) -- which is a useful finding in itself: a second, vendor-format
+ * control already exists on this repo. Our gate covers what that one cannot:
+ * evidence paths, quoted channel material, and formats nobody has listed.
+ */
+const STRIPE_FIXTURE = ['sk', 'live', '51ABCDEFGHIJKLMNOPQRSTUV'].join('_');
+
+describe('fail-closed', () => {
+  it('an EMPTY file set FAILS -- the most common silent fail-open', () => {
+    const r = runGate([]);
+    expect(r.ok).toBe(false);
+    expect(r.findings[0].reason).toMatch(/EMPTY/);
+  });
+
+  it('a file that could not be read FAILS instead of passing quietly', () => {
+    const r = runGate([{ path: 'assets/huge.bin', unreadable: { reason: 'file is 42.0 MB, above the 5 MB scan limit' } }]);
+    expect(r.ok).toBe(false);
+    expect(r.findings[0].severity).toBe('unscannable');
+    expect(r.findings[0].reason).toMatch(/could not read this file/);
+  });
+
+  it('a clean, readable set passes', () => {
+    const r = runGate([f('src/index.ts', 'export const x = 1;\n')]);
+    expect(r.ok).toBe(true);
+    expect(r.scannedCount).toBe(1);
+  });
+});
+
+describe('detector 1: path', () => {
+  it.each([
+    '.pre-ship-evidence/2026-07-22.md',
+    'docs/.pre-ship-evidence/run.txt',
+    'evidence/session.log',
+    'transcripts/telegram-2026-07-22.json',
+  ])('blocks %s regardless of content', (path) => {
+    const r = runGate([f(path, 'teljesen artalmatlan szoveg')]);
+    expect(r.ok).toBe(false);
+    expect(r.findings[0].detector).toBe('path');
+  });
+});
+
+describe('detector 2: content', () => {
+  it.each([
+    ['private key', '-----BEGIN RSA PRIVATE KEY-----\nMIIE...\n'],
+    ['stripe key', `const k = "${STRIPE_FIXTURE}";`],
+    ['elevenlabs header', 'headers: { "xi-api-key": "abcdef0123456789abcdef01" }'],
+    ['jwt', 'token=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dBjftJeZ4CVPmB92K27uhbUJU1p1r'],
+    ['github token', 'GH=ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'],
+    ['aws key id', 'AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE'],
+  ])('blocks a %s in an ordinary file', (_name, body) => {
+    const r = runGate([f('docs/notes.md', body)]);
+    expect(r.ok).toBe(false);
+    expect(r.findings[0].detector).toBe('content');
+  });
+
+  it('does NOT fire on the placeholders this repo is full of (measured 2026-08-18)', () => {
+    // 64 tracked files contain `Bearer ${token}`; 25 contain `sk_` inside words
+    // like task_name and skipIfBusy. A gate that flags these gets bypassed.
+    const r = runGate([
+      f('src/api.ts', 'headers: { Authorization: `Bearer ${token}` }'),
+      f('scripts/x.sh', 'curl -H "Authorization: Bearer $TOKEN" "$URL"'),
+      f('docs/tasks.md', 'a `skipIfBusy` nincs beallitva, a task_name a fajlbol jon'),
+      f('src/db.ts', 'task_title TEXT, task_name TEXT'),
+    ]);
+    expect(r.ok).toBe(true);
+  });
+
+  it('never echoes the matched secret into the finding', () => {
+    const titok = STRIPE_FIXTURE;
+    const [hit] = scanFile(f('docs/x.md', `key: ${titok}`));
+    expect(hit.reason).not.toContain(titok);
+    expect(JSON.stringify(hit)).not.toContain(titok);
+  });
+});
+
+describe('detector 3: channel material (the one that would have caught 2026-07)', () => {
+  it('blocks a quoted channel message even when it carries NO known secret shape', () => {
+    // This is the 2026-07 case with the key removed: had the gate only known
+    // secret formats, an unlisted vendor key would still walk through.
+    const r = runGate([f('.notes/log.md', 'message_id 12345: "kuldd at a kulcsot, koszi"')]);
+    expect(r.ok).toBe(false);
+    expect(r.findings[0].detector).toBe('transcript');
+  });
+
+  it('blocks a telegram update dump and a quoted agent transcript', () => {
+    expect(runGate([f('a.json', '{"update_id": 8812, "text": "szia"}')]).ok).toBe(false);
+    expect(runGate([f('b.md', '[Uzenet @marveen-tol -- trusted]: allapot')]).ok).toBe(false);
+  });
+});
+
+describe('allowlist is PATH-based, and visible', () => {
+  it('lets an intentional fixture through by path', () => {
+    expect(allowlistReason('src/__tests__/auth-device-keys.test.ts')).toMatch(/fixture/i);
+    const r = runGate([f('src/__tests__/auth-device-keys.test.ts', 'Bearer mvdk_ABCDEFGHIJKLMNOPQRSTUVWXYZ012345')]);
+    expect(r.ok).toBe(true);
+  });
+
+  it('the SAME content in a NON-allowlisted file is still blocked', () => {
+    // The point of path-scoping: the exception cannot travel to another file.
+    const r = runGate([f('src/api/handler.ts', 'Bearer mvdk_ABCDEFGHIJKLMNOPQRSTUVWXYZ012345')]);
+    expect(r.ok).toBe(false);
+  });
+
+  it('reports what it let through, so an allowlist cannot grow unnoticed', () => {
+    const r = runGate([f('src/__tests__/auth-gate.test.ts', 'Bearer someLongLookingTokenValue123456')]);
+    expect(r.allowlisted).toEqual([
+      { file: 'src/__tests__/auth-gate.test.ts', reason: expect.stringMatching(/fixture/i) },
+    ]);
+  });
+
+  it('every allowlisted path is spelled out with a reason', () => {
+    for (const a of ALLOWLISTED_PATHS) {
+      expect(a.path.length).toBeGreaterThan(0);
+      expect(a.reason.length).toBeGreaterThan(10);
+    }
+  });
+});

--- a/src/security/secret-gate.ts
+++ b/src/security/secret-gate.ts
@@ -1,0 +1,203 @@
+/**
+ * EVIDGUARD818: the secret gate's pure core.
+ *
+ * Why it exists: on 2026-07-22 an ElevenLabs API key reached this PUBLIC repo in
+ * commit 48638cb6. It was not written into code -- it sat inside a QUOTED
+ * TELEGRAM MESSAGE in our own `.pre-ship-evidence` artifact. Nothing looked at
+ * that file, because nothing looked at anything. The key is dead and that case
+ * is closed; this module closes the mechanism.
+ *
+ * Three detectors, because any one of them alone would have missed it:
+ *   1. PATH      -- evidence/artifact directories have no business in the repo.
+ *   2. CONTENT   -- known secret shapes (sk_live_, private keys, JWTs, ...).
+ *   3. TRANSCRIPT-- channel material (message_id NNN: "...") regardless of what
+ *                   it quotes. This is the one that would have caught the 2026-07
+ *                   leak even though nobody had listed the ElevenLabs key format.
+ *
+ * FAIL-CLOSED is the rule, not a mode: an empty file set, an unreadable file, a
+ * file too large to scan -- each is a FAILURE with a named reason, never a pass.
+ * A silent skip reads as "scanned and clean", which is the failure mode that let
+ * the original leak through.
+ */
+
+export type Severity = 'blocked' | 'unscannable';
+
+export interface Finding {
+  file: string;
+  detector: 'path' | 'content' | 'transcript' | 'unscannable';
+  severity: Severity;
+  /** 1-based line, when the detector found a location. */
+  line?: number;
+  /** Human-readable reason. NEVER contains the matched secret itself. */
+  reason: string;
+}
+
+export interface ScanInput {
+  path: string;
+  /** File bytes. Undefined when the file could not be read at all. */
+  content?: string;
+  /** Set when the caller could not fully read the file (size, binary, timeout). */
+  unreadable?: { reason: string };
+}
+
+export interface GateResult {
+  ok: boolean;
+  findings: Finding[];
+  scannedCount: number;
+  /** Files the gate deliberately let through, with the reason. Always reported. */
+  allowlisted: { file: string; reason: string }[];
+}
+
+/**
+ * Directories whose whole point is to hold captured output: pre-ship evidence,
+ * run artifacts, transcripts. Nothing in here is reviewed line by line, which is
+ * exactly why a secret inside one survives review.
+ */
+export const DENIED_PATH_PATTERNS: { pattern: RegExp; reason: string }[] = [
+  { pattern: /(^|\/)\.pre-ship-evidence(\/|$)/, reason: 'pre-ship evidence directory (EVIDGUARD818: this is where the 2026-07 key leaked)' },
+  { pattern: /(^|\/)evidence(\/|$)/, reason: 'evidence directory' },
+  { pattern: /(^|\/)\.evidence(\/|$)/, reason: 'evidence directory' },
+  { pattern: /(^|\/)transcripts?(\/|$)/, reason: 'transcript directory' },
+  { pattern: /(^|\/)\.session-capture(\/|$)/, reason: 'session capture directory' },
+  { pattern: /\.pre-ship-evidence[^/]*$/, reason: 'pre-ship evidence file' },
+];
+
+/**
+ * Content shapes. Kept deliberately anchored: measured against this repo on
+ * 2026-08-18, a bare `sk_` matches `task_name` and `skipIfBusy`, and a bare
+ * `Bearer ` matches 64 files of `Bearer ${token}`. A gate that cries wolf gets
+ * bypassed, and a bypassed gate protects nothing.
+ */
+export const SECRET_PATTERNS: { name: string; pattern: RegExp }[] = [
+  { name: 'private key block', pattern: /-----BEGIN [A-Z ]*PRIVATE KEY-----/ },
+  { name: 'Stripe secret/restricted key', pattern: /\b(sk|rk)_(live|test)_[A-Za-z0-9]{16,}/ },
+  { name: 'ElevenLabs key header', pattern: /xi-api-key["'\s:=]+[A-Za-z0-9_-]{16,}/i },
+  { name: 'ElevenLabs key literal', pattern: /\bsk_[a-f0-9]{32,}/ },
+  { name: 'bearer token literal', pattern: /\bBearer\s+[A-Za-z0-9_-]{24,}\.?[A-Za-z0-9_.-]*/ },
+  { name: 'JWT', pattern: /\beyJ[A-Za-z0-9_-]{8,}\.eyJ[A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{16,}/ },
+  { name: 'GitHub token', pattern: /\bgh[pousr]_[A-Za-z0-9]{30,}/ },
+  { name: 'Slack token', pattern: /\bxox[baprs]-[A-Za-z0-9-]{10,}/ },
+  { name: 'OpenAI project key', pattern: /\bsk-proj-[A-Za-z0-9_-]{20,}/ },
+  { name: 'AWS access key id', pattern: /\bAKIA[0-9A-Z]{16}\b/ },
+  { name: 'Supabase service_role JWT hint', pattern: /service_role["'\s:=]+eyJ/ },
+];
+
+/**
+ * Channel material. The 2026-07 leak was a pasted Telegram message; the secret
+ * inside it was incidental. Quoted channel traffic does not belong in the repo
+ * whatever it happens to contain, so this detector does not look at the payload.
+ */
+export const TRANSCRIPT_PATTERNS: { name: string; pattern: RegExp }[] = [
+  { name: 'quoted channel message', pattern: /\bmessage_id\s*[:=]?\s*\d{2,}\s*[:\-]/ },
+  { name: 'telegram update dump', pattern: /"(update_id|from_user|chat_id)"\s*:\s*\d+/ },
+  { name: 'quoted agent transcript header', pattern: /^\s*\[Uzenet @[a-z0-9_-]+-tol/im },
+];
+
+/**
+ * Paths that MAY carry a matching pattern on purpose. Path-based by design:
+ * a pattern-level exception would punch the same hole in every file, which is
+ * how a real leak walks through a gate that was meant to allow a fixture.
+ *
+ * Seeded from measurement (2026-08-18), not from memory: these are the tracked
+ * files that legitimately contain token-shaped fixtures today.
+ */
+export const ALLOWLISTED_PATHS: { path: string; reason: string }[] = [
+  { path: 'src/__tests__/auth-device-keys.test.ts', reason: 'device-key auth test: synthetic Bearer fixtures' },
+  { path: 'src/__tests__/auth-gate.test.ts', reason: 'auth gate test: synthetic Bearer fixtures' },
+  { path: 'src/__tests__/secret-gate.test.ts', reason: 'the gate\'s own tests: synthetic secrets are the subject under test' },
+  { path: 'src/security/secret-gate.ts', reason: 'the detector definitions themselves' },
+];
+
+export function allowlistReason(path: string): string | null {
+  const hit = ALLOWLISTED_PATHS.find((a) => a.path === path);
+  return hit ? hit.reason : null;
+}
+
+function lineOf(text: string, index: number): number {
+  return text.slice(0, index).split('\n').length;
+}
+
+/** All findings for ONE file. An allowlisted path yields none. */
+export function scanFile(input: ScanInput): Finding[] {
+  const { path } = input;
+  if (allowlistReason(path)) return [];
+
+  const findings: Finding[] = [];
+
+  for (const { pattern, reason } of DENIED_PATH_PATTERNS) {
+    if (pattern.test(path)) {
+      findings.push({ file: path, detector: 'path', severity: 'blocked', reason });
+      break;
+    }
+  }
+
+  // An unreadable file is a FAILURE, not a skip: "could not scan" must never
+  // render as "scanned and clean".
+  if (input.unreadable) {
+    findings.push({
+      file: path,
+      detector: 'unscannable',
+      severity: 'unscannable',
+      reason: `${input.unreadable.reason} -- the gate could not read this file, so it cannot clear it. Allowlist the path if it is intentional.`,
+    });
+    return findings;
+  }
+
+  const text = input.content ?? '';
+  for (const { name, pattern } of SECRET_PATTERNS) {
+    const m = pattern.exec(text);
+    if (m) {
+      findings.push({
+        file: path,
+        detector: 'content',
+        severity: 'blocked',
+        line: lineOf(text, m.index),
+        reason: `secret shape: ${name}`,
+      });
+    }
+  }
+  for (const { name, pattern } of TRANSCRIPT_PATTERNS) {
+    const m = pattern.exec(text);
+    if (m) {
+      findings.push({
+        file: path,
+        detector: 'transcript',
+        severity: 'blocked',
+        line: lineOf(text, m.index),
+        reason: `channel material: ${name}`,
+      });
+    }
+  }
+  return findings;
+}
+
+/**
+ * The whole change set.
+ *
+ * An EMPTY set fails. That is the point of the gate: "nothing to check" is what
+ * a broken file-list computation looks like from the inside, and it is the most
+ * common silent fail-open. The caller must pass a non-empty set or explain
+ * itself upstream.
+ */
+export function runGate(inputs: ScanInput[]): GateResult {
+  const allowlisted = inputs
+    .map((i) => ({ file: i.path, reason: allowlistReason(i.path) }))
+    .filter((a): a is { file: string; reason: string } => a.reason !== null);
+
+  if (inputs.length === 0) {
+    return {
+      ok: false,
+      scannedCount: 0,
+      allowlisted,
+      findings: [{
+        file: '(file set)',
+        detector: 'unscannable',
+        severity: 'unscannable',
+        reason: 'the file set is EMPTY -- the gate cannot determine what to check, which is a failure, not a pass (EVIDGUARD818 fail-closed rule)',
+      }],
+    };
+  }
+
+  const findings = inputs.flatMap(scanFile);
+  return { ok: findings.length === 0, findings, scannedCount: inputs.length, allowlisted };
+}

--- a/src/security/secret-gate.ts
+++ b/src/security/secret-gate.ts
@@ -109,12 +109,18 @@ export const TRANSCRIPT_PATTERNS: { name: string; pattern: RegExp }[] = [
  *
  * Seeded from measurement (2026-08-18), not from memory: these are the tracked
  * files that legitimately contain token-shaped fixtures today.
+ *
+ * This file is deliberately NOT on the list. Measured: the detectors are regex
+ * LITERALS, and the character class breaks the pattern against its own source
+ * (after `sk-proj-` the text has `[`, which the class does not accept), so the
+ * gate passes over itself with 757/757. An exemption here would be the one
+ * place a real secret could be pasted and cleared, and `secret-gate.test.ts`
+ * pins that the exemption stays absent.
  */
 export const ALLOWLISTED_PATHS: { path: string; reason: string }[] = [
   { path: 'src/__tests__/auth-device-keys.test.ts', reason: 'device-key auth test: synthetic Bearer fixtures' },
   { path: 'src/__tests__/auth-gate.test.ts', reason: 'auth gate test: synthetic Bearer fixtures' },
   { path: 'src/__tests__/secret-gate.test.ts', reason: 'the gate\'s own tests: synthetic secrets are the subject under test' },
-  { path: 'src/security/secret-gate.ts', reason: 'the detector definitions themselves' },
   { path: 'src/__tests__/channel-inbound-framing.test.ts', reason: 'channel framing test: synthetic wrapper frames with sample ids are the subject under test' },
   { path: 'scripts/__tests__/conversation-ledger.test.sh', reason: 'ledger test: synthetic wrapper frames with sample ids' },
 ];

--- a/src/security/secret-gate.ts
+++ b/src/security/secret-gate.ts
@@ -78,6 +78,11 @@ export const SECRET_PATTERNS: { name: string; pattern: RegExp }[] = [
   { name: 'GitHub token', pattern: /\bgh[pousr]_[A-Za-z0-9]{30,}/ },
   { name: 'Slack token', pattern: /\bxox[baprs]-[A-Za-z0-9-]{10,}/ },
   { name: 'OpenAI project key', pattern: /\bsk-proj-[A-Za-z0-9_-]{20,}/ },
+  // BOTH separators, on purpose. Boni's first detector looked for `sk-` only
+  // and returned zero on a key that used `sk_` -- and zero looks reassuring.
+  // No upper length bound either: the leaked key was 51 chars, a rule written
+  // around "32 hex" would have missed it.
+  { name: 'generic vendor secret key (sk_ or sk-)', pattern: /\bsk[-_][A-Za-z0-9_-]{24,}/ },
   { name: 'AWS access key id', pattern: /\bAKIA[0-9A-Z]{16}\b/ },
   { name: 'Supabase service_role JWT hint', pattern: /service_role["'\s:=]+eyJ/ },
 ];
@@ -91,6 +96,10 @@ export const TRANSCRIPT_PATTERNS: { name: string; pattern: RegExp }[] = [
   { name: 'quoted channel message', pattern: /\bmessage_id\s*[:=]?\s*\d{2,}\s*[:\-]/ },
   { name: 'telegram update dump', pattern: /"(update_id|from_user|chat_id)"\s*:\s*\d+/ },
   { name: 'quoted agent transcript header', pattern: /^\s*\[Uzenet @[a-z0-9_-]+-tol/im },
+  // Same trap on the transcript side: this repo's evidence files use
+  // `message_id NNN:`, but a wrapper tag is just as much channel material.
+  // One form only would give a clean zero on the other.
+
 ];
 
 /**
@@ -106,7 +115,21 @@ export const ALLOWLISTED_PATHS: { path: string; reason: string }[] = [
   { path: 'src/__tests__/auth-gate.test.ts', reason: 'auth gate test: synthetic Bearer fixtures' },
   { path: 'src/__tests__/secret-gate.test.ts', reason: 'the gate\'s own tests: synthetic secrets are the subject under test' },
   { path: 'src/security/secret-gate.ts', reason: 'the detector definitions themselves' },
+  { path: 'src/__tests__/channel-inbound-framing.test.ts', reason: 'channel framing test: synthetic wrapper frames with sample ids are the subject under test' },
+  { path: 'scripts/__tests__/conversation-ledger.test.sh', reason: 'ledger test: synthetic wrapper frames with sample ids' },
 ];
+
+/**
+ * The wrapper tag ALONE is not evidence: this repo implements channel framing,
+ * so `<channel source="...">` legitimately appears in 24 tracked files (code,
+ * tests, docs, hook scripts -- measured 2026-08-18). Flagging those would make
+ * the gate noise, and a noisy gate gets switched off.
+ *
+ * Captured material is the tag TOGETHER WITH a payload marker in the same file.
+ * That pair narrows 27 files to 3, all of them deliberate test fixtures.
+ */
+export const WRAPPER_TAG = /<\s*(channel|trusted-peer)\b[^>]*\bsource\s*=\s*["'][^"']+["'][^>]*>/i;
+export const WRAPPED_PAYLOAD = /\bmessage_id\s*[:=]?\s*\d{2,}|"(update_id|chat_id|from_user)"\s*:\s*\d+/;
 
 export function allowlistReason(path: string): string | null {
   const hit = ALLOWLISTED_PATHS.find((a) => a.path === path);
@@ -155,6 +178,16 @@ export function scanFile(input: ScanInput): Finding[] {
         reason: `secret shape: ${name}`,
       });
     }
+  }
+  const tag = WRAPPER_TAG.exec(text);
+  if (tag && WRAPPED_PAYLOAD.test(text)) {
+    findings.push({
+      file: path,
+      detector: 'transcript',
+      severity: 'blocked',
+      line: lineOf(text, tag.index),
+      reason: 'channel material: wrapper tag carrying a real payload marker',
+    });
   }
   for (const { name, pattern } of TRANSCRIPT_PATTERNS) {
     const m = pattern.exec(text);


### PR DESCRIPTION
## A kiváltó ok

2026-07-22-én egy ElevenLabs API kulcs került a **nyilvános** repóba (`48638cb6`). Nem kódba írva: egy **idézett Telegram üzenetben** ült, a saját `.pre-ship-evidence` bizonyíték-fájlunkban. A kulcs halott, az az eset külön kártyán zárt (GGELEVEN818). Ami nyitva maradt, az a **mechanizmus**: 195 ilyen fájl van a történetben, semmi nem nézett rájuk, a `.gitignore` nem tud róluk, és a gyakorlat nem lezárult, hanem abbamaradt.

## Két réteg, egy szkenner

| réteg | mit ad | megkerülhető? |
|---|---|---|
| `scripts/install-secret-gate-hook.sh` (pre-commit) | gyors visszajelzés commit előtt, a `sync-hooks.sh` automatikusan telepíti, ahogy a meglévő force-push őrt | **igen**, `--no-verify` vagy `SKIP_SECRET_GATE=1` |
| `.github/workflows/secret-gate.yml` (PR) | **ez a kapu** | nem |

A hook szándékosan megkerülhető, és ezt a PR-sablonba is beírtam, hogy senki ne higgye elégnek. A repónak eddig **egyáltalán nem volt CI-je**, ez az első workflow.

## Három detektor

1. **Útvonal**: bizonyíték-, transzkript- és capture-mappák, tartalomtól függetlenül.
2. **Tartalom**: privát kulcs blokk, Stripe/GitHub/Slack/AWS/OpenAI alakok, JWT, `xi-api-key`.
3. **Csatorna-tartalom**: idézett üzenet (`message_id NNN:`), Telegram update-dump, ügynök-üzenet fejléc, **a payloadtól függetlenül**.

A harmadik a lényeg: a 2026-07-es eset azért csúszott át, mert a kulcs formátumát senki nem listázta. A csatorna-detektor akkor is fog, ha a szolgáltató ismeretlen.

## Fail-closed, kikényszerítve

| eset | kimenet |
|---|---|
| üres fájlhalmaz | **exit 1** ("a halmaz ÜRES, ez bukás, nem átengedés") |
| meghatározhatatlan halmaz (rossz range, ismeretlen mód, git-hiba) | **exit 2** |
| olvashatatlan vagy méret-limit fölötti fájl | bukás, nevesített okkal |
| `npx` hiányzik a hook alatt | blokkol |

Mind a négy mérve, kilépési kóddal (lent). A néma kihagyás "átvizsgálva"-ként olvasódna, és pontosan ez engedte át az eredeti szivárgást.

## Kalibráció mérésből, nem emlékezetből

A minták a repó valóságához igazítva: egy csupasz `sk_` **25 fájlban** talál (`task_name`, `skipIfBusy`, `task_title`); egy csupasz `Bearer` **64-ben** (`Bearer ${token}`). Ezekre a kapu nem tüzel, mert egy hamis-pozitív gyárat mindenki kikapcsol.

A **szándékos fixtúrák útvonal-allowlisttel** mennek át, soha nem minta-kivétellel: egy minta-kivétel ugyanazt a lyukat ütné minden fájlon. Az allowlistát is mérésből építettem, nem névsorból: a specben megnevezett három fájl (`kb-quarantine-credentials`, `kb-local-ingest`, `radar-selfreport-suppress`) **nem létezik ebben a repóban** (`PRIVATE KEY` mintára nulla találat a 750 trackelt fájlon), a valódi fixtúrák az `auth-device-keys.test.ts` és az `auth-gate.test.ts`. A kapu minden futásnál kiírja, mit engedett át, hogy a lista ne tudjon észrevétlenül nőni.

A találat **soha nem írja ki a talált szöveget**: egy titok CI-logba írása másodszor is kiszivárogtatná.

## Verify

**Teljes repó, ma:** `--all` 752 fájlon **PASS**, nulla hamis pozitív, a két allowlistelt fájl nevesítve.

**Piros-próba 1, elhelyezett hamis titok** (`--staged`): mind a három detektor tüzelt, kilépési kód **1**.
```
BLOCKED (4):
  .pre-ship-evidence/proba.md      [path]        pre-ship evidence directory
  .pre-ship-evidence/proba.md:1    [content]     secret shape: Stripe secret/restricted key
  .pre-ship-evidence/proba.md:1    [transcript]  channel material: quoted channel message
  src/proba-titok.ts:1             [content]     secret shape: Stripe secret/restricted key
```

**Piros-próba 2, a kapu kiütése:** a `runGate` detektor-hívásának eltávolítása után **14 teszt piros** (21-ből), visszaállítás után 21/21 zöld. Igazolt mutációval.

**Fail-closed kilépési kódok, mérve:** üres range -> 1, érvénytelen range -> 2, ismeretlen mód -> 2, tiszta `--all` -> 0.

**A hook végponttól végpontig, IZOLÁLT repóban** (szándékosan nem a közös hook-mappában, mert a worktree-k osztoznak rajta): telepítés OK, tiszta commit **átment**, titkot tartalmazó commit **blokkolva**, a dokumentált `SKIP_SECRET_GATE=1` megkerülés **működik**.

**Suite:** 3652 teszt zöld (271 fájl), `tsc` tiszta, em-dash 0.

## Egy lelet, ami a scope-ot pontosítja

**A GitHub saját push protectionje ÉL ezen a repón, és ezt a saját pushom mérte meg:** az első push-omat visszautasította, mert a teszt-fixtúrám Stripe-kulcs alakú literál volt ("Stripe API Key", push declined). Ez a felmérésben nem látszott, mert a repóban nincs nyoma.

Amit ez jelent: **van már egy szűrő, de csak ismert szolgáltatói formátumokra**. Pont azt nem fedi, amitől a 2026-07-es eset megtörtént: a bizonyíték-mappát, az idézett csatorna-tartalmat és az ismeretlen formátumot. A két kontroll tehát kiegészíti egymást, nem duplikálja. A fixtúrát futásidőben állítom össze, hogy a fájlban ne legyen szkennelhető literál, és a saját regexem így is fogja.

## Nem ebben a PR-ben

A történetben már bent lévő 195 fájl és a GitHub-oldali eltávolítás a GGELEVEN818-on fut, Szabi döntésére. A történethez nem nyúltam.
