### PR TITLE
feat(web): thinking-orb indicator on the working activity badge

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -775,7 +775,7 @@ function renderActivity(entries) {
           '<span style="display:flex;align-items:center;gap:8px">' +
             modeChip +
             termIcon +
-            '<span class="activity-badge ' + meta.cls + '" title="' + escapeHtml(meta.tip || '') + '">' + meta.label + '</span>' +
+            '<span class="activity-badge ' + meta.cls + '" title="' + escapeHtml(meta.tip || '') + '">' + (a.state === 'working' ? '<span class="act-orb" aria-hidden="true"></span>' : '') + meta.label + '</span>' +
           '</span>' +
         '</div>' +
         (tail

--- a/web/style.css
+++ b/web/style.css
@@ -6479,6 +6479,33 @@ main.kanban-active { padding-left: 16px; padding-right: 16px; }
   0%, 100% { background: rgba(34,197,94,0.12); box-shadow: 0 0 0 0 rgba(34,197,94,0); }
   50%      { background: rgba(34,197,94,0.32); box-shadow: 0 0 8px 1px rgba(34,197,94,0.40); }
 }
+
+/* Thinking orb: a tiny animated sphere inside the "working" activity badge, so a
+   live agent reads as *thinking* at a glance (inspired by the "thinking orb"
+   pattern in AI chat UIs). Pure CSS, no JS lifecycle: the badge markup is
+   re-rendered every few seconds via innerHTML, and a CSS-only orb survives that
+   for free. Colors stay in the same green family as .act-working. */
+.activity-badge.act-working { display: inline-flex; align-items: center; gap: 6px; }
+.act-orb {
+  position: relative; width: 13px; height: 13px; border-radius: 50%;
+  overflow: hidden; flex-shrink: 0;
+  background: #15803d;
+  box-shadow: 0 0 6px rgba(34,197,94,0.55);
+}
+.act-orb::before {
+  content: ''; position: absolute; inset: -30%; border-radius: 50%;
+  background: conic-gradient(from 0deg, #166534, #22c55e, #86efac, #16a34a, #166534);
+  animation: orb-swirl 2.8s linear infinite;
+}
+.act-orb::after {
+  /* fixed specular highlight over the swirling core sells the "sphere" */
+  content: ''; position: absolute; inset: 0; border-radius: 50%;
+  background: radial-gradient(circle at 32% 28%, rgba(255,255,255,0.85), rgba(255,255,255,0) 46%);
+}
+@keyframes orb-swirl { to { transform: rotate(360deg); } }
+@media (prefers-reduced-motion: reduce) {
+  .act-orb::before { animation: none; }
+}
 .activity-tail {
   margin: 0; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11px;
   line-height: 1.45; color: var(--text-muted); white-space: pre-wrap; word-break: break-word;


### PR DESCRIPTION
## What

A tiny animated "thinking orb" inside the green **working** badge on the Activity page, so a live agent reads as *thinking* at a glance — inspired by the thinking-orb pattern common in AI chat UIs (e.g. https://orbs.jakubantalik.com/, used here only as visual inspiration; this is an original, dependency-free implementation).

## How

- **Pure CSS, no JS lifecycle.** The activity list is re-rendered via `innerHTML` every few seconds, so a canvas/JS orb would need re-init on every tick. A CSS-only sphere (conic-gradient swirl rotating under a fixed specular highlight) survives the re-render for free.
- One-line change in `renderActivity()`: the orb `<span>` is prepended only for the `working` state, `aria-hidden` so screen readers still read the badge label only.
- Colors stay in the existing `act-working` green family; the badge keeps its breathe pulse.
- `prefers-reduced-motion: reduce` disables the swirl.

## Diff size

+28 / −1, two files (`web/app.js`, `web/style.css`). No dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)