### PR TITLE
feat(channel-monitor): surface main-session respawns performed outside the dashboard (SOAKRESPAWN819)

### DIFF
--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -1000,6 +1000,32 @@ PLUGIN_DEAD_SINCE=0
 # and the unit stayed inactive/dead for the next ten minutes.
 RESTART_REQUESTED=0
 
+# Producer-side respawn breadcrumb (SOAKRESPAWN819). The watchdog WARNs below
+# go to stderr, which under systemd lands ONLY in journald -- invisible to
+# every store/-file reader (dashboard log tails, soak checks, support
+# bundles). Measured on a live soak box 2026-08-19: 210 service restarts at a
+# ~40min cadence with zero trace outside the journal. This mirror gives the
+# store a copy of WHY the process exited; the dashboard's external-respawn
+# detector (channel-monitor.ts) says THAT a respawn happened, this file says
+# WHY. Best-effort by design: a failed write must never break the watchdog.
+CHANNELS_RESPAWN_LOG="$INSTALL_DIR/store/channels-respawn.log"
+respawn_log() {
+  echo "$(date '+%Y-%m-%d %H:%M:%S') $*" >> "$CHANNELS_RESPAWN_LOG" 2>/dev/null || true
+  # Chronic-churn cap (the 40-min cycle writes ~36 lines/day forever): trim to
+  # the newest 500 once past 1000. mv-free rewrite keeps the inode stable for
+  # anything tailing the file.
+  # tr strip is mandatory: BSD wc pads the count with leading spaces, which
+  # the non-numeric guard below would otherwise zero out (trim never firing
+  # on macOS -- caught by the runnable probe in external-respawn-detect).
+  _lines=$(wc -l < "$CHANNELS_RESPAWN_LOG" 2>/dev/null | tr -d '[:space:]')
+  case "$_lines" in (*[!0-9]*|'') _lines=0;; esac
+  if [ "$_lines" -gt 1000 ]; then
+    _trimmed=$(tail -n 500 "$CHANNELS_RESPAWN_LOG" 2>/dev/null)
+    [ -n "$_trimmed" ] && printf '%s\n' "$_trimmed" > "$CHANNELS_RESPAWN_LOG" 2>/dev/null || true
+  fi
+  unset _lines _trimmed
+}
+
 # Várakozás amíg a session él
 while $TMUX has-session -t "$SESSION" 2>/dev/null; do
   sleep 5
@@ -1043,6 +1069,7 @@ while $TMUX has-session -t "$SESSION" 2>/dev/null; do
       echo "WARN: $CHANNEL_PROVIDER plugin (bot.pid) disappeared -- ${PLUGIN_DEAD_GRACE}s grace before restart" >&2
     elif [ "$((NOW - PLUGIN_DEAD_SINCE))" -ge "$PLUGIN_DEAD_GRACE" ]; then
       echo "WARN: $CHANNEL_PROVIDER plugin dead for $((NOW - PLUGIN_DEAD_SINCE))s -- exiting for service-manager restart" >&2
+      respawn_log "died-after-up: $CHANNEL_PROVIDER plugin dead for $((NOW - PLUGIN_DEAD_SINCE))s -- exiting for service-manager restart"
       RESTART_REQUESTED=1
       break
     fi
@@ -1056,6 +1083,7 @@ while $TMUX has-session -t "$SESSION" 2>/dev/null; do
       _next_streak=$((NEVER_STARTED_STREAK + 1))
       echo "$_next_streak" > "$NEVER_STARTED_STREAK_FILE" 2>/dev/null || true
       echo "WARN: $CHANNEL_PROVIDER plugin never started within ${PLUGIN_NEVER_STARTED_BUDGET}s -- exiting for service-manager restart (consecutive: $_next_streak, next budget: $(never_started_budget "$_next_streak")s)" >&2
+      respawn_log "never-started: $CHANNEL_PROVIDER plugin never started within ${PLUGIN_NEVER_STARTED_BUDGET}s (consecutive: $_next_streak, next budget: $(never_started_budget "$_next_streak")s)"
       RESTART_REQUESTED=1
       break
     fi

