### PR TITLE
fix(vault): pin 0600 on credential MCP config writes (VAULTMODE818)

### DIFF
--- a/src/__tests__/atomic-write-tmp-mode.test.ts
+++ b/src/__tests__/atomic-write-tmp-mode.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync, statSync, rmSync, writeFileSync, chmodSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { randomBytes } from 'node:crypto'
+import { tmpdir } from 'node:os'
+import { atomicWriteFileSync } from '../web/atomic-write.js'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const atomicWriteSrc = join(here, '..', 'web', 'atomic-write.ts')
+
+// VAULTMODE818 (tmp-window half): atomicWriteFileSync must create the tmp file
+// AT the requested mode, not write it mode-less and chmod afterwards. The
+// mode-less+chmod path leaves a short-lived tmp holding the full content at the
+// umask default (0644) in the same directory as the protected target -- a
+// world-readable window even though the final renamed file ends up 0600.
+describe('atomic-write tmp-file creation mode', () => {
+  it('passes the mode to writeFileSync at tmp creation (not chmod-only)', () => {
+    const src = readFileSync(atomicWriteSrc, 'utf8')
+    // The tmp create call must carry the mode; a mode-less writeFileSync(tmp, data)
+    // followed only by chmod is the bug being guarded.
+    const tmpCreate = src.match(/writeFileSync\(\s*tmp\s*,[^\n]*\)/)?.[0] ?? ''
+    expect(tmpCreate, `tmp create line:\n${tmpCreate}`).toMatch(/mode/)
+  })
+
+  it('final file is 0600 when mode 0600 is requested (overwriting a 0644 file)', () => {
+    const path = join(tmpdir(), `atomicmode-${process.pid}-${randomBytes(4).toString('hex')}.json`)
+    try {
+      writeFileSync(path, '{}')
+      chmodSync(path, 0o644)
+      atomicWriteFileSync(path, JSON.stringify({ x: 1 }), { mode: 0o600 })
+      expect(statSync(path).mode & 0o777).toBe(0o600)
+    } finally {
+      rmSync(path, { force: true })
+    }
+  })
+
+  it('a fresh write with mode 0600 is never group/other-readable', () => {
+    const path = join(tmpdir(), `atomicmode-fresh-${process.pid}-${randomBytes(4).toString('hex')}.json`)
+    try {
+      atomicWriteFileSync(path, 'secret-bearing', { mode: 0o600 })
+      expect(statSync(path).mode & 0o077).toBe(0) // no group/other bits
+    } finally {
+      rmSync(path, { force: true })
+    }
+  })
+})

