### PR TITLE
feat: MiniMax M3 provider integration + agent-card context-window badge

### DIFF
--- a/src/__tests__/agent-provider-env.test.ts
+++ b/src/__tests__/agent-provider-env.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import { resolveProviderEnv } from '../web/agent-process.js'
+
+describe('resolveProviderEnv', () => {
+  it('returns no export chain for a claude- model (uses host OAuth/API key elsewhere)', () => {
+    const r = resolveProviderEnv('claude-sonnet-5', () => null)
+    expect(r.provider).toBe('claude')
+    expect(r.exportsStr).toBe('')
+  })
+
+  it('routes deepseek- models to the DeepSeek Anthropic-compatible endpoint with DEEPSEEK_API_KEY', () => {
+    const seen: string[] = []
+    const r = resolveProviderEnv('deepseek-v4-pro', (id) => {
+      seen.push(id)
+      return 'ds-secret'
+    })
+    expect(r.provider).toBe('deepseek')
+    expect(seen).toEqual(['DEEPSEEK_API_KEY'])
+    expect(r.exportsStr).toContain('ANTHROPIC_AUTH_TOKEN="ds-secret"')
+    expect(r.exportsStr).toContain('ANTHROPIC_BASE_URL=https://api.deepseek.com/anthropic')
+    expect(r.exportsStr).toContain(`ANTHROPIC_MODEL='deepseek-v4-pro'`)
+  })
+
+  it('routes minimax- models to the MiniMax Anthropic-compatible endpoint with MINIMAX_API_KEY', () => {
+    const seen: string[] = []
+    const r = resolveProviderEnv('minimax-m3', (id) => {
+      seen.push(id)
+      return 'mm-secret'
+    })
+    expect(r.provider).toBe('minimax')
+    expect(seen).toEqual(['MINIMAX_API_KEY'])
+    expect(r.exportsStr).toContain('ANTHROPIC_AUTH_TOKEN="mm-secret"')
+    expect(r.exportsStr).toContain('ANTHROPIC_BASE_URL=https://api.minimax.io/anthropic')
+    expect(r.exportsStr).toContain(`ANTHROPIC_MODEL='minimax-m3'`)
+  })
+
+  it('routes provider/model ids (containing "/") to OpenRouter, not minimax or ollama', () => {
+    const seen: string[] = []
+    const r = resolveProviderEnv('minimax/minimax-m3', (id) => {
+      seen.push(id)
+      return 'or-secret'
+    })
+    expect(r.provider).toBe('openrouter')
+    expect(seen).toEqual(['openrouter-fleet-key'])
+    expect(r.exportsStr).toContain('ANTHROPIC_BASE_URL=https://openrouter.ai/api')
+  })
+
+  it('falls back to Ollama for a bare tag (no "claude-"/"deepseek-"/"minimax-" prefix, no "/")', () => {
+    const r = resolveProviderEnv('qwen3.6:27b', () => null)
+    expect(r.provider).toBe('ollama')
+    expect(r.exportsStr).toContain('ANTHROPIC_AUTH_TOKEN=ollama')
+    expect(r.exportsStr).toContain(`ANTHROPIC_MODEL='qwen3.6:27b'`)
+  })
+
+  it('never asks the secret lookup for a claude- model', () => {
+    let called = false
+    resolveProviderEnv('claude-sonnet-5', () => {
+      called = true
+      return 'unused'
+    })
+    expect(called).toBe(false)
+  })
+})

--- a/src/__tests__/agent-provider-env.test.ts
+++ b/src/__tests__/agent-provider-env.test.ts
@@ -34,6 +34,16 @@ describe('resolveProviderEnv', () => {
     expect(r.exportsStr).toContain(`ANTHROPIC_MODEL='minimax-m3'`)
   })
 