--- a/src/__tests__/external-respawn-detect.test.ts
+++ b/src/__tests__/external-respawn-detect.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { readFileSync, writeFileSync, mkdtempSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { classifyRespawnStampAdvance } from '../channel-coordinator/liveness.js'
+
+// SOAKRESPAWN819: a main-session respawn performed by anyone but the dashboard
+// (service-manager relaunch of channels.sh after a watchdog exit, the
+// systemd-timer channel-watchdog, a manual launch) used to be structurally
+// silent in dashboard.log -- the respawn stamp is a suppression contract, so
+// the evidence of the respawn quieted the watchers instead of surfacing.
+// Measured live on the hermes soak box 2026-08-19: 210 service-manager
+// restarts at a ~40min cadence, zero dashboard.log lines.
+//
+// Two halves close the gap:
+//   consumer -- channel-monitor logs every stamp advance it cannot attribute
+//               to a dashboard-initiated respawn (THAT it happened);
+//   producer -- channels.sh mirrors its watchdog-exit WARNs into
+//               store/channels-respawn.log (WHY it happened).
+
+const GRACE = 360_000
+
+describe('classifyRespawnStampAdvance (pure)', () => {
+  const base = { lastSeenStampMs: 1_000_000, graceMs: GRACE }
+
+  it('no advance -> none', () => {
+    expect(classifyRespawnStampAdvance({ ...base, stampMs: 1_000_000, lastSelfRespawnMs: 0 })).toBe('none')
+    expect(classifyRespawnStampAdvance({ ...base, stampMs: 999_000, lastSelfRespawnMs: 0 })).toBe('none')
+  })
+
+  it('missing/garbage stamp (0) -> none, never external', () => {
+    expect(classifyRespawnStampAdvance({ ...base, stampMs: 0, lastSelfRespawnMs: 0 })).toBe('none')
+  })
+
+  it('advance within grace of a dashboard-initiated respawn -> self (channels.sh writes the stamp on OUR launches too)', () => {
+    const selfAt = 2_000_000
+    // channels.sh stamps ~35-90s after the dashboard's own write during a
+    // dashboard-initiated hard restart; both sides of the window fold to self.
+    expect(classifyRespawnStampAdvance({ ...base, stampMs: selfAt + 90_000, lastSelfRespawnMs: selfAt })).toBe('self')
+    expect(classifyRespawnStampAdvance({ ...base, stampMs: selfAt - 5_000, lastSelfRespawnMs: selfAt })).toBe('self')
+    expect(classifyRespawnStampAdvance({ ...base, stampMs: selfAt + GRACE, lastSelfRespawnMs: selfAt })).toBe('self')
+  })
+
+  it('advance with no dashboard respawn nearby -> external', () => {
+    expect(classifyRespawnStampAdvance({ ...base, stampMs: 2_000_000, lastSelfRespawnMs: 0 })).toBe('external')
+    expect(classifyRespawnStampAdvance({ ...base, stampMs: 2_000_000, lastSelfRespawnMs: 2_000_000 - GRACE - 1 })).toBe('external')
+  })
+
+  it('the 40-min churn cadence classifies external on every cycle (regression shape of the live finding)', () => {
+    // Steady state on a never-starting-plugin host: a fresh stamp every
+    // ~2415s with the dashboard never initiating any of them.
+    let lastSeen = 1_000_000
+    const selfRespawn = 0
+    for (let i = 1; i <= 3; i++) {
+      const stampMs = 1_000_000 + i * 2_415_000
+      expect(classifyRespawnStampAdvance({ stampMs, lastSeenStampMs: lastSeen, lastSelfRespawnMs: selfRespawn, graceMs: GRACE })).toBe('external')
+      lastSeen = stampMs
+    }
+  })
+})
+
+// --- wiring contract (static): the halves must stay connected ---
+
+const ROOT = join(__dirname, '..', '..')
+const MONITOR = readFileSync(join(ROOT, 'src', 'web', 'channel-monitor.ts'), 'utf-8')
+const CHANNELS = readFileSync(join(ROOT, 'scripts', 'channels.sh'), 'utf-8')
+
+describe('external-respawn wiring contract', () => {
+  it('channel-monitor runs the detector every sweep and records self stamp writes', () => {
+    expect(MONITOR).toMatch(/checkExternalMainRespawn\(\)/)
+    // The self-write MUST be recorded inside writeRespawnStamp, or every
+    // dashboard-initiated respawn would be misreported as external.
+    const writeFn = MONITOR.slice(MONITOR.indexOf('function writeRespawnStamp'), MONITOR.indexOf('}', MONITOR.indexOf('lastSelfStampWriteMs = Date.now()')))
+    expect(writeFn).toMatch(/lastSelfStampWriteMs = Date\.now\(\)/)
+  })
+
+  it('boot baseline: the first observation seeds lastSeen and must not warn', () => {
+    const det = MONITOR.slice(MONITOR.indexOf('function checkExternalMainRespawn'))
+    const firstReturn = det.indexOf('return')
+    expect(det.slice(0, firstReturn)).toMatch(/lastSeenRespawnStampMs = stampMs/)
+  })
+
+  it('channels.sh mirrors BOTH watchdog-exit reasons into store/channels-respawn.log', () => {
+    expect(CHANNELS).toMatch(/respawn_log "never-started:/)
+    expect(CHANNELS).toMatch(/respawn_log "died-after-up:/)
+    expect(CHANNELS).toMatch(/channels-respawn\.log/)
+  })
+})
+
+// --- runnable probe: respawn_log writes, appends, and trims ---
+
+function sliceShellFn(src: string, name: string): string {
+  const start = src.indexOf(`${name}() {`)
+  if (start < 0) throw new Error(`function ${name}() not found`)
+  const end = src.indexOf('\n}', start)
+  if (end < 0) throw new Error(`unterminated ${name}()`)
+  return src.slice(start, end + 2)
+}
+
+describe('channels.sh respawn_log (runnable)', () => {
+  it('appends timestamped lines and trims past 1000 to the newest 500', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'respawnlog-'))
+    const logPath = join(dir, 'channels-respawn.log')
+    const body = [
+      '#!/bin/bash',
+      `CHANNELS_RESPAWN_LOG="${logPath}"`,
+      sliceShellFn(CHANNELS, 'respawn_log'),
+      'respawn_log "never-started: probe line one"',
+      'respawn_log "died-after-up: probe line two"',
+      // Inflate past the cap, then one more call must trigger the trim.
+      `for i in $(seq 1 1100); do echo "filler $i" >> "${logPath}"; done`,
+      'respawn_log "never-started: post-cap line"',
+    ].join('\n')
+    const p = join(dir, 'probe.sh')
+    writeFileSync(p, body + '\n')
+    execFileSync('bash', [p], { encoding: 'utf-8' })
+
+    const lines = readFileSync(logPath, 'utf-8').trim().split('\n')
+    // Trimmed to the newest 500, and the newest entry survived the trim.
+    expect(lines.length).toBeLessThanOrEqual(500)
+    expect(lines[lines.length - 1]).toMatch(/never-started: post-cap line/)
+    // Timestamp prefix on real entries (YYYY-MM-DD HH:MM:SS).
+    expect(lines[lines.length - 1]).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} /)
+  })
+
+  it('a failing log write never breaks the caller (best-effort contract)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'respawnlog-'))
+    const body = [
+      '#!/bin/bash',
+      // Unwritable target: parent dir does not exist.
+      `CHANNELS_RESPAWN_LOG="${join(dir, 'nope', 'x.log')}"`,
+      sliceShellFn(CHANNELS, 'respawn_log'),
+      'respawn_log "never-started: into the void"',
+      'echo SURVIVED',
+    ].join('\n')
+    const p = join(dir, 'probe.sh')
+    writeFileSync(p, body + '\n')
+    const out = execFileSync('bash', [p], { encoding: 'utf-8' })
+    expect(out).toMatch(/SURVIVED/)
+  })
+})

