### PR TITLE
fix(heartbeat-scaffold): ship the complete kanban extractor, ban pipe+heredoc (HBHEREDOC819)

### DIFF
--- a/src/__tests__/heartbeat-agent-scaffold.test.ts
+++ b/src/__tests__/heartbeat-agent-scaffold.test.ts
@@ -312,7 +312,10 @@ describe('kanban extraction is a shipped one-liner, never an improvised pipe+her
     // recognise it), and NOTHING else in the prompt may contain one -- a
     // runnable heredoc anywhere would be exactly the copy-surface that broke
     // the 18:00 round. Window: the ban paragraph's own bounds.
-    const matches = [...out.matchAll(/python3\s*<</g)]
+    // Flag-tolerant: `python3 -u <<` (or any switch) is the same footgun as
+    // the bare form -- Marveen's mutation 2 on the first version slipped
+    // through exactly there.
+    const matches = [...out.matchAll(/python3(\s+-\w+)*\s*<</g)]
     expect(matches.length).toBe(1)
     const banStart = out.indexOf('FORBIDDEN SHAPE (HBHEREDOC819)')
     expect(banStart).toBeGreaterThanOrEqual(0)

--- a/src/__tests__/heartbeat-agent-scaffold.test.ts
+++ b/src/__tests__/heartbeat-agent-scaffold.test.ts
@@ -289,3 +289,48 @@ describe('deferred MCP tools (HBCALMCP808)', () => {
     expect(md).toMatch(/ONLY[\s\S]{0,80}ToolSearch itself cannot surface/)
   })
 })
