### PR TITLE
fix(stuck-tool-call-watcher): last-instant verdict-validity gate at the kill boundary (STUCKFREEZE819)

### DIFF
--- a/src/__tests__/stuck-tool-call.test.ts
+++ b/src/__tests__/stuck-tool-call.test.ts
@@ -452,3 +452,83 @@ describe('confirmsWedgeProfile (#248 CPU-profile guard)', () => {
     expect(confirmsWedgeProfile(null, MAX)).toBe(true)
   })
 })
+
+// STUCKFREEZE819: both false kills of 2026-08-19 hit a LIVE session with a
+// STALE verdict -- stagnation accrued in a parked/idle stretch, and the kill
+// executed ~2 minutes after the verdict's inputs, right as the session woke
+// (measured transcript ages at the two kills: ~2s and ~9s; the 20:23:19 kill
+// landed ONE second after a healthy tool_result). The gate below re-checks
+// validity at KILL time via the session transcript's mtime; a genuinely
+// wedged TUI writes nothing, so its transcript is >= freezeSeconds old by
+// construction.
+import { verdictStaleByTranscript, STALE_VERDICT_FRESH_MS } from '../web/stuck-tool-call-watcher.js'
+import { readFileSync as rfs, writeFileSync as wfs, mkdtempSync as mkdt, statSync as st } from 'node:fs'
+import { join as pjoin } from 'node:path'
+import { tmpdir as ostmp } from 'node:os'
+import { spawn as pspawn } from 'node:child_process'
+
+describe('verdictStaleByTranscript (pure) -- STUCKFREEZE819', () => {
+  const NOW = 10_000_000
+  it('a transcript written moments ago marks the verdict stale (both measured false-kill ages abort)', () => {
+    expect(verdictStaleByTranscript(NOW - 2_000, NOW)).toBe(true)   // 20:23:19 shape (~2s)
+    expect(verdictStaleByTranscript(NOW - 9_400, NOW)).toBe(true)   // 14:08:59 shape (~9s)
+  })
+
+  it('a real wedge does not abort: by construction its transcript is at least freezeSeconds old', () => {
+    expect(verdictStaleByTranscript(NOW - THRESHOLDS.freezeSeconds * 1000, NOW)).toBe(false)
+    expect(verdictStaleByTranscript(NOW - STALE_VERDICT_FRESH_MS, NOW)).toBe(false) // boundary: exactly N -> proceed
+  })
+
+  it('null mtime (dir unreadable) fails OPEN -- the stagnation signal stands, same rule as the CPU guard', () => {
+    expect(verdictStaleByTranscript(null, NOW)).toBe(false)
+  })
+
+  it('the threshold is derived, not round: above the 9s measured false-kill maximum with margin, well below the 180s wedge floor', () => {
+    expect(STALE_VERDICT_FRESH_MS).toBeGreaterThan(9_400 * 2)
+    expect(STALE_VERDICT_FRESH_MS).toBeLessThanOrEqual((THRESHOLDS.freezeSeconds * 1000) / 3)
+  })
+})
+
+describe('negative control: a stopped process writes nothing, so the mtime signal cannot mask a real wedge', () => {
+  it('SIGSTOP freezes the writer and its file mtime stands still', async () => {
+    const dir = mkdt(pjoin(ostmp(), 'wedge-sim-'))
+    const f = pjoin(dir, 'transcript.jsonl')
+    wfs(f, '')
+    // A writer that appends every 100ms -- the healthy-session analogue.
+    const child = pspawn('/bin/sh', ['-c', `while :; do echo line >> ${JSON.stringify(f)}; sleep 0.1; done`], { stdio: 'ignore' })
+    try {
+      await new Promise(r => setTimeout(r, 500))
+      const liveAge = Date.now() - st(f).mtimeMs
+      expect(liveAge).toBeLessThan(STALE_VERDICT_FRESH_MS) // alive -> gate would abort a kill
+      // The simulated wedge: stop the process (the stdio-blocked render loop's analogue).
+      process.kill(child.pid!, 'SIGSTOP')
+      const mtimeAtStop = st(f).mtimeMs
+      await new Promise(r => setTimeout(r, 1200))
+      expect(st(f).mtimeMs).toBe(mtimeAtStop) // the mtime STANDS: a wedge ages past N and recovery proceeds
+      expect(verdictStaleByTranscript(mtimeAtStop, mtimeAtStop + STALE_VERDICT_FRESH_MS + 1)).toBe(false)
+    } finally {
+      try { process.kill(child.pid!, 'SIGKILL') } catch { /* gone */ }
+    }
+  })
+})
+
+describe('wiring: the stale-verdict gate sits at the KILL boundary, not in verdict formation', () => {
+  const SRC = rfs(pjoin(__dirname, '..', 'web', 'stuck-tool-call-watcher.ts'), 'utf-8')
+
+  it('checkSession calls the gate after the CPU guard and before resumeMarveenSession', () => {
+    // Window: the checkSession function's own structural bounds.
+    const start = SRC.indexOf('async function checkSession')
+    expect(start).toBeGreaterThanOrEqual(0)
+    const body = SRC.slice(start, SRC.indexOf('\n}', start))
+    const cpuIdx = body.indexOf('confirmsWedgeProfile(')
+    const gateIdx = body.indexOf('verdictStaleByTranscript(')
+    const killIdx = body.indexOf('resumeMarveenSession()')
+    expect(cpuIdx).toBeGreaterThanOrEqual(0)
+    expect(gateIdx).toBeGreaterThan(cpuIdx)
+    expect(killIdx).toBeGreaterThan(gateIdx)
+  })
+
+  it('an abort logs loudly and names the incident, so a suppressed kill is findable, not a hole', () => {
+    expect(SRC).toContain('ABORTING recovery (STUCKFREEZE819)')
+  })
+})

