### PR TITLE
fix(ci): the secret gate must not need a native module it never builds (GATENATIV818)

### DIFF
--- a/.github/workflows/secret-gate.yml
+++ b/.github/workflows/secret-gate.yml
@@ -41,4 +41,8 @@ jobs:
           fi
 
       - name: Gate's own tests must pass (a disabled detector is a red test)
-        run: npx vitest run src/__tests__/secret-gate.test.ts
+        # vitest.gate.config.ts, not the repo default: the install above is
+        # --ignore-scripts, so no native module is built in this job, and a
+        # global setup file that probes one would kill the run before the first
+        # assertion (GATENATIV818). See that config for the full reasoning.
+        run: npx vitest run --config vitest.gate.config.ts src/__tests__/secret-gate.test.ts

--- a/vitest.gate.config.ts
+++ b/vitest.gate.config.ts
@@ -1,0 +1,48 @@
+import { defineConfig } from 'vitest/config'
+
+import baseConfig from './vitest.config'
+
+// GATENATIV818 -- the config the secret-gate job runs its own tests with
+// (.github/workflows/secret-gate.yml).
+//
+// That job installs with `npm ci --ignore-scripts` on purpose: a job whose
+// entire subject is unreviewed incoming material must not execute every
+// dependency's install script. The consequence is that no native module is ever
+// built in it -- better-sqlite3 has no compiled binding there, and never will.
+//
+// The suite's global setup files are shared with local runs, and one of them
+// probes that binding to catch a Node ABI mismatch. Measured 2026-08-18 on PR
+// #994: the gate job died at `new Database(':memory:')` with "Could not locate
+// the bindings file", before a single assertion ran. The gate is fail-closed,
+// so with that setup file on the base branch it is not a slower pipeline, it is
+// every PR blocked.
+//
+// The gate's own tests need no database at all -- they exercise pure scanning
+// logic. So this config inherits the base config unchanged and drops only the
+// setup files that require a compiled native module. It is deliberately a
+// subtraction from the base rather than a second copy of it: anything added to
+// the base config later is inherited here too.
+//
+// Scope note: this config exists for CI. It is not the way to run the suite
+// locally -- `npm test` (the base config, with every gate in place) is.
+
+/**
+ * Setup files that load a native module, identified by name because what
+ * matters is what the file does, not where it sits. If a future setup file
+ * takes the same dependency and is not listed here, this job goes red on the
+ * very next PR -- loudly, and before any merge -- rather than passing quietly.
+ */
+const NATIVE_DEPENDENT_SETUP_FILES = ['assert-supported-node']
+
+const baseSetupFiles = baseConfig.test?.setupFiles ?? []
+const inheritedSetupFiles = Array.isArray(baseSetupFiles) ? baseSetupFiles : [baseSetupFiles]
+
+export default defineConfig({
+  ...baseConfig,
+  test: {
+    ...baseConfig.test,
+    setupFiles: inheritedSetupFiles.filter(
+      (file) => !NATIVE_DEPENDENT_SETUP_FILES.some((name) => String(file).includes(name)),
+    ),
+  },
+})


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)

## Rövid leírás / Summary

**HU.** A secret-gate job szándékosan `npm ci --ignore-scripts`-tel telepít: egy olyan job, aminek a teljes tárgya át nem nézett beérkező anyag, nem futtathatja végig minden függőség telepítő-szkriptjét. Ennek az ára, hogy natív modul soha nem épül meg benne (nincs better-sqlite3 binding, és nem is lesz).

A második lépés viszont a repo alapértelmezett vitest configjával futtatta a kapu saját tesztjeit, és annak a globális setup-fájljai közösek a lokális futtatással. A #994 hozzáad egy olyat, ami import-időben adatbázist nyit, hogy elkapja a Node ABI-eltérést. A #994 gate-futásában (run 32142463311) mérve: a lépés a `new Database(':memory:')`-nél halt meg, "Could not locate the bindings file", egyetlen assertion előtt.

Ma csak a #994 saját futása bukik, mert a setup az ő merge-fájában van. Bemergelve a BÁZISBA kerül, minden PR alá, és a kapu fail-closed: ez nem lassabb pipeline, hanem minden PR blokkolva.

A kapu saját tesztjeinek nincs szükségük adatbázisra, tiszta scan-logikát futtatnak. Ezért `vitest.gate.config.ts`-n keresztül futnak: az örökli a base configot, és CSAK azokat a setup-fájlokat dobja el, amik lefordított natív modult igényelnek. Kivonás, nem másolat, tehát a base config későbbi bővítései ide is átjönnek. Az `--ignore-scripts` marad.

**EN.** The gate job installs with `--ignore-scripts` by design, so nothing native is ever built in it. Its test step used the default vitest config, whose global setup files are shared with local runs; #994 adds one that opens a better-sqlite3 database at import time. Merged, that setup file lands in the base of every PR and the fail-closed gate stops the whole queue. The gate's own tests need no database, so they now run through `vitest.gate.config.ts`, which inherits the base config and subtracts only the native-dependent setup files.

**Sorrend / Order:** ez a PR megy be először, a #994 csak utána (a #994 újrafuttatása után a merge-ref már ezt a workflow-t használja).

## Mérés / Verification

Lokálisan, friss worktree, `npm ci --ignore-scripts` (nincs binding), a fa = develop + #994 bemergelve:

| próba | eredmény |
|---|---|
| régi parancs (`npx vitest run src/__tests__/secret-gate.test.ts`) | meghal a bindings-hibán, 0 teszt (a CI-piros reprodukálva) |
| új parancs (`--config vitest.gate.config.ts`) | 26/26 zöld |
| új parancs tiszta developen (#994 nélkül) | 26/26 zöld |
| PIROS PRÓBA: a szűrőlista kiürítve | vissza a bindings-hibára, tehát a szűrő az, ami javít |
| PIROS PRÓBA: hamis `store/.dashboard-token` | "REFUSING TO RUN TESTS ... looks like a LIVE install", tehát az élő-telepítés kapu TOVÁBBRA IS érvényes ezzel a configgal; csak a natív-függő setup esik ki (a próba-fájl utána törölve) |

Regresszió-védelem: ha valaki később új, natív modult igénylő setup-fájlt vesz fel és nem írja bele a listába, ez a job a következő PR-en pirosra megy, nem csendben átenged.

## Kapcsolódó issue / Related issue

Blokkolja / blocks: #994

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást (worktree, `npm ci --ignore-scripts`, a fenti mérési tábla). CI-only változás, a dashboard/ágens-futást nem érinti; a lokális `npm test` útvonala (base config, minden kapuval) változatlan.
- [ ] `docs/` frissítés: nem érintett (nem telepítés/architektúra).
- [x] A kód nem tartalmaz beleégetett szenzitív adatot. A gate saját maga is átfuttatva a change-seten: `PASS: no denied path, no secret shape, no channel material in 2 file(s)`.
- [x] Saját, beszédes nevű branch-ről nyitom.
