### PR TITLE
fix(gitignore): cover backup/copy variants of secret files (GITIGNENV820)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,13 @@ __pycache__/
 *.pyc
 
 # Secrets & personal data
+# GITIGNENV820: editor backups / copies of .env (.env~, .env.bak, .env.local)
+# were not covered -- only the exact name was. Cover every variant, keep the
+# tracked example file. *~ catches editor backups of ANY secret-bearing file.
 .env
+.env.*
+!.env.example
+*~
 store/
 workspace/
 agents/
@@ -68,6 +74,7 @@ HANDOFF.md
 DREAM.md
 .external-ops-last-run
 REBUILD_PROMPT_V3.1.md
+.lang
 
 # Main agent's runtime voice config (responseMode/voiceModel). Sub-agents store
 # theirs under agents/ (already ignored); the main agent's lives at the repo root

--- a/.gitignore
+++ b/.gitignore
@@ -88,8 +88,11 @@ scripts/support-mail/no-support-reply.html
 
 # M365 / Graph mail credentials (client secret, tenant/client IDs). Plaintext
 # secret -- never commit. Operator keeps this locally per install.
-marveen-mail-ugyfelkod
+# GITIGNENV820 same-class gap: exact-name-only patterns left their backup/copy
+# variants (name.bak, name.old, name.secret.bak) stageable. Glob the whole family.
+marveen-mail-ugyfelkod*
 *.secret
+*.secret.*
 .mail-credentials*
 
 # Python bytecode cache


### PR DESCRIPTION
## What

`.gitignore` protected secret-bearing files by exact name only. Editor backups and copies (`.env~`, `.env.bak`, `.env.local`) were stageable on every install -- `git add -A` could publish a live secret. Reported privately via SECURITY.md (external, no repo access).

**Commit 1 (security):**
- `.env.*` -- covers copy/suffix variants at any depth
- `!.env.example` -- the tracked example file stays visible
- `*~` -- editor backups of any secret-bearing file
- `.lang` in the local-artifacts block -- housekeeping only, NOT a security item

**Commit 2 (same gap class, separate as requested):**
- `marveen-mail-ugyfelkod*` -- the M365 client-secret file had the same exact-name-only gap (`~`/`.bak` variants stageable); glob replaces the exact name
- `*.secret.*` -- covers `name.secret.bak`-style copies of `*.secret`

## Evidence (both directions, measured on this branch)

BEFORE (5ac53fbb):
```
.env~      -> NO MATCH (exit 1)
.env.bak   -> NO MATCH (exit 1)
.lang      -> NO MATCH (exit 1)
.env       -> .gitignore:10:.env        (positive control)
```

AFTER (b369650c + 59be2b4b):
```
.env~                 -> .gitignore:16:*~
.env.bak              -> .gitignore:14:.env.*
sub/dir/.env.bak      -> .gitignore:14:.env.*
.lang                 -> .gitignore:77:.lang
.env                  -> .gitignore:13:.env   (positive control still holds)
.env.example          -> NO MATCH (exit 1)    (stays trackable)
marveen-mail-ugyfelkod.bak -> .gitignore:93:marveen-mail-ugyfelkod*
client.secret.bak     -> .gitignore:95:*.secret.*
```

`.env.example` explicitly re-verified: `git add --dry-run .env.example` -> `add '.env.example'` after the change (the `!` exception works; `.env.*`/`*~` do not over-exclude).

Tracked-file safety: `git ls-files -ci --exclude-standard` lists only `.claude/settings.json`, which is **pre-existing** on the HEAD gitignore too (the `!.claude/settings.json` negation is dead because the `.claude/` directory pattern stops traversal) -- noted as a separate finding, not touched here.

No live leak on this clone: no `.env~`/`.env.bak`/`.lang` files exist in the working tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
