### PR TITLE
fix(fleet-helper): CWD-relative Quick-start path, not machine-specific absolute

### DIFF
--- a/seed-skills/fleet-helper/SKILL.md
+++ b/seed-skills/fleet-helper/SKILL.md
@@ -34,8 +34,19 @@ No secrets or personal data are baked in: the dashboard token is read from
 - `scripts/README.md` - full usage and the heartbeat gate pattern write-up.
 
 ## Quick start
+🛑 **USE A `../../`-RELATIVE PATH, NOT A BARE RELATIVE PATH -- your shell's
+CWD is your own agent directory (`<project-root>/agents/<name>/`), NOT the
+repo root, so a bare relative path below resolves to nothing there.** A
+sub-agent's CWD is always exactly two levels under the project root
+(`agentDir()` in `src/web/agent-config.ts`: `PROJECT_ROOT/agents/<name>`), so
+`../../` reaches the root from ANY agent, on ANY machine -- no hardcoded
+absolute path needed. (`$CLAUDE_PROJECT_DIR`, used elsewhere for hook
+`command` fields, does NOT help here: it is unset in a normal agent Bash
+call, measured empty.) (Bitten twice in one night, 2026-08-17: two fleet
+agents each ran a root-level `find / -iname fleet.py` trying to locate this
+script -- a 10+ minute runaway search under macOS/iCloud folders.)
 ```bash
-P=seed-skills/fleet-helper/scripts
+P=../../seed-skills/fleet-helper/scripts
 python3 $P/fleet.py mdv2 "Tomorrow (8:00) - report!"   # escaped MarkdownV2
 python3 $P/fleet.py kanban-due
 python3 $P/mail_triage.py 90                            # unread <= 90 min -> JSON


### PR DESCRIPTION
<!--
  HU + EN. Töltsd ki minden szakaszt. / Fill in every section.
  A jelölőnégyzeteket így pipáld: [x]  /  Tick a box like this: [x]
-->

## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [x] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

hu: A `fleet-helper` skill Quick-start példája relatív útvonalat használt a
saját scriptjéhez (`P=seed-skills/fleet-helper/scripts`), ami csak akkor
talál rá, ha a shell CWD-je épp a repo gyökere. Egy sub-agent CWD-je viszont
mindig a saját agent-mappája (`<repo-gyökér>/agents/<név>/`), nem a gyökér --
ott ez az útvonal semmire nem mutat. Két fej éles használat közben ebbe
futott bele: a script nem volt sehol a relatív útvonalon, ezért egy teljes
`find /` keresésbe kezdtek, ami 10+ percig futott feleslegesen (macOS/iCloud
mappák alatt egy ilyen keresés gyakorlatilag soha nem ér véget).

A javítás `../../`-relatív útvonalra vált, mert egy sub-agent CWD-je a
forrás szerint (`agentDir()`, `src/web/agent-config.ts`) MINDIG pontosan két
szinttel a repo-gyökér alatt van (`PROJECT_ROOT/agents/<név>`) -- ez minden
telepítésen igaz, géptől függetlenül. Egy hardcode-olt abszolút útvonal NEM
ment volna, mert az egy adott gépen/telepítésen kívül nem létezik.

en: The `fleet-helper` skill's Quick-start example used a relative path to
its own script (`P=seed-skills/fleet-helper/scripts`), which only resolves
when the shell's CWD happens to be the repo root. A sub-agent's CWD is
always its own agent directory (`<repo-root>/agents/<name>/`), not the
root -- there the path points to nothing. Two fleet agents hit this live:
the script wasn't found on the relative path, so each started a root-level
`find /` search, which ran for 10+ minutes uselessly (such a search under
macOS/iCloud-synced folders effectively never terminates).

Fixed with a `../../`-relative path, because a sub-agent's CWD, per
`agentDir()` in `src/web/agent-config.ts`, is ALWAYS exactly two levels
under the repo root (`PROJECT_ROOT/agents/<name>`) -- true on every
install, regardless of machine. A hardcoded absolute path wouldn't have
worked either, since it wouldn't exist outside one specific machine/install.

## Kapcsolódó issue / Related issue

Closes #

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
      <!-- hu: kezzel igazolva -- egy agent-konyvtarbol (agents/<nev>/) futtatva a "P=../../seed-skills/fleet-helper/scripts" valoban a fleet.py-ra mutat.
           en: verified manually -- run from an agent directory (agents/<name>/), "P=../../seed-skills/fleet-helper/scripts" does resolve to fleet.py. -->
- [ ] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
      <!-- hu: nem erinti a telepitest vagy architekturat, csak egy skill-pelda utvonal-javitasa. / en: doesn't affect install or architecture, just a skill example's path fix. -->
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).
