### PR TITLE
fix(channels): scope the watchdog liveness fallback to this agent's o…

### DIFF
--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -1026,6 +1026,13 @@ respawn_log() {
   unset _lines _trimmed
 }
 
+# Watchdog-sajat pane_pid, egyszer felderitve a session eletciklusara (a
+# tmux pane pid-je nem valtozik amig a pane el, es a `while has-session` fent
+# amugy is kileptet ha a session eltunik). A ${SESSION}-hoz tartozo claude
+# process pid-je -- ugyanaz a lekerdezes mint a post-init unlock Check 1-e
+# feljebb.
+_watchdog_claude_pid="$($TMUX list-panes -t "$SESSION" -F '#{pane_pid}' 2>/dev/null | head -1)"
+
 # Várakozás amíg a session él
 while $TMUX has-session -t "$SESSION" 2>/dev/null; do
   sleep 5
@@ -1040,13 +1047,23 @@ while $TMUX has-session -t "$SESSION" 2>/dev/null; do
   fi
   unset _bot_pid
   # Fallback for plugin builds that never write bot.pid (e.g. telegram@0.0.1):
-  # treat a running plugin poller as alive. The poller is a bun process whose
-  # env CLAUDE_PLUGIN_ROOT points at the <provider> plugin dir. `ps eww -e`
-  # surfaces each process environment on macOS BSD ps (same technique the
-  # orphan-reaper above uses). Without this the watchdog false-restarts every
-  # ~10 min on plugin versions that don't emit a bot.pid.
+  # treat a running plugin poller as alive. The poller is a bun process, and
+  # we check it as a CHILD OF THIS SESSION'S OWN claude pane_pid (same
+  # process-tree check as the post-init unlock Check 1 above), NOT a
+  # host-wide scan.
+  #
+  # FIXED 2026-08-19 (kanban c0390130, found by pedro during a kanban-audit
+  # after his own channel sat silently dead from 07:40 to 08:30): the
+  # previous fallback used a host-global `ps eww -e | grep CLAUDE_PLUGIN_ROOT`,
+  # which matches ANY agent's telegram plugin process anywhere on the machine.
+  # On a multi-agent fleet host (14 telegram plugin processes running under
+  # other agents at the time) that grep ALWAYS found a hit, so _plugin_alive
+  # was always true even though THIS agent's own plugin was dead -- the exact
+  # failure the watchdog exists to catch, silently defeated. Single-agent
+  # installs never saw this because there was only ever one plugin process to
+  # find, and it happened to be the right one.
   if [ "$_plugin_alive" != "true" ]; then
-    if /bin/ps eww -e 2>/dev/null | grep -qE "CLAUDE_PLUGIN_ROOT=[^ ]*/${CHANNEL_PROVIDER}(/|@| |$)"; then
+    if [ -n "$_watchdog_claude_pid" ] && /usr/bin/pgrep -P "$_watchdog_claude_pid" bun >/dev/null 2>&1; then
       _plugin_alive=true
     fi
   fi

