### PR TITLE
fix(channels): honest, platform-aware recovery-owner log (CHANWDOG818 log half)

### DIFF
--- a/scripts/channel-keepalive-probe.sh
+++ b/scripts/channel-keepalive-probe.sh
@@ -34,6 +34,20 @@ LOG_TAG="channel-keepalive-probe"
 
 log() { echo "$(date '+%Y-%m-%d %H:%M:%S') [$LOG_TAG] $*"; }
 
+# Whether a dedicated channel-watchdog recovery owner is actually installed on
+# THIS host. The probe declines to recover a dead pipe on purpose -- but only a
+# real, installed watchdog legitimately "owns recovery". The systemd
+# channel-watchdog timer has NO launchd twin, so on macOS it is simply absent
+# (CHANWDOG818): claiming an owner that isn't there turns a genuine outage into
+# silence. Fail loud instead when nothing owns recovery.
+channel_watchdog_installed() {
+  if [ "$(uname -s)" = "Darwin" ]; then
+    launchctl list 2>/dev/null | grep -q 'com\.marveen\.channel-watchdog'
+  else
+    systemctl --user is-enabled channel-watchdog.timer >/dev/null 2>&1
+  fi
+}
+
 # --- resolve the channels session (launch-order / rename independent) ---
 MAIN_AGENT_ID="$(grep -E '^MAIN_AGENT_ID=' "$INSTALL_DIR/.env" 2>/dev/null | head -1 | cut -d= -f2-)"
 MAIN_AGENT_ID="${MAIN_AGENT_ID:-marveen}"
@@ -87,7 +101,13 @@ while read -r cand; do
 done < <(ps -axo pid,command 2>/dev/null | grep -E '(^| )(bun|node)( |$|.*/)' | grep -E '/telegram/' | grep -v grep | awk '{print $1}')
 
 if [ "$alive" -ne 1 ]; then
-  log "no live telegram poller under $SESSION (pane $pane_pid) -- pipe may be down; not touching (watchdog owns recovery)"
+  # Do NOT advance the keepalive: a dead pipe must stay visibly stale so a real
+  # recovery owner can act. But only claim an owner that actually exists here.
+  if channel_watchdog_installed; then
+    log "no live telegram poller under $SESSION (pane $pane_pid) -- pipe may be down; not touching (channel-watchdog owns recovery)"
+  else
+    log "WARN no live telegram poller under $SESSION (pane $pane_pid) -- pipe may be down AND no channel-watchdog recovery unit is installed on this host (CHANWDOG818); automatic recovery relies only on process-death KeepAlive + the dashboard channel-monitor, so a FROZEN session while the dashboard is also down is NOT auto-recovered"
+  fi
   exit 0
 fi
 


### PR DESCRIPTION
## What
`scripts/channel-keepalive-probe.sh` declines to recover a dead telegram poller (correct — a real recovery owner should act on the visibly stale keepalive) but logged **"watchdog owns recovery" unconditionally**. The systemd `channel-watchdog.timer` has **no launchd twin**, so on macOS that owner is **absent** — the log turned a genuine outage into false reassurance. This is the gap behind the 04:20 "are you working?" moment.

## Fix (log-honesty half of CHANWDOG818)
- New `channel_watchdog_installed()`: platform-aware detection (`launchctl` on macOS, `systemctl --user is-enabled` on Linux).
- Dead-poller branch is now conditional:
  - **owner present** → `not touching (channel-watchdog owns recovery)` (accurate).
  - **owner absent** → `WARN … no channel-watchdog recovery unit is installed on this host … a FROZEN session while the dashboard is also down is NOT auto-recovered` (fail-loud).

## Evidence
- `bash -n` clean.
- Detection verified with **positive control** (unit present → claims owner) and **negative control** (this macOS host, no unit → fail-loud), plus the real live-host function run → `NOT installed → fail-loud`, matching the measurement on the card.

## Explicitly out of scope
Installing a macOS launchd unit for the watchdog is a **separate, deliberate host change** (5-min auto-restart side effect) — per the card owner's decision it is **not** part of this PR. Marveen measured the residual uncovered case as narrow: session alive-but-frozen **and** dashboard simultaneously down.

Card CHANWDOG818.

🤖 Generated with [Claude Code](https://claude.com/claude-code)