--- a/src/__tests__/stuck-tool-call.test.ts
+++ b/src/__tests__/stuck-tool-call.test.ts
@@ -520,9 +520,14 @@ describe('wiring: the stale-verdict gate sits at the KILL boundary, not in verdi
     const start = SRC.indexOf('async function checkSession')
     expect(start).toBeGreaterThanOrEqual(0)
     const body = SRC.slice(start, SRC.indexOf('\n}', start))
-    const cpuIdx = body.indexOf('confirmsWedgeProfile(')
-    const gateIdx = body.indexOf('verdictStaleByTranscript(')
-    const killIdx = body.indexOf('resumeMarveenSession()')
+    // Comment lines dropped, and the guard pinned as the EXACT live line --
+    // a bare indexOf would stay green with the call neutered (`false && ...`),
+    // which is precisely the declaration-vs-reachability trap: the text is
+    // present, the gate never runs. Caught by mutation on the first version.
+    const code = body.split('\n').filter(l => !l.trim().startsWith('//')).join('\n')
+    const cpuIdx = code.indexOf('confirmsWedgeProfile(')
+    const gateIdx = code.indexOf('if (verdictStaleByTranscript(transcriptMtime, Date.now())) {')
+    const killIdx = code.indexOf('resumeMarveenSession()')
     expect(cpuIdx).toBeGreaterThanOrEqual(0)
     expect(gateIdx).toBeGreaterThan(cpuIdx)
     expect(killIdx).toBeGreaterThan(gateIdx)

--- a/src/web/stuck-tool-call-watcher.ts
+++ b/src/web/stuck-tool-call-watcher.ts
@@ -40,7 +40,9 @@
 import { execFileSync } from 'node:child_process'
 import { logger } from '../logger.js'
 import { resolveFromPath } from '../platform.js'
+import { PROJECT_ROOT } from '../config.js'
 import { capturePane } from './agent-process.js'
+import { readTranscriptMtimeFromProjectDir } from './active-model.js'
 import { MAIN_CHANNELS_SESSION } from './main-agent.js'
 import { resumeMarveenSession, sendAlert, lastMainRespawnAt, MARVEEN_POST_RESPAWN_GRACE_MS } from './channel-monitor.js'
 import {
@@ -68,6 +70,44 @@ const WEDGE_MAX_CPU_PERCENT = 30
 export function confirmsWedgeProfile(cpuPercent: number | null, maxCpuPercent: number): boolean {
   if (cpuPercent === null) return true
   return cpuPercent <= maxCpuPercent
+}
+
+// STUCKFREEZE819: last-instant verdict-validity gate, at KILL EXECUTION time
+// (deliberately NOT folded into the verdict formation -- that would rebuild
+// the same gap smaller). Both false kills measured on 2026-08-19 hit a LIVE
+// session with a STALE verdict: stagnation accrued during a parked/idle
+// stretch, and by the time the kill executed (~2 minutes after the verdict's
+// inputs), the session had woken and was working -- the 20:23:19 kill landed
+// ONE second after a healthy tool_result, mid-turn (79s of healthy work); the
+// 14:08:59 kill landed 9 seconds after an inbox-wakeup injection. The
+// cheapest live-signal is the session transcript's mtime: a working session
+// appends constantly (measured ages at the two false kills: ~2s and ~9s),
+// while a genuinely wedged TUI writes nothing -- by construction its
+// transcript is at least freezeSeconds (180s) old when the verdict fires.
+//
+// Threshold derivation (not a round guess): must sit ABOVE the largest
+// measured false-kill age (9s, with margin) and WELL BELOW the 180s
+// stagnation floor of a real wedge. 30s = 3x the measured maximum and 6x
+// under the floor; any value in (9s, 180s) discriminates the two measured
+// populations.
+//
+// Known limit, stated not hidden: the mtime is DIRECTORY-level (newest jsonl
+// under the main session's project dir), so a hypothetical sibling session
+// with the same cwd could mask a real wedge -- for at most one sweep at a
+// time, because an abort keeps the spell and the next poll re-fires the
+// verdict once the masking writer pauses.
+export const STALE_VERDICT_FRESH_MS = 30_000
+
+// Pure: is the recovery verdict stale because the session's transcript shows
+// recent activity? null mtime (dir unreadable) -> false: fail-open, the
+// stagnation signal stands on its own, same rule as the CPU guard.
+export function verdictStaleByTranscript(
+  transcriptMtimeMs: number | null,
+  nowMs: number,
+  freshMs = STALE_VERDICT_FRESH_MS,
+): boolean {
+  if (transcriptMtimeMs === null) return false
+  return nowMs - transcriptMtimeMs < freshMs
 }
 
 // Recent CPU% of the main session's pane-leader claude (claudePid == panePid for
@@ -227,6 +267,20 @@ async function checkSession(label: string, session: string): Promise<void> {
       logger.info(
         { label, session, cpuPercent, maxCpuPercent: WEDGE_MAX_CPU_PERCENT, seconds: next.lastSeconds },
         'stuck-tool-call-watcher: counter stagnant but claude is CPU-active (not the idle wedge profile) -- deferring recovery',
+      )
+      return
+    }
+    // STUCKFREEZE819: last-instant validity re-check at the kill boundary.
+    // Every earlier guard sampled state at VERDICT time; this one samples at
+    // EXECUTION time, because the two are ~2 minutes apart and both measured
+    // false kills happened exactly in that gap (the session woke up between
+    // verdict and kill). Abort keeps the spell: a real wedge re-fires on the
+    // next poll, so this gate can only delay a true recovery by one sweep.
+    const transcriptMtime = readTranscriptMtimeFromProjectDir(PROJECT_ROOT)
+    if (verdictStaleByTranscript(transcriptMtime, Date.now())) {
+      logger.warn(
+        { label, session, transcriptAgeMs: transcriptMtime ? Date.now() - transcriptMtime : null, freshMs: STALE_VERDICT_FRESH_MS, seconds: next.lastSeconds },
+        'stuck-tool-call-watcher: verdict stale -- the session transcript was written moments ago, the session is alive; ABORTING recovery (STUCKFREEZE819)',
       )
       return
     }


### PR DESCRIPTION
## STUCKFREEZE819: last-instant verdict-validity gate at the kill boundary

**The measured finding** (main-session transcripts, both 2026-08-19 WARNs): both kills hit a LIVE session with a STALE verdict. Stagnation accrued during a parked/idle stretch; the kill executed ~2 minutes after the verdict's inputs, by which time the session had woken. The 20:23:19 kill landed one second after a healthy tool_result, 79 seconds into healthy work (four thinking+tool+result rounds); the 14:08:59 kill landed 9 seconds after an inbox-wakeup injection. The slow-network hypothesis was refuted: neither moment had an in-flight tool call. The instrument was right in its own moment; the action arrived late.

### The three review conditions, as implemented
1. **Gate at kill execution, not verdict formation**: right before `resumeMarveenSession()`, after every existing guard. It re-reads the session transcript's mtime; if written within `STALE_VERDICT_FRESH_MS`, recovery ABORTS with a loud, incident-named log. An abort keeps the spell, so a real wedge re-fires next poll: the gate can delay a true recovery by at most one sweep. The 180s threshold and the 43/45-correct suppression filters are untouched.
2. **Negative control, measured not inferred**: a SIGSTOP-simulated wedge (writer process appending every 100ms, then stopped) shows the file mtime stands still; it ages past N, and the gate proceeds with recovery. The live direction is covered by both measured false-kill shapes (~2s and ~9s ages abort).
3. **N derived from measurement**: `STALE_VERDICT_FRESH_MS = 30s` sits at 3x the largest measured false-kill transcript age (9s) and 6x under the 180s stagnation floor a real wedge cannot avoid (a wedged TUI writes nothing). Any value in (9s, 180s) discriminates the two measured populations; the derivation is in the code comment, and a bounds test pins it.

Known limit, stated in code: the mtime is directory-level (newest jsonl in the main session's project dir); a same-cwd sibling could mask a real wedge for at most one sweep. Fail-open on null mtime, same rule as the CPU guard.

### Evidence
- Full suite 282 files / 3781 tests green; real tsc clean.
- Mutation red-runs: comparison flipped (3 tests red incl. the SIGSTOP control), gate neutered with `false &&` (wiring pin red). The first wiring pin stayed green on the neutering (declaration vs reachability); it now pins the exact live guard line on comment-stripped code, and the same mutation was re-run red.
- Reuses the existing `readTranscriptMtimeFromProjectDir` helper (the context-guard's own instrument).

Rollout: compiled code; live after host pull + build + dashboard restart. Acceptance is behavioral: no owner-facing "beragadt, ujrainditottam" alert while the session demonstrably works, and a genuine wedge still recovers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
