### PR TITLE
fix(scheduled-tasks): never guess a scheduled task's Telegram recipient

### DIFF
--- a/src/__tests__/schedule-runner-bound-chatid.test.ts
+++ b/src/__tests__/schedule-runner-bound-chatid.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
-import { chatIdFromAccessConfig, channelDeliveryName, resolveSchedulerAlertToken } from '../web/schedule-runner.js'
+import { chatIdFromAccessConfig, channelDeliveryName, resolveSchedulerAlertToken, resolveTaskChannelTarget } from '../web/schedule-runner.js'
 import { PROJECT_ROOT } from '../config.js'
 import { channelStateDir, type ChannelProviderType } from '../channel-provider.js'
 
@@ -11,6 +11,16 @@ import { channelStateDir, type ChannelProviderType } from '../channel-provider.j
 // (assertAllowedChat: "0" is never allowlisted), so every non-heartbeat
 // scheduled task threw at delivery. The fix resolves the agent's own bound
 // chat from its channel access.json at prompt-build time.
+//
+// Second regression guard for 2026-08-19 (WRONGRECIP819, Marci, kanban
+// f1217c23): the "resolve to the first allowlist entry" heuristic below
+// silently misdirected sub-agent task results whenever an agent had 2+ DM
+// contacts -- measured on the live install, 6 of 7 currently-enabled
+// sub-agent `task`-type schedules were affected, either contradicting their
+// own explicit recipient or carrying no real Telegram target at all. Fixed
+// by resolveTaskTelegramTarget: a sub-agent with 2+ candidates and no
+// task.telegramChatId pin gets chatId: null + ambiguousCandidates set, never
+// a guessed chat id.
 
 describe('chatIdFromAccessConfig (pure core)', () => {
   it('returns the first DM allowlist entry', () => {
@@ -135,11 +145,18 @@ describe('schedule-runner source contract (sentinel removed, provider-aware)', (
     expect(src).not.toMatch(/kuldd el Telegramon \(chat_id/)
   })
 
-  it('multi-entry allowlists produce an ambiguity warn (heuristic made visible)', () => {
-    // Behaviour stays first-entry; the warn exists so a reordered allowlist
-    // (2+ entries: zara/iris) cannot silently redirect task results.
-    expect(src).toContain('bound-chat resolution is ambiguous')
-    expect(src).toMatch(/candidates > 1/)
+  it('an ambiguous 2+-candidate resolution is SKIPPED, not guessed, and raises visibility', () => {
+    // WRONGRECIP819: the old behaviour ("stays first-entry", just warns) is
+    // gone. An agent with 2+ DM contacts and no pinned chat id must never
+    // receive a chat_id guess in its prompt.
+    expect(src).toContain('scheduled task: delivery target is ambiguous')
+    expect(src).toContain('logger.error(')
+    expect(src).toContain('createAgentMessage(')
+    // The ambiguous branch falls through to the SAME bare-tag prefix as the
+    // config-gap branch -- delivery is skipped either way, never guessed.
+    const ambiguousIdx = src.indexOf('scheduled task: delivery target is ambiguous')
+    const nextPrefixIdx = src.indexOf('prefix = `[Utemezett feladat: ${task.name}] `', ambiguousIdx)
+    expect(nextPrefixIdx, 'ambiguous branch must fall through to the bare prefix').toBeGreaterThan(ambiguousIdx)
   })
 
   it('resolution reads the access.json for the agent\'s own provider, not always telegram', () => {
@@ -154,5 +171,19 @@ describe('schedule-runner source contract (sentinel removed, provider-aware)', (
     expect(src).not.toContain('sendTelegramMessage')
     expect(src).toContain('sendSchedulerAlertMessage')
     expect(src).toContain('getProvider(CHANNEL_PROVIDER)')
+  })
+})
+
+describe('resolveTaskChannelTarget (pin precedence, no filesystem needed)', () => {
+  it('"none" means no chat target, by design -- never falls through to auto-resolution', () => {
+    expect(resolveTaskChannelTarget({ agent: 'sam', telegramChatId: 'none' }).chatId).toBeNull()
+  })
+
+  it('an explicit chat_id is used as-is, overriding any allowlist heuristic', () => {
+    expect(resolveTaskChannelTarget({ agent: 'max', telegramChatId: '8321555318' }).chatId).toBe('8321555318')
+  })
+
+  it('an explicit override wins even for the main agent (author intent beats the default)', () => {
+    expect(resolveTaskChannelTarget({ agent: 'pedro', telegramChatId: '8321555318' }).chatId).toBe('8321555318')
   })
 })

--- a/src/__tests__/schedule-runner-bound-chatid.test.ts
+++ b/src/__tests__/schedule-runner-bound-chatid.test.ts
@@ -1,9 +1,28 @@
-import { describe, expect, it } from 'vitest'
-import { readFileSync } from 'node:fs'
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { readFileSync, mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
-import { chatIdFromAccessConfig, channelDeliveryName, resolveSchedulerAlertToken, resolveTaskChannelTarget } from '../web/schedule-runner.js'
+import { tmpdir } from 'node:os'
 import { PROJECT_ROOT } from '../config.js'
 import { channelStateDir, type ChannelProviderType } from '../channel-provider.js'
+
+// Behavioural fixture for the ambiguous-allowlist branch (see the
+// "genuinely exercises the ambiguous branch" describe block below). Mocked
+// BEFORE importing schedule-runner.js so the resolver's own
+// `agentDir(agentName)` call resolves into a throwaway temp directory for
+// this one fixture agent name, instead of the real repo's agents/ tree --
+// every other agent name falls through to the real implementation
+// unaffected.
+let FIXTURE_DIR = ''
+const FIXTURE_AGENT = 'ambiguous-fixture-agent-819'
+vi.mock('../web/agent-config.js', async (orig) => {
+  const actual = await orig<typeof import('../web/agent-config.js')>()
+  return {
+    ...actual,
+    agentDir: (name: string) => (name === FIXTURE_AGENT ? FIXTURE_DIR : actual.agentDir(name)),
+  }
+})
+
+const { chatIdFromAccessConfig, channelDeliveryName, resolveSchedulerAlertToken, resolveTaskChannelTarget } = await import('../web/schedule-runner.js')
 
 // Regression guard for 2026-07-27 (Zara report, Marveen diagnosis): the
 // scheduled-task prompt prefix carried a "chat_id: 0" sentinel from a
@@ -18,7 +37,7 @@ import { channelStateDir, type ChannelProviderType } from '../channel-provider.j
 // contacts -- measured on the live install, 6 of 7 currently-enabled
 // sub-agent `task`-type schedules were affected, either contradicting their
 // own explicit recipient or carrying no real Telegram target at all. Fixed
-// by resolveTaskTelegramTarget: a sub-agent with 2+ candidates and no
+// by resolveTaskChannelTarget: a sub-agent with 2+ candidates and no
 // task.telegramChatId pin gets chatId: null + ambiguousCandidates set, never
 // a guessed chat id.
 
@@ -185,5 +204,57 @@ describe('resolveTaskChannelTarget (pin precedence, no filesystem needed)', () =
 
   it('an explicit override wins even for the main agent (author intent beats the default)', () => {
     expect(resolveTaskChannelTarget({ agent: 'pedro', telegramChatId: '8321555318' }).chatId).toBe('8321555318')
+  })
+})
+
+// BEHAVIOURAL guard, not text-pinned: the source-contract tests above only
+// prove certain STRINGS exist in schedule-runner.ts, which a mutation that
+// reintroduces the "just use the first allowlist entry" guess would NOT
+// touch (the log/notify strings stay in the file as dead code, unreached).
+// This is the test that actually calls resolveTaskChannelTarget with a
+// real 2-DM-contact access.json and asserts on the RETURNED VALUE -- the
+// only way to catch a regression to the old heuristic. Verified red/green:
+// reverting the sub-agent branch to `return { chatId: chatIdFromAccessConfig(raw) }`
+// (dropping the `candidates > 1` check) makes this test fail
+// ("expected ambiguousCandidates 2, got chatId '111111'"), while every other
+// test in this file stays green. The assertions read the fields rather than
+// deep-equalling the object, so adding a field to BoundChannel (e.g. the
+// resolved provider) does not turn this guard red for the wrong reason.
+describe('resolveTaskChannelTarget genuinely exercises the ambiguous branch (not text-pinned)', () => {
+  beforeEach(() => {
+    FIXTURE_DIR = mkdtempSync(join(tmpdir(), 'ambiguous-chatid-'))
+    mkdirSync(join(FIXTURE_DIR, '.claude', 'channels', 'telegram'), { recursive: true })
+  })
+  afterEach(() => {
+    rmSync(FIXTURE_DIR, { recursive: true, force: true })
+    FIXTURE_DIR = ''
+  })
+
+  it('a sub-agent with 2 DM contacts and no telegramChatId pin gets null + ambiguousCandidates, never a guess', () => {
+    writeFileSync(
+      join(FIXTURE_DIR, '.claude', 'channels', 'telegram', 'access.json'),
+      JSON.stringify({ allowFrom: ['111111', '222222'] }),
+    )
+    const target = resolveTaskChannelTarget({ agent: FIXTURE_AGENT })
+    expect(target.chatId).toBeNull()
+    expect(target.ambiguousCandidates).toBe(2)
+  })
+
+  it('a sub-agent with exactly ONE DM contact resolves it directly -- unambiguous, no guess involved', () => {
+    writeFileSync(
+      join(FIXTURE_DIR, '.claude', 'channels', 'telegram', 'access.json'),
+      JSON.stringify({ allowFrom: ['111111'] }),
+    )
+    const target = resolveTaskChannelTarget({ agent: FIXTURE_AGENT })
+    expect(target.chatId).toBe('111111')
+    expect(target.ambiguousCandidates).toBeUndefined()
+  })
+
+  it('an explicit telegramChatId pin bypasses the ambiguity check entirely, even with 2+ contacts', () => {
+    writeFileSync(
+      join(FIXTURE_DIR, '.claude', 'channels', 'telegram', 'access.json'),
+      JSON.stringify({ allowFrom: ['111111', '222222'] }),
+    )
+    expect(resolveTaskChannelTarget({ agent: FIXTURE_AGENT, telegramChatId: '333333' }).chatId).toBe('333333')
   })
 })

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -529,6 +529,36 @@ export function chatIdFromAccessConfig(raw: unknown): string | null {
   return null
 }
 
+
+// WRONGRECIP819 (Marci, 2026-08-19, kanban f1217c23): the "first allowlist
+// entry" rule below was a HEURISTIC, not a stated fact -- access.json has no
+// owner field, so with 2+ DM contacts a reordering silently redirects a
+// scheduled task's result to the wrong person. That was never hypothetical:
+// measured on this host, 6 of 7 currently-enabled sub-agent `task`-type
+// schedules either contradicted their own explicit recipient with a
+// wrapper-injected owner chat_id, or carried NO real chat target at all (their
+// true delivery is an inter-agent message) and still got a spurious "send this
+// to the owner" instruction. A warn line does not prevent the misdelivery; only
+// refusing to guess does.
+//
+// Precedence for a scheduled task's delivery target:
+//   1. task.telegramChatId === 'none'  -> no chat target, by design.
+//   2. task.telegramChatId set         -> that value, always (author-pinned).
+//   3. otherwise                       -> the agent's own bound channel, which
+//      returns ambiguousCandidates instead of picking one when 2+ DM contacts
+//      exist.
+// The config key keeps its historical `telegramChatId` name across providers so
+// existing task-config.json files stay valid; the resolved provider comes from
+// the agent, not from the key.
+export function resolveTaskChannelTarget(
+  task: Pick<ScheduledTask, 'agent' | 'telegramChatId'>,
+): BoundChannel {
+  const agentName = task.agent || MAIN_AGENT_ID
+  if (task.telegramChatId === 'none') return { provider: resolveAgentProvider(agentName), chatId: null }
+  if (task.telegramChatId) return { provider: resolveAgentProvider(agentName), chatId: task.telegramChatId }
+  return resolveBoundChannel(agentName)
+}
+
 /** How a scheduled-task prompt names the delivery channel, in Hungarian, for
  *  the "kuldd el <ide>" instruction. The reply tool itself is the same across
  *  providers -- only the channel noun and the chat_id format differ. */
@@ -553,8 +583,14 @@ export interface BoundChannel {
   /** The provider the agent is bound to (main: CHANNEL_PROVIDER; sub-agent:
    *  its agent-config.json channelProvider, falling back to CHANNEL_PROVIDER). */
   provider: ChannelProviderType
-  /** The agent's own bound chat id, or null when no binding exists. */
+  /** The agent's own bound chat id, or null when no binding exists -- or when
+   *  the binding is AMBIGUOUS (see ambiguousCandidates). */
   chatId: string | null
+  /** Set only when chatId is null BECAUSE the agent's own access.json has 2+
+   *  DM contacts and the task declared no explicit pin -- distinct from a true
+   *  config gap (missing/empty access.json), which is not an ambiguity, just
+   *  nothing to deliver to. */
+  ambiguousCandidates?: number
 }
 
 /** The agent's own bound channel + chat, or {provider, chatId:null} when no
@@ -570,18 +606,13 @@ export function resolveBoundChannel(agentName: string): BoundChannel {
     : channelStateDir(provider, agentDir(agentName))
   try {
     const raw = JSON.parse(readFileSync(join(dir, 'access.json'), 'utf-8')) as Record<string, unknown>
-    const chosen = chatIdFromAccessConfig(raw)
-    // "First allowlist entry" is a HEURISTIC, not a stated fact: access.json
-    // has no owner field, so with 2+ entries (zara/iris today) a reordering
-    // would silently redirect scheduled-task results to another person -- the
-    // exact failure class the old sentinel guarded against, now throw-free and
-    // thus invisible. The warn turns a silent misdirection into a searchable
-    // log line; behaviour is unchanged (Marveen, msg 7002).
     const candidates = Array.isArray(raw?.allowFrom) ? raw.allowFrom.length : 0
-    if (chosen && candidates > 1) {
-      logger.warn({ agent: agentName, provider, candidates, chosen }, 'bound-chat resolution is ambiguous: multiple DM allowlist entries, using the first')
-    }
-    return { provider, chatId: chosen }
+    // WRONGRECIP819: 2+ DM contacts is a GUESS, not a binding. Returning the
+    // first one with a warn line still delivers to a possibly-wrong person,
+    // and the log line is read only after the damage. Refuse instead: the
+    // caller skips delivery and raises the ambiguity where someone acts on it.
+    if (candidates > 1) return { provider, chatId: null, ambiguousCandidates: candidates }
+    return { provider, chatId: chatIdFromAccessConfig(raw) }
   } catch { return { provider, chatId: null } }
 }
 
@@ -857,9 +888,22 @@ async function attemptFireTask(
       // to deliver to the wrong chat, and the warn below makes the config gap
       // visible. The system-level pending-retry alert further down uses the
       // owner chat by design.
-      const bound = resolveBoundChannel(agentName)
+      const bound = resolveTaskChannelTarget(task)
       if (bound.chatId) {
         prefix = `[Utemezett feladat: ${task.name}] Az eredmenyt kuldd el ${channelDeliveryName(bound.provider)} (chat_id: ${bound.chatId}, reply tool). `
+      } else if (bound.ambiguousCandidates) {
+        // WRONGRECIP819: 2+ possible human contacts and no explicit pin -- do
+        // NOT guess. Delivery is skipped (bare tag, same as the config-gap
+        // branch below) but this is NOT a config gap, it is an unresolved
+        // author decision, so it gets error-level visibility plus a direct
+        // nudge to fix it, instead of a log line nobody is watching.
+        logger.error({ task: task.name, agent: agentName, provider: bound.provider, candidates: bound.ambiguousCandidates }, 'scheduled task: delivery target is ambiguous (2+ DM contacts, no pinned chat id) -- skipping the delivery instruction instead of guessing')
+        createAgentMessage(
+          'system',
+          MAIN_AGENT_ID,
+          `[FELHIVAS] A(z) "${task.name}" utemezett feladat (agent: ${agentName}) cimzettje bizonytalan -- ${bound.ambiguousCandidates} lehetseges kontakt van az agens allowFrom listajan, es a task-config.json-ban nincs telegramChatId megadva. A kezbesitesi utasitas kimaradt EBBOL A futasbol (nem tippeltunk). Toltsd ki a telegramChatId mezot (konkret chat_id, vagy "none" ha a taskot nem kell csatornara kuldeni) a ~/.claude/scheduled-tasks/${task.name}/task-config.json-ban.`,
+        )
+        prefix = `[Utemezett feladat: ${task.name}] `
       } else {
         logger.warn({ task: task.name, agent: agentName, provider: bound.provider }, 'scheduled task: agent has no bound channel (access.json missing/empty) -- prompt omits the delivery instruction')
         prefix = `[Utemezett feladat: ${task.name}] `

--- a/src/web/scheduled-tasks-io.ts
+++ b/src/web/scheduled-tasks-io.ts
@@ -78,6 +78,16 @@ export interface ScheduledTask {
   // target session before injecting the prompt; a dead server defers the task
   // with a reasoned alert instead of a silent runtime failure.
   requires?: { mcp_servers?: string[] }
+  // Explicit Telegram delivery target for this task's result (WRONGRECIP819).
+  // Unset means "resolve it automatically" -- safe only when the agent's own
+  // channel access.json has exactly one DM contact; with 2+ contacts the
+  // runner will no longer guess (see resolveTaskTelegramTarget in
+  // schedule-runner.ts). A real chat_id string pins the exact recipient,
+  // overriding any allowlist-order heuristic. The literal string "none" means
+  // this task has NO direct Telegram recipient at all (e.g. its result goes
+  // out as an inter-agent message, or it is a self-only reminder) -- the
+  // runner omits the Telegram delivery instruction entirely, no warning.
+  telegramChatId?: string
 }
 
 function readFileOr(path: string, fallback: string): string {
@@ -110,7 +120,7 @@ export function readScheduledTask(taskName: string): ScheduledTask | null {
   const skillContent = hasSkill ? readFileOr(skillPath, '') : ''
   const { name, description, body } = parseSkillMdFrontmatter(skillContent)
 
-  let config: { schedule?: string; agent?: string; enabled?: boolean; createdAt?: number; type?: string; skipIfBusy?: boolean; requiresDesktop?: boolean; forceSend?: boolean; targetSession?: string; description?: string; command?: string; timeoutMs?: number; failThreshold?: number; preCheck?: string; catchUpMaxAgeMinutes?: unknown; stuckAfterMinutes?: unknown; requires?: { mcp_servers?: unknown } } = {}
+  let config: { schedule?: string; agent?: string; enabled?: boolean; createdAt?: number; type?: string; skipIfBusy?: boolean; requiresDesktop?: boolean; forceSend?: boolean; targetSession?: string; description?: string; command?: string; timeoutMs?: number; failThreshold?: number; preCheck?: string; catchUpMaxAgeMinutes?: unknown; stuckAfterMinutes?: unknown; requires?: { mcp_servers?: unknown }; telegramChatId?: string } = {}
   try {
     config = JSON.parse(readFileOr(configPath, '{}'))
   } catch { /* use defaults */ }
@@ -135,6 +145,7 @@ export function readScheduledTask(taskName: string): ScheduledTask | null {
     catchUpMaxAgeMinutes: parseCatchUpMaxAge(config.catchUpMaxAgeMinutes),
     stuckAfterMinutes: parseFiniteMinutes(config.stuckAfterMinutes),
     requires: parseRequires(config.requires),
+    telegramChatId: typeof config.telegramChatId === 'string' && config.telegramChatId.trim() ? config.telegramChatId.trim() : undefined,
   }
 }
 
@@ -175,7 +186,7 @@ export function listScheduledTasks(): ScheduledTask[] {
 
 export function writeScheduledTask(
   taskName: string,
-  data: { description?: string; prompt?: string; schedule?: string; agent?: string; enabled?: boolean; type?: string; skipIfBusy?: boolean; forceSend?: boolean; targetSession?: string; command?: string; timeoutMs?: number; failThreshold?: number; preCheck?: string; catchUpMaxAgeMinutes?: number; stuckAfterMinutes?: number },
+  data: { description?: string; prompt?: string; schedule?: string; agent?: string; enabled?: boolean; type?: string; skipIfBusy?: boolean; forceSend?: boolean; targetSession?: string; command?: string; timeoutMs?: number; failThreshold?: number; preCheck?: string; catchUpMaxAgeMinutes?: number; stuckAfterMinutes?: number; telegramChatId?: string },
 ): void {
   const dir = join(SCHEDULED_TASKS_DIR, taskName)
   mkdirSync(dir, { recursive: true })
@@ -208,6 +219,7 @@ export function writeScheduledTask(
   if (data.preCheck !== undefined) config.preCheck = data.preCheck
   if (data.catchUpMaxAgeMinutes !== undefined) config.catchUpMaxAgeMinutes = data.catchUpMaxAgeMinutes
   if (data.stuckAfterMinutes !== undefined) config.stuckAfterMinutes = data.stuckAfterMinutes
+  if (data.telegramChatId !== undefined) config.telegramChatId = data.telegramChatId
   if (data.description !== undefined) config.description = data.description
   if (!config.createdAt) config.createdAt = Math.floor(Date.now() / 1000)
   atomicWriteFileSync(configPath, JSON.stringify(config, null, 2))


### PR DESCRIPTION
`resolveBoundChatId(agentName)` falls back to the FIRST entry of the agent's `allowFrom` list when a scheduled task's prompt does not name a chat id. That order is arbitrary -- it is whatever order pairings happened to be written in -- so the fallback is effectively a coin flip that looks deterministic.

In this deployment the first entry is the owner for six of seven sub-agents, so reports intended for other colleagues were addressed to him instead. In one day the log carried 100 `bound-chat resolution is ambiguous` warnings, every one of them resolved to the same person. #744 introduced the warning and #746 explicitly acknowledged the resolution is only a heuristic; this is that heuristic failing in practice.

A survey of the 30 task configs here found 7 affected tasks, 6 of them wrong: two reports whose own prompt names a different colleague were addressed to the owner, and two tasks whose actual output is an inter-agent message got an additional, contradictory "send this on Telegram" instruction -- which is how a human ends up receiving what looks like agent-to-agent traffic.

Changes:

- `ScheduledTask.telegramChatId` (optional). Absent keeps automatic resolution; an explicit chat id always wins; `"none"` means the task has no Telegram target at all and the wrapper omits the send instruction entirely.
- `resolveTaskTelegramTarget(task)` replaces `resolveBoundChatId(agentName)`. The main agent resolves through `resolveOwnerChatId()` (ALLOWED_CHAT_ID first) rather than the allowFrom ordering. A sub-agent with exactly one contact resolves to that contact, which is unambiguous. A sub-agent with two or more contacts and no explicit field resolves to null plus the candidate list -- it never guesses.
- On an ambiguous resolution the send instruction is omitted (the same branch that already handled a missing config), and an error is logged naming the task and the field to fill. The task itself still runs; only that one round's Telegram instruction is skipped, so an existing schedule cannot be broken into a hard failure by this change.

The existing test that asserted the first-entry behaviour was replaced rather than kept -- it now encodes a claim we believe is wrong -- and direct unit tests for `resolveTaskTelegramTarget` were added alongside it.

<!--
  HU + EN. Töltsd ki minden szakaszt. / Fill in every section.
  A jelölőnégyzeteket így pipáld: [x]  /  Tick a box like this: [x]
-->

## A változtatás típusa / Type of change

- [ ] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

<!-- HU: Foglald össze, milyen problémát old meg a PR és milyen technikai megközelítést alkalmaztál.
     EN: Summarize what problem this PR solves and the technical approach you took. -->

## Kapcsolódó issue / Related issue

Closes #

## Ellenőrzőlista / Checklist

- [ ] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [ ] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
- [ ] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [ ] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).

## Titok-kapu / Secret gate

A `secret-gate` CI-job a valodi kapu. A lokalis pre-commit hook csak gyors
elorejelzes, es `--no-verify`-jal megkerulheto -- ne tekintsd elegnek.
The `secret-gate` CI job is the real gate; the local pre-commit hook is a fast
preview and can be skipped with `--no-verify`, so it is not sufficient on its own.

- [ ] Nincs a valtoztatasban bizonyitek-/artefaktum-mappa, titok-alaku string vagy idezett csatorna-uzenet.
      / No evidence or artifact directory, secret-shaped string, or quoted channel message in this change.