+
+// HBHEREDOC819: the 18:00 round reported "empty response from
+// /api/kanban/heartbeat-summary" while the endpoint served 200/3173B in 9ms
+// and the SAME shell POSTed fine with the same token. The agent had composed
+//   KANBAN=$(curl ...); echo "$KANBAN" | python3 << 'PY' ... PY
+// -- the heredoc replaces python3's stdin, the piped data is silently lost,
+// json.load reads EOF. A command the agent re-improvises every hour is not a
+// mechanism (the HBMEMBLIND819 lesson, extraction-side): the scaffold now
+// ships the COMPLETE one-line extractor and bans the pipe+heredoc shape.
+describe('kanban extraction is a shipped one-liner, never an improvised pipe+heredoc (HBHEREDOC819)', () => {
+  it('ships the complete python3 -c extractor with every counts field', () => {
+    const out = renderHeartbeatClaudeMd(ID)
+    expect(out).toContain(`python3 -c "import json,urllib.request;`)
+    expect(out).toContain(`${ID.dashboardOrigin}/api/kanban/heartbeat-summary`)
+    expect(out).toMatch(/COUNTS urgent=%s in_progress=%s waiting=%s planned=%s new_hot_memories_1h=%s waiting_shown=%s/)
+  })
+
+  it('the ONLY python3-heredoc mention is the quoted example inside the ban paragraph', () => {
+    const out = renderHeartbeatClaudeMd(ID)
+    // The ban paragraph must quote the forbidden shape (so the agent can
+    // recognise it), and NOTHING else in the prompt may contain one -- a
+    // runnable heredoc anywhere would be exactly the copy-surface that broke
+    // the 18:00 round. Window: the ban paragraph's own bounds.
+    const matches = [...out.matchAll(/python3\s*<</g)]
+    expect(matches.length).toBe(1)
+    const banStart = out.indexOf('FORBIDDEN SHAPE (HBHEREDOC819)')
+    expect(banStart).toBeGreaterThanOrEqual(0)
+    const banEnd = out.indexOf('It returns exactly', banStart)
+    expect(banEnd).toBeGreaterThan(banStart)
+    const idx = matches[0].index ?? -1
+    expect(idx).toBeGreaterThan(banStart)
+    expect(idx).toBeLessThan(banEnd)
+  })
+
+  it('the kanban endpoint is never fetched with curl (the curl+shell-var path is what got improvised)', () => {
+    const out = renderHeartbeatClaudeMd(ID)
+    expect(out).not.toMatch(/curl[^\n]*heartbeat-summary/)
+  })
+
+  it('names the forbidden shape and the incident so the ban survives paraphrase', () => {
+    const out = renderHeartbeatClaudeMd(ID)
+    expect(out).toContain('FORBIDDEN SHAPE (HBHEREDOC819)')
+    expect(out).toMatch(/heredoc becomes python3's stdin/)
+  })
+})

--- a/src/__tests__/heartbeat-agent-scaffold.test.ts
+++ b/src/__tests__/heartbeat-agent-scaffold.test.ts
@@ -312,10 +312,12 @@ describe('kanban extraction is a shipped one-liner, never an improvised pipe+her
     // recognise it), and NOTHING else in the prompt may contain one -- a
     // runnable heredoc anywhere would be exactly the copy-surface that broke
     // the 18:00 round. Window: the ban paragraph's own bounds.
-    // Flag-tolerant: `python3 -u <<` (or any switch) is the same footgun as
-    // the bare form -- Marveen's mutation 2 on the first version slipped
-    // through exactly there.
-    const matches = [...out.matchAll(/python3(\s+-\w+)*\s*<</g)]
+    // Class-level, not variant-enumerated: two review rounds each found a
+    // form the previous narrow regex missed (bare, then -u, then `python3 -`
+    // dash-stdin -- the commonest shape here). The pinned property is that on
+    // one line, `python3` is never followed by `<<` at all; enumerating
+    // switches guarantees a fourth variant.
+    const matches = [...out.matchAll(/python3[^\n]*<</g)]
     expect(matches.length).toBe(1)
     const banStart = out.indexOf('FORBIDDEN SHAPE (HBHEREDOC819)')
     expect(banStart).toBeGreaterThanOrEqual(0)

--- a/src/web/heartbeat-agent-scaffold.ts
+++ b/src/web/heartbeat-agent-scaffold.ts
@@ -204,12 +204,28 @@ When you receive the heartbeat prompt:
      If the call fails (token revoked / 401), record the failure
      reason rather than the events; the main agent can act on the
      failure.
-   - **Kanban** -- ONE call, and do not compose a query of your own:
+   - **Kanban** -- ONE command, fetch AND extract together; run it EXACTLY
+     as written, do not recompose it:
 
      \`\`\`bash
-     curl -s -H "Authorization: Bearer $(cat ${id.storeDir}/.dashboard-token)" \\
-       ${id.dashboardOrigin}/api/kanban/heartbeat-summary
+     python3 -c "import json,urllib.request; tok=open('${id.storeDir}/.dashboard-token').read().strip(); d=json.load(urllib.request.urlopen(urllib.request.Request('${id.dashboardOrigin}/api/kanban/heartbeat-summary', headers={'Authorization':'Bearer '+tok}))); c=d['counts']; print('COUNTS urgent=%s in_progress=%s waiting=%s planned=%s new_hot_memories_1h=%s waiting_shown=%s' % (c['urgent'],c['in_progress'],c['waiting'],c['planned'],c['new_hot_memories_1h'],d.get('waiting_shown'))); [print('URGENT',x['id'],x['title']) for x in d['urgent']]; [print('WAITING',x['id'],x['title']) for x in d['waiting']]"
      \`\`\`
+
+     The command is ONE line on purpose: it survives copy-paste from any
+     indentation, needs no shell variable, no pipe, and no second
+     process -- the failure modes that produced HBHEREDOC819 and
+     HBKANBANDRIFT819 structurally cannot occur in it.
+
+     FORBIDDEN SHAPE (HBHEREDOC819): NEVER pipe the response into a
+     python3 HEREDOC (\`echo "$X" | python3 << 'PY' ... PY\`) -- the
+     heredoc becomes python3's stdin, the piped data is silently lost,
+     and json.load reads EOF. Measured 2026-08-19 18:00: the round
+     reported "empty response from /api/kanban/heartbeat-summary"
+     while the endpoint was serving 200 with 3173 bytes in 9ms, and
+     the SAME shell POSTed to the same origin with the same token
+     right after. The command above has no pipe and no heredoc; if it
+     fails, REPORT the failure line as-is -- do not rebuild the
+     extraction some other way, and do not hide the error.
 
      It returns exactly what this section may report:
      \`{"counts":{...}, "urgent":[...], "waiting":[...]}\`, where the


### PR DESCRIPTION
## HBHEREDOC819: the kanban extraction ships as a complete one-liner; the pipe+heredoc shape is banned by name

**Finding (Marveen's measurement, reproduced):** the 18:00 heartbeat round reported "empty response from /api/kanban/heartbeat-summary" while the endpoint served 200/3173B in 9ms, and the SAME shell POSTed to the same origin with the same token immediately after. The agent had improvised `KANBAN=$(curl ...); echo "$KANBAN" | python3 << 'PY' ... PY` — the heredoc replaces python3's stdin, the piped response is silently lost, `json.load` reads EOF. The 17:00 round worked: the agent rewrites this shell hourly, so the failure is nondeterministic. Same class as HBMEMBLIND819, extraction-side: **a command re-improvised every hour is not a mechanism.**

### The fix (scaffold only — the endpoint is innocent and untouched, no fail-safe catch added)
- The Kanban bullet now ships the **complete one-line `python3 -c` extractor** (fetch + extract in one process: no shell variable, no pipe, no heredoc). One line on purpose: it survives copy-paste from any indentation — a first-draft multi-line `-c` block would have shipped an IndentationError with the markdown indentation, caught before commit by running the rendered command.
- **Run live against the real endpoint before committing:** `COUNTS urgent=4 in_progress=1 waiting=281 planned=305 new_hot_memories_1h=5 waiting_shown=8` — byte-consistent with SQL.
- The **FORBIDDEN SHAPE** paragraph names the pipe+heredoc construct, the incident, and instructs: on failure report the failure line as-is — never rebuild the extraction another way, never hide the error.

### Pins (each seen failing)
- The extractor with every counts field present; `curl` never touches the kanban endpoint. Mutation (extractor→curl): both fail.
- The ONLY `python3 <<` occurrence is the quoted example inside the ban paragraph (count==1 + position-bounded). A bare `not.toMatch` would have been self-defeated by the ban's own illustration — the first version of the pin failed on exactly that and was tightened. Mutation (runnable heredoc example outside the ban): fails.

### Evidence
Full suite **281 files / 3768 tests green**; real tsc clean; two mutation red-runs on the right assertions; restore green.

Rollout: scaffold regenerates at dashboard boot. Acceptance (the gate Marveen stated): a heartbeat round completes with the numbers present, and the scaffold test goes red if the heredoc shape returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