--- a/src/__tests__/external-respawn-detect.test.ts
+++ b/src/__tests__/external-respawn-detect.test.ts
@@ -71,7 +71,14 @@ describe('external-respawn wiring contract', () => {
     expect(MONITOR).toMatch(/checkExternalMainRespawn\(\)/)
     // The self-write MUST be recorded inside writeRespawnStamp, or every
     // dashboard-initiated respawn would be misreported as external.
-    const writeFn = MONITOR.slice(MONITOR.indexOf('function writeRespawnStamp'), MONITOR.indexOf('}', MONITOR.indexOf('lastSelfStampWriteMs = Date.now()')))
+    // Slice to the FUNCTION's own closing brace (same idiom as sliceShellFn
+    // below) -- an earlier version sliced to the first brace AFTER the sought
+    // string, an ever-growing window that could not fail (Marveen's mutation
+    // probe on 331b7d2d: assignment moved out of the function, test stayed
+    // green). Verified red against that same mutation after this fix.
+    const start = MONITOR.indexOf('function writeRespawnStamp')
+    expect(start).toBeGreaterThanOrEqual(0)
+    const writeFn = MONITOR.slice(start, MONITOR.indexOf('\n}', start))
     expect(writeFn).toMatch(/lastSelfStampWriteMs = Date\.now\(\)/)
   })
 