--- a/src/__tests__/atomic-write-tmp-mode.test.ts
+++ b/src/__tests__/atomic-write-tmp-mode.test.ts
@@ -15,6 +15,13 @@ const atomicWriteSrc = join(here, '..', 'web', 'atomic-write.ts')
 // umask default (0644) in the same directory as the protected target -- a
 // world-readable window even though the final renamed file ends up 0600.
 describe('atomic-write tmp-file creation mode', () => {
+  // DO NOT delete this source-scan as "redundant" with the behaviour tests
+  // below. Verified 2026-08-19 (Marveen's negative control): reverting the fix
+  // to a mode-less tmp create keeps BOTH behaviour tests GREEN -- the trailing
+  // chmod still repairs the END state, so statSync on the final file sees 0600.
+  // Only this source-scan turns red. This fault class (a transient world-readable
+  // tmp) is invisible to end-state assertions; the source-scan is the only guard
+  // that catches a regression, so removing it silently re-opens the window.
   it('passes the mode to writeFileSync at tmp creation (not chmod-only)', () => {
     const src = readFileSync(atomicWriteSrc, 'utf8')
     // The tmp create call must carry the mode; a mode-less writeFileSync(tmp, data)

--- a/src/__tests__/vault-bindings-file-mode.test.ts
+++ b/src/__tests__/vault-bindings-file-mode.test.ts
@@ -41,15 +41,21 @@ describe('VAULTMODE818: vault-bindings pins 0600 on credential-bearing writes', 
 
   it('atomicWriteFileSync WITHOUT mode inherits the umask (the bug being guarded)', () => {
     const path = join(tmpdir(), `vaultmode-nomode-${process.pid}-${randomBytes(4).toString('hex')}.json`)
+    // The prior 0600 is lost on rewrite because rename swaps the inode: the new
+    // file's perms come from the umask, not the old target. Tie the expectation
+    // to THIS process's umask (0666 & ~umask) rather than hard-coding "not 0600"
+    // -- under a restrictive umask (e.g. 077) the default is itself 0600 and a
+    // bare "not 0600" would falsely fail.
+    const um = process.umask()
+    process.umask(um) // read-only: restore immediately
+    const umaskDefault = 0o666 & ~um
     try {
-      // Start secure, then rewrite without a mode: rename swaps the inode, so
-      // the prior 0600 is lost and the tmp file's umask perms win.
       writeFileSync(path, '{}')
       chmodSync(path, 0o600)
       const tmp = `${path}.${randomBytes(4).toString('hex')}.tmp`
       writeFileSync(tmp, '{"x":1}')
       renameSync(tmp, path)
-      expect(statSync(path).mode & 0o777).not.toBe(0o600)
+      expect(statSync(path).mode & 0o777).toBe(umaskDefault)
     } finally {
       rmSync(path, { force: true })
     }

--- a/src/__tests__/vault-bindings-file-mode.test.ts
+++ b/src/__tests__/vault-bindings-file-mode.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync, writeFileSync, chmodSync, renameSync, statSync, rmSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { randomBytes } from 'node:crypto'
+import { tmpdir } from 'node:os'
+import { atomicWriteFileSync } from '../web/atomic-write.js'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const vaultBindingsSrc = join(here, '..', 'web', 'vault-bindings.ts')
+
+// VAULTMODE818: the vault-binding sync rewrites credential-bearing MCP config
+// files (for the user target this IS ~/.claude.json). atomicWriteFileSync
+// renames a fresh tmp file over the target, so WITHOUT an explicit mode the
+// result inherits the umask (0644) and silently loosens a 0600 credential file
+// to group/other-readable. Every write of target.mcpFilePath must pin 0600.
+describe('VAULTMODE818: vault-bindings pins 0600 on credential-bearing writes', () => {
+  it('every atomicWriteFileSync(target.mcpFilePath, ...) passes mode 0o600', () => {
+    const src = readFileSync(vaultBindingsSrc, 'utf8')
+    // Each such write is a single line; the credential-file write must pin 0600.
+    const lines = src.split('\n').filter(l => l.includes('atomicWriteFileSync(target.mcpFilePath'))
+    expect(lines.length).toBeGreaterThan(0)
+    for (const line of lines) {
+      expect(line, `credential-file write must set 0600:\n${line}`).toMatch(/mode:\s*0o600/)
+    }
+  })
+
+  it('atomicWriteFileSync with mode 0600 keeps a file 0600 even overwriting a 0644 one', () => {
+    const path = join(tmpdir(), `vaultmode-${process.pid}-${randomBytes(4).toString('hex')}.json`)
+    try {
+      // Simulate an existing world-readable file the sync would overwrite.
+      writeFileSync(path, '{}')
+      chmodSync(path, 0o644)
+      expect(statSync(path).mode & 0o777).toBe(0o644)
+      atomicWriteFileSync(path, JSON.stringify({ x: 1 }), { mode: 0o600 })
+      expect(statSync(path).mode & 0o777).toBe(0o600)
+    } finally {
+      rmSync(path, { force: true })
+    }
+  })
+
+  it('atomicWriteFileSync WITHOUT mode inherits the umask (the bug being guarded)', () => {
+    const path = join(tmpdir(), `vaultmode-nomode-${process.pid}-${randomBytes(4).toString('hex')}.json`)
+    try {
+      // Start secure, then rewrite without a mode: rename swaps the inode, so
+      // the prior 0600 is lost and the tmp file's umask perms win.
+      writeFileSync(path, '{}')
+      chmodSync(path, 0o600)
+      const tmp = `${path}.${randomBytes(4).toString('hex')}.tmp`
+      writeFileSync(tmp, '{"x":1}')
+      renameSync(tmp, path)
+      expect(statSync(path).mode & 0o777).not.toBe(0o600)
+    } finally {
+      rmSync(path, { force: true })
+    }
+  })
+})

--- a/src/web/atomic-write.ts
+++ b/src/web/atomic-write.ts
@@ -11,7 +11,14 @@ export function atomicWriteFileSync(
   opts: { mode?: number } = {},
 ): void {
   const tmp = `${path}.${process.pid}.${Date.now()}.${randomBytes(4).toString('hex')}.tmp`
-  writeFileSync(tmp, data)
+  // Create the tmp file at the requested mode from the FIRST byte. Writing it
+  // mode-less and chmod-ing afterwards leaves a short-lived tmp that already
+  // holds the full (possibly credential) content at the umask default (0644)
+  // in the same directory as the protected target -- a world-readable window
+  // (VAULTMODE818). The chmod stays as a belt-and-suspenders: writeFileSync's
+  // mode is still reduced by the umask, so for modes with bits the umask would
+  // strip the explicit chmod enforces the exact value.
+  writeFileSync(tmp, data, opts.mode !== undefined ? { mode: opts.mode } : undefined)
   if (opts.mode !== undefined) {
     try { chmodSync(tmp, opts.mode) } catch { /* best-effort */ }
   }

--- a/src/web/vault-bindings.ts
+++ b/src/web/vault-bindings.ts
@@ -123,7 +123,12 @@ export function removeBindingsForSecret(vaultSecretId: string): void {
           delete serverCfg.env[binding.envVar]
           if (!serverHasVaultRefs(serverCfg.env)) unwrapCommand(serverCfg)
         }
-        atomicWriteFileSync(target.mcpFilePath, JSON.stringify(content, null, 2))
+        // 0600: these files carry vault:-wrapped credential references and,
+        // for the user target, this IS ~/.claude.json. atomicWriteFileSync
+        // renames a fresh tmp file over the target, so without an explicit mode
+        // the result inherits the umask (0644) and silently loosens a 0600
+        // credential file to group/other-readable (VAULTMODE818).
+        atomicWriteFileSync(target.mcpFilePath, JSON.stringify(content, null, 2), { mode: 0o600 })
       } catch { /* skip */ }
     }
   }
@@ -299,7 +304,12 @@ export function syncSecret(vaultSecretId: string): SyncResult {
           serverCfg.env[binding.envVar] = `vault:${vaultSecretId}`
           if (serverCfg.command && !serverCfg.url) wrapCommand(serverCfg)
         }
-        atomicWriteFileSync(target.mcpFilePath, JSON.stringify(content, null, 2))
+        // 0600: these files carry vault:-wrapped credential references and,
+        // for the user target, this IS ~/.claude.json. atomicWriteFileSync
+        // renames a fresh tmp file over the target, so without an explicit mode
+        // the result inherits the umask (0644) and silently loosens a 0600
+        // credential file to group/other-readable (VAULTMODE818).
+        atomicWriteFileSync(target.mcpFilePath, JSON.stringify(content, null, 2), { mode: 0o600 })
         updated++
       } catch (err: any) {
         errors.push(`Failed to update ${target.mcpFilePath}: ${err.message}`)
@@ -337,7 +347,12 @@ export function unsyncBinding(vaultSecretId: string, envVar: string): void {
           delete serverCfg.env[envVar]
           if (!serverHasVaultRefs(serverCfg.env)) unwrapCommand(serverCfg)
         }
-        atomicWriteFileSync(target.mcpFilePath, JSON.stringify(content, null, 2))
+        // 0600: these files carry vault:-wrapped credential references and,
+        // for the user target, this IS ~/.claude.json. atomicWriteFileSync
+        // renames a fresh tmp file over the target, so without an explicit mode
+        // the result inherits the umask (0644) and silently loosens a 0600
+        // credential file to group/other-readable (VAULTMODE818).
+        atomicWriteFileSync(target.mcpFilePath, JSON.stringify(content, null, 2), { mode: 0o600 })
       } catch { /* skip */ }
     }
   }


### PR DESCRIPTION
## What
The vault-binding sync (`src/web/vault-bindings.ts`) rewrites credential-bearing MCP config files with `atomicWriteFileSync`. For the **user** target this file is `~/.claude.json`. `atomicWriteFileSync` writes a fresh tmp file and renames it over the target, so **without an explicit mode the result inherits the umask (0644)** — silently loosening a `0600` credential file to group/other-readable on the next sync.

## Fix
Pass `{ mode: 0o600 }` at the three `target.mcpFilePath` write sites (lines were 126/302/340), mirroring the existing `mode: 0o600` pattern in `agent-worker.ts:421`.

## Evidence
- **Mechanism reproduced** (scratch, exact lib body): `600 → atomicWrite no-mode → 644 → mode:0600 → 600`.
- **Live state** at time of finding: `~/.claude.json` was `600` (not yet touched by a sync since last secure write); the next sync writing the user config would have dropped it to `644`.
- **Regression guard** (`vault-bindings-file-mode.test.ts`): source-scan asserts every `atomicWriteFileSync(target.mcpFilePath, …)` pins `0600`, plus mechanism assertions. Adversarially verified: removing any one `mode` makes the guard **fail**.

## Scope
Internal posture fix, no outward-facing behaviour change. Card VAULTMODE818.

🤖 Generated with [Claude Code](https://claude.com/claude-code)