### PR TITLE
docs(ci): name the Node pin as the gate job's only version control (GATENATIV818 follow-up)

### DIFF
--- a/.github/workflows/secret-gate.yml
+++ b/.github/workflows/secret-gate.yml
@@ -20,6 +20,10 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
+          # This pin is the ONLY Node-version control in this job. The suite's
+          # ABI probe (assert-supported-node) cannot help here: the install
+          # below is --ignore-scripts, so no binding exists to probe, which is
+          # why vitest.gate.config.ts subtracts it. Keep the pin.
           node-version: '22'
 
       - run: npm ci --ignore-scripts


### PR DESCRIPTION
One comment block, zero behavior change: Marveen's #998 review observation, kept in the file in my own words (his ask). The `setup-node` pin is this job's only Node-version control; the suite's ABI probe cannot run here because `--ignore-scripts` builds no binding to probe, which is exactly why `vitest.gate.config.ts` subtracts it. If the pin is ever removed, nothing else in this job warns.

Merge is Marveen's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