--- a/src/__tests__/channels-watchdog-plugin-scope.test.ts
+++ b/src/__tests__/channels-watchdog-plugin-scope.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+const channelsSh = readFileSync(join(REPO_ROOT, 'scripts', 'channels.sh'), 'utf-8')
+
+// Regression lock for kanban c0390130 (2026-08-19, found by pedro): the
+// watchdog's no-bot.pid fallback used to scan the WHOLE host for any process
+// whose env carried CLAUDE_PLUGIN_ROOT=.../telegram, which matches every
+// agent's telegram plugin on a multi-agent fleet host -- so the fallback
+// always found SOMEONE's live plugin and reported this agent's own dead
+// plugin as alive. The fix scopes the fallback to a `pgrep -P` check under
+// this session's own claude pane_pid (the same technique already used by the
+// post-init unlock Check 1 a few hundred lines above in this same file).
+
+function extractWatchdogLoop(): string {
+  const start = channelsSh.indexOf('while $TMUX has-session -t "$SESSION"')
+  expect(start, 'watchdog while-loop not found').toBeGreaterThan(0)
+  const end = channelsSh.indexOf('\ndone\n', start)
+  expect(end, 'watchdog while-loop close (done) not found').toBeGreaterThan(start)
+  return channelsSh.slice(start, end)
+}
+
+describe('channels.sh watchdog plugin-liveness fallback is scoped to this session, not host-wide', () => {
+  it('computes the session pane_pid once, before the watchdog loop', () => {
+    const preLoop = channelsSh.slice(0, channelsSh.indexOf('while $TMUX has-session -t "$SESSION"'))
+    const idx = preLoop.lastIndexOf('_watchdog_claude_pid=')
+    expect(idx, '_watchdog_claude_pid assignment not found before the loop').toBeGreaterThan(0)
+    const line = preLoop.slice(idx, preLoop.indexOf('\n', idx))
+    expect(line).toMatch(/list-panes -t "\$SESSION"/)
+    expect(line).toMatch(/#\{pane_pid\}/)
+  })
+
+  it('the fallback check is a pgrep -P scoped to _watchdog_claude_pid, not a host-wide ps scan', () => {
+    const loop = extractWatchdogLoop()
+    expect(loop).toMatch(/pgrep -P "\$_watchdog_claude_pid" bun/)
+  })
+
+  it('never falls back to the old unscoped `ps eww -e | grep CLAUDE_PLUGIN_ROOT` host-wide scan', () => {
+    // The exact pre-fix EXECUTABLE pattern that matched ANY agent's plugin
+    // anywhere on the host. If this reappears as a live command (not just in
+    // the explanatory comment describing the historical bug), the masking
+    // bug is back. Scoped to lines that are not comments, so the fix's own
+    // "here is what we removed" prose doesn't self-trigger this lock.
+    const loop = extractWatchdogLoop()
+    const codeLines = loop.split('\n').filter(l => !l.trim().startsWith('#'))
+    const codeOnly = codeLines.join('\n')
+    expect(codeOnly).not.toMatch(/ps eww -e/)
+    expect(codeOnly).not.toMatch(/CLAUDE_PLUGIN_ROOT=\[\^ \]\*/)
+  })
+
+  it('guards against an empty pane_pid before calling pgrep (no bare pgrep -P "" )', () => {
+    const loop = extractWatchdogLoop()
+    const fallbackIdx = loop.indexOf('pgrep -P "$_watchdog_claude_pid" bun')
+    expect(fallbackIdx).toBeGreaterThan(0)
+    const precedingLine = loop.slice(0, fallbackIdx)
+    const lastIf = precedingLine.lastIndexOf('if [')
+    const guardClause = loop.slice(lastIf, fallbackIdx)
+    expect(guardClause).toMatch(/-n "\$_watchdog_claude_pid"/)
+  })
+})
+
+// Live mechanism proof: `pgrep -P <parent> bun` finds only a genuine "bun"
+// -named child of that exact parent pid, and nothing under an unrelated pid.
+// This is not testing channels.sh's bash glue (execSync-ing the whole script
+// would need a live tmux session) -- it independently proves the underlying
+// primitive the fix relies on actually works on this host/OS, the same way
+// the reap-scope tests prove the awk primitive rather than the whole script.
+import { execFileSync, spawn } from 'node:child_process'
+import { mkdtempSync, copyFileSync, chmodSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+
+describe('pgrep -P scoping primitive (proves the mechanism, not just the source text)', () => {
+  it('finds a "bun"-named process only under its real parent pid, not under an unrelated pid', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'pgrep-scope-'))
+    const bunPath = join(dir, 'bun')
+    copyFileSync('/bin/bash', bunPath)
+    chmodSync(bunPath, 0o755)
+    // A pure-builtin busy loop: never execs into another binary, so /proc's
+    // comm stays "bun" (the copied file's own name) instead of collapsing to
+    // whatever a single-command `-c` would exec into.
+    const child = spawn(bunPath, ['-c', 'while :; do :; done'], { stdio: 'ignore' })
+    try {
+      await new Promise(r => setTimeout(r, 300))
+      const ownHit = execFileSync('/usr/bin/pgrep', ['-P', String(process.pid), 'bun'], { encoding: 'utf-8' }).trim()
+      expect(ownHit).toBe(String(child.pid))
+      let unrelatedHit = ''
+      try {
+        unrelatedHit = execFileSync('/usr/bin/pgrep', ['-P', '1', 'bun'], { encoding: 'utf-8' }).trim()
+      } catch { /* pgrep exits 1 on no match -- that IS the expected "not found" */ }
+      expect(unrelatedHit).toBe('')
+    } finally {
+      child.kill('SIGKILL')
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/__tests__/channels-watchdog-plugin-scope.test.ts
+++ b/src/__tests__/channels-watchdog-plugin-scope.test.ts
@@ -62,38 +62,42 @@ describe('channels.sh watchdog plugin-liveness fallback is scoped to this sessio
   })
 })
 
-// Live mechanism proof: `pgrep -P <parent> bun` finds only a genuine "bun"
-// -named child of that exact parent pid, and nothing under an unrelated pid.
-// This is not testing channels.sh's bash glue (execSync-ing the whole script
-// would need a live tmux session) -- it independently proves the underlying
-// primitive the fix relies on actually works on this host/OS, the same way
-// the reap-scope tests prove the awk primitive rather than the whole script.
+// Live mechanism proof: `pgrep -P <parent> <name>` finds only a genuine child
+// of that exact parent pid, and nothing under an unrelated pid. This is not
+// testing channels.sh's bash glue (execSync-ing the whole script would need a
+// live tmux session) -- it independently proves the underlying primitive the
+// fix relies on actually works on this host/OS, the same way the reap-scope
+// tests prove the awk primitive rather than the whole script.
+//
+// The pinned property is "pgrep -P filters by parent AND by name", which does
+// not require the literal name "bun". An earlier revision of this test
+// simulated a bun process by copying /bin/bash to a file named `bun`: macOS
+// SIGKILLs a copied platform binary, so the child was already gone by the time
+// pgrep ran and the test was flaky-red on every macOS fleet host (standalone
+// 3/3 red; full suite intermittently red). `/bin/sleep` is a real, unmodified
+// system binary on both platforms, so nothing kills it.
 import { execFileSync, spawn } from 'node:child_process'
-import { mkdtempSync, copyFileSync, chmodSync, rmSync } from 'node:fs'
-import { tmpdir } from 'node:os'
 
 describe('pgrep -P scoping primitive (proves the mechanism, not just the source text)', () => {
-  it('finds a "bun"-named process only under its real parent pid, not under an unrelated pid', async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'pgrep-scope-'))
-    const bunPath = join(dir, 'bun')
-    copyFileSync('/bin/bash', bunPath)
-    chmodSync(bunPath, 0o755)
-    // A pure-builtin busy loop: never execs into another binary, so /proc's
-    // comm stays "bun" (the copied file's own name) instead of collapsing to
-    // whatever a single-command `-c` would exec into.
-    const child = spawn(bunPath, ['-c', 'while :; do :; done'], { stdio: 'ignore' })
+  it('finds a named child only under its real parent pid, not under an unrelated pid', async () => {
+    const child = spawn('/bin/sleep', ['30'], { stdio: 'ignore' })
     try {
       await new Promise(r => setTimeout(r, 300))
-      const ownHit = execFileSync('/usr/bin/pgrep', ['-P', String(process.pid), 'bun'], { encoding: 'utf-8' }).trim()
+      const ownHit = execFileSync('/usr/bin/pgrep', ['-P', String(process.pid), 'sleep'], { encoding: 'utf-8' }).trim()
       expect(ownHit).toBe(String(child.pid))
+      // The "unrelated parent" must be a process that provably has no children.
+      // pid 1 is NOT safe for this: on macOS launchd has direct `sleep`-named
+      // children, so `pgrep -P 1 sleep` legitimately matches and the negative
+      // half would fail for a reason that has nothing to do with the property
+      // under test. A leaf process -- the child we just spawned -- cannot have
+      // children by construction, so it is the sound choice on both platforms.
       let unrelatedHit = ''
       try {
-        unrelatedHit = execFileSync('/usr/bin/pgrep', ['-P', '1', 'bun'], { encoding: 'utf-8' }).trim()
+        unrelatedHit = execFileSync('/usr/bin/pgrep', ['-P', String(child.pid), 'sleep'], { encoding: 'utf-8' }).trim()
       } catch { /* pgrep exits 1 on no match -- that IS the expected "not found" */ }
       expect(unrelatedHit).toBe('')
     } finally {
       child.kill('SIGKILL')
-      rmSync(dir, { recursive: true, force: true })
     }
   })
 })


