### PR TITLE
fix(heartbeat): serve the hot-memory count from the dashboard, stop prescribing the query (HBMEMBLIND819)

### DIFF
--- a/src/__tests__/heartbeat-agent-scaffold.test.ts
+++ b/src/__tests__/heartbeat-agent-scaffold.test.ts
@@ -208,29 +208,34 @@ describe('shouldBootHeartbeatAgent', () => {
   })
 })
 
-// HBMEMBLIND807: the hot-memory metric must ship as a READY-MADE query, the
-// way task_runs does -- a prose-only bullet let the heartbeat agent compose
-// its own SQL and report 0 with three hot memories in the window. Lock the
-// contract: the exact query, the SECONDS cutoff (no ms multiplier -- that is
-// the task_runs unit, not this one), and the do-not-rewrite instruction.
-describe('hot-memory metric is a ready-made query (HBMEMBLIND807)', () => {
-  it('ships the exact scoped count query', () => {
+// HBMEMBLIND807 -> HBMEMBLIND819: the hot-memory metric went through TWO
+// contracts, and both failures are why the current one exists. 807: a
+// prose-only bullet let the agent compose its own SQL (reported 0 beside 3
+// hot memories); the fix shipped a ready-made query with "do not rewrite the
+// query". 819: that failed too -- post-compact rounds reconstructed the query
+// from memory with agent_id='heartbeat' and reported 0 for 24h straight
+// (14/14, real value 2 in three rounds). Current contract: the number is
+// computed server-side (countNewHotMemories, served as
+// counts.new_hot_memories_1h on /api/kanban/heartbeat-summary) and the
+// scaffold tells the agent to COPY it -- there is no query left to rewrite.
+describe('hot-memory metric is an endpoint number, never an agent-run query (HBMEMBLIND819)', () => {
+  it('points the agent at counts.new_hot_memories_1h from the heartbeat-summary call', () => {
     const out = renderHeartbeatClaudeMd(ID)
-    expect(out).toContain("SELECT COUNT(*) FROM memories")
-    expect(out).toContain(`agent_id='${ID.mainAgentId}'`)
-    expect(out).toContain("category='hot'")
-    expect(out).toContain('created_at > unixepoch()-3600')
+    expect(out).toContain('counts.new_hot_memories_1h')
   })
 
-  it('the memory cutoff carries NO millisecond multiplier', () => {
+  it('ships NO runnable hot-memory SQL anywhere in the prompt', () => {
     const out = renderHeartbeatClaudeMd(ID)
-    const memBullet = out.slice(out.indexOf('Memory + system'))
-    expect(memBullet.slice(0, 1200)).not.toContain("(unixepoch()-3600)*1000")
+    // The exact surface that drifted twice: a memories/hot query the agent
+    // could run (and, measured, rewrite). Shape-agnostic: any SQL touching
+    // the memories table near a hot filter is out of contract.
+    expect(out).not.toMatch(/FROM memories[\s\S]{0,120}category='hot'/)
+    expect(out).not.toContain('do not rewrite the query')
   })
 
-  it('tells the agent to report the number, not to rewrite the query', () => {
+  it('degrades a missing field to "no data", never to a self-run query or a zero', () => {
     const out = renderHeartbeatClaudeMd(ID)
-    expect(out).toContain('do not rewrite the query')
+    expect(out).toContain('nincs adat (a summary nem adja)')
   })
 })
 

--- a/src/__tests__/heartbeat-hot-memory-count.test.ts
+++ b/src/__tests__/heartbeat-hot-memory-count.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest'
+import Database from 'better-sqlite3'
+import { readFileSync, mkdtempSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { HEARTBEAT_NEW_HOT_MEMORIES_SQL } from '../db.js'
+
+// HBMEMBLIND819: the heartbeat's "new hot memories (1h)" line said 0 for
+// 14/14 rounds over 24h while the real value was 2 in three of them. Second
+// failure of the prescribe-the-query pattern for this metric (HBMEMBLIND807
+// was the first): the agent ran the prescribed query SHAPE but substituted
+// agent_id='heartbeat' for the main agent's id on post-compact rounds, and
+// the wrong form then persisted as its own precedent. The closure is the same
+// one the kanban counts already use: the number is computed server-side and
+// served over /api/kanban/heartbeat-summary; the agent copies it and never
+// runs a query. These tests pin BOTH halves: the shipped SQL counts the right
+// rows, and the scaffold no longer tells the agent to run anything for it.
+
+const ROOT = join(__dirname, '..', '..')
+
+function fixtureDb() {
+  const dir = mkdtempSync(join(tmpdir(), 'hb-hotmem-'))
+  const db = new Database(join(dir, 'test.db'))
+  db.exec(`CREATE TABLE memories (
+    id INTEGER PRIMARY KEY, agent_id TEXT, category TEXT, content TEXT, created_at INTEGER
+  )`)
+  const ins = db.prepare('INSERT INTO memories (agent_id,category,content,created_at) VALUES (?,?,?,?)')
+  return { db, ins }
+}
+
+describe('HEARTBEAT_NEW_HOT_MEMORIES_SQL (the shipped statement, on a fixture DB)', () => {
+  it('counts only the given agent, only hot, only the last hour', () => {
+    const { db, ins } = fixtureDb()
+    const now = Math.floor(Date.now() / 1000)
+    ins.run('marveen', 'hot', 'fresh main-agent hot #1', now - 60)
+    ins.run('marveen', 'hot', 'fresh main-agent hot #2', now - 3599)
+    // The exact wrong-row family HBMEMBLIND819 measured: the heartbeat's OWN
+    // id. It must not be countable by accident when the caller passes the
+    // main agent's id.
+    ins.run('heartbeat', 'hot', 'heartbeat own hot', now - 60)
+    ins.run('marveen', 'hot', 'main-agent hot but old', now - 3700)
+    ins.run('marveen', 'warm', 'fresh but warm', now - 60)
+
+    const forMain = db.prepare(HEARTBEAT_NEW_HOT_MEMORIES_SQL).get('marveen') as { n: number }
+    expect(forMain.n).toBe(2)
+
+    // And the failure shape itself, replayed: querying with the heartbeat's
+    // own id sees a different world -- which is WHY the id must be supplied
+    // server-side, not reconstructed by the agent.
+    const forHeartbeat = db.prepare(HEARTBEAT_NEW_HOT_MEMORIES_SQL).get('heartbeat') as { n: number }
+    expect(forHeartbeat.n).toBe(1)
+  })
+
+  it('empty table -> 0, not NULL-shaped surprises', () => {
+    const { db } = fixtureDb()
+    const row = db.prepare(HEARTBEAT_NEW_HOT_MEMORIES_SQL).get('marveen') as { n: number }
+    expect(row.n).toBe(0)
+  })
+})
+
+describe('wiring contract: the number flows endpoint -> agent, never agent -> query', () => {
+  const KANBAN = readFileSync(join(ROOT, 'src', 'web', 'routes', 'kanban.ts'), 'utf-8')
+  const SCAFFOLD = readFileSync(join(ROOT, 'src', 'web', 'heartbeat-agent-scaffold.ts'), 'utf-8')
+
+  it('heartbeat-summary serves counts.new_hot_memories_1h computed with MAIN_AGENT_ID', () => {
+    // Anchor the window to the endpoint handler's own structural bounds
+    // (start marker to the closing `return true`), NOT to the sought string --
+    // a window derived from the needle grows until it contains it and the
+    // assertion cannot fail (the #1006 review lesson).
+    const start = KANBAN.indexOf("'/api/kanban/heartbeat-summary'")
+    expect(start).toBeGreaterThanOrEqual(0)
+    const end = KANBAN.indexOf('return true', start)
+    expect(end).toBeGreaterThan(start)
+    const handler = KANBAN.slice(start, end)
+    expect(handler).toMatch(/new_hot_memories_1h:\s*countNewHotMemories\(MAIN_AGENT_ID\)/)
+  })
+
+  it('the scaffold tells the agent to COPY the field and forbids running a query for it', () => {
+    expect(SCAFFOLD).toMatch(/counts\.new_hot_memories_1h/)
+    // The memory bullet must not prescribe (or even show) a runnable
+    // hot-memory SQL anymore -- that is the exact surface that drifted twice.
+    expect(SCAFFOLD).not.toMatch(/FROM memories[\s\S]{0,120}category='hot'/)
+    // Missing field degrades to "no data", never to a self-run query or a 0.
+    expect(SCAFFOLD).toMatch(/nincs adat \(a summary nem adja\)/)
+  })
+})

--- a/src/db.ts
+++ b/src/db.ts
@@ -2050,6 +2050,35 @@ export function getHeartbeatKanbanSummary(): HeartbeatKanbanSummary {
   return { urgent, in_progress, waiting }
 }
 
+/**
+ * HBMEMBLIND819: the heartbeat's "new hot memories (1h)" number is computed
+ * HERE, server-side, and served over /api/kanban/heartbeat-summary -- the
+ * heartbeat agent copies it like the kanban counts, it never runs the query.
+ *
+ * This is the SECOND failure of the prescribe-the-query pattern for this
+ * metric. HBMEMBLIND807 (2026-08-07): the agent composed its own SQL and
+ * reported 0 beside three hot memories; the fix prescribed a ready-made query
+ * with "do not rewrite the query". HBMEMBLIND819 (2026-08-19): measured
+ * 14/14 rounds reporting 0 over 24h with real values of 2 in three of them --
+ * the agent ran the prescribed query SHAPE but with agent_id='heartbeat'
+ * substituted for the main agent's id. Timeline over 8 sessions / 196 runs:
+ * the identity rewrite appears on post-compact rounds (the agent reconstructs
+ * the query from memory as "count MY hot memories" instead of re-reading the
+ * prescription) and then persists as its own precedent. A prescription the
+ * measured party must re-copy every round is not a mechanism; the kanban
+ * counts on the SAME agent never drifted, because an endpoint number has no
+ * query to rewrite. Same closure as getHeartbeatKanbanSummary above.
+ */
+/** Exported so a test can execute the SHIPPED statement against a fixture DB
+ *  instead of re-typing an equivalent one and proving nothing. */
+export const HEARTBEAT_NEW_HOT_MEMORIES_SQL =
+  "SELECT COUNT(*) AS n FROM memories WHERE agent_id = ? AND category = 'hot' AND created_at > unixepoch() - 3600"
+
+export function countNewHotMemories(agentId: string): number {
+  const row = db.prepare(HEARTBEAT_NEW_HOT_MEMORIES_SQL).get(agentId) as { n: number } | undefined
+  return row?.n ?? 0
+}
+
 // --- Agent Messages ---
 
 export interface AgentMessage {

--- a/src/web/heartbeat-agent-scaffold.ts
+++ b/src/web/heartbeat-agent-scaffold.ts
@@ -255,22 +255,27 @@ When you receive the heartbeat prompt:
      costume of a check. If a warnings line ever returns, it must come
      with a READY-MADE query against a REAL source, like the hot-memory
      count below.
-     HBMEMBLIND807: the hot-memory count is a READY-MADE query,
-     exactly like task_runs above -- when this bullet was prose only, the
-     heartbeat agent composed its own SQL and reported 0 while three hot
-     memories sat in the window (measured 2026-08-07 09:00, ids
-     2442-2444). A metric line that can silently read 0 is worse than no
-     line: real change looks identical to silence. NOTE the unit
-     difference from task_runs: \`memories.created_at\` is SECONDS, so
-     the cutoff is \`unixepoch()-3600\` with NO millisecond multiplier:
+     HBMEMBLIND807+819: the hot-memory count comes from the SAME
+     \`/api/kanban/heartbeat-summary\` call you already made for the
+     Kanban section: report \`counts.new_hot_memories_1h\` from that
+     response. Do NOT run any query for this number -- not even a
+     correct-looking one.
 
-     \`\`\`bash
-     sqlite3 ${id.storeDir}/claudeclaw.db "SELECT COUNT(*) FROM memories \\
-       WHERE agent_id='${id.mainAgentId}' AND category='hot' \\
-       AND created_at > unixepoch()-3600"
-     \`\`\`
+     Why an endpoint number and not a query, measured twice:
+     2026-08-07 (HBMEMBLIND807) this bullet was prose, the agent
+     composed its own SQL and reported 0 while three hot memories sat
+     in the window. The fix prescribed a ready-made query with "do not
+     rewrite the query" -- and 2026-08-19 (HBMEMBLIND819) that failed
+     too: 14/14 rounds over 24h reported 0 against real values of 2,
+     because post-compact rounds reconstructed the query from memory as
+     "count MY hot memories" and substituted the wrong agent_id. A
+     prescription you must re-copy every hour is not a mechanism; a
+     number computed server-side has nothing to rewrite. The kanban
+     counts above never drifted for exactly this reason.
 
-     Report the number this query returns -- do not rewrite the query.
+     If the field is MISSING from the response (older dashboard build),
+     write \`new hot memories (1h): nincs adat (a summary nem adja)\` --
+     do not fall back to your own query, and never fill the line with 0.
 
 2. **Format** the result as a single inter-agent message:
 

--- a/src/web/routes/kanban.ts
+++ b/src/web/routes/kanban.ts
@@ -12,6 +12,7 @@ import {
   listArchivedKanbanCards,
   revertIdeaFromKanban,
   getHeartbeatKanbanSummary,
+  countNewHotMemories,
 } from '../../db.js'
 import { normalizeKanbanRefs } from '../kanban-ref-normalize.js'
 import { OWNER_NAME, BOT_NAME, MAIN_AGENT_ID, STORE_DIR, WEB_HOST, WEB_PORT, KANBAN_LABEL_COLORS } from '../../config.js'
@@ -148,6 +149,10 @@ export async function tryHandleKanban(ctx: RouteContext): Promise<boolean> {
         urgent: summary.urgent.length,
         in_progress: summary.in_progress.length,
         waiting: summary.waiting.length,
+        // HBMEMBLIND819: computed server-side with the MAIN agent's id so the
+        // heartbeat agent copies a number instead of running (and rewriting)
+        // a query -- see HEARTBEAT_NEW_HOT_MEMORIES_SQL in db.ts.
+        new_hot_memories_1h: countNewHotMemories(MAIN_AGENT_ID),
       },
     })
     return true


### PR DESCRIPTION
## HBMEMBLIND819: the heartbeat's hot-memory count is now a served number, not a prescribed query

**Finding (measured):** the heartbeat's "new hot memories (1h)" line reported 0 for 14/14 rounds over 24h while the real value was 2 in three rounds. Raw evidence from the heartbeat's own transcript: it ran the prescribed query SHAPE but with `agent_id='heartbeat'` substituted for the main agent's id -- output 0, structurally, since the heartbeat never writes hot memories. The on-disk prescription (agents/heartbeat/CLAUDE.md) was correct.

**This is the second failure of prescribe-the-query for this exact metric.** HBMEMBLIND807 (08-07) was self-composed SQL; the fix shipped a ready-made query with "do not rewrite the query". Timeline over 8 sessions / 196 runs: 176 correct, 20 rewritten -- every rewrite appears on a post-compact round (the agent reconstructs the query from memory as "count MY hot memories" instead of re-reading the prescription); earlier sessions self-corrected within 1-2 rounds, the current one locked the wrong form in as its own precedent since 08-18 10:12.

**The closure copies the pattern that measurably held on the same agent:** the kanban counts never drifted, because an endpoint number has no query to rewrite (the db.ts comment for `getHeartbeatKanbanSummary` already names this principle: "the real fix is that the heartbeat agent no longer writes its own query").

- `db.ts`: `HEARTBEAT_NEW_HOT_MEMORIES_SQL` (exported shipped statement) + `countNewHotMemories(agentId)`.
- `/api/kanban/heartbeat-summary`: `counts.new_hot_memories_1h`, computed server-side with `MAIN_AGENT_ID`.
- Scaffold: the memory bullet now says copy that field from the call the agent already makes for the kanban section; **no runnable hot-memory SQL remains in the prompt**; a missing field (older dashboard build) degrades to `nincs adat (a summary nem adja)` -- never to a self-run query, never to a 0.

### Evidence
- Full suite **279 files / 3747 tests green**; real tsc clean; build exit 0 (non-/tmp worktree).
- Fixture tests execute the SHIPPED SQL, including the exact measured wrong-id shape (`agent_id='heartbeat'` sees a different world -- which is why the id is supplied server-side).
- **Mutation red-runs, both seen failing:** (A) removing the endpoint field -> the endpoint wiring test fails alone; (B) restoring a runnable SQL to the scaffold -> the three scaffold guards fail. Restore -> green. Wiring windows are structurally anchored (start marker -> handler's own `return true` / rendered-output matching), not derived from the sought string -- the #1006 review lesson applied.
- The old HBMEMBLIND807 prescription pins are rewritten to the new contract (they pinned the exact surface that drifted).

Rollout note: the scaffold CLAUDE.md regenerates on dashboard boot, so the fix is live only after build + restart on each install -- same caveat as #1006.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
