### PR TITLE
fix(kanban): guard modal backdrop-click close against unsaved input

### DIFF
--- a/src/__tests__/kanban-modal-overlay-click-data-loss.test.ts
+++ b/src/__tests__/kanban-modal-overlay-click-data-loss.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+// Contract test for a data-loss bug reported 2026-08-19 (Józsi): clicking the
+// backdrop of a modal (e.g. the kanban "Új kártya" modal) closed it
+// UNCONDITIONALLY, silently discarding any typed title/description -- a full
+// page of typed text was lost this way. Every `*Overlay.addEventListener(
+// 'click', ...)` background-close in web/app.js had this same shape.
+//
+// Fix (Józsi's acceptance criteria, 2026-08-19): empty form -> backdrop click
+// closes freely (no friction); form has typed input -> a confirm() gates the
+// close. A single shared guard (`attachOverlayCloseGuard`) replaces every
+// direct `closeModal(...)` call on backdrop click, so the fix is uniform
+// across all overlays, not one-off per modal.
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const appJsPath = join(__dirname, '..', '..', 'web', 'app.js')
+const src = readFileSync(appJsPath, 'utf8')
+
+// Every overlay identifier in the file that ends in "Overlay" and is closed
+// via the background-click pattern, measured independently (not taken from
+// a prior report): `grep -n "Overlay.addEventListener('click'" web/app.js`.
+const OVERLAY_IDS = [
+  'cardModalOverlay',
+  'cardDetailOverlay',
+  'agentWizardOverlay',
+  'agentDetailOverlay',
+  'skillModalOverlay',
+  'scheduleModalOverlay',
+  'scheduleRunHistoryOverlay',
+  'memModalOverlay',
+  'catalogInstallOverlay',
+  'connectorModalOverlay',
+  'connectorDetailOverlay',
+  'memImportOverlay',
+  'skillDetailOverlay',
+  'adOverlay',
+]
+
+describe('modal backdrop click must not silently discard unsaved input', () => {
+  it('none of the overlays close unconditionally on backdrop click any more', () => {
+    for (const id of OVERLAY_IDS) {
+      const unconditional = new RegExp(
+        `${id}\\.addEventListener\\('click',\\s*e?\\s*=>\\s*\\{\\s*if\\s*\\(e\\.target\\s*===\\s*${id}\\)\\s*closeModal\\(${id}\\)\\s*\\}\\s*\\)`,
+      )
+      expect(src, `${id} still closes unconditionally on backdrop click`).not.toMatch(unconditional)
+    }
+  })
+
+  it('a shared guard checks for unsaved input before closing on backdrop click', () => {
+    expect(src).toMatch(/function\s+overlayHasUnsavedInput\s*\(/)
+    expect(src).toMatch(/function\s+attachOverlayCloseGuard\s*\(/)
+    // the guard must actually gate on a confirm() -- not just check and ignore
+    const guardBody = src.slice(src.indexOf('function attachOverlayCloseGuard'))
+    expect(guardBody.slice(0, 400)).toMatch(/confirm\(/)
+  })
+
+  it('every measured overlay is wired through the shared guard', () => {
+    for (const id of OVERLAY_IDS) {
+      expect(src, `${id} is not wired through attachOverlayCloseGuard`).toMatch(
+        new RegExp(`attachOverlayCloseGuard\\(${id}\\)`),
+      )
+    }
+  })
+})

--- a/web/app.js
+++ b/web/app.js
@@ -846,8 +846,8 @@ const columns = document.querySelectorAll('.kanban-col-body')
 // Modal wiring
 document.getElementById('cardModalClose').addEventListener('click', () => closeModal(cardModalOverlay))
 document.getElementById('cardDetailClose').addEventListener('click', () => closeModal(cardDetailOverlay))
-cardModalOverlay.addEventListener('click', (e) => { if (e.target === cardModalOverlay) closeModal(cardModalOverlay) })
-cardDetailOverlay.addEventListener('click', (e) => { if (e.target === cardDetailOverlay) closeModal(cardDetailOverlay) })
+attachOverlayCloseGuard(cardModalOverlay)
+attachOverlayCloseGuard(cardDetailOverlay)
 
 // Add card buttons per column
 document.querySelectorAll('.kanban-add-btn').forEach((btn) => {
@@ -2536,6 +2536,30 @@ function closeModal(overlay) {
   if (overlay && overlay.id === 'skillModalOverlay') skillModalScope = null
 }
 
+// True if any visible text/textarea field inside the overlay has typed
+// content. Used to gate backdrop-click close so a stray click can't
+// silently discard unsaved input (data loss reported 2026-08-19: a full
+// card description was lost by clicking outside the "Új kártya" modal).
+function overlayHasUnsavedInput(overlay) {
+  const fields = overlay.querySelectorAll(
+    'input[type="text"]:not([list]), input[type="date"], input[type="email"], input[type="url"], textarea',
+  )
+  for (const f of fields) {
+    if (f.offsetParent !== null && f.value && f.value.trim()) return true
+  }
+  return false
+}
+
+// Backdrop click closes the modal only if it has no unsaved input; if it
+// does, a confirm() gates the close so the click has to be deliberate.
+function attachOverlayCloseGuard(overlay) {
+  overlay.addEventListener('click', (e) => {
+    if (e.target !== overlay) return
+    if (overlayHasUnsavedInput(overlay) && !confirm('Van be nem mentett szöveg -- biztosan bezárod mentés nélkül?')) return
+    closeModal(overlay)
+  })
+}
+
 // Wizard open
 addBtn.addEventListener('click', () => {
   resetWizard()
@@ -2549,9 +2573,9 @@ document.getElementById('agentDetailClose').addEventListener('click', () => clos
 document.getElementById('skillModalClose').addEventListener('click', () => closeModal(skillModalOverlay))
 
 // Click-outside-to-close
-agentWizardOverlay.addEventListener('click', (e) => { if (e.target === agentWizardOverlay) closeModal(agentWizardOverlay) })
-agentDetailOverlay.addEventListener('click', (e) => { if (e.target === agentDetailOverlay) closeModal(agentDetailOverlay) })
-skillModalOverlay.addEventListener('click', (e) => { if (e.target === skillModalOverlay) closeModal(skillModalOverlay) })
+attachOverlayCloseGuard(agentWizardOverlay)
+attachOverlayCloseGuard(agentDetailOverlay)
+attachOverlayCloseGuard(skillModalOverlay)
 
 // Close all modals on Escape
 document.addEventListener('keydown', (e) => {
@@ -5666,7 +5690,7 @@ document.getElementById('addScheduleBtn').addEventListener('click', () => {
   })
 })
 document.getElementById('scheduleModalClose').addEventListener('click', () => closeModal(scheduleModalOverlay))
-scheduleModalOverlay.addEventListener('click', (e) => { if (e.target === scheduleModalOverlay) closeModal(scheduleModalOverlay) })
+attachOverlayCloseGuard(scheduleModalOverlay)
 
 // Frequency change handler
 // Type toggle (task vs heartbeat)
@@ -6105,7 +6129,7 @@ function renderScheduleList(tasks) {
 
 const scheduleRunHistoryOverlay = document.getElementById('scheduleRunHistoryOverlay')
 document.getElementById('scheduleRunHistoryClose').addEventListener('click', () => closeModal(scheduleRunHistoryOverlay))
-scheduleRunHistoryOverlay.addEventListener('click', (e) => { if (e.target === scheduleRunHistoryOverlay) closeModal(scheduleRunHistoryOverlay) })
+attachOverlayCloseGuard(scheduleRunHistoryOverlay)
 
 const RUN_STATUS_LABEL = {
   fired: () => t('tasks.run_status.fired'),
@@ -6664,7 +6688,7 @@ document.getElementById('memAddBtn').addEventListener('click', () => {
 
 // Close memory modal
 document.getElementById('memModalClose').addEventListener('click', () => closeModal(memModalOverlay))
-memModalOverlay.addEventListener('click', (e) => { if (e.target === memModalOverlay) closeModal(memModalOverlay) })
+attachOverlayCloseGuard(memModalOverlay)
 
 // Save memory (create or edit)
 document.getElementById('saveMemBtn').addEventListener('click', async () => {
@@ -7729,7 +7753,7 @@ document.querySelectorAll('.catalog-filter-btn').forEach(btn => {
 
 // Catalog install modal
 document.getElementById('catalogInstallClose').addEventListener('click', () => closeModal(catalogInstallOverlay))
-catalogInstallOverlay.addEventListener('click', (e) => { if (e.target === catalogInstallOverlay) closeModal(catalogInstallOverlay) })
+attachOverlayCloseGuard(catalogInstallOverlay)
 
 async function loadCatalog() {
   const grid = document.getElementById('catalogGrid')
@@ -7910,8 +7934,8 @@ document.getElementById('addConnectorBtn').addEventListener('click', () => {
 })
 document.getElementById('connectorModalClose').addEventListener('click', () => closeModal(connectorModalOverlay))
 document.getElementById('connectorDetailClose').addEventListener('click', () => closeModal(connectorDetailOverlay))
-connectorModalOverlay.addEventListener('click', (e) => { if (e.target === connectorModalOverlay) closeModal(connectorModalOverlay) })
-connectorDetailOverlay.addEventListener('click', (e) => { if (e.target === connectorDetailOverlay) closeModal(connectorDetailOverlay) })
+attachOverlayCloseGuard(connectorModalOverlay)
+attachOverlayCloseGuard(connectorDetailOverlay)
 
 // Type toggle
 document.getElementById('connectorType').addEventListener('change', () => {
@@ -9886,7 +9910,7 @@ document.getElementById('memImportOpenBtn').addEventListener('click', () => {
 
 // Close import modal
 document.getElementById('memImportClose').addEventListener('click', () => closeModal(memImportOverlay))
-memImportOverlay.addEventListener('click', (e) => { if (e.target === memImportOverlay) closeModal(memImportOverlay) })
+attachOverlayCloseGuard(memImportOverlay)
 
 // File area click -> trigger file input
 memImportFileArea.addEventListener('click', () => memImportFileInput.click())
@@ -10404,7 +10428,7 @@ function formatMtime(ms) {
 }
 
 document.getElementById('skillDetailClose').addEventListener('click', () => closeModal(skillDetailOverlay))
-skillDetailOverlay.addEventListener('click', (e) => { if (e.target === skillDetailOverlay) closeModal(skillDetailOverlay) })
+attachOverlayCloseGuard(skillDetailOverlay)
 
 // Scope for the next skill create/import action. 'global' means the
 // Skills page opened the modal (write to ~/.claude/skills/); any other
@@ -16370,7 +16394,7 @@ async function openResearchDoc(agent, name) {
       if (backBtn) backBtn.addEventListener('click', () => switchPage('kanban'))
       const adOverlay = document.getElementById('archivedDetailOverlay')
       document.getElementById('archivedDetailClose').addEventListener('click', () => closeModal(adOverlay))
-      adOverlay.addEventListener('click', e => { if (e.target === adOverlay) closeModal(adOverlay) })
+      attachOverlayCloseGuard(adOverlay)
     }
     populateArchivedProjects()
     doArchivedSearch()


### PR DESCRIPTION
<!--
  HU + EN. Töltsd ki minden szakaszt. / Fill in every section.
  A jelölőnégyzeteket így pipáld: [x]  /  Tick a box like this: [x]
-->

## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

HU: A kanban új-kártya modal (és a kártya-részlet modal) a hátterére/overlay-re kattintva
feltétel nélkül bezáródott, a begépelt cím/leírás mentés nélkül elveszett. Ugyanez a minta 14
helyen fordult elő `web/app.js`-ben. Javítva egy közös `overlayHasUnsavedInput()` +
`attachOverlayCloseGuard()` párral: üres form esetén a hátterre kattintás továbbra is szabadon
bezár, kitöltött mező esetén egy `confirm()` dönt. Mind a 14 érintett overlay ezen keresztül megy.

EN: The kanban new-card modal (and the card-detail modal) closed unconditionally on backdrop
click, silently discarding any typed title/description. The same pattern existed in 14 places in
`web/app.js`. Fixed with a shared `overlayHasUnsavedInput()` + `attachOverlayCloseGuard()` pair:
an empty form still closes freely on backdrop click, a filled one gates the close behind a
`confirm()`. All 14 affected overlays now go through this guard.

## Kapcsolódó issue / Related issue

Closes #

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors. (Automata teszt: `kanban-modal-overlay-click-data-loss.test.ts`, 3/3 zöld, node@22. Élő dashboardon még nem próbáltam ki kézzel. / Automated test only; not manually exercised in the live dashboard yet.)
- [ ] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture. (Nem érinti. / Not applicable.)
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).

## Titok-kapu / Secret gate

A `secret-gate` CI-job a valodi kapu. A lokalis pre-commit hook csak gyors
elorejelzes, es `--no-verify`-jal megkerulheto -- ne tekintsd elegnek.
The `secret-gate` CI job is the real gate; the local pre-commit hook is a fast
preview and can be skipped with `--no-verify`, so it is not sufficient on its own.

- [x] Nincs a valtoztatasban bizonyitek-/artefaktum-mappa, titok-alaku string vagy idezett csatorna-uzenet.
      / No evidence or artifact directory, secret-shaped string, or quoted channel message in this change.