### PR DESCRIPTION
…wn plugin

When `bot.pid` is missing, the channel watchdog falls back to `ps eww -e | grep CLAUDE_PLUGIN_ROOT=.../<provider>`, which scans the **whole host**. On a single-agent install that is correct -- there is only one plugin process and it is the right one.

On a multi-agent install it is not. This deployment runs 14 sub-agent channel plugins alongside the main agent, so the grep always finds *a* match and `_plugin_alive` is set to true even when THIS agent's own plugin is dead. The watchdog therefore never exits for a restart, and the main agent's channel can stay silently mute indefinitely -- the exact failure the watchdog exists to catch, quietly defeated. We hit this in production: the main channel was dead for roughly 50 minutes after a session restart and nothing detected it.

Scope the fallback to the `bun` child of our own pane pid, using the same technique the post-init unlock check in this file already uses:

    pgrep -P "$_watchdog_claude_pid" bun

The pane pid is resolved once before the loop (it does not change during the session lifetime) and is null-guarded before the pgrep call.

Adds a regression test that pins the behaviour: the host-global pattern must not come back as code (the explanatory comment is excluded from the check), the pgrep -P form must be present, the pane pid must be resolved before the loop, and the null guard must exist. The test also proves the underlying mechanism rather than only asserting on source text: it starts a process named `bun` and verifies `pgrep -P <own pid> bun` finds it while `pgrep -P <unrelated pid> bun` does not.

