### PR TITLE
fix(outgoing-copy-gate): whole hyphenated tokens, identifier skip, context in findings (GATEKOTOJEL817, GATEHYPH816)

### DIFF
--- a/scripts/hooks/outgoing-copy-gate.py
+++ b/scripts/hooks/outgoing-copy-gate.py
@@ -217,8 +217,60 @@ def _name_correction() -> str:
 
 BAD_NAME = load_bad_name()
 ACCENTED = set("áéíóöőúüűÁÉÍÓÖŐÚÜŰ")
-WORD = re.compile(r"[a-záéíóöőúüűA-ZÁÉÍÓÖŐÚÜŰ]+")
 TAG = re.compile(r"<[^>]+>")
+
+# GATEKOTOJEL817 + GATEHYPH816 (2026-08-19 este, ket hamis pozitiv elo
+# gazda-beszelgetesben, ot perc alatt): a kapu nem tett kulonbseget PROZA es
+# AZONOSITO kozott. (1) `Drive-ot` -- az idegen tulajdonnevhez a magyar
+# toldalek kotojellel kapcsolodik (ez a HELYES iras), de a betu-only WORD
+# tokenizalo a kotojelnel vagott, es a maradek `ot` darabot onallo magyar
+# szonak nezte (ot -> öt). (2) `Video atalakitas` -- egy Drive-mappa NEVE a
+# szovegben: mondatkozi nagybetus szo, azonosito, nem proza. A javitas a
+# TOKENIZALAS, nem a szotar (szo-kivetel a valodi hibakat is atengedne):
+#   - kotojeles alaknal a TELJES szoalak vizsgalando (a `drive-ot` egeszkent
+#     nincs a szotarban -> atmegy; az onallo `ot` prozaban tovabbra is bukik);
+#   - a MONDATKOZI nagybetus szo azonosito/tulajdonnev -> kimarad; mondat
+#     elejen (. ! ? : ujsor vagy lista-jel utan) a nagybetu normal proza,
+#     ott tovabbra is vizsgaljuk.
+HYPHEN_WORD = re.compile(r"[a-záéíóöőúüűA-ZÁÉÍÓÖŐÚÜŰ]+(?:-[a-záéíóöőúüűA-ZÁÉÍÓÖŐÚÜŰ]+)*")
+
+
+def _at_sentence_start(text: str, idx: int) -> bool:
+    i = idx - 1
+    while i >= 0 and text[i] in " \t\"'([{":
+        i -= 1
+    if i < 0:
+        return True
+    ch = text[i]
+    if ch in ".!?:\n":
+        return True
+    if ch in "-*•":
+        j = i - 1
+        while j >= 0 and text[j] in " \t":
+            j -= 1
+        return j < 0 or text[j] == "\n"
+    return False
+
+
+def accent_check_tokens(prose: str):
+    """(lowercase alak, kezdo-pozicio) parok az ekezet-vizsgalathoz."""
+    out = []
+    for m in HYPHEN_WORD.finditer(prose):
+        tok = m.group(0)
+        if "-" not in tok and tok[0].isupper() and not _at_sentence_start(prose, m.start()):
+            continue
+        out.append((tok.lower(), m.start()))
+    return out
+
+
+def _hit_context(prose: str, pos: int, length: int) -> str:
+    """A talalat elotti/utani 3-3 szo + karakter-pozicio (GATEHYPH816 (B):
+    elo beszelgetes kozben ne kelljen greppelni, melyik szorol van szo)."""
+    before = prose[:pos].split()[-3:]
+    token = prose[pos:pos + length]
+    after = prose[pos + length:].split()[:3]
+    frag = " ".join(before + [token] + after)
+    return f'"...{frag}..." @{pos}'
 
 
 # Technikai tokenek maszkolasa AZ EKEZET-ELLENORZES ELOTT. Merve 2026-08-13, a
@@ -413,7 +465,8 @@ def audit(text: str):
             f"VEGYES IRASRENDSZERU SZO (homoglifa), {len(mixed)} db: {shown}{more}. "
             "Latin szoba keveredett nem-latin betu: olvasva lathatatlan, de a keresest/grepet neman eltori."
         )
-    words = [w.lower() for w in WORD.findall(prose)]
+    tok_pos = accent_check_tokens(prose)
+    words = [w for w, _ in tok_pos]
     if is_hungarian(plain) or accentless_evidence(words):
         hits = sorted({w for w in words if w in ACCENTLESS})
         # Az aranyot is a prozan merjuk: a technikai tokenekben nincs ekezet, tehat
@@ -422,7 +475,14 @@ def audit(text: str):
         acc = sum(1 for ch in prose if ch in ACCENTED)
         ratio = (acc / letters) if letters else 0.0
         if hits:
-            shown = ", ".join(f"{h} -> {ACCENTLESS[h]}" for h in hits[:12])
+            first_pos = {}
+            for w, p in tok_pos:
+                if w in ACCENTLESS and w not in first_pos:
+                    first_pos[w] = p
+            shown = ", ".join(
+                f"{h} -> {ACCENTLESS[h]} ({_hit_context(prose, first_pos[h], len(h))})"
+                for h in hits[:12]
+            )
             more = f" (+{len(hits) - 12} tovabbi)" if len(hits) > 12 else ""
             problems.append(f"HIANYZO EKEZETEK, {len(hits)} szo: {shown}{more}")
         elif letters > 200 and ratio < 0.01:

