### PR TITLE
fix(gitignore): make the .claude/settings.json negation actually work (CLAUDEIGN820)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,14 @@ store/
 workspace/
 agents/
 reports/
-.claude/
+# CLAUDEIGN820: '.claude/' (directory pattern) stopped traversal, so the
+# '!.claude/settings.json' negation never fired -- the tracked settings file
+# was invisible as untracked and git add refused it on fresh clones.
+# '.claude/*' lets git enumerate the first level so the negation can work;
+# '*/**/.claude/' keeps nested .claude dirs ignored like before.
+.claude/*
 !.claude/settings.json
+*/**/.claude/
 .config/
 
 # Database


### PR DESCRIPTION
## What

`.claude/` is a **directory pattern**, so git stopped traversal at the directory and the `!.claude/settings.json` negation on the next line never fired. Symptom on fresh clones: the tracked settings file was invisible as untracked, `git add .claude/settings.json` refused without `-f`, and it was the only entry in `git ls-files -ci --exclude-standard`. No secret risk -- purely a silent behavior gap (found during GITIGNENV820 verification).

Fix (measured first, per the card's instruction):
- `.claude/*` -- git enumerates the first level, so the negation can fire
- `!.claude/settings.json` -- unchanged, now effective
- `*/**/.claude/` -- preserves the old any-depth coverage for nested `.claude` dirs (depth >= 1), which `.claude/*` alone would have silently un-ignored

## Evidence (both directions)

**BEFORE (48580cd2), functional proof in an empty scratch repo** (`.gitignore` copied, `.claude/{settings.json,settings.local.json,skills/foo}` created):
```
git status --porcelain -> ?? .gitignore        (settings.json INVISIBLE -- negation dead)
```
Note: `git check-ignore .claude/settings.json` says "not ignored" even BEFORE the fix -- check-ignore evaluates the path directly, while status/add use traversal. The dead negation only shows in `ls-files -ci` / `status`, which is why the functional scratch-repo proof is the authoritative one.

**AFTER, same scratch repo:**
```
git status --porcelain -> ?? .claude/  ?? .gitignore   (settings.json visible)
git add .claude/settings.json -> stages cleanly, no -f needed
```

**AFTER, this branch, nothing else changes state:**
```
.claude/settings.json          -> NO MATCH (not ignored)
.claude/settings.local.json    -> .gitignore:26:.claude/*
.claude/skills/foo/SKILL.md    -> .gitignore:26:.claude/*
.claude/worktrees/x/y          -> .gitignore:26:.claude/*
scripts/.claude/settings.json  -> .gitignore:28:*/**/.claude/   (old any-depth behavior kept)
sub/dir/.claude/z              -> .gitignore:28:*/**/.claude/
git ls-files -ci --exclude-standard -> EMPTY (was: .claude/settings.json; no tracked file newly ignored)
```

**Existing-install noise check** (scratch repo with settings.json committed): `git status --porcelain` -> empty. Zero new noise; `settings.local.json`/`skills/` stay hidden.

Survey basis: on the prod tree the only `.claude` dirs outside ignored areas are the root one and nested ones under `.claude/worktrees/` (both covered); the only tracked file under `.claude/` is `settings.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
