### PR TITLE
fix(heartbeat-summary): counts-first, truncated, capped payload (HBKANBANDRIFT819)

### DIFF
--- a/src/__tests__/heartbeat-hot-memory-count.test.ts
+++ b/src/__tests__/heartbeat-hot-memory-count.test.ts
@@ -72,7 +72,15 @@ describe('wiring contract: the number flows endpoint -> agent, never agent -> qu
     const end = KANBAN.indexOf('return true', start)
     expect(end).toBeGreaterThan(start)
     const handler = KANBAN.slice(start, end)
-    expect(handler).toMatch(/new_hot_memories_1h:\s*countNewHotMemories\(MAIN_AGENT_ID\)/)
+    // HBKANBANDRIFT819 moved the response shape into the pure builder; the
+    // protected property is unchanged: the hot count is computed with the
+    // MAIN agent's id and flows into the served response.
+    expect(handler).toMatch(/buildHeartbeatSummaryResponse\([\s\S]*countNewHotMemories\(MAIN_AGENT_ID\)/)
+    // And the builder puts it under counts (the copy-surface the scaffold names).
+    const bStart = KANBAN.indexOf('export function buildHeartbeatSummaryResponse')
+    expect(bStart).toBeGreaterThanOrEqual(0)
+    const builder = KANBAN.slice(bStart, KANBAN.indexOf('\n}', bStart))
+    expect(builder).toMatch(/new_hot_memories_1h:\s*newHotMemories1h/)
   })
 
   it('the scaffold tells the agent to COPY the field and forbids running a query for it', () => {

--- a/src/__tests__/heartbeat-summary-truncation-safe.test.ts
+++ b/src/__tests__/heartbeat-summary-truncation-safe.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import {
+  buildHeartbeatSummaryResponse,
+  HEARTBEAT_SUMMARY_TITLE_MAX,
+  HEARTBEAT_SUMMARY_WAITING_CAP,
+} from '../web/routes/kanban.js'
+
+// HBKANBANDRIFT819: the 16:42 heartbeat reported waiting:12 against a real
+// 280. The endpoint's counts were CORRECT -- but the payload was ~31KB (board
+// titles here run to 15KB each) and `counts` serialized LAST, so a reader
+// that lost the tail lost exactly the numbers and counted the visible list
+// instead. Same family as HBMEMBLIND807/819: the number's production must not
+// depend on the measured party's reading stamina. Three properties pinned:
+// counts-first ordering, server-side truncation, capped list with FULL totals.
+
+function card(id: string, title: string, status: string, updated_at: number) {
+  return { id, title, status, priority: 'normal', assignee: null, updated_at }
+}
+
+function bigSummary() {
+  const waiting = Array.from({ length: 280 }, (_, i) =>
+    card(`W${i}`, 'x'.repeat(15_000), 'waiting', 1000 + i))
+  const urgent = Array.from({ length: 4 }, (_, i) =>
+    card(`U${i}`, 'sürgős '.repeat(400), 'planned', 2000 + i))
+  return { urgent, in_progress: [], waiting }
+}
+
+describe('buildHeartbeatSummaryResponse (pure)', () => {
+  it('counts is the FIRST serialized key, so truncated reads lose lists, never numbers', () => {
+    const json = JSON.stringify(buildHeartbeatSummaryResponse(bigSummary(), 2))
+    expect(json.startsWith('{"counts":')).toBe(true)
+    // The whole counts object must fit well inside any sane read window: the
+    // first 200 bytes carry every number even if 99% of the payload is lost.
+    const head = json.slice(0, 200)
+    expect(head).toContain('"waiting":280')
+    expect(head).toContain('"new_hot_memories_1h":2')
+  })
+
+  it('counts.waiting is the FULL total, never the capped list length (the 2026-08-04 lesson in endpoint form)', () => {
+    const r = buildHeartbeatSummaryResponse(bigSummary(), 0)
+    expect(r.counts.waiting).toBe(280)
+    expect(r.waiting.length).toBe(HEARTBEAT_SUMMARY_WAITING_CAP)
+    expect(r.waiting_shown).toBe(HEARTBEAT_SUMMARY_WAITING_CAP)
+  })
+
+  it('the waiting list carries the most recently UPDATED cards', () => {
+    const r = buildHeartbeatSummaryResponse(bigSummary(), 0)
+    // Fixture updated_at grows with the index, so the newest ids are the highest.
+    expect(r.waiting[0].id).toBe('W279')
+    expect(r.waiting[HEARTBEAT_SUMMARY_WAITING_CAP - 1].id).toBe(`W${280 - HEARTBEAT_SUMMARY_WAITING_CAP}`)
+  })
+
+  it('every title is truncated server-side; short titles pass through untouched', () => {
+    const r = buildHeartbeatSummaryResponse(bigSummary(), 0)
+    for (const c of [...r.urgent, ...r.waiting]) {
+      expect(c.title.length).toBeLessThanOrEqual(HEARTBEAT_SUMMARY_TITLE_MAX + 1) // +1 for the ellipsis
+    }
+    const small = buildHeartbeatSummaryResponse(
+      { urgent: [card('A', 'rövid cím', 'waiting', 1)], in_progress: [], waiting: [] }, 0)
+    expect(small.urgent[0].title).toBe('rövid cím')
+  })
+
+  it('the payload with 280 huge-titled cards stays small enough to never truncate in practice', () => {
+    const json = JSON.stringify(buildHeartbeatSummaryResponse(bigSummary(), 0))
+    // Pre-fix this was ~4.2MB with these fixtures (280 x 15KB); the cap+trunc
+    // must keep it in the low KB range.
+    expect(json.length).toBeLessThan(10_000)
+  })
+})
+
+// --- wiring contract (structurally anchored windows) ---
+
+const ROOT = join(__dirname, '..', '..')
+const KANBAN = readFileSync(join(ROOT, 'src', 'web', 'routes', 'kanban.ts'), 'utf-8')
+const SCAFFOLD = readFileSync(join(ROOT, 'src', 'web', 'heartbeat-agent-scaffold.ts'), 'utf-8')
+
+describe('wiring: the endpoint serves the pure builder, the scaffold forbids counting lists', () => {
+  it('the heartbeat-summary handler goes through buildHeartbeatSummaryResponse', () => {
+    const start = KANBAN.indexOf("'/api/kanban/heartbeat-summary'")
+    expect(start).toBeGreaterThanOrEqual(0)
+    const handler = KANBAN.slice(start, KANBAN.indexOf('return true', start))
+    expect(handler).toMatch(/buildHeartbeatSummaryResponse\(/)
+  })
+
+  it('the scaffold says numbers come from counts.* only and names the drift incident', () => {
+    expect(SCAFFOLD).toMatch(/EVERY NUMBER COMES FROM \\`counts\.\*\\`/)
+    expect(SCAFFOLD).toMatch(/HBKANBANDRIFT819/)
+    expect(SCAFFOLD).toMatch(/never count the lists as/)
+  })
+})

--- a/src/__tests__/heartbeat-summary-truncation-safe.test.ts
+++ b/src/__tests__/heartbeat-summary-truncation-safe.test.ts
@@ -29,41 +29,44 @@ function bigSummary() {
 
 describe('buildHeartbeatSummaryResponse (pure)', () => {
   it('counts is the FIRST serialized key, so truncated reads lose lists, never numbers', () => {
-    const json = JSON.stringify(buildHeartbeatSummaryResponse(bigSummary(), 2))
+    const json = JSON.stringify(buildHeartbeatSummaryResponse(bigSummary(), 2, 305))
     expect(json.startsWith('{"counts":')).toBe(true)
     // The whole counts object must fit well inside any sane read window: the
     // first 200 bytes carry every number even if 99% of the payload is lost.
     const head = json.slice(0, 200)
     expect(head).toContain('"waiting":280')
+    // planned has no list at all, so its ONLY existence is this number --
+    // measured 2026-08-19 17:00: planned: 0 reported against a real 305.
+    expect(head).toContain('"planned":305')
     expect(head).toContain('"new_hot_memories_1h":2')
   })
 
   it('counts.waiting is the FULL total, never the capped list length (the 2026-08-04 lesson in endpoint form)', () => {
-    const r = buildHeartbeatSummaryResponse(bigSummary(), 0)
+    const r = buildHeartbeatSummaryResponse(bigSummary(), 0, 305)
     expect(r.counts.waiting).toBe(280)
     expect(r.waiting.length).toBe(HEARTBEAT_SUMMARY_WAITING_CAP)
     expect(r.waiting_shown).toBe(HEARTBEAT_SUMMARY_WAITING_CAP)
   })
 
   it('the waiting list carries the most recently UPDATED cards', () => {
-    const r = buildHeartbeatSummaryResponse(bigSummary(), 0)
+    const r = buildHeartbeatSummaryResponse(bigSummary(), 0, 305)
     // Fixture updated_at grows with the index, so the newest ids are the highest.
     expect(r.waiting[0].id).toBe('W279')
     expect(r.waiting[HEARTBEAT_SUMMARY_WAITING_CAP - 1].id).toBe(`W${280 - HEARTBEAT_SUMMARY_WAITING_CAP}`)
   })
 
   it('every title is truncated server-side; short titles pass through untouched', () => {
-    const r = buildHeartbeatSummaryResponse(bigSummary(), 0)
+    const r = buildHeartbeatSummaryResponse(bigSummary(), 0, 305)
     for (const c of [...r.urgent, ...r.waiting]) {
       expect(c.title.length).toBeLessThanOrEqual(HEARTBEAT_SUMMARY_TITLE_MAX + 1) // +1 for the ellipsis
     }
     const small = buildHeartbeatSummaryResponse(
-      { urgent: [card('A', 'rövid cím', 'waiting', 1)], in_progress: [], waiting: [] }, 0)
+      { urgent: [card('A', 'rövid cím', 'waiting', 1)], in_progress: [], waiting: [] }, 0, 0)
     expect(small.urgent[0].title).toBe('rövid cím')
   })
 
   it('the payload with 280 huge-titled cards stays small enough to never truncate in practice', () => {
-    const json = JSON.stringify(buildHeartbeatSummaryResponse(bigSummary(), 0))
+    const json = JSON.stringify(buildHeartbeatSummaryResponse(bigSummary(), 0, 305))
     // Pre-fix this was ~4.2MB with these fixtures (280 x 15KB); the cap+trunc
     // must keep it in the low KB range.
     expect(json.length).toBeLessThan(10_000)
@@ -82,6 +85,9 @@ describe('wiring: the endpoint serves the pure builder, the scaffold forbids cou
     expect(start).toBeGreaterThanOrEqual(0)
     const handler = KANBAN.slice(start, KANBAN.indexOf('return true', start))
     expect(handler).toMatch(/buildHeartbeatSummaryResponse\(/)
+    // planned must come from its sanctioned server-side counter, or the agent
+    // manufactures it again (planned: 0 vs real 305, 2026-08-19 17:00).
+    expect(handler).toMatch(/countPlannedKanbanCards\(\)/)
   })
 
   it('the scaffold says numbers come from counts.* only and names the drift incident', () => {

--- a/src/db.ts
+++ b/src/db.ts
@@ -2043,6 +2043,19 @@ export const HEARTBEAT_IN_PROGRESS_SQL =
 export const HEARTBEAT_WAITING_SQL =
   "SELECT * FROM kanban_cards WHERE archived_at IS NULL AND status = 'waiting'"
 
+// HBKANBANDRIFT819 follow-up: the heartbeat report format asks for a planned
+// line, so the number needs a sanctioned server-side source like every other
+// count -- without it the agent manufactures the value (measured: planned: 0
+// reported against a real 305). COUNT only: no card list is served for
+// planned, the line is a bare number.
+export const HEARTBEAT_PLANNED_COUNT_SQL =
+  "SELECT COUNT(*) AS n FROM kanban_cards WHERE archived_at IS NULL AND status = 'planned'"
+
+export function countPlannedKanbanCards(): number {
+  const row = db.prepare(HEARTBEAT_PLANNED_COUNT_SQL).get() as { n: number } | undefined
+  return row?.n ?? 0
+}
+
 export function getHeartbeatKanbanSummary(): HeartbeatKanbanSummary {
   const urgent = db.prepare(HEARTBEAT_URGENT_SQL).all() as KanbanCard[]
   const in_progress = db.prepare(HEARTBEAT_IN_PROGRESS_SQL).all() as KanbanCard[]

--- a/src/web/heartbeat-agent-scaffold.ts
+++ b/src/web/heartbeat-agent-scaffold.ts
@@ -212,11 +212,21 @@ When you receive the heartbeat prompt:
      \`\`\`
 
      It returns exactly what this section may report:
-     \`{"urgent":[...], "waiting":[...], "counts":{...}}\`, where the
+     \`{"counts":{...}, "urgent":[...], "waiting":[...]}\`, where the
      lists contain only UNFINISHED cards -- never archived, never
      \`done\`, but \`planned\` included, because "urgent and nobody
      has touched it" is exactly what this line is for. Report the ids
      and titles it gives you and nothing else.
+
+     EVERY NUMBER COMES FROM \`counts.*\` AND NOWHERE ELSE
+     (HBKANBANDRIFT819): the lists are capped and their titles
+     truncated BY DESIGN (waiting shows only the few most recently
+     updated; \`counts.waiting\` is the full total), so counting the
+     array items gives a number that is WRONG on purpose. Measured
+     2026-08-19 16:42: a heartbeat counted a truncated list and
+     reported waiting: 12 against a real 280. If \`counts\` is missing
+     from the response, write "nincs adat" -- never count the lists as
+     a substitute.
 
      Two things this replaces, both measured: the old instruction told
      you to write the filter yourself, and on 2026-08-04 the 09:00

--- a/src/web/routes/kanban.ts
+++ b/src/web/routes/kanban.ts
@@ -117,6 +117,53 @@ function fireKanbanDispatch(id: string, actor?: string | null): void {
   }
 }
 
+// HBKANBANDRIFT819: the heartbeat-summary payload, shaped so that TRUNCATED
+// reads still carry the truth. Pure and exported so tests can pin all three
+// properties without HTTP:
+//   1. `counts` is the FIRST key -- JSON.stringify preserves insertion order,
+//      so a reader that loses the tail loses list items, never the numbers;
+//   2. every title is truncated server-side (board titles here run to 15KB);
+//   3. the waiting LIST is capped to the most recently-updated few, while
+//      counts.waiting always carries the FULL total -- the list names items,
+//      the numbers only ever come from counts.
+export const HEARTBEAT_SUMMARY_TITLE_MAX = 160
+export const HEARTBEAT_SUMMARY_WAITING_CAP = 8
+
+type HeartbeatSummaryCard = {
+  id: string; title: string; status: string; priority: string;
+  assignee?: string | null; updated_at?: number | null;
+}
+
+export function buildHeartbeatSummaryResponse(
+  summary: { urgent: HeartbeatSummaryCard[]; in_progress: HeartbeatSummaryCard[]; waiting: HeartbeatSummaryCard[] },
+  newHotMemories1h: number,
+) {
+  const trunc = (t: string) =>
+    t.length > HEARTBEAT_SUMMARY_TITLE_MAX ? t.slice(0, HEARTBEAT_SUMMARY_TITLE_MAX) + '…' : t
+  const slim = (c: HeartbeatSummaryCard) => ({
+    id: c.id, title: trunc(c.title), status: c.status, priority: c.priority, assignee: c.assignee ?? null,
+  })
+  const waitingRecent = [...summary.waiting]
+    .sort((a, b) => (b.updated_at ?? 0) - (a.updated_at ?? 0))
+    .slice(0, HEARTBEAT_SUMMARY_WAITING_CAP)
+  return {
+    counts: {
+      urgent: summary.urgent.length,
+      in_progress: summary.in_progress.length,
+      // The FULL total, never the capped list length -- the 2026-08-04 lesson
+      // (waiting: 10 reported against 130 real) in endpoint form.
+      waiting: summary.waiting.length,
+      // HBMEMBLIND819: computed server-side with the MAIN agent's id so the
+      // heartbeat agent copies a number instead of running (and rewriting)
+      // a query -- see HEARTBEAT_NEW_HOT_MEMORIES_SQL in db.ts.
+      new_hot_memories_1h: newHotMemories1h,
+    },
+    urgent: summary.urgent.map(slim),
+    waiting: waitingRecent.map(slim),
+    waiting_shown: Math.min(summary.waiting.length, HEARTBEAT_SUMMARY_WAITING_CAP),
+  }
+}
+
 export async function tryHandleKanban(ctx: RouteContext): Promise<boolean> {
   const { req, res, path, method } = ctx
 
@@ -137,24 +184,18 @@ export async function tryHandleKanban(ctx: RouteContext): Promise<boolean> {
   // not a mechanism; an endpoint that cannot return a closed card is. It also
   // removes the sqlite3 CLI from that path, which does not exist on a stock
   // Linux install (#870).
+  //
+  // HBKANBANDRIFT819 (2026-08-19): the 16:42 heartbeat reported waiting:12
+  // against a real 280 -- the endpoint's counts were CORRECT, but the payload
+  // was ~31KB (card titles on this board run to 15KB EACH) and `counts` was
+  // serialized LAST, after the huge arrays. An agent reading truncated output
+  // lost exactly the numbers and counted the visible list instead. Fixes here:
+  // counts serialize FIRST (truncation-resilient ordering), titles are
+  // truncated server-side, and the waiting list is capped to the most recent
+  // few -- while counts.* always carries the FULL totals. The list is for
+  // naming items; the numbers ONLY ever come from counts.
   if (path === '/api/kanban/heartbeat-summary' && method === 'GET') {
-    const summary = getHeartbeatKanbanSummary()
-    const slim = (c: { id: string; title: string; status: string; priority: string; assignee?: string | null }) => ({
-      id: c.id, title: c.title, status: c.status, priority: c.priority, assignee: c.assignee ?? null,
-    })
-    json(res, {
-      urgent: summary.urgent.map(slim),
-      waiting: summary.waiting.map(slim),
-      counts: {
-        urgent: summary.urgent.length,
-        in_progress: summary.in_progress.length,
-        waiting: summary.waiting.length,
-        // HBMEMBLIND819: computed server-side with the MAIN agent's id so the
-        // heartbeat agent copies a number instead of running (and rewriting)
-        // a query -- see HEARTBEAT_NEW_HOT_MEMORIES_SQL in db.ts.
-        new_hot_memories_1h: countNewHotMemories(MAIN_AGENT_ID),
-      },
-    })
+    json(res, buildHeartbeatSummaryResponse(getHeartbeatKanbanSummary(), countNewHotMemories(MAIN_AGENT_ID)))
     return true
   }
 

--- a/src/web/routes/kanban.ts
+++ b/src/web/routes/kanban.ts
@@ -13,6 +13,7 @@ import {
   revertIdeaFromKanban,
   getHeartbeatKanbanSummary,
   countNewHotMemories,
+  countPlannedKanbanCards,
 } from '../../db.js'
 import { normalizeKanbanRefs } from '../kanban-ref-normalize.js'
 import { OWNER_NAME, BOT_NAME, MAIN_AGENT_ID, STORE_DIR, WEB_HOST, WEB_PORT, KANBAN_LABEL_COLORS } from '../../config.js'
@@ -137,6 +138,7 @@ type HeartbeatSummaryCard = {
 export function buildHeartbeatSummaryResponse(
   summary: { urgent: HeartbeatSummaryCard[]; in_progress: HeartbeatSummaryCard[]; waiting: HeartbeatSummaryCard[] },
   newHotMemories1h: number,
+  plannedCount: number,
 ) {
   const trunc = (t: string) =>
     t.length > HEARTBEAT_SUMMARY_TITLE_MAX ? t.slice(0, HEARTBEAT_SUMMARY_TITLE_MAX) + '…' : t
@@ -153,6 +155,10 @@ export function buildHeartbeatSummaryResponse(
       // The FULL total, never the capped list length -- the 2026-08-04 lesson
       // (waiting: 10 reported against 130 real) in endpoint form.
       waiting: summary.waiting.length,
+      // The report format asks for a planned line; without a sanctioned
+      // source here the agent manufactured the value (planned: 0 against a
+      // real 305, measured 2026-08-19 17:00). Count only, no list.
+      planned: plannedCount,
       // HBMEMBLIND819: computed server-side with the MAIN agent's id so the
       // heartbeat agent copies a number instead of running (and rewriting)
       // a query -- see HEARTBEAT_NEW_HOT_MEMORIES_SQL in db.ts.
@@ -195,7 +201,7 @@ export async function tryHandleKanban(ctx: RouteContext): Promise<boolean> {
   // few -- while counts.* always carries the FULL totals. The list is for
   // naming items; the numbers ONLY ever come from counts.
   if (path === '/api/kanban/heartbeat-summary' && method === 'GET') {
-    json(res, buildHeartbeatSummaryResponse(getHeartbeatKanbanSummary(), countNewHotMemories(MAIN_AGENT_ID)))
+    json(res, buildHeartbeatSummaryResponse(getHeartbeatKanbanSummary(), countNewHotMemories(MAIN_AGENT_ID), countPlannedKanbanCards()))
     return true
   }
 


### PR DESCRIPTION
## HBKANBANDRIFT819: a truncated read of heartbeat-summary must lose list items, never the numbers

**Finding (Marveen's measurement):** the 16:42 heartbeat reported `waiting: 12` against a real **280**. The endpoint's counts were correct and byte-identical to the SQL — but the payload was ~31KB (single card titles on this board run to **15KB**, measured) and `counts` serialized **last**, after the huge arrays. An agent reading truncated output lost exactly the numbers and counted the visible list instead. Same family as HBMEMBLIND807/819: the number's production must not depend on the measured party's reading stamina.

### The fix (pure, exported builder — three pinned properties)
1. **`counts` is the FIRST serialized key** — `JSON.stringify` preserves insertion order, so a lost tail loses list items, never numbers. With the measured fixture shape, every number sits in the first 200 bytes.
2. **Titles truncated server-side** (160 chars + ellipsis).
3. **Waiting list capped to the 8 most recently updated**, while `counts.waiting` always carries the **full** total (the 2026-08-04 `waiting:10`-vs-130 lesson in endpoint form); `waiting_shown` says how many are listed.

Payload with the measured shape (280 cards × 15KB titles): **~4.2MB → <10KB**.

### Scaffold
The kanban bullet now states every number comes from `counts.*` and that counting the arrays gives a number that is **wrong on purpose** (the lists are capped by design), naming the incident. Missing `counts` degrades to "nincs adat" — never to counting.

### Evidence
- Full suite **281 files / 3764 tests green**; real tsc clean (non-/tmp worktree).
- **Three mutation red-runs, each seen failing on its own assertion:** (A) a real-valued key ahead of `counts` → the counts-first test fails alone (first attempt used an `undefined`-valued key, which `JSON.stringify` drops — an invalid no-op mutation, caught and redone); (B) `counts.waiting` switched to the capped length → the full-total test fails; (C) truncation removed → the truncation + payload-size tests fail. Restore → green.
- The #1007 wiring pin went red on this refactor exactly as designed and was updated to the new contract (hot count still computes with `MAIN_AGENT_ID` and flows into the served `counts`).

Rollout: scaffold CLAUDE.md regenerates on dashboard boot — live after build + restart (tonight's HOSTUP819 covers it). Acceptance is a positive control: the next heartbeat round after rollout must report `waiting` equal to `counts.waiting` (currently ~280), not a small list-count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
