### PR TITLE
fix(stuck-input-watcher): owner alert requires an idle pane (RIASZTASZAJ819)

### DIFF
--- a/src/__tests__/stuck-input-owner-alert-busy-gate.test.ts
+++ b/src/__tests__/stuck-input-owner-alert-busy-gate.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { shouldAlertParkedGiveUp } from '../web/stuck-input-watcher.js'
+
+// RIASZTASZAJ819: three identical owner alerts in one afternoon ("a samu
+// agens bemenete beragadt ... kezi restart kell") at an agent that was
+// demonstrably WORKING -- its outbound messages bracket every alert
+// timestamp, and no manual restart happened or was needed. Parked input at a
+// BUSY agent is a message waiting out the current turn; the owner alert must
+// require an IDLE pane. The naive fix (raising thresholds or muting the
+// alert) would silence the REAL wedge too -- the goal is a correct alert,
+// not fewer alerts.
+
+const MAX = 5
+
+describe('shouldAlertParkedGiveUp (pure)', () => {
+  const base = { attempts: MAX, maxAttempts: MAX, alreadyAlerted: false }
+
+  it('busy pane suppresses the owner alert (waiting, not wedged)', () => {
+    expect(shouldAlertParkedGiveUp({ ...base, paneState: 'busy' })).toBe(false)
+  })
+
+  it('idle pane with a spent give-up threshold alerts (the genuine wedge)', () => {
+    expect(shouldAlertParkedGiveUp({ ...base, paneState: 'idle' })).toBe(true)
+  })
+
+  it("typing and unknown panes alert too -- 'unknown' must not become a silent hole", () => {
+    expect(shouldAlertParkedGiveUp({ ...base, paneState: 'typing' })).toBe(true)
+    expect(shouldAlertParkedGiveUp({ ...base, paneState: 'unknown' })).toBe(true)
+    expect(shouldAlertParkedGiveUp({ ...base, paneState: null })).toBe(true)
+  })
+
+  it('below the give-up threshold never alerts, whatever the pane says', () => {
+    expect(shouldAlertParkedGiveUp({ ...base, attempts: MAX - 1, paneState: 'idle' })).toBe(false)
+  })
+
+  it('one alert per spell: alreadyAlerted suppresses a repeat', () => {
+    expect(shouldAlertParkedGiveUp({ ...base, alreadyAlerted: true, paneState: 'idle' })).toBe(false)
+  })
+
+  it('the deferred-alert shape: busy ticks suppress, the first idle tick fires', () => {
+    // A spell that crosses max while the agent is mid-turn must not lose its
+    // alert forever -- when the turn ends and the input is STILL parked, the
+    // next tick alerts. Replayed as the decision sequence:
+    const ticks: Array<{ paneState: 'busy' | 'idle'; expected: boolean }> = [
+      { paneState: 'busy', expected: false },
+      { paneState: 'busy', expected: false },
+      { paneState: 'idle', expected: true },
+    ]
+    let alerted = false
+    for (const t of ticks) {
+      const fire = shouldAlertParkedGiveUp({ ...base, alreadyAlerted: alerted, paneState: t.paneState })
+      expect(fire).toBe(t.expected)
+      if (fire) alerted = true
+    }
+  })
+})
+
+// --- wiring contract (structurally anchored windows, never needle-derived) ---
+
+const ROOT = join(__dirname, '..', '..')
+const SRC = readFileSync(join(ROOT, 'src', 'web', 'stuck-input-watcher.ts'), 'utf-8')
+
+describe('wiring: the owner alert goes through the gate, recovery does not', () => {
+  // Window: from the checkLocalSession declaration to the function's own
+  // closing brace (column-0), not derived from any sought string.
+  const start = SRC.indexOf('async function checkLocalSession')
+  const fnBody = SRC.slice(start, SRC.indexOf('\n}', start))
+
+  it('checkLocalSession exists and its alert is gated by shouldAlertParkedGiveUp', () => {
+    expect(start).toBeGreaterThanOrEqual(0)
+    expect(fnBody).toMatch(/shouldAlertParkedGiveUp\(/)
+    // The sendAlert call must be INSIDE the gated branch: no sendAlert may
+    // appear in the body before the gate call.
+    const gateIdx = fnBody.indexOf('shouldAlertParkedGiveUp(')
+    const alertIdx = fnBody.indexOf('sendAlert(')
+    expect(alertIdx).toBeGreaterThan(gateIdx)
+  })
+
+  it('the pane state is read fresh at alert time (capturePane + detectPaneState)', () => {
+    expect(fnBody).toMatch(/capturePane\(session\)/)
+    expect(fnBody).toMatch(/detectPaneState\(pane\)/)
+  })
+
+  it('a spell that ends clears the one-alert-per-spell marker', () => {
+    // Spell end is the parkedSig === null branch; the marker delete must sit
+    // in it, or a session could alert only once across its whole lifetime.
+    const spellEnd = fnBody.indexOf('watchState.delete(session)')
+    expect(spellEnd).toBeGreaterThanOrEqual(0)
+    const after = fnBody.slice(spellEnd, spellEnd + 120)
+    expect(after).toMatch(/alertedSpells\.delete\(session\)/)
+  })
+
+  it('recovery attempts are NOT busy-gated (only the escalation is)', () => {
+    // recoverStuckInputForSession runs before any pane-state gate in the
+    // body: the first gate mention must come after the recovery call.
+    const recoverIdx = fnBody.indexOf('recoverStuckInputForSession(')
+    const gateIdx = fnBody.indexOf('shouldAlertParkedGiveUp(')
+    expect(recoverIdx).toBeGreaterThanOrEqual(0)
+    expect(gateIdx).toBeGreaterThan(recoverIdx)
+  })
+})

--- a/src/web/stuck-input-watcher.ts
+++ b/src/web/stuck-input-watcher.ts
@@ -1,7 +1,7 @@
 import { logger } from '../logger.js'
 import { MAIN_AGENT_ID } from '../config.js'
 import { listAgentNames, readAgentRemoteHost } from './agent-config.js'
-import { isAgentRunning, captureParkedInputView, sendEnterToSession } from './agent-process.js'
+import { isAgentRunning, captureParkedInputView, sendEnterToSession, capturePane } from './agent-process.js'
 import { resolveAgentSession } from './channel-mcp-reconnect.js'
 import { MAIN_CHANNELS_SESSION } from './main-agent.js'
 import { recoverStuckInputForSession, sendAlert } from './channel-monitor.js'
@@ -9,9 +9,42 @@ import {
   stuckInputSignature,
   parkedPasteSignature,
   decideStuckInputRecovery,
+  detectPaneState,
+  type PaneState,
   type StuckInputState,
   type StuckInputThresholds,
 } from '../pane-state.js'
+
+// RIASZTASZAJ819: the owner alert for a parked-past-max-attempts sub-agent
+// fired three times in one afternoon at an agent that was WORKING the whole
+// time (its outbound messages bracket every alert timestamp). Parked input at
+// a BUSY agent is normal: a message that arrives mid-turn sits in the TUI
+// until the turn ends and then submits on its own. The recovery Enters are
+// harmless and stay; only the OWNER ESCALATION must require an idle pane.
+//
+// PURE decision, unit-tested: alert exactly once per spell, and only when the
+// give-up threshold is spent AND the pane is NOT busy at this tick.
+//   - 'busy'            -> suppress (waiting, not wedged). The spell stays
+//                          open, so if the turn ends and the input is STILL
+//                          parked, a later idle tick fires the alert -- the
+//                          real bug is never silenced, only deferred to the
+//                          moment it is distinguishable from waiting.
+//   - idle/typing/unknown -> alert: parked input at a non-busy pane after all
+//                          recovery attempts is the genuine wedge ('unknown'
+//                          deliberately alerts -- an unreadable pane with a
+//                          stuck spell deserves eyes, not silence).
+export function shouldAlertParkedGiveUp(opts: {
+  attempts: number
+  maxAttempts: number
+  alreadyAlerted: boolean
+  paneState: PaneState | null
+}): boolean {
+  const { attempts, maxAttempts, alreadyAlerted, paneState } = opts
+  if (alreadyAlerted) return false
+  if (attempts < maxAttempts) return false
+  if (paneState === 'busy') return false
+  return true
+}
 
 // Backstop recovery for a swallowed Enter on the channel-notification
 // path. Inbound Telegram/Slack messages are delivered into the session by
@@ -78,6 +111,10 @@ const INTERVAL_MS = 15_000
 const NO_STATE: StuckInputState = { parkedSig: null, firstSeenAt: null, lastRecoverAt: null, attempts: 0 }
 
 const watchState = new Map<string, StuckInputState>()
+// One owner alert per spell (RIASZTASZAJ819): entries live while a spell is
+// open and are dropped with it, so a NEW spell on the same session alerts
+// again. Not persisted -- a dashboard restart may re-alert once, acceptable.
+const alertedSpells = new Set<string>()
 
 // Backstop for a PARKED `[Pasted text #N]` placeholder -- a long inbound prompt
 // (e.g. a scheduled-task notice > ~700 chars) the TUI collapsed into a paste
@@ -196,15 +233,31 @@ async function checkLocalSession(label: string, session: string, alertOnGiveUp: 
 
   if (next.parkedSig === null) {
     watchState.delete(session)
+    alertedSpells.delete(session)
   } else {
     watchState.set(session, next)
-    if (
-      alertOnGiveUp &&
-      next.attempts >= LOCAL_FAST_THRESHOLDS.maxAttempts &&
-      prev.attempts < LOCAL_FAST_THRESHOLDS.maxAttempts
-    ) {
-      logger.warn({ label, session }, 'stuck-input-watcher: sub-agent input still parked after max recovery attempts, alerting for manual restart')
-      sendAlert(`⚠️ A(z) ${label} agens bemenete beragadt és az auto-recovery (Enter + clear/re-inject) nem szabadította ki. Valószínűleg kézi restart kell: POST /api/agents/${label}/restart vagy a dashboardon.`)
+    if (alertOnGiveUp && next.attempts >= LOCAL_FAST_THRESHOLDS.maxAttempts) {
+      // RIASZTASZAJ819: the owner escalation requires an IDLE pane. A parked
+      // input at a busy agent is a message waiting out the current turn, not
+      // a wedge -- three false owner alerts in one afternoon came from
+      // exactly this (the agent's own outbound messages bracketed every
+      // alert). Recovery attempts above are untouched; only the alert gates.
+      const pane = capturePane(session)
+      const paneState = pane != null ? detectPaneState(pane) : null
+      if (shouldAlertParkedGiveUp({
+        attempts: next.attempts,
+        maxAttempts: LOCAL_FAST_THRESHOLDS.maxAttempts,
+        alreadyAlerted: alertedSpells.has(session),
+        paneState,
+      })) {
+        alertedSpells.add(session)
+        logger.warn({ label, session, paneState }, 'stuck-input-watcher: sub-agent input still parked after max recovery attempts at a non-busy pane, alerting for manual restart')
+        sendAlert(`⚠️ A(z) ${label} agens bemenete beragadt és az auto-recovery (Enter + clear/re-inject) nem szabadította ki. Valószínűleg kézi restart kell: POST /api/agents/${label}/restart vagy a dashboardon.`)
+      } else if (paneState === 'busy' && prev.attempts < LOCAL_FAST_THRESHOLDS.maxAttempts) {
+        // Once per spell, at the crossing tick: say WHY no alert went out, so
+        // a real wedge investigation finds the suppression instead of a hole.
+        logger.info({ label, session }, 'stuck-input-watcher: parked past max attempts but the pane is BUSY -- input is waiting out the turn, owner alert suppressed until an idle tick (RIASZTASZAJ819)')
+      }
     }
   }
 }


### PR DESCRIPTION
## RIASZTASZAJ819: the owner alert for a parked sub-agent input now requires an idle pane

**Finding (Marveen's measurement):** three identical owner alerts in 2.5h ("a samu agens bemenete beragadt ... kezi restart kell", 13:43/14:37/15:37) at an agent that was working the whole time -- its outbound messages bracket every alert timestamp, no manual restart happened or was needed. Mechanism: `checkLocalSession` escalates after `maxAttempts` with **no busy-check** -- but a message arriving mid-turn legitimately sits parked in the TUI until the turn ends, then submits on its own. Parked+busy = waiting; parked+idle = the real bug.

### The fix
Only the **owner escalation** gates; recovery (Enter -> clear+re-inject) is untouched. The decision is a pure, exported, unit-tested function (`shouldAlertParkedGiveUp`):

- `busy` pane -> suppress, **but the spell keeps its alert armed**: the first idle tick with the input still parked fires it. The real wedge is deferred to the moment it is distinguishable from waiting -- never silenced. (This is deliberately NOT threshold-raising or muting: those would silence the genuine positive too.)
- `idle` / `typing` / `unknown` / `error` -> alert (an unreadable pane with a stuck spell deserves eyes, not silence).
- One alert per spell (`alertedSpells`, dropped with the spell so a new spell re-alerts).
- The suppression is logged once per spell at the crossing tick, so a wedge investigation finds the suppression instead of a hole.

### Evidence
- Full suite **280 files / 3757 tests green**; real tsc clean (non-/tmp worktree).
- Pure-fn unit cases incl. the deferred-alert tick sequence (busy, busy, idle -> fires exactly on the idle tick).
- **Two mutation red-runs, both seen failing on the right assertions:** (A) busy-suppress removed from the pure fn -> the two busy tests fail; (B) gate bypassed in `checkLocalSession` (old one-shot condition restored) -> the two wiring pins fail. Restore -> green. Wiring windows are structurally anchored (function start -> its own closing brace), never derived from the sought string.

Not addressed here (per the card): the pr-figyeles zero-output finding is PRWATCHBLIND818 (task disabled by Marveen until fixed, with positive control required); the broader "agent-ops alerts should route to the coordinator first" question is an owner decision, separate PR if approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