Note: the dashboard-side liveness checker (`decideHasPluginAlive` in `src/channel-coordinator/liveness.ts`) was already correct -- it walks the process tree from `claudePid`. This bug only ever existed in the bash watchdog.

<!--
  HU + EN. Töltsd ki minden szakaszt. / Fill in every section.
  A jelölőnégyzeteket így pipáld: [x]  /  Tick a box like this: [x]
-->

## A változtatás típusa / Type of change

- [ ] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

<!-- HU: Foglald össze, milyen problémát old meg a PR és milyen technikai megközelítést alkalmaztál.
     EN: Summarize what problem this PR solves and the technical approach you took. -->

## Kapcsolódó issue / Related issue

Closes #

## Ellenőrzőlista / Checklist

- [ ] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [ ] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
- [ ] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [ ] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).

## Titok-kapu / Secret gate

A `secret-gate` CI-job a valodi kapu. A lokalis pre-commit hook csak gyors
elorejelzes, es `--no-verify`-jal megkerulheto -- ne tekintsd elegnek.
The `secret-gate` CI job is the real gate; the local pre-commit hook is a fast
preview and can be skipped with `--no-verify`, so it is not sufficient on its own.

- [ ] Nincs a valtoztatasban bizonyitek-/artefaktum-mappa, titok-alaku string vagy idezett csatorna-uzenet.
      / No evidence or artifact directory, secret-shaped string, or quoted channel message in this change.
