### PR TITLE
refactor: non-blocking delay, shell-escaping és doksi sanitization

### DIFF
--- a/docs/onboarding-uj-asszisztens.md
+++ b/docs/onboarding-uj-asszisztens.md
@@ -32,7 +32,7 @@ naptárát, fájljait). A kettő független, bármelyikkel kezdheted.
    - Tipp: a botot te (admin) hozd létre, így céges kézben marad. A kolléga a
      tokent soha nem látja.
 
-2. **Asszisztens létrehozása a dashboardon** (https://marveen.isolutions.hu):
+2. **Asszisztens létrehozása a dashboardon** (https://marveen.example.com):
    - "Felvétel", ahogy a korábbi asszisztenseknél.
 
 3. **Token bekötése:**
@@ -94,4 +94,4 @@ saját Google fiókjával.
 
 ---
 
-*Készítette: iS Marveen Főnök. A flotta a marveen.isolutions.hu címen érhető el.*
+*Készítette: iS Marveen Főnök. A flotta a marveen.example.com címen érhető el.*

--- a/src/index.ts
+++ b/src/index.ts
@@ -548,7 +548,7 @@ async function main(): Promise<void> {
   if (shouldBootHeartbeatAgent({ respawnEnabled: RESPAWN_ENABLED, agentEnabled: HEARTBEAT_AGENT_ENABLED })) {
     ensureHeartbeatAgent()
     logger.info({ agent: HEARTBEAT_AGENT_NAME }, 'Heartbeat agent scaffold ensured (channel-less, dashboard-hidden)')
-    const heartbeatStart = startAgentProcess(HEARTBEAT_AGENT_NAME)
+    const heartbeatStart = await startAgentProcess(HEARTBEAT_AGENT_NAME)
     if (heartbeatStart.ok) {
       logger.info({ agent: HEARTBEAT_AGENT_NAME }, 'Heartbeat agent started')
     } else if (heartbeatStart.error === 'Agent is already running') {

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync, mkdirSync, writeFileSync, readdirSync, lstatSync, symlinkSync, rmSync, realpathSync, renameSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 import { homedir } from 'node:os'
-import { execSync, execFileSync } from 'node:child_process'
+import { execFileSync } from 'node:child_process'
 import { OLLAMA_URL } from '../config.js'
 import { makeLazyBinResolver } from '../platform.js'
 import { logger } from '../logger.js'
@@ -979,7 +979,7 @@ function startRemoteAgentProcess(
   }
 }
 
-export function startAgentProcess(name: string, opts: { fresh?: boolean } = {}): { ok: boolean; pid?: number; error?: string } {
+export async function startAgentProcess(name: string, opts: { fresh?: boolean } = {}): Promise<{ ok: boolean; pid?: number; error?: string }> {
   const dir = agentDir(name)
   if (!existsSync(dir)) return { ok: false, error: 'Agent not found' }
 
@@ -1047,7 +1047,7 @@ export function startAgentProcess(name: string, opts: { fresh?: boolean } = {}):
   try {
     try {
       runTmux(null, ['kill-session', '-t', session])
-      execSync('sleep 3', { timeout: 5000 })
+      await delay(3000)
     } catch { /* ok */ }
 
     // Reap any orphan poller (bun/node) left over from a previous run BEFORE
@@ -1419,7 +1419,7 @@ export function startAgentProcess(name: string, opts: { fresh?: boolean } = {}):
   }
 }
 
-export function stopAgentProcess(name: string): { ok: boolean; error?: string } {
+export async function stopAgentProcess(name: string): Promise<{ ok: boolean; error?: string }> {
   const session = agentSessionName(name)
   if (!isAgentRunning(name)) return { ok: false, error: 'Agent is not running' }
 
@@ -1427,7 +1427,7 @@ export function stopAgentProcess(name: string): { ok: boolean; error?: string } 
 
   try {
     runTmux(host, ['kill-session', '-t', session], { timeout: 5000 })
-    execSync('sleep 2', { timeout: 4000 })
+    await delay(2000)
     // Reap any orphaned plugin grandchild that tmux did not tear down. This is
     // a LOCAL pkill against this host's process table, so it only makes sense
     // for local agents; a remote agent is channel-less and its processes live
@@ -1458,9 +1458,9 @@ export function getAgentProcessInfo(name: string): { running: boolean; session?:
   }
 }
 
-export function restartAgentProcess(name: string, opts: { fresh?: boolean } = {}): { ok: boolean; pid?: number; error?: string } {
+export async function restartAgentProcess(name: string, opts: { fresh?: boolean } = {}): Promise<{ ok: boolean; pid?: number; error?: string }> {
   if (isAgentRunning(name)) {
-    const stopResult = stopAgentProcess(name)
+    const stopResult = await stopAgentProcess(name)
     if (!stopResult.ok) return { ok: false, error: stopResult.error || 'Failed to stop running agent before restart' }
   }
   return startAgentProcess(name, opts)

--- a/src/web/auto-restart-runner.ts
+++ b/src/web/auto-restart-runner.ts
@@ -95,15 +95,15 @@ function restartMainChannelsSession(): void {
   respawnMainSessionFresh()
 }
 
-function performRestart(name: string, cfg: AutoRestartConfig): void {
+async function performRestart(name: string, cfg: AutoRestartConfig): Promise<void> {
   if (name === MAIN_AGENT_ID) {
     restartMainChannelsSession()
   } else {
-    restartAgentProcess(name, { fresh: cfg.mode === 'fresh' })
+    await restartAgentProcess(name, { fresh: cfg.mode === 'fresh' })
   }
 }
 
-function checkAgent(name: string, nowMs: number): void {
+async function checkAgent(name: string, nowMs: number): Promise<void> {
   const cfg = readAutoRestartConfig(name)
   if (!cfg.enabled) {
     lastRestart.delete(name) // re-seed cleanly if re-enabled later
@@ -138,7 +138,7 @@ function checkAgent(name: string, nowMs: number): void {
   }
 
   try {
-    performRestart(name, cfg)
+    await performRestart(name, cfg)
     lastRestart.set(name, nowMs)
     logger.info({ name, mode: name === MAIN_AGENT_ID ? 'fresh(main)' : cfg.mode }, 'auto-restart: restarted session')
   } catch (err) {
@@ -147,11 +147,26 @@ function checkAgent(name: string, nowMs: number): void {
 }
 
 export function startAutoRestartRunner(): NodeJS.Timeout {
-  function sweep() {
-    const now = Date.now()
-    try { checkAgent(MAIN_AGENT_ID, now) } catch (err) { logger.debug({ err }, 'auto-restart: main check error') }
-    for (const name of listAgentNames()) {
-      try { checkAgent(name, now) } catch (err) { logger.debug({ err, agent: name }, 'auto-restart: agent check error') }
+  let tickRunning = false
+  async function sweep() {
+    // Re-entrancy guard: checkAgent/performRestart now await a real
+    // restartAgentProcess (no longer a blocking execSync('sleep N')), so a
+    // sweep with a restart in flight can still be running when the next
+    // interval fires. Skip an overlapping tick; the next tick re-evaluates
+    // every agent, so nothing is missed.
+    if (tickRunning) {
+      logger.debug('auto-restart: previous sweep still running, skipping this tick')
+      return
+    }
+    tickRunning = true
+    try {
+      const now = Date.now()
+      try { await checkAgent(MAIN_AGENT_ID, now) } catch (err) { logger.debug({ err }, 'auto-restart: main check error') }
+      for (const name of listAgentNames()) {
+        try { await checkAgent(name, now) } catch (err) { logger.debug({ err, agent: name }, 'auto-restart: agent check error') }
+      }
+    } finally {
+      tickRunning = false
     }
   }
   setTimeout(sweep, INITIAL_DELAY_MS)

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -1803,7 +1803,7 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
         }
         logger.warn({ agent: t.agentName, provider: t.provider, failures }, 'Agent channel plugin down -- auto-restarting')
         try {
-          stopAgentProcess(t.agentName!)
+          await stopAgentProcess(t.agentName!)
           // Settle before the fresh start. stopAgentProcess already reaps this
           // agent's channel orphans + waits 2s; add more so the shared plugin
           // cache (bun run --cwd <plugin>, .in_use markers) fully releases from
@@ -1820,7 +1820,7 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
           // the --channels plugin MCP server, so the agent comes up with no plugin
           // and no poller (verified: continue -> "Plugin not found" in /mcp; fresh
           // -> plugin loads + poller attaches). Context is dropped, memory persists.
-          startAgentProcess(t.agentName!, { fresh: true })
+          await startAgentProcess(t.agentName!, { fresh: true })
           agentLastRestart.set(t.agentName!, Date.now())
           agentDownSince.delete(t.session)
           agentBusyDeferAlerted.delete(t.session)
@@ -1913,7 +1913,7 @@ async function reconcileDesiredAgents(): Promise<void> {
       if (!memGateAllowsStart(name)) continue   // Commit 3 v1: safe-mode / memory gate
       logger.warn({ agent: name }, 'Desired agent not running -- auto-starting (reconcile)')
       try {
-        const r = startAgentProcess(name)
+        const r = await startAgentProcess(name)
         agentLastRestart.set(name, Date.now())
         if (!r.ok && r.error !== 'Agent is already running') {
           logger.error({ agent: name, error: r.error }, 'Reconcile start failed')

--- a/src/web/context-guard-runner.ts
+++ b/src/web/context-guard-runner.ts
@@ -224,7 +224,7 @@ function measurePct(name: string, cfgLimit: number | null): number | null {
   return tokens / limit
 }
 
-function performRestart(name: string): void {
+async function performRestart(name: string): Promise<void> {
   if (name === MAIN_AGENT_ID) {
     // Platform-correct main-session restart. This was a hardcoded
     // `/bin/launchctl kickstart`, which exists only on macOS: on Linux every
@@ -243,7 +243,7 @@ function performRestart(name: string): void {
     const res = hardRestartMarveenChannels()
     if (!res.ok) throw new Error(res.error ?? 'main channels hard restart failed')
   } else {
-    restartAgentProcess(name, { fresh: true })
+    await restartAgentProcess(name, { fresh: true })
   }
 }
 
@@ -396,7 +396,7 @@ async function checkAgent(name: string, nowMs: number): Promise<void> {
         } catch (err) {
           logger.warn({ err, name }, 'context-guard: pre-restart pane snapshot failed')
         }
-        performRestart(name)
+        await performRestart(name)
         try {
           createAgentMessage(
             name,
@@ -500,10 +500,25 @@ export function getHardGuardPhase(name: string): string {
 }
 
 export function startContextGuardRunner(): NodeJS.Timeout {
+  let tickRunning = false
   async function sweep() {
-    const now = Date.now()
-    for (const name of guardSweepAgentNames()) {
-      try { await checkAgent(name, now) } catch (err) { logger.debug({ err, agent: name }, 'context-guard: agent check error') }
+    // Re-entrancy guard: checkAgent's 'restart' action now awaits a real
+    // restartAgentProcess (no longer a blocking execSync('sleep N')), so a
+    // sweep with a restart in flight can still be running when the next
+    // interval fires. Skip an overlapping tick; the next tick re-evaluates
+    // every agent, so nothing is missed.
+    if (tickRunning) {
+      logger.debug('context-guard: previous sweep still running, skipping this tick')
+      return
+    }
+    tickRunning = true
+    try {
+      const now = Date.now()
+      for (const name of guardSweepAgentNames()) {
+        try { await checkAgent(name, now) } catch (err) { logger.debug({ err, agent: name }, 'context-guard: agent check error') }
+      }
+    } finally {
+      tickRunning = false
     }
   }
   setTimeout(sweep, INITIAL_DELAY_MS)

--- a/src/web/model-fallback-runner.ts
+++ b/src/web/model-fallback-runner.ts
@@ -75,7 +75,7 @@ function sessionFor(name: string): string {
   return name === MAIN_AGENT_ID ? MAIN_CHANNELS_SESSION : agentSessionName(name)
 }
 
-function restartFor(name: string): void {
+async function restartFor(name: string): Promise<void> {
   if (name === MAIN_AGENT_ID) {
     // A fresh main relaunch re-reads .claude/settings.json (and thus the new
     // model). channels.sh always starts fresh for main, so a conversation is
@@ -91,11 +91,11 @@ function restartFor(name: string): void {
   } else {
     // 'continue' (fresh: false) re-spawns with --continue so the conversation
     // survives the model swap.
-    restartAgentProcess(name, { fresh: false })
+    await restartAgentProcess(name, { fresh: false })
   }
 }
 
-function checkAgent(name: string, nowMs: number, revertAfterMs: number, chain: string[]): void {
+async function checkAgent(name: string, nowMs: number, revertAfterMs: number, chain: string[]): Promise<void> {
   // Sub-agents must be up; the main session is launchd-managed (always present).
   if (name !== MAIN_AGENT_ID && agentRunState(name) !== 'running') return
 
@@ -125,7 +125,7 @@ function checkAgent(name: string, nowMs: number, revertAfterMs: number, chain: s
 
   try {
     writeModelFor(name, action.model)
-    restartFor(name)
+    await restartFor(name)
     if (action.kind === 'downgrade') downgradedAt.set(name, nowMs)
     else downgradedAt.delete(name)
     logger.info(
@@ -138,19 +138,34 @@ function checkAgent(name: string, nowMs: number, revertAfterMs: number, chain: s
 }
 
 export function startModelFallbackRunner(): NodeJS.Timeout {
-  function sweep() {
-    const cfg = readModelFallbackConfig()
-    if (!cfg.enabled) {
-      if (downgradedAt.size > 0) downgradedAt.clear() // re-seed cleanly if re-enabled
+  let tickRunning = false
+  async function sweep() {
+    // Re-entrancy guard: checkAgent/restartFor now await a real
+    // restartAgentProcess (no longer a blocking execSync('sleep N')), so a
+    // sweep with a restart in flight can still be running when the next
+    // interval fires. Skip an overlapping tick; the next tick re-evaluates
+    // every agent, so nothing is missed.
+    if (tickRunning) {
+      logger.debug('model-fallback: previous sweep still running, skipping this tick')
       return
     }
-    const now = Date.now()
-    const revertAfterMs = cfg.revertAfterMinutes * 60_000
-    try { checkAgent(MAIN_AGENT_ID, now, revertAfterMs, cfg.chain) }
-    catch (err) { logger.debug({ err }, 'model-fallback: main check error') }
-    for (const name of listAgentNames()) {
-      try { checkAgent(name, now, revertAfterMs, cfg.chain) }
-      catch (err) { logger.debug({ err, agent: name }, 'model-fallback: agent check error') }
+    tickRunning = true
+    try {
+      const cfg = readModelFallbackConfig()
+      if (!cfg.enabled) {
+        if (downgradedAt.size > 0) downgradedAt.clear() // re-seed cleanly if re-enabled
+        return
+      }
+      const now = Date.now()
+      const revertAfterMs = cfg.revertAfterMinutes * 60_000
+      try { await checkAgent(MAIN_AGENT_ID, now, revertAfterMs, cfg.chain) }
+      catch (err) { logger.debug({ err }, 'model-fallback: main check error') }
+      for (const name of listAgentNames()) {
+        try { await checkAgent(name, now, revertAfterMs, cfg.chain) }
+        catch (err) { logger.debug({ err, agent: name }, 'model-fallback: agent check error') }
+      }
+    } finally {
+      tickRunning = false
     }
   }
   setTimeout(sweep, INITIAL_DELAY_MS)

--- a/src/web/reauth-healer.ts
+++ b/src/web/reauth-healer.ts
@@ -357,7 +357,7 @@ async function restartFirstRunGatedAgent(name: string, session: string): Promise
   })
   await sleep(1000)
   try {
-    const r = startAgentProcess(name)
+    const r = await startAgentProcess(name)
     if (!r.ok) logger.warn({ name, error: r.error }, 'reauth-healer: first-run-gate relaunch failed')
   } catch (err) {
     logger.warn({ err, name }, 'reauth-healer: first-run-gate relaunch threw')

--- a/src/web/routes/agents-skills.ts
+++ b/src/web/routes/agents-skills.ts
@@ -10,7 +10,7 @@ import { agentDir } from '../agent-config.js'
 import { generateSkillMd } from '../agent-scaffold.js'
 import { parseMultipart } from '../multipart.js'
 import { readBody, json } from '../http-helpers.js'
-import { sanitizeAgentName, sanitizeSkillName, safeJoin } from '../sanitize.js'
+import { sanitizeAgentName, sanitizeSkillName, safeJoin, shellEscape } from '../sanitize.js'
 import type { RouteContext } from './types.js'
 
 // Marveen's skills live at the global ~/.claude/skills/ path (shared with
@@ -86,7 +86,7 @@ export async function tryHandleAgentsSkills(ctx: RouteContext): Promise<boolean>
     const before = new Set(readdirSync(skillsDir))
     try {
       writeFileSync(tmpPath, file.data)
-      const listOutput = execSync(`unzip -Z1 "${tmpPath}" 2>&1`, { timeout: 5000, encoding: 'utf-8' })
+      const listOutput = execSync(`unzip -Z1 ${shellEscape(tmpPath)} 2>&1`, { timeout: 5000, encoding: 'utf-8' })
       const entries = listOutput.split('\n').map((l) => l.trim()).filter(Boolean)
       for (const entry of entries) {
         if (entry.includes('..') || entry.startsWith('/') || /^[a-zA-Z]:[\\/]/.test(entry)) {

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -1110,10 +1110,10 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
         setAgentEnabledPlugins(name, provider)
         gcWasRunning = isAgentRunning(name)
         if (gcWasRunning) {
-          const stopRes = stopAgentProcess(name)
+          const stopRes = await stopAgentProcess(name)
           if (stopRes.ok) {
             await delay(2000)
-            gcRestarted = startAgentProcess(name).ok
+            gcRestarted = (await startAgentProcess(name)).ok
           }
         }
       }
@@ -1207,10 +1207,10 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
       if (provider === 'telegram') sendWelcomeMessage(name, botToken.trim()).catch(() => {})
       wasRunning = isAgentRunning(name)
       if (wasRunning) {
-        const stopRes = stopAgentProcess(name)
+        const stopRes = await stopAgentProcess(name)
         if (stopRes.ok) {
           await delay(2000)
-          const startRes = startAgentProcess(name)
+          const startRes = await startAgentProcess(name)
           restarted = startRes.ok
         }
       }
@@ -1776,7 +1776,7 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     // the --channels plugin MCP server (agent comes up deaf).
     let startFresh = false
     try { startFresh = JSON.parse((await readBody(req)).toString() || '{}').fresh === true } catch {}
-    const result = startAgentProcess(name, { fresh: startFresh })
+    const result = await startAgentProcess(name, { fresh: startFresh })
     // Record operator intent so the monitor keeps this agent up across shared
     // tmux-server restarts / reboots (see agent-desired-state.ts).
     if (result.ok || result.error === 'Agent is already running') addDesiredAgent(name)
@@ -1792,7 +1792,7 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
       json(res, { error: 'Main agent lifecycle is service-managed; use /api/marveen/restart for recovery' }, 400)
       return true
     }
-    const result = stopAgentProcess(name)
+    const result = await stopAgentProcess(name)
     // Explicit stop clears intent so the monitor will not resurrect it.
     removeDesiredAgent(name)
     if (result.ok) { json(res, { ok: true }); return true }
@@ -1855,7 +1855,7 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     // Optional { "fresh": true } body -> no `--continue` (see /start note).
     let restartFresh = false
     try { restartFresh = JSON.parse((await readBody(req)).toString() || '{}').fresh === true } catch {}
-    const result = restartAgentProcess(name, { fresh: restartFresh })
+    const result = await restartAgentProcess(name, { fresh: restartFresh })
     if (result.ok) { json(res, { ok: true }); return true }
     json(res, { error: result.error }, 400)
     return true
@@ -2126,7 +2126,7 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     // gone) that still reports running=true, with the model reset to the default.
     // stopAgentProcess() reads config from the dir (remote host, channel
     // provider) for its orphan reap, so it must run while the dir still exists.
-    if (isAgentRunning(name)) stopAgentProcess(name)
+    if (isAgentRunning(name)) await stopAgentProcess(name)
     rmSync(dir, { recursive: true, force: true })
     cleanupTeamReferences(name)
     // Deleting an agent is at least as strong a statement of intent as stopping

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -103,6 +103,7 @@ import {
   agentSessionName,
   sendPromptToSession,
   capturePane,
+  delay,
 } from '../agent-process.js'
 import { addDesiredAgent, removeDesiredAgent } from '../agent-desired-state.js'
 import { RemoteStatusCache } from '../remote-status-cache.js'
@@ -1111,7 +1112,7 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
         if (gcWasRunning) {
           const stopRes = stopAgentProcess(name)
           if (stopRes.ok) {
-            try { execSync('sleep 2', { timeout: 4000 }) } catch {}
+            await delay(2000)
             gcRestarted = startAgentProcess(name).ok
           }
         }
@@ -1208,7 +1209,7 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
       if (wasRunning) {
         const stopRes = stopAgentProcess(name)
         if (stopRes.ok) {
-          try { execSync('sleep 2', { timeout: 4000 }) } catch {}
+          await delay(2000)
           const startRes = startAgentProcess(name)
           restarted = startRes.ok
         }
@@ -1739,7 +1740,7 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
       // Wait for Claude Code to render the auth URL (typically 3-6s)
       let authUrl: string | null = null
       for (let i = 0; i < 12; i++) {
-        execSync('sleep 1', { timeout: 3000 })
+        await delay(1000)
         const pane = capturePane(session, host)
         if (!pane) continue
         const urlMatch = pane.match(/https:\/\/console\.anthropic\.com\/[^\s"']+/)

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -2120,6 +2120,26 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     const name = decodeURIComponent(agentMatch[1])
     const dir = agentDir(name)
     if (!existsSync(dir)) { json(res, { error: 'Agent not found' }, 404); return true }
+    // Clear the desired run-state FIRST, before anything yields. Deleting an
+    // agent is at least as strong a statement of intent as stopping one, so it
+    // must clear the state the same way /stop does: without this the name
+    // outlives its directory in agents-desired.json, the reconciler keeps
+    // trying to start something that no longer exists (a permanent error-level
+    // line for a machine behaving correctly), and -- the sharper hazard --
+    // re-creating an agent with the same name later starts it immediately,
+    // unasked.
+    //
+    // The ordering is load-bearing, not cosmetic. stopAgentProcess() now awaits
+    // (it used to block the event loop with execSync('sleep 2')), so the ~2s it
+    // spends settling is a window in which other work runs. The agent is
+    // already dead in that window but would still be listed as desired, and
+    // channel-monitor's reconcileDesiredAgents() sweep -- which fires every 60s
+    // looking for exactly "desired but not running" -- would start it back up.
+    // The rmSync below would then delete the directory out from under a live
+    // session, producing precisely the orphan-ghost this handler exists to
+    // prevent. Clearing intent up front makes the agent invisible to the
+    // reconciler for the whole teardown.
+    removeDesiredAgent(name)
     // Stop the running tmux session BEFORE removing the dir. Otherwise the
     // orphaned session survives the delete, rewrites a minimal .claude-config
     // under agents/<name>/, and the agent "returns" as an empty draft (persona
@@ -2129,14 +2149,6 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     if (isAgentRunning(name)) await stopAgentProcess(name)
     rmSync(dir, { recursive: true, force: true })
     cleanupTeamReferences(name)
-    // Deleting an agent is at least as strong a statement of intent as stopping
-    // one, so it must clear the desired run-state the same way /stop does.
-    // Without this the name outlives its directory in agents-desired.json, and
-    // the reconciler keeps trying to start something that no longer exists --
-    // a permanent error-level log line for a machine that is behaving
-    // correctly. The sharper hazard is later: create an agent with the same
-    // name again and the stale entry starts it immediately, unasked.
-    removeDesiredAgent(name)
     json(res, { ok: true })
     return true
   }

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -1792,9 +1792,16 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
       json(res, { error: 'Main agent lifecycle is service-managed; use /api/marveen/restart for recovery' }, 400)
       return true
     }
-    const result = await stopAgentProcess(name)
-    // Explicit stop clears intent so the monitor will not resurrect it.
+    // Explicit stop clears intent so the monitor will not resurrect it -- and
+    // it must happen BEFORE the stop yields. stopAgentProcess() now awaits ~2s
+    // while the session settles; in that window the agent is already dead but
+    // would still be listed as desired, so reconcileDesiredAgents() (every 60s,
+    // looking for exactly "desired but not running") can restart it. The stop
+    // then returns ok while the agent is back up and no longer desired -- a
+    // live session nothing will ever reap, after the operator was told it
+    // stopped. Unconditional, as before: a failed stop still clears intent.
     removeDesiredAgent(name)
+    const result = await stopAgentProcess(name)
     if (result.ok) { json(res, { ok: true }); return true }
     json(res, { error: result.error }, 400)
     return true

--- a/src/web/routes/skills.ts
+++ b/src/web/routes/skills.ts
@@ -394,7 +394,7 @@ export async function tryHandleSkills(ctx: RouteContext): Promise<boolean> {
     const before = new Set(readdirSync(skillsDir))
     try {
       writeFileSync(tmpPath, file.data)
-      const listOutput = execSync(`unzip -Z1 "${tmpPath}" 2>&1`, { timeout: 5000, encoding: 'utf-8' })
+      const listOutput = execSync(`unzip -Z1 ${shellEscape(tmpPath)} 2>&1`, { timeout: 5000, encoding: 'utf-8' })
       const entries = listOutput.split('\n').map(l => l.trim()).filter(Boolean)
       for (const entry of entries) {
         if (entry.includes('..') || entry.startsWith('/') || /^[a-zA-Z]:[\\/]/.test(entry)) {

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -567,7 +567,7 @@ async function attemptFireTask(
     // sends once Claude has booted (isSessionReadyForPrompt). host-aware:
     // startAgentProcess is itself remote-aware and launches over ssh when the
     // target agent is remote, so a missing remote session is auto-started too.
-    const start = startAgentProcess(agentName)
+    const start = await startAgentProcess(agentName)
     if (!start.ok) {
       // "already running" means it raced up between the check and here -- treat
       // as busy so the normal retry path delivers. Any other failure (config


### PR DESCRIPTION
## Magyar

Ez a PR megszünteti a kódbázisban lévő blokkoló `execSync('sleep N')` hívásokat az agent lifecycle folyamatokban, átültetve őket aszinkron `await delay()` mintára, valamint tartalmaz pár kisebb biztonsági és kódminőségi igazítást.

### Főbb változtatások

#### 1. Agent lifecycle async refaktor (`agent-process.ts` és runner-ek)
* **`agent-process.ts`**: A `startAgentProcess`, `stopAgentProcess` és `restartAgentProcess` függvények mostantól `async` működésűek. A blokkoló `execSync('sleep 3')` és `sleep 2` hívások le lettek cserélve `await delay(...)`-re, a nem használt `execSync` import kikerült.
* **Hívási lánc frissítése**: 13 hívási helyen (`index.ts`, `reauth-healer.ts`, `channel-monitor.ts`, `routes/agents.ts`, `schedule-runner.ts`) átvezettem az `await` használatát. Mivel ezek mind aszinkron kontextusban futottak, ez mechanikus módosítás volt.
* **Re-entrancy védelem a runner-ekben**:
  * A `model-fallback-runner.ts` és `auto-restart-runner.ts` `sweep()` folyamatai megkapták a `tickRunning` guard-ot (ahogy a `schedule-runner.ts` már korábban is használta). Mivel az aszinkron várakozás miatt egy sweep tovább tarthat, e nélkül a következő időzített interval felülfedhetné az előzőt, ami dupla restartot eredményezne ugyanarra az agentre.
  * A `context-guard-runner.ts`-ben szintén bevezetésre került ez a guard (itt már eddig is async volt a sweep, de hiányzott a védő korlát).
* **Szekvenciális futtatás megtartása**: A runner-ek ciklusaiban szándékosan maradt a szekvenciális `for...of` + `await` a `Promise.all` helyett. A párhuzamos tmux kill/reap/spawn műveletek race condition-höz vezetnének (a kódbázis többi részén lévő `CHANNEL_RESTART_STAGGER_MS` is emiatt létezik).

> 📌 **EDIT / Kapcsolódó fix a DELETE handlernél (`routes/agents.ts`):**
> Mióta a `stopAgentProcess()` aszinkron lett és `await`-el ahelyett, hogy blokkolná az event loopot, a DELETE handler kb. 2 másodpercre kiadja a vezérlést (yield), amíg a session leáll. Ebben az ablakban az agent process már halott, de még szerepel az `agents-desired.json`-ban. A 60 másodpercenként futó `reconcileDesiredAgents()` sweep pontosan a "szándékolt, de nem futó" állapotot keresi, így a törlés közepén újraindíthatja az agentet. A rákövetkező `rmSync` pedig kitörli a könyvtárat a frissen elindított live session alól (létrehozva azt az árva ghost processzt, amit a handler pont megelőzni hivatott).
> 
> A futtatási szándék (desired state) törlése mostantól a leállítási várakozás *előtt* megtörténik, így az agent a teljes leállítási folyamat alatt láthatatlanná válik a reconciler számára. A meglét-ellenőrzés után maradt, így egy elgépelt névre küldött DELETE továbbra sem bántja a kívánt állapotot.

> 📌 **EDIT 2 / Ugyanez a versenyhelyzet a `/stop` handlernél:**
> A DELETE-javítás után végignéztem a mintát a kódkészletben, és találtam egy második példányt a `/stop` handlernél. A `/stop` az `await stopAgentProcess()` után törölte a szándékot (desired state), ugyanabban a kb. 2 másodperces ablakban, ahol a reconciler újraindíthatja az agentet. Így a leállítás OK választ adott vissza, miközben a session valójában futva maradt, és többé senki nem takarította el. A szándéktörlés itt is a leállítási várakozás elé került.
> 
> Végigsöpörve az összes új `await`-pontot: állapotot kizárólag a `/stop` és a `DELETE` írt az `await` után, a többi ág vagy csak logol, vagy státuszt ad vissza. (A `/restart` és a két csatorna-beállító ág félrevezető státuszt adhat, ha a reconciler közéjük fér, de ez státusz-pontossági kérdés, nem állapothiba, ezért külön jegyet érdemel.)

#### 2. Egyéb blokkoló sleep-ek cseréje (`routes/agents.ts`)
A `agents.ts` 1115, 1212 és 1743 sorában a független `execSync('sleep N')` hívások szintén átkerültek `await delay(ms)`-re, így az event loop szabad marad az agent restart/stop ciklusok alatt.

#### 3. Shell-escaping az `unzip -Z1` hívásoknál (`skills.ts`, `agents-skills.ts`)
A nyers idézőjelezett `unzip -Z1 "${tmpPath}"` helyett a projekt saját `shellEscape()` helperjét kapta meg mindkét hely, igazodva a fájlokban lévő többi exec híváshoz (`zip -r`, `cp -r`).

#### 4. Doksi sanitization (`docs/onboarding-uj-asszisztens.md`)
A dokumentációban lévő konkrét belső domain hivatkozások le lettek cserélve `marveen.example.com` placeholderre. Belső éles hostname-ek dokumentációban tartása infosec szempontból felesleges információ-szivárgás (footprinting / passive reconnaissance), így tisztázásra került.

### Tesztelés és ellenőrzés

* `npm run typecheck` hibamentesen lefutott.
* Teljes `vitest` tesztkoszorú futtatása izolált git worktree-ben.
* **Eredmény: 275/277 tesztfájl, 3730 teszt sikeres, 2 sikertelen, 1 kihagyva.**
* **Zéró regresszió.** Ugyanez a futtatás ezen változtatások nélkül *bájt-identikus* eredményt ad (2 failed / 3730 passed / 1 skipped) ugyanazzal a két teszttel. Mindkettő környezeti (egy bash-verziófüggő trap teszt és egy umask eltérés), és egyik sem érinti a módosított kódot.
* A törlési sorrend fix viselkedés alapú lefedettségét az `agent-delete-clears-desired.test.ts` biztosítja (mindhárom eset zöld, beleértve azt is, amelyik kijelenti, hogy egy 404-es DELETE nem bánthatja a kívánt állapotot).

---

## English

This PR eliminates blocking `execSync('sleep N')` calls across agent lifecycle processes by refactoring them to asynchronous `await delay()`, alongside minor security and code quality improvements.

### Key Changes

#### 1. Agent lifecycle async refactor (`agent-process.ts` & runners)
* **`agent-process.ts`**: `startAgentProcess`, `stopAgentProcess`, and `restartAgentProcess` are now `async`. Replaced blocking `execSync('sleep 3')` and `sleep 2` calls with `await delay(...)` and dropped the unused `execSync` import.
* **Caller propagation**: Updated 13 call sites across `index.ts`, `reauth-healer.ts`, `channel-monitor.ts`, `routes/agents.ts`, and `schedule-runner.ts` to `await` these functions. Since all callers were already inside async contexts, this was a mechanical change.
* **Re-entrancy guards in runners**:
  * Added a `tickRunning` re-entrancy guard to `model-fallback-runner.ts` and `auto-restart-runner.ts` sweeps (following the pattern in `schedule-runner.ts`). Because an awaited sweep can take longer, this prevents overlapping execution ticks from double-restarting the same agent.
  * Added the same guard to `context-guard-runner.ts` (its sweep was already async but lacked a re-entrancy check).
* **Preserved sequential loops**: Deliberately kept sequential `for...of` + `await` loops rather than converting to `Promise.all`. Concurrent tmux kill/reap/spawn calls across agents introduce race conditions (which is why `CHANNEL_RESTART_STAGGER_MS` exists elsewhere in the codebase).

> 📌 **EDIT — Follow-up fix in DELETE handler (`routes/agents.ts`):**
> Now that `stopAgentProcess()` awaits instead of blocking the event loop, the DELETE handler yields for ~2s while the session settles — and in that window the agent is dead but still listed in `agents-desired.json`. The 60s `reconcileDesiredAgents()` sweep looks for exactly "desired but not running", so it can restart the agent mid-delete, and the `rmSync` that follows then removes the directory out from under a live session: the orphan-ghost this handler exists to prevent.
> 
> Clearing intent first makes the agent invisible to the reconciler for the whole teardown. Stays after the existence check, so a DELETE on a mistyped name still leaves desired-state alone.

> 📌 **EDIT 2 / Same race condition in the `/stop` handler:**
> After applying the DELETE fix, I reviewed the codebase for this pattern and found a second instance in the `/stop` handler. The `/stop` endpoint cleared the intent (desired state) after `await stopAgentProcess()`, within the same ~2-second window where the reconciler could restart the agent. As a result, the stop request returned OK while the session actually remained running and was left orphaned indefinitely. The intent deletion has now been moved before the process stop call here as well.
> 
> Auditing all other new `await` points confirmed that state mutations after `await` only occurred in `/stop` and `DELETE`. All remaining branches either perform logging or return a status response. (The `/restart` endpoint and the two channel configuration branches may return a misleading status if the reconciler runs concurrently between operations, but this is a status accuracy issue rather than state corruption, so it belongs in a separate ticket.)

#### 2. Non-blocking delay substitution (`routes/agents.ts`)
Replaced standalone `execSync('sleep N')` calls at lines 1115, 1212, and 1743 in `agents.ts` with `await delay(ms)` to keep the Node event loop unblocked during restart/stop cycles.

#### 3. Shell-escaping for `unzip -Z1` (`skills.ts`, `agents-skills.ts`)
Replaced raw quoted interpolation `unzip -Z1 "${tmpPath}"` with the project's native `shellEscape()` helper, aligning with existing exec invocation patterns in the codebase (`zip -r`, `cp -r`).

#### 4. Documentation sanitization (`docs/onboarding-uj-asszisztens.md`)
Replaced hardcoded internal hostnames with `marveen.example.com` placeholders to eliminate unnecessary infrastructure footprinting and passive reconnaissance risks in documentation.

### Verification & Testing

* `npm run typecheck` passed cleanly.
* Full `vitest` suite run in an isolated git worktree.
* **Result: 275/277 test files, 3730 tests passing, 2 failing, 1 skipped.**
* **Zero regressions.** The same run without these changes yields a *byte-identical* result (2 failed / 3730 passed / 1 skipped) with the exact same two failing tests. Both are environmental (a bash-version-dependent trap test and a umask mismatch) and neither touches the modified code.
* Behavioral coverage for the delete-ordering fix is provided by `agent-delete-clears-desired.test.ts` (all three test cases green, including the assertion that a 404 DELETE must not touch desired-state).