### PR TITLE
fix(security): reject inward-resolving names and unknown message filters

### DIFF
--- a/src/__tests__/quarantine-allowlist-render.test.ts
+++ b/src/__tests__/quarantine-allowlist-render.test.ts
@@ -126,6 +126,36 @@ describe('isPublicFetchHost', () => {
     }
   })
 
+  // #797 review, point 4: the literal check is not enough, because a PUBLIC
+  // NAME can still resolve inward. Wildcard-DNS services encode the address in
+  // the name, so these passed every earlier check and then pointed at loopback,
+  // RFC1918 or the cloud metadata endpoint.
+  it('rejects names that resolve inward via wildcard DNS', () => {
+    for (const bad of [
+      '127.0.0.1.nip.io', '10.0.0.1.nip.io', '192.168.1.50.nip.io',
+      '169.254.169.254.nip.io', '172.16.4.9.sslip.io', '100.64.0.1.nip.io',
+      '192-168-1-50.sslip.io', '127-0-0-1.sslip.io', '10-0-0-1.my.sslip.io',
+      'app.127.0.0.1.nip.io',
+    ]) {
+      expect(isPublicFetchHost(bad)).toBe(false)
+    }
+  })
+
+  it('rejects in-cluster service names', () => {
+    for (const bad of ['kubernetes.default.svc', 'api.prod.svc', 'db.svc.cluster.local', 'redis.ns.cluster']) {
+      expect(isPublicFetchHost(bad)).toBe(false)
+    }
+  })
+
+  // The guard is deliberately narrow: a PUBLIC address embedded in a name is
+  // not a bypass of the loopback/RFC1918 boundary, and rejecting every numeric
+  // label would break legitimate hosts.
+  it('still accepts ordinary public names, including numeric labels', () => {
+    for (const good of ['claude.com', 'api.example.co.uk', '8.8.8.8.nip.io', 'v2.api.example.com', '123.example.com']) {
+      expect(isPublicFetchHost(good)).toBe(true)
+    }
+  })
+
   it('rejects internal suffixes and single-label names', () => {
     for (const bad of ['printer.local', 'db.internal', 'box.lan', 'wiki.intranet', 'nas', 'router.home']) {
       expect(isPublicFetchHost(bad)).toBe(false)

--- a/src/web/agent-scaffold.ts
+++ b/src/web/agent-scaffold.ts
@@ -520,9 +520,47 @@ export function isPublicFetchHost(value: string): boolean {
   const labels = host.split('.')
   if (labels.length < 2) return false                 // single label: localhost and friends
   if (labels.some((l) => !l || l.length > 63 || l.startsWith('-') || l.endsWith('-'))) return false
-  const INTERNAL_SUFFIX = ['local', 'internal', 'localdomain', 'lan', 'intranet', 'home', 'arpa', 'test', 'invalid', 'localhost']
+  const INTERNAL_SUFFIX = ['local', 'internal', 'localdomain', 'lan', 'intranet', 'home', 'arpa', 'test', 'invalid', 'localhost', 'svc', 'cluster']
   if (INTERNAL_SUFFIX.includes(labels[labels.length - 1])) return false
+  // A public NAME can still resolve inward. Wildcard-DNS services (nip.io,
+  // sslip.io and friends) encode the address in the name itself, so
+  // 127.0.0.1.nip.io and 192-168-1-50.sslip.io pass every check above and then
+  // resolve to loopback/RFC1918. Reaching them needs an allowlist entry, so
+  // this is defence-in-depth rather than an open door -- but it is the same
+  // class of bypass the literal check already rejects, and it costs one pass.
+  if (labels.some((l) => isInwardDashQuad(l))) return false
+  for (let i = 0; i + 3 < labels.length; i++) {
+    if (isInwardQuad(labels[i], labels[i + 1], labels[i + 2], labels[i + 3])) return false
+  }
   return true
+}
+
+// True for an IPv4 that points back at us or into a private network. Kept
+// narrow on purpose: a PUBLIC address embedded in a name is not a bypass of
+// the loopback/RFC1918 guard, and rejecting every numeric label would break
+// legitimate hosts.
+function isInwardIPv4(o: number[]): boolean {
+  if (o.length !== 4 || o.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) return false
+  const [a, b] = o
+  if (a === 0 || a === 127) return true                      // this-host, loopback
+  if (a === 10) return true                                  // RFC1918
+  if (a === 172 && b >= 16 && b <= 31) return true           // RFC1918
+  if (a === 192 && b === 168) return true                    // RFC1918
+  if (a === 169 && b === 254) return true                    // link-local, cloud metadata
+  if (a === 100 && b >= 64 && b <= 127) return true          // CGNAT
+  return false
+}
+
+function isInwardQuad(a: string, b: string, c: string, d: string): boolean {
+  const parts = [a, b, c, d]
+  if (!parts.every((p) => /^\d{1,3}$/.test(p))) return false
+  return isInwardIPv4(parts.map((p) => parseInt(p, 10)))
+}
+
+function isInwardDashQuad(label: string): boolean {
+  const m = label.match(/^(\d{1,3})-(\d{1,3})-(\d{1,3})-(\d{1,3})$/)
+  if (!m) return false
+  return isInwardIPv4(m.slice(1).map((p) => parseInt(p, 10)))
 }
 
 export function ownerAllowedDomains(storeDir = STORE_DIR): string[] {

--- a/src/web/routes/messages.ts
+++ b/src/web/routes/messages.ts
@@ -152,6 +152,23 @@ export async function tryHandleMessages(ctx: RouteContext): Promise<boolean> {
   }
 
   if (path === '/api/messages' && method === 'GET') {
+    // An UNKNOWN filter param used to fall through to the global list: a typo,
+    // or the plausible-but-wrong `agent_id`, silently returned the fleet's last
+    // N messages instead of one agent's mailbox. Not an error, not an empty
+    // list -- MORE than asked for, which is the expensive direction to be wrong
+    // in: a caller acting in good faith on that answer reads other agents'
+    // traffic as its own. Fail loudly instead.
+    const KNOWN_PARAMS = new Set(['agent', 'status', 'limit', 'before'])
+    const unknown = [...url.searchParams.keys()].filter((k) => !KNOWN_PARAMS.has(k))
+    if (unknown.length) {
+      json(res, {
+        error: 'unknown query parameter',
+        unknown,
+        known: [...KNOWN_PARAMS],
+        hint: 'the mailbox filter is "agent"; "agent_id" and "to" are not read',
+      }, 400)
+      return true
+    }
     const agent = url.searchParams.get('agent') || ''
     const status = url.searchParams.get('status') || ''
     const limit = Math.min(parseInt(url.searchParams.get('limit') || '50', 10), 200)


### PR DESCRIPTION
Két lelet a #797 review-ból és a saját flotta-üzemeltetésből. Mindkettő ugyanabba az irányba hibázik: csendben, és TÖBB hozzáférés felé, mint amit kértek.

## 1. `isPublicFetchHost` átengedte a befelé feloldó NEVEKET

A cím-literál ellenőrzés elutasítja a `127.0.0.1`-et, de a wildcard-DNS szolgáltatások magába a névbe kódolják a címet. Így `127.0.0.1.nip.io`, `10.0.0.1.nip.io` és `192-168-1-50.sslip.io` minden korábbi ellenőrzésen átment, majd loopbackre vagy RFC1918-ra oldódott fel. A `kubernetes.default.svc` szintén átment, miközben a `db.svc.cluster.local` már a suffixén elbukott.

Ez a #797 review 4. pontja. Eléréséhez kell egy allowlist-bejegyzés, tehát defence-in-depth, nem nyitott ajtó — de pontosan az az osztály, ami ellen a literál-ellenőrzés már véd.

**A guard szándékosan szűk.** Csak loopback, RFC1918, link-local (felhő-metaadat) és CGNAT kerül elutasításra. Egy PUBLIKUS cím a névbe ágyazva nem kerüli meg ezt a határt, és minden numerikus címke elutasítása legitim hosztokat törne el, ezért a `8.8.8.8.nip.io` és a `123.example.com` továbbra is átmegy.

## 2. `GET /api/messages` némán a GLOBÁLIS listára esett vissza

Ismeretlen szűrő-paraméternél — elgépelés, vagy a hihető, de rossz `agent_id` — a route nem hibát és nem üres listát adott, hanem a flotta utolsó N üzenetét, egyetlen ügynök postafiókja helyett. Aki jóhiszeműen cselekszik a válaszra, más ügynökök forgalmát olvassa sajátként; nálunk pontosan így született egy félreolvasás.

Mostantól 400, ami megnevezi az ismeretlen kulcsot és rámutat a helyesre.

## Tesztek

A `quarantine-allowlist-render` suite kiegészítve a wildcard-DNS alakokkal, a kötőjeles változattal, a fürtön belüli nevekkel, és azokkal a publikus nevekkel, amiknek működniük kell. 24 teszt zöld.

Teljes suite a fenti commiton: **3535 zöld, 1 piros**. A piros az `installer-start-and-fallback` egy bash ERR-trap sorszám-állítása (`TRAP:5` kontra `TRAP:6`), és **ugyanígy piros a HEAD~1-en is**, tehát nem ehhez a változáshoz tartozik.