--- a/src/__tests__/outgoing-copy-gate-tokens.test.ts
+++ b/src/__tests__/outgoing-copy-gate-tokens.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { join } from 'node:path'
+
+// GATEKOTOJEL817 + GATEHYPH816: two false positives in five minutes, in a live
+// owner conversation, both the same class -- the gate could not tell PROSE
+// from IDENTIFIER. (1) `Drive-ot`: a Hungarian suffix attaches to a foreign
+// proper noun WITH a hyphen (that is the correct spelling); the letters-only
+// tokenizer cut at the hyphen and read the `ot` remainder as a standalone
+// Hungarian word (ot -> öt). (2) `Video atalakitas`: a Drive FOLDER NAME
+// quoted in prose -- a mid-sentence capitalized word is an identifier, not
+// prose. The fix is TOKENIZATION, not the dictionary (a word exception list
+// would also pass real errors): hyphenated forms are checked as the WHOLE
+// token, and mid-sentence capitalized words are skipped -- while sentence-
+// start capitals and lowercase prose remain fully checked.
+
+const ROOT = join(__dirname, '..', '..')
+const GATE = join(ROOT, 'scripts', 'hooks', 'outgoing-copy-gate.py')
+
+function auditAccent(text: string): string[] {
+  const out = execFileSync('python3', ['-c', `
+import importlib.util, json, sys
+spec = importlib.util.spec_from_file_location("gate", ${JSON.stringify(GATE)})
+g = importlib.util.module_from_spec(spec); spec.loader.exec_module(g)
+print(json.dumps([p for p in g.audit(sys.argv[1]) if "HIANYZO" in p]))
+`, text], { encoding: 'utf-8' })
+  return JSON.parse(out.trim())
+}
+
+describe('outgoing-copy gate tokenization: prose vs identifier (GATEKOTOJEL817/GATEHYPH816)', () => {
+  it('a hyphen-suffixed foreign proper noun passes: the suffix fragment is not a standalone word', () => {
+    // Marveen's real blocked sentence, correctly accented -- must go through.
+    expect(auditAccent('Ha a Drive-ot választod, elég a mappába dobni, és köszönöm, hogy már átküldted.')).toEqual([])
+  })
+
+  it('a quoted identifier (mid-sentence capitalized folder name) passes', () => {
+    // The second real blocked sentence: a Drive folder called "Video atalakitas".
+    expect(auditAccent('A neve Video átalakítás, ott találod, hogy már ne kelljen külön keresni.')).toEqual([])
+  })
+
+  it('lowercase prose "video" still fails -- the fix must not widen into a whitelist', () => {
+    const probs = auditAccent('Szia, a video nagyon jól sikerült, köszönöm, hogy átküldted.')
+    expect(probs.length).toBe(1)
+    expect(probs[0]).toContain('video -> videó')
+  })
+
+  it('a sentence-START capitalized word is prose and still fails (the skip-rule must not over-reach)', () => {
+    const probs = auditAccent('Köszönöm, hogy megnézted. Video lett a vége, már csak fel kell tölteni.')
+    expect(probs.length).toBe(1)
+    expect(probs[0]).toContain('video -> videó')
+  })
+
+  it('a standalone accentless word that ALSO exists as a suffix still fails (ot -> öt)', () => {
+    const probs = auditAccent('Kérlek, küldj át ot darabot, hogy már ne kelljen várni.')
+    expect(probs.length).toBe(1)
+    expect(probs[0]).toContain('ot -> öt')
+  })
+
+  it('the finding names its context: 3 words each side plus the character position (no more grepping mid-conversation)', () => {
+    const probs = auditAccent('Szia, a video nagyon jól sikerült, köszönöm, hogy átküldted.')
+    // Neighbours on both sides and an @<pos> marker.
+    expect(probs[0]).toMatch(/"\.\.\.[^"]*a video nagyon[^"]*\.\.\." @\d+/)
+  })
+})


### PR DESCRIPTION
## GATEKOTOJEL817 + GATEHYPH816: the copy gate learns the difference between prose and identifier

**Finding (Marveen, two false positives in five minutes, live owner conversation):** (1) `Drive-ot`: the Hungarian suffix attaches to a foreign proper noun with a hyphen (that is the correct spelling), but the letters-only tokenizer cut at the hyphen and read the `ot` remainder as a standalone word (ot: öt). (2) `Video atalakitas`: a Drive folder name quoted in prose; a mid-sentence capitalized word is an identifier, not prose. Both blocked a reply the owner was actively waiting on.

### The fix: tokenization, not the dictionary (as requested; a word whitelist would also pass real errors)
- **Hyphenated tokens are checked as the whole form**: `drive-ot` is not a dictionary word, so it passes; a standalone `ot` in prose still fails.
- **Mid-sentence capitalized words are skipped** (identifier/proper noun); sentence-start capitals (after `.`/`!`/`?`/`:`/newline or a list marker) remain fully checked, so the skip cannot over-reach into normal prose.
- **(B) Every finding now carries context**: 3 words each side plus the character position (`video: videó ("...a video nagyon jól..." @8)`); a future false positive costs one glance, not a grep of your own text mid-conversation.
- The now-unused letters-only `WORD` regex is removed.

### Evidence
- **Live-probed on the gate module before commit, all five controls**: both real blocked sentences pass; lowercase prose `video`, sentence-start `Video`, and standalone `ot` all still fail, with context.
- New test file pins all six properties; **three mutation red-runs, each failing exactly its own assertion**: hyphen-splitting restored, capital-skip removed, context removed. Restore: green.
- Full suite 282 files / 3774 tests green; the accent dictionary and the trigger logic are untouched.

Rollout note: the gate is a hook script read per-invocation; no session restart needed, live after host pull.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