--- a/src/channel-coordinator/liveness.ts
+++ b/src/channel-coordinator/liveness.ts
@@ -308,6 +308,17 @@ export function probeNativeChannelDown(session: string, provider: ChannelProvide
 //                 other actor recreated the main session. The caller logs
 //                 this loudly; false positives are deliberate signal (a manual
 //                 operator launch IS an external actor worth a log line).
+//
+// KNOWN SHADOW (do not read the absence of a warning as absence of external
+// respawns): the abs() window means a REAL external respawn landing within
+// graceMs (6 min) of a dashboard-initiated one classifies 'self' and is lost.
+// On the measured 40-min churn that is a ~15% blind window per cycle, wider
+// during an active recovery cascade (several self respawns back to back).
+// Deliberate trade-off: shrinking the window would misreport channels.sh's
+// own delayed stamp write on OUR launches as external -- a false alarm on
+// every dashboard restart is worse than a shadowed edge case. The producer
+// mirror (store/channels-respawn.log) still records WHY lines for shadowed
+// respawns, so the evidence survives even when this classifier stays quiet.
 export type RespawnStampAdvance = 'none' | 'self' | 'external'
 
 export function classifyRespawnStampAdvance(opts: {

--- a/src/channel-coordinator/liveness.ts
+++ b/src/channel-coordinator/liveness.ts
@@ -285,3 +285,39 @@ export function probeNativeChannelDown(session: string, provider: ChannelProvide
     msSinceLastRespawn: respawnMs > 0 ? now - respawnMs : null,
   })
 }
+
+// --- external-respawn attribution (SOAKRESPAWN819) ---
+//
+// The respawn stamp is a SUPPRESSION contract: five watchers read it to stay
+// quiet during the post-respawn grace. That contract makes an externally
+// triggered respawn (channels.sh relaunched by the service manager, the
+// systemd-timer channel-watchdog, a manual launch) structurally silent in the
+// dashboard log -- the evidence of the respawn is consumed to suppress, never
+// surfaced. Measured on a live soak box 2026-08-19: 210 service-manager
+// restarts at a ~40min cadence, zero dashboard.log lines.
+//
+// PURE classifier: did the stamp advance, and was the advance ours?
+//   'none'     -- no new stamp value since the last one we processed.
+//   'self'     -- advanced, but within graceMs of a dashboard-initiated
+//                 respawn. channels.sh writes the stamp unconditionally on
+//                 EVERY launch, including launches the dashboard itself
+//                 initiated (hard restart -> service reload -> channels.sh),
+//                 so a second write shortly after our own is part of OUR
+//                 restart, not an external actor.
+//   'external' -- advanced with no dashboard-initiated respawn nearby: some
+//                 other actor recreated the main session. The caller logs
+//                 this loudly; false positives are deliberate signal (a manual
+//                 operator launch IS an external actor worth a log line).
+export type RespawnStampAdvance = 'none' | 'self' | 'external'
+
+export function classifyRespawnStampAdvance(opts: {
+  stampMs: number
+  lastSeenStampMs: number
+  lastSelfRespawnMs: number
+  graceMs: number
+}): RespawnStampAdvance {
+  const { stampMs, lastSeenStampMs, lastSelfRespawnMs, graceMs } = opts
+  if (!(stampMs > 0) || stampMs <= lastSeenStampMs) return 'none'
+  if (lastSelfRespawnMs > 0 && Math.abs(stampMs - lastSelfRespawnMs) <= graceMs) return 'self'
+  return 'external'
+}

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -50,7 +50,7 @@ import { readLastIngestionTimestamp, TRANSCRIPT_DIR } from './inbound-probe.js'
 import { decideDownAgentAction, AGENT_MAX_RESTART_ATTEMPTS, parseEtimeToSeconds } from './agent-restart-policy.js'
 // getClaudePidForSession + hasChannelPluginAlive live in the shared liveness
 // module so the standalone channel-coordinator reuses the exact same probe.
-import { getClaudePidForSession, hasChannelPluginAlive, probeChannelPluginLiveness } from '../channel-coordinator/liveness.js'
+import { getClaudePidForSession, hasChannelPluginAlive, probeChannelPluginLiveness, classifyRespawnStampAdvance } from '../channel-coordinator/liveness.js'
 import { getDesiredAgents } from './agent-desired-state.js'
 
 const TMUX = resolveFromPath('tmux')
@@ -908,7 +908,49 @@ function fileRespawnStampMs(): number {
 function writeRespawnStamp(): void {
   try {
     writeFileSync(RESPAWN_STAMP_FILE, String(Math.floor(Date.now() / 1000)))
+    // Attribution input for the external-respawn detector below: a stamp we
+    // wrote ourselves must never be reported as an external actor.
+    lastSelfStampWriteMs = Date.now()
   } catch { /* best effort */ }
+}
+
+// --- external-respawn detector (SOAKRESPAWN819) ---
+//
+// The stamp is consumed by five watchers purely to SUPPRESS themselves, so a
+// respawn performed by anyone but this process (channels.sh relaunched by the
+// service manager after a watchdog exit, the systemd-timer channel-watchdog,
+// a manual operator launch) leaves no dashboard.log trace at all -- the
+// evidence quiets the watchers instead of surfacing. Measured live
+// (hermes soak box, 2026-08-19): 210 service-manager restarts at a ~40min
+// cadence, zero dashboard.log lines. This detector closes that: every stamp
+// advance not attributable to a dashboard-initiated respawn is logged loudly.
+// WHY the respawn happened lives in store/channels-respawn.log (producer-side
+// mirror written by channels.sh); this line says THAT it happened.
+let lastSelfStampWriteMs = 0
+let lastSeenRespawnStampMs = -1
+function checkExternalMainRespawn(): void {
+  const stampMs = fileRespawnStampMs()
+  if (lastSeenRespawnStampMs < 0) {
+    // Boot baseline: whatever the stamp said before this dashboard started is
+    // history, not this boot's news -- without this, every dashboard restart
+    // after any respawn would fire a spurious external-actor warning.
+    lastSeenRespawnStampMs = stampMs
+    return
+  }
+  const verdict = classifyRespawnStampAdvance({
+    stampMs,
+    lastSeenStampMs: lastSeenRespawnStampMs,
+    lastSelfRespawnMs: Math.max(marveenLastHardRestart, marveenLastKeepaliveRespawn, marveenLastSessionCreate, lastSelfStampWriteMs),
+    graceMs: MARVEEN_POST_RESPAWN_GRACE_MS,
+  })
+  if (verdict === 'none') return
+  lastSeenRespawnStampMs = stampMs
+  if (verdict === 'external') {
+    logger.warn(
+      { stampAt: new Date(stampMs).toISOString() },
+      'Main-session respawn stamp advanced by an EXTERNAL actor (service-manager relaunch of channels.sh, channel-watchdog timer, or manual launch) -- the main session was recreated outside the dashboard; reason breadcrumb: store/channels-respawn.log (SOAKRESPAWN819)'
+    )
+  }
 }
 
 // --- Vanished-session recovery (self-healing main session) ---
@@ -1499,6 +1541,12 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
     // Restore persisted failure counts on first tick so a dashboard restart
     // does not reset the cap and restart agents that have already been given up on.
     ensureAgentRestartFailuresInitialized()
+
+    // Surface main-session respawns performed by anyone but this process
+    // (SOAKRESPAWN819) -- must run every sweep, not only when the plugin
+    // probe reaches the main target, so an external churn is visible even
+    // while the plugin is structurally down.
+    checkExternalMainRespawn()
 
     type Target = { session: string; isMarveen: boolean; agentName?: string; provider: ChannelProviderType }
     const targets: Target[] = [{ session: MAIN_CHANNELS_SESSION, isMarveen: true, provider: mainProvider }]


### PR DESCRIPTION
## SOAKRESPAWN819: external main-session respawns are now visible

**Finding (measured live, hermes soak box 2026-08-19):** the marveen-channels.service restarted 210 times at a ~40min cadence (channels.sh never-started watchdog cap on an AVX-less host), each cycle recreating the main session and dropping its context -- with **zero** trace in dashboard.log. Root cause of the silence: the respawn stamp (`store/.channel-last-respawn`) is a suppression contract -- five watchers read it to stay quiet during the grace window -- so the evidence of an external respawn silenced the watchers instead of surfacing.

### Consumer half (THAT it happened)
`channel-monitor` now classifies every stamp advance via `classifyRespawnStampAdvance` (pure, in `channel-coordinator/liveness.ts`) on each 60s sweep and WARNs on any advance it cannot attribute to a dashboard-initiated respawn. Generic by design: a future new respawn path is caught without this code knowing it exists. Boot baseline seeds silently, so a dashboard restart never misreports pre-boot history.

### Producer half (WHY it happened)
`channels.sh` mirrors its watchdog-exit WARNs (`never-started`, `died-after-up`) into `store/channels-respawn.log` (timestamped, best-effort, 1000->500 line trim). Until now these went to stderr only, which under systemd lands exclusively in journald -- invisible to every store-file reader (soak checks, log tails, support bundles).

### Named false-positive analysis (per review instruction: name, do not silently filter)
- `channels.sh` writes the stamp on **every** launch, including launches the dashboard itself initiated (hard restart -> service reload -> channels.sh). These fold to `'self'` via the existing `MARVEEN_POST_RESPAWN_GRACE_MS` window (the same contract constant the watchers use).
- A **manual operator launch** of channels.sh and a **channel-watchdog timer** respawn DO warn. That is deliberate signal: both are external actors worth a log line; filtering them would recreate the blind spot.
- Clock skew is a non-issue: stamp writer and reader share the host clock; stamp resolution is seconds.

### Also in this PR
BSD-wc portability fix caught by the runnable probe: `wc -l` pads its count with spaces on macOS, which the non-numeric guard zeroed -- the trim would never have fired on Mac installs.

### Evidence
- Full vitest suite: **278 files / 3743 tests green** (non-/tmp worktree).
- `tsc` (real, local 5.9.3): clean. `npm run build`: exit 0.
- New tests: pure-classifier unit cases (including the live 40-min churn shape as a regression test), static wiring contract (detector runs every sweep; self-writes recorded; both shell branches mirrored), runnable shell probes (append+trim, best-effort on unwritable target).

Not a develop regression and not release-blocking (per SOAKRESPAWN819 card) -- this is the observability closure for a designed damped-churn behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