+  it('forces CLAUDE_CODE_MAX_CONTEXT_TOKENS=1000000 for minimax- models -- the /anthropic compat layer misreports 200K (MiniMax-AI/MiniMax-M2.7#46), so the CLI must be told the real window explicitly', () => {
+    const r = resolveProviderEnv('minimax-m3', () => 'mm-secret')
+    expect(r.exportsStr).toContain('CLAUDE_CODE_MAX_CONTEXT_TOKENS=1000000')
+  })
+
+  it('does NOT force CLAUDE_CODE_MAX_CONTEXT_TOKENS for a claude- model -- the override is minimax-specific, not a blanket setting', () => {
+    const r = resolveProviderEnv('claude-sonnet-5', () => null)
+    expect(r.exportsStr).not.toContain('CLAUDE_CODE_MAX_CONTEXT_TOKENS')
+  })
+
   it('routes provider/model ids (containing "/") to OpenRouter, not minimax or ollama', () => {
     const seen: string[] = []
     const r = resolveProviderEnv('minimax/minimax-m3', (id) => {

--- a/src/__tests__/context-guard.test.ts
+++ b/src/__tests__/context-guard.test.ts
@@ -89,6 +89,22 @@ describe('contextLimitForModel / calibrateLimit', () => {
     expect(contextLimitForModel(null)).toBe(200_000)
   })
 
+  it('trusts minimax-m3 for the real 1M window -- but ONLY because agent-process.ts forces CLAUDE_CODE_MAX_CONTEXT_TOKENS=1000000 to work around a vendor-side compat-layer bug', () => {
+    // MiniMax's own /anthropic compat endpoint misreports 200K in its model
+    // metadata instead of M3's real 1M (MiniMax-AI/MiniMax-M2.7#46). Measured
+    // live 2026-08-19 BEFORE the workaround, on two independently running
+    // fleet agents (mag 108992/54%=201.8k, rendezo 62810/31%=202.6k) -- both
+    // converged on ~200k, matching the vendor bug exactly. AFTER
+    // resolveProviderEnv started forcing CLAUDE_CODE_MAX_CONTEXT_TOKENS=1000000,
+    // a live restart confirmed the CLI itself now reports a ~1M window (pane
+    // showed "999k left" / "937k left" post-restart, up from "199k left" /
+    // "137k left"). This constant and that env var override are a PAIR: if the
+    // override in agent-process.ts is ever removed, this must revert to
+    // 200_000 (like deepseek-v4-pro above), or the guard will under-restart
+    // against a window the CLI no longer actually has.
+    expect(contextLimitForModel('minimax-m3')).toBe(1_000_000)
+  })
+
   it('defaults the handoff timeout to 20 minutes (6 was shorter than a working turn)', () => {
     expect(DEFAULT_CONTEXT_GUARD.handoffTimeoutMinutes).toBe(20)
   })

--- a/src/__tests__/minimax-model-selector.test.ts
+++ b/src/__tests__/minimax-model-selector.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+// /api/models/available (src/web/routes/agents.ts) has served a `minimax`
+// array + `minimaxConfigured` flag since kanban card 964a9567 (direct
+// MiniMax API). The dashboard frontend never grew the matching optgroup or
+// loadAvailableModels() wiring to render it -- the model is reachable by the
+// launcher (agent-process.ts) but unreachable from the "Fej - Beállítások /
+// Modell" picker. Reported live 2026-08-18 (Telegram {519}/{520}): the key
+// is configured, the picker still shows nothing.
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const indexHtml = readFileSync(join(__dirname, '..', '..', 'web', 'index.html'), 'utf8')
+const appSource = readFileSync(join(__dirname, '..', '..', 'web', 'app.js'), 'utf8')
+
+describe('MiniMax option group in the model selector', () => {
+  it('wizard "Modell" select has a MiniMax optgroup', () => {
+    expect(indexHtml).toContain('id="agentModelMinimaxGroup"')
+  })
+
+  it('agent edit panel "Modell" select has a MiniMax optgroup', () => {
+    expect(indexHtml).toContain('id="minimaxModelGroup"')
+  })
+
+  it('loadAvailableModels() reads data.minimax and populates both groups', () => {
+    const start = appSource.indexOf('async function loadAvailableModels()')
+    expect(start).toBeGreaterThan(-1)
+    const end = appSource.indexOf('\n// --- OpenRouter manual-list curation', start)
+    expect(end).toBeGreaterThan(start)
+    const body = appSource.slice(start, end)
+
+    expect(body).toContain('data.minimax')
+    expect(body).toContain('agentModelMinimaxGroup')
+    expect(body).toContain('minimaxModelGroup')
+  })
+})

--- a/src/context-guard.ts
+++ b/src/context-guard.ts
@@ -176,6 +176,17 @@ export function contextLimitForModel(model: string | null | undefined): number {
   const m = model.toLowerCase()
   if (m.includes('[1m]')) return 1_000_000
   if (ONE_MILLION_FAMILIES.some(rx => rx.test(m))) return 1_000_000
+  // minimax-m3 is a special case, NOT a general "trust the vendor" precedent
+  // (see deepseek-v4-pro below, which stays 200_000 on live measurement).
+  // MiniMax's own /anthropic compat endpoint misreports 200K in its model
+  // metadata instead of M3's real 1M (MiniMax-AI/MiniMax-M2.7#46) -- but
+  // agent-process.ts's resolveProviderEnv forces
+  // CLAUDE_CODE_MAX_CONTEXT_TOKENS=1000000 for every minimax- launch, which a
+  // live restart confirmed actually works (pane went from "199k left" to
+  // "999k left"). This 1M and that env var override are a pair: dropping the
+  // override without reverting this would under-restart against a window the
+  // CLI no longer has.
+  if (m.startsWith('minimax-')) return 1_000_000
   return 200_000
 }
 

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -829,6 +829,61 @@ export function shSingleQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`
 }
 
+/**
+ * hu: A modell-azonosító alapján eldönti, melyik providerhez tartozik, és felépíti a shell
+ * export-láncot, ami a Claude Code CLI-t az adott provider Anthropic-kompatibilis végpontjára
+ * téríti. Tiszta függvény (nincs I/O) -- a titkot a hívó adja át `secretLookup`-on keresztül,
+ * hogy vault nélkül tesztelhető legyen.
+ * <br />
+ * en: Resolves which provider a model id belongs to and builds the shell export chain that
+ * redirects the Claude Code CLI to that provider's Anthropic-compatible endpoint. Pure function
+ * (no I/O) -- the caller supplies secrets via `secretLookup` so this is testable without a vault.
+ */
+export type ProviderKind = 'claude' | 'deepseek' | 'minimax' | 'openrouter' | 'ollama'
+
+export function resolveProviderEnv(
+  model: string,
+  secretLookup: (id: string) => string | null,
+): { provider: ProviderKind; exportsStr: string } {
+  const isClaude = model.startsWith('claude-')
+  const isDeepseek = model.startsWith('deepseek-')
+  const isMinimax = model.startsWith('minimax-')
+  // OpenRouter model ids are `provider/model` (contain '/'); Ollama tags use
+  // ':' and no '/'. This discriminator keeps OpenRouter ids off the Ollama path.
+  const isOpenRouter = !isClaude && !isDeepseek && !isMinimax && model.includes('/')
+  const isOllama = !isClaude && !isDeepseek && !isMinimax && !isOpenRouter
+
+  if (isDeepseek) {
+    const key = secretLookup('DEEPSEEK_API_KEY') ?? ''
+    return {
+      provider: 'deepseek',
+      exportsStr: `export ANTHROPIC_AUTH_TOKEN="${key}" && export ANTHROPIC_BASE_URL=https://api.deepseek.com/anthropic && export ANTHROPIC_MODEL=${shSingleQuote(model)} && `,
+    }
+  }
+  if (isMinimax) {
+    const key = secretLookup('MINIMAX_API_KEY') ?? ''
+    return {
+      provider: 'minimax',
+      exportsStr: `export ANTHROPIC_AUTH_TOKEN="${key}" && export ANTHROPIC_BASE_URL=https://api.minimax.io/anthropic && export ANTHROPIC_MODEL=${shSingleQuote(model)} && `,
+    }
+  }
+  if (isOpenRouter) {
+    // Anthropic-compatible endpoint at https://openrouter.ai/api (the SDK appends /v1/messages).
+    const key = secretLookup('openrouter-fleet-key') ?? ''
+    return {
+      provider: 'openrouter',
+      exportsStr: `export ANTHROPIC_AUTH_TOKEN="${key}" && export ANTHROPIC_BASE_URL=https://openrouter.ai/api && export ANTHROPIC_MODEL=${shSingleQuote(model)} && `,
+    }
+  }
+  if (isOllama) {
+    return {
+      provider: 'ollama',
+      exportsStr: `export ANTHROPIC_AUTH_TOKEN=ollama && export ANTHROPIC_BASE_URL=${OLLAMA_URL} && export ANTHROPIC_MODEL=${shSingleQuote(model)} && `,
+    }
+  }
+  return { provider: 'claude', exportsStr: '' }
+}
+
 // All tmux operations route through these two wrappers so the local-vs-remote
 // (ssh) decision and the quoting live in ONE place (ssh-tmux.ts). host=null is
 // byte-identical to the prior direct local tmux call. Remote calls get a larger
@@ -1081,11 +1136,6 @@ export function startAgentProcess(name: string, opts: { fresh?: boolean } = {}):
     const model = resolveOpenRouterModel(readAgentModel(name))
     const authMode = readAgentAuthMode(name)
     const isClaude = model.startsWith('claude-')
-    const isDeepseek = model.startsWith('deepseek-')
-    // OpenRouter model ids are `provider/model` (contain '/'); Ollama tags use
-    // ':' and no '/'. This discriminator keeps OpenRouter ids off the Ollama path.
-    const isOpenRouter = !isClaude && !isDeepseek && model.includes('/')
-    const isOllama = !isClaude && !isDeepseek && !isOpenRouter
     // ANTHROPIC_MODEL is REQUIRED for non-Claude models: the interactive TUI
     // validates the `--model` flag against known Anthropic models and silently
     // falls back to the built-in default (claude-opus-...) for an unrecognized
@@ -1093,13 +1143,9 @@ export function startAgentProcess(name: string, opts: { fresh?: boolean } = {}):
     // the custom ANTHROPIC_BASE_URL ("model does not exist"). The env var is
     // authoritative and bypasses that validation. (`--print` honors --model, but
     // the agents run the TUI.) Single-quoted so a `:` in the tag is shell-safe.
-    const ollamaEnv = isOllama ? `export ANTHROPIC_AUTH_TOKEN=ollama && export ANTHROPIC_BASE_URL=${OLLAMA_URL} && export ANTHROPIC_MODEL=${shSingleQuote(model)} && ` : ''
-    const deepseekKey = isDeepseek ? (getSecret('DEEPSEEK_API_KEY') ?? '') : ''
-    const deepseekEnv = isDeepseek ? `export ANTHROPIC_AUTH_TOKEN="${deepseekKey}" && export ANTHROPIC_BASE_URL=https://api.deepseek.com/anthropic && export ANTHROPIC_MODEL=${shSingleQuote(model)} && ` : ''
-    // OpenRouter: Anthropic-compatible endpoint at https://openrouter.ai/api
-    // (the SDK appends /v1/messages). Key from the vault (openrouter-fleet-key).
-    const openrouterKey = isOpenRouter ? (getSecret('openrouter-fleet-key') ?? '') : ''
-    const openrouterEnv = isOpenRouter ? `export ANTHROPIC_AUTH_TOKEN="${openrouterKey}" && export ANTHROPIC_BASE_URL=https://openrouter.ai/api && export ANTHROPIC_MODEL=${shSingleQuote(model)} && ` : ''
+    // Provider discriminator + env-export chain live in resolveProviderEnv (pure,
+    // unit-tested in agent-provider-env.test.ts) so a new provider is one branch there.
+    const { exportsStr: providerEnv } = resolveProviderEnv(model, getSecret)
     // When authMode is 'api', the agent uses its own ANTHROPIC_API_KEY from
     // the vault instead of the host's OAuth. The vault entry ID follows the
     // convention `agent-{name}-api-key`. We inject it as an env var so Claude
@@ -1374,7 +1420,7 @@ export function startAgentProcess(name: string, opts: { fresh?: boolean } = {}):
     // values like `claude-opus-4-8[1m]` (1M-context suffix) from being glob-expanded AND makes a `'`
     // in the value inert rather than a quote-break -> command injection. Same escape at the three
     // ANTHROPIC_MODEL env sites above.
-    const cmd = `export PATH="/opt/homebrew/bin:$HOME/.bun/bin:/usr/local/bin:/usr/bin:/bin:$PATH" && ${unsetTokens} && ${autoUpdaterEnv}${promptSuggestionEnv}${mcpEnv}${channelSetup}${apiKeyEnv}${claudeConfigEnv}${oauthTokenEnv}${ollamaEnv}${deepseekEnv}${openrouterEnv}cd "${dir}" && ${claudeBin()} ${continueFlag}${skipFlag}--model ${shSingleQuote(model)} ${channelFlag}`.trimEnd()
+    const cmd = `export PATH="/opt/homebrew/bin:$HOME/.bun/bin:/usr/local/bin:/usr/bin:/bin:$PATH" && ${unsetTokens} && ${autoUpdaterEnv}${promptSuggestionEnv}${mcpEnv}${channelSetup}${apiKeyEnv}${claudeConfigEnv}${oauthTokenEnv}${providerEnv}cd "${dir}" && ${claudeBin()} ${continueFlag}${skipFlag}--model ${shSingleQuote(model)} ${channelFlag}`.trimEnd()
     runTmux(null, ['new-session', '-d', '-s', session, cmd], { timeout: 10000 })
 
     logger.info({ name, session, channelDir: agentChannelDir }, 'Agent tmux session started')

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -862,9 +862,16 @@ export function resolveProviderEnv(
   }
   if (isMinimax) {
     const key = secretLookup('MINIMAX_API_KEY') ?? ''
+    // MiniMax's own /anthropic compat layer misreports a 200K context window in
+    // its model metadata instead of M3's real 1M (MiniMax-AI/MiniMax-M2.7#46,
+    // confirmed live 2026-08-19: two independently running fleet agents on
+    // minimax-m3 converged on a measured ~200-203k ceiling). Claude Code trusts
+    // that metadata and auto-compacts at ~167k as a result. This env var is the
+    // vendor-documented workaround -- it tells the CLI the real number instead
+    // of the compat layer's wrong one.
     return {
       provider: 'minimax',
-      exportsStr: `export ANTHROPIC_AUTH_TOKEN="${key}" && export ANTHROPIC_BASE_URL=https://api.minimax.io/anthropic && export ANTHROPIC_MODEL=${shSingleQuote(model)} && `,
+      exportsStr: `export ANTHROPIC_AUTH_TOKEN="${key}" && export ANTHROPIC_BASE_URL=https://api.minimax.io/anthropic && export ANTHROPIC_MODEL=${shSingleQuote(model)} && export CLAUDE_CODE_MAX_CONTEXT_TOKENS=1000000 && `,
     }
   }
   if (isOpenRouter) {

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -568,6 +568,8 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
   // markup) does not silently offer a stale set.
   if (path === '/api/models/available' && method === 'GET') {
     const hasDeepseek = getSecret('DEEPSEEK_API_KEY') !== null
+    // Direct MiniMax API (bypasses the OpenRouter markup) -- same gating pattern.
+    const hasMinimax = getSecret('MINIMAX_API_KEY') !== null
     // OpenRouter is gated behind the vault key, same as DeepSeek: surfacing the
     // options without the key would let the operator pick a model that 401s.
     const hasOpenRouter = getSecret('openrouter-fleet-key') !== null
@@ -588,6 +590,11 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
           ]
         : [],
       deepseekConfigured: hasDeepseek,
+      // Direct MiniMax API -- native Anthropic-compatible endpoint (no OpenRouter markup).
+      // Model id verified live against the real endpoint before this list is trusted;
+      // see agent-provider-env.test.ts + the marveen kanban card 964a9567.
+      minimax: hasMinimax ? [{ id: 'minimax-m3', label: 'MiniMax M3 (közvetlen API)' }] : [],
+      minimaxConfigured: hasMinimax,
       // OpenRouter tiers for the model picker. `auto` per tier feeds the "Auto"
       // mode (stored as `openrouter-auto:<tierKey>`, resolved weekly-fresh at
       // launch); `manual` (2 ids) feeds the "Manual" mode.

--- a/web/app.js
+++ b/web/app.js
@@ -2503,6 +2503,11 @@ const AVATARS = [
 let selectedAvatar = null
 let selectedAvatarFile = null // custom upload chosen in the create wizard (deferred until the agent exists)
 let agents = []
+// Agent name -> measured context-window fraction (0..1), from /api/context-guard.
+// Refreshed alongside the agent list (loadAgents), not on its own poll timer --
+// the underlying measurement reads each agent's transcript from disk, so it is
+// only worth paying for when the Agents page is actually being (re)drawn.
+let contextGuardPct = {}
 let currentAgent = null
 // API-safe agent id for the currently open detail modal. Sub-agents key off
 // their name; the main agent's detail object carries name:'marveen' for legacy
@@ -2871,13 +2876,23 @@ async function loadAgents() {
     // The federation status fetch is deliberately failure-proof (.catch ->
     // null): it must NEVER take down the Agents page -- including on an
     // older backend where the route 404s.
-    const [agentsRes, marveenRes, fedStatus] = await Promise.all([
+    const [agentsRes, marveenRes, fedStatus, ctxGuard] = await Promise.all([
       fetch('/api/agents'),
       fetch('/api/marveen'),
       fetch('/api/federation/status').then((r) => (r.ok ? r.json() : null)).catch(() => null),
+      // Same failure-proofing as federation status above: an older backend or a
+      // transient error here must not take down the whole Agents page over a
+      // badge.
+      fetch('/api/context-guard').then((r) => (r.ok ? r.json() : null)).catch(() => null),
     ])
     agents = await agentsRes.json()
     if (fedStatus && Array.isArray(fedStatus.peers)) federatedPeerStatus = fedStatus.peers
+    contextGuardPct = {}
+    if (ctxGuard && Array.isArray(ctxGuard.agents)) {
+      for (const g of ctxGuard.agents) {
+        if (typeof g.pct === 'number' && isFinite(g.pct)) contextGuardPct[g.agent] = g.pct
+      }
+    }
     if (marveenRes.ok) {
       window._marveen = await marveenRes.json()
       // A backend CHANNEL_PROVIDER-éhez igazitsuk a kliens-default-ot,
@@ -2901,6 +2916,24 @@ function formatContextTokens(n) {
   if (n < 1000) return `${n} token`
   const k = n / 1000
   return `≈${k < 10 ? k.toFixed(1) : Math.round(k)}k token`
+}
+
+// Small "context window used" badge for an Agents-grid card, sourced from
+// contextGuardPct (populated in loadAgents from /api/context-guard -- the
+// same measurement the context-guard runner itself acts on, so this reads
+// the identical number a [CONTEXT-GUARD] restart would fire on, not a
+// second, potentially-drifting calculation).
+// Empty string when there is nothing to show (guard disabled, agent not
+// running, or the measurement genuinely failed) -- no badge is better than a
+// misleading "0%".
+function contextPctBadgeHtml(agentName) {
+  const pct = contextGuardPct[agentName]
+  if (typeof pct !== 'number' || !isFinite(pct) || pct < 0) return ''
+  const pctRound = Math.round(pct * 100)
+  // Mirrors context-guard's own default tiers (actPct 0.90, hardPct 0.97):
+  // green under act, amber from act to hard, red at/over hard.
+  const tier = pct >= 0.97 ? 'danger' : pct >= 0.90 ? 'warning' : 'ok'
+  return `<span class="agent-ctx-badge ${tier}" title="${escapeHtml(t('agents.context_tip', { pct: pctRound }))}">${pctRound}%</span>`
 }
 
 // Populate the auto-restart controls + context display from an agent payload.
@@ -3216,6 +3249,7 @@ function renderAgents() {
       </div>
       <div class="agent-card-footer">
         <span class="agent-model-badge ${escapeHtml(mainModelClass)}">${escapeHtml(mainModelLabel)}</span>
+        ${contextPctBadgeHtml(mainAgentId())}
         <span class="process-indicator" title="${t('agents.marveen_process_tip')}"><span class="process-dot running"></span>${t('agents.status.running')}</span>
         <span class="tg-status" title="${t('agents.marveen_channel_tip')}"><span class="tg-dot connected"></span>${t('agents.status.online')}</span>
       </div>
@@ -3272,6 +3306,7 @@ function renderAgents() {
       </div>
       <div class="agent-card-footer">
         <span class="agent-model-badge ${escapeHtml(modelClass)}">${escapeHtml(modelLabel)}</span>
+        ${contextPctBadgeHtml(agent.name)}
         <span class="process-indicator" title="${escapeHtml(processTip(isRunning))}"><span class="process-dot ${runDotClass}"></span>${runLabel}</span>
         <span class="tg-status" title="${escapeHtml(channelTip(chConnected))}"><span class="tg-dot ${chDotClass}"></span>${chLabel}</span>
       </div>

--- a/web/app.js
+++ b/web/app.js
@@ -4002,6 +4002,27 @@ async function loadAvailableModels() {
     }
     if (hint) hint.style.display = deepseekModels.length === 0 ? 'block' : 'none'
 
+    // MiniMax: direct Anthropic-compatible API (no OpenRouter markup), gated
+    // behind MINIMAX_API_KEY same as DeepSeek. Empty array -> hide the group.
+    const minimaxModels = Array.isArray(data.minimax) ? data.minimax : []
+    const editMinimaxGroup = document.getElementById('minimaxModelGroup')
+    const wizardMinimaxGroup = document.getElementById('agentModelMinimaxGroup')
+    for (const group of [editMinimaxGroup, wizardMinimaxGroup]) {
+      if (!group) continue
+      group.innerHTML = ''
+      if (minimaxModels.length === 0) {
+        group.style.display = 'none'
+        continue
+      }
+      group.style.display = ''
+      for (const m of minimaxModels) {
+        const opt = document.createElement('option')
+        opt.value = m.id
+        opt.textContent = m.label
+        group.appendChild(opt)
+      }
+    }
+
     // OpenRouter: two optgroups per select (Auto = weekly-fresh tier
     // recommendation, value `openrouter-auto:<tier>`; Manual = the 2 concrete
     // ids per tier). Backend gates the whole block behind the vault key, so a

--- a/web/index.html
+++ b/web/index.html
@@ -2224,6 +2224,8 @@
               </optgroup>
               <optgroup label="🌊 DeepSeek (alternatív)" id="agentModelDeepseekGroup">
               </optgroup>
+              <optgroup label="🚀 MiniMax (közvetlen API)" id="agentModelMinimaxGroup" style="display:none">
+              </optgroup>
               <optgroup label="🔀 OpenRouter - Auto (heti frissítésű ajánlott)" id="agentModelOpenrouterAutoGroup" style="display:none">
               </optgroup>
               <optgroup label="🔀 OpenRouter - kézi" id="agentModelOpenrouterManualGroup" style="display:none">
@@ -2392,6 +2394,8 @@
                 <option value="claude-haiku-4-5-20251001" data-i18n="agents.model.haiku45">Haiku 4.5 (leggyorsabb)</option>
               </optgroup>
               <optgroup label="🌊 DeepSeek (alternatív)" id="deepseekModelGroup">
+              </optgroup>
+              <optgroup label="🚀 MiniMax (közvetlen API)" id="minimaxModelGroup" style="display:none">
               </optgroup>
               <optgroup label="🔀 OpenRouter - Auto (heti frissítésű ajánlott)" id="openrouterAutoGroup" style="display:none">
               </optgroup>

--- a/web/lang/en.js
+++ b/web/lang/en.js
@@ -945,6 +945,7 @@ window._i18n.en = {
   'agents.stopped_tip':            'Stopped: no live tmux session for this agent. Source: tmux list-sessions.',
   'agents.online_tip':             'Online: a channel token is configured (own bot). Note: this is not a live connection check, only confirms the token exists.',
   'agents.offline_tip':            'Offline: no channel configured (channel-less, inter-agent only).',
+  'agents.context_tip':            'Context window used: {pct}%. Same measurement the context-guard handoff/restart decision is based on.',
   'agents.tmux_copy_aria':         'Copy tmux attach command',
   'agents.tmux_copied':            'copied',
   'agents.tmux_copy_failed':       'Copy failed',

--- a/web/lang/hu.js
+++ b/web/lang/hu.js
@@ -354,6 +354,7 @@ window._i18n.hu = {
   'agents.stopped_tip':            'Leállva: nincs élő tmux session az ágensnek. Forrás: tmux list-sessions.',
   'agents.online_tip':             'Online: van bekonfigurált csatorna-token (saját bot). Figyelem: ez nem élő kapcsolat, csak a token meglétét jelzi.',
   'agents.offline_tip':            'Offline: nincs csatorna bekötve (channel-less, csak inter-agent ágens).',
+  'agents.context_tip':            'Kontextusablak kihasználtsága: {pct}%. Ugyanaz a mérés, amin a context-guard handoff/restart-döntése is alapul.',
   'agents.tmux_copy_aria':         'tmux attach parancs másolása',
   'agents.tmux_copied':            'másolva',
   'agents.tmux_copy_failed':       'Másolás sikertelen',

--- a/web/style.css
+++ b/web/style.css
@@ -1529,6 +1529,20 @@ main.kanban-active { padding-left: 16px; padding-right: 16px; }
 .agent-model-badge.sonnet { background: var(--info-soft); color: var(--info); }
 .agent-model-badge.haiku { background: var(--success-soft); color: var(--success); }
 
+/* Context-window-used badge (Agents grid card). Tiers mirror context-guard's
+   own default actPct/hardPct (90%/97%) -- see contextPctBadgeHtml in app.js. */
+.agent-ctx-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+.agent-ctx-badge.ok { background: var(--success-soft); color: var(--success); }
+.agent-ctx-badge.warning { background: rgba(212,165,44,0.12); color: var(--warning, #d4a52c); }
+.agent-ctx-badge.danger { background: var(--danger-soft); color: var(--danger); }
+
 /* === Per-agent tmux attach copy buttons (running agents only) === */
 .agent-tmux-cmds {
   display: flex;


### PR DESCRIPTION
<!--
  HU + EN. Töltsd ki minden szakaszt. / Fill in every section.
  A jelölőnégyzeteket így pipáld: [x]  /  Tick a box like this: [x]
-->

## A változtatás típusa / Type of change

- [ ] Bug fix (hibajavítás / bug fix)
- [x] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

hu: Két, egymástól független, de egy körben kiadott változtatás:

1. **MiniMax provider-bekötés.** Natív (nem OpenRouteren át menő) Anthropic-
   kompatibilis végponti kapcsolat MiniMax M3-hoz, a meglévő DeepSeek-mintát
   követve: `MINIMAX_API_KEY` a vault-ból (`secretLookup`, nincs beégetett
   kulcs), a provider-diszkriminátor lánc egy tiszta, tesztelt
   `resolveProviderEnv()`-be kiemelve, a modell választható a Fej-
   Beállítások/Modell legördülőből. Külön javítás: a MiniMax `/anthropic`
   kompatibilis végpontja tévesen 200K-t jelent a modell-metaadatban a
   valódi 1M helyett (dokumentált gyártói hiba, MiniMax-AI/MiniMax-M2.7#46)
   -- két függetlenül futó flotta-ágens élesben mért adata (~200-203k)
   igazolta. A `CLAUDE_CODE_MAX_CONTEXT_TOKENS=1000000` env-var + a
   `contextLimitForModel` denominátor együtt javítja.

2. **Kontextusablak-kihasználtság badge az Ügynökök-kártyákon.** Minden
   agent-kártya lábléce mostantól mutat egy százalék-badge-et a
   `/api/context-guard` mérésből (ugyanaz a szám, amin a context-guard
   handoff/restart-döntése alapul), három színsávval (90%/97% küszöb).

**Tudott átfedés:** van egy másik, nyitott PR (#902,
`feat(dashboard): add per-agent context-guard UI`), ami egy per-agent
beállítás-UI részeként SZINTÉN tesz egy context-badge-et az agent-kártyára,
de FELTÉTELESEN (csak aktív handoff-fázisban, fázis+% szöveggel). Ez a PR
mindig-látható, egyszerűbb badge-et ad. A két megoldás funkcionálisan nem
ütközik (más CSS class, más adatforrás), de ugyanazt a DOM-területet
(`agent-card-footer`, `web/app.js`) érinti -- ha mindkettő bekerül, egy
apró, mechanikus merge-igazítás várható.

en: Two independent changes shipped together:

1. **MiniMax provider integration.** Native (not OpenRouter-relayed)
   Anthropic-compatible endpoint connection for MiniMax M3, following the
   existing DeepSeek pattern: `MINIMAX_API_KEY` from the vault
   (`secretLookup`, no hardcoded key), the provider discriminator chain
   extracted into a pure, unit-tested `resolveProviderEnv()`, model
   selectable from the Agent Settings/Model dropdown. Separate fix:
   MiniMax's own `/anthropic` compat endpoint misreports a 200K context
   window in its model metadata instead of the real 1M (documented
   vendor-side bug, MiniMax-AI/MiniMax-M2.7#46) -- confirmed by live
   measurement from two independently running fleet agents (~200-203k).
   Fixed by a `CLAUDE_CODE_MAX_CONTEXT_TOKENS=1000000` env override plus
   matching `contextLimitForModel` denominator.

2. **Context-window-used badge on the Agents cards.** Every agent card's
   footer now shows a percentage badge sourced from `/api/context-guard`
   (the same number the context-guard's own handoff/restart decision acts
   on), three colour tiers matching its default thresholds (90%/97%).

**Known overlap:** there's another open PR (#902,
`feat(dashboard): add per-agent context-guard UI`) that, as part of a
larger per-agent settings UI, ALSO adds a context badge to the agent card,
but CONDITIONALLY (only during an active handoff phase, showing
phase+percent). This PR's badge is always visible and simpler. The two
don't conflict functionally (different CSS class, different data source),
but they touch the same DOM area (`agent-card-footer`, `web/app.js`) -- if
both land, expect a small, mechanical merge adjustment.

## Kapcsolódó issue / Related issue

Closes #

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
      <!-- hu: elesben futtatva mertem a MiniMax context-window javitast (ket fuggetlen flotta-agens, lasd fent) -- ez a merese, nem csak automata teszt.
           en: the MiniMax context-window fix was measured live (two independent fleet agents, see above) -- not just the automated test. -->
- [ ] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
      <!-- hu: uj provider, de a mintat kovetve (mint DeepSeek), nincs uj telepitesi lepes. / en: new provider following the existing pattern (like DeepSeek), no new install step. -->
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).
