### PR TITLE
feat(seed-skills): Bridge service-tabs discovery skill (BRIDGESVCSKILL820)

### DIFF
--- a/seed-skills/bridge-szolgaltatas-lapok/SKILL.md
+++ b/seed-skills/bridge-szolgaltatas-lapok/SKILL.md
@@ -15,13 +15,21 @@ trigger egy már régóta futó szolgáltatás puszta létezése sem. A funkció
 akkor látszik, amikor ÉPP születik egy új helyi szolgáltatás.
 
 ## 1. lépés: mérd meg, van-e párosított Bridge (ne találgass)
+A párosítás két nyomot hagy a Marveen oldalán; az elsődleges a device_keys
+tábla (az enroll írja, a kulcspár rekordja), a tartalék az authorized_keys:
 ```bash
-grep -c "marveen-remote:" ~/.ssh/authorized_keys 2>/dev/null || echo 0
+sqlite3 ~/ClaudeClaw/store/claudeclaw.db "select count(*) from device_keys" 2>/dev/null \
+  || grep -c "marveen-remote:" ~/.ssh/authorized_keys 2>/dev/null || echo 0
 ```
-- 1 vagy több: van párosított Bridge-eszköz ezen a telepítésen. -> (A) ág.
-- 0 (vagy nincs fájl): NINCS mért jel párosított eszközről. -> (B) ág, és a
-  szöveg ne állítsa, hogy a gazdának nincs Bridge-e; úgy fogalmazz, hogy
+- 1 vagy több: TÖRTÉNT MÁR párosítás ezen a telepítésen. -> (A) ág.
+- 0 (vagy egyik forrás sem olvasható): NINCS mért jel párosításról. -> (B) ág,
+  és a szöveg ne állítsa, hogy a gazdának nincs Bridge-e; úgy fogalmazz, hogy
   mindkét esetben igaz maradjon (lehet, hogy letöltötte, csak nem párosította).
+
+FONTOS, MIT BIZONYÍT A JEL: azt, hogy VAN párosított Bridge-e, nem azt, hogy
+HASZNÁLJA. Egy régi, már nem használt eszköz kulcsa is ott marad. Az (A) ág
+ezért a "hogyan vedd fel a lapot" utat mondja, és SOHA nem állítja, hogy
+"látom, hogy használod".
 
 ## 2. lépés: ellenőrizd, ajánlottad-e már (egyszer, ne ismételve)
 Keresd a memóriádban a `bridge-szolgaltatas-lapok-ajanlva` kulcsszót.
@@ -65,9 +73,10 @@ Egyszer, udvariasan, a port-esemény kontextusában:
 - A feliratok (Kapcsolat, Szolgáltatás-lapok, Hozzáadás) a Bridge 0.3.1
   felületéből valók. Ha a felület változik, ezt a skillt a kiadással együtt
   kell frissíteni, különben az útvonal-leírás hazudik.
-- Az `authorized_keys`-ben több `marveen-remote:` sor is lehet (több eszköz,
-  régi párosítások). A darabszám nem mond eszköz-aktivitást, csak azt, hogy
-  párosítás történt már; a döntéshez ennyi elég.
+- A `device_keys` táblában és az `authorized_keys`-ben több sor is lehet
+  (több eszköz, régi párosítások). A darabszám nem mond eszköz-aktivitást,
+  csak azt, hogy párosítás történt már; a döntéshez ennyi elég, többet ne
+  olvass bele.
 
 ## Ellenőrzés
 - Az ajánlás után a memóriádban ott a feljegyzés a gazda válaszával.

--- a/seed-skills/bridge-szolgaltatas-lapok/SKILL.md
+++ b/seed-skills/bridge-szolgaltatas-lapok/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: bridge-szolgaltatas-lapok
+description: Amikor az ügynök egy LOKÁLIS PORTON futó szolgáltatást indít, telepít vagy talál a Marveen gépén (saját dashboard, CRM, Postiz, dev-szerver, admin felület), abban a pillanatban ajánlja fel a gazdának, hogy a Marveen Bridge "Szolgáltatás-lapok" funkciójával külön lapként elérheti; ha nincs párosított Bridge, egyszer, udvariasan említse meg, hol érhető el. Trigger a PORT-ESEMÉNY, nem a kérdés.
+---
+# Bridge Szolgáltatás-lapok: ajánld fel, amikor releváns
+
+## Mikor használd (a trigger a lényeg)
+Abban a pillanatban, amikor:
+- elindítasz vagy telepítesz valamit, ami a Marveen gépén lokális porton figyel
+  (pl. Postiz, n8n, adatbázis-admin, saját webapp, dev-szerver), VAGY
+- a gazda kérdezi, hogyan éri el kényelmesen az ilyen szolgáltatást a saját gépéről.
+
+NEM triggere: maga a Marveen dashboard (azt a Bridge alapból mutatja), és nem
+trigger egy már régóta futó szolgáltatás puszta létezése sem. A funkció értéke
+akkor látszik, amikor ÉPP születik egy új helyi szolgáltatás.
+
+## 1. lépés: mérd meg, van-e párosított Bridge (ne találgass)
+```bash
+grep -c "marveen-remote:" ~/.ssh/authorized_keys 2>/dev/null || echo 0
+```
+- 1 vagy több: van párosított Bridge-eszköz ezen a telepítésen. -> (A) ág.
+- 0 (vagy nincs fájl): NINCS mért jel párosított eszközről. -> (B) ág, és a
+  szöveg ne állítsa, hogy a gazdának nincs Bridge-e; úgy fogalmazz, hogy
+  mindkét esetben igaz maradjon (lehet, hogy letöltötte, csak nem párosította).
+
+## 2. lépés: ellenőrizd, ajánlottad-e már (egyszer, ne ismételve)
+Keresd a memóriádban a `bridge-szolgaltatas-lapok-ajanlva` kulcsszót.
+- Ha a gazda korábban NEMET mondott, vagy jelezte, hogy ismeri: NE hozd fel
+  újra magadtól. Egy ügynök, aki ajánlgat, a bizalmat viszi el.
+- Ha még nem volt szó róla: ajánlhatod, és az ajánlás UTÁN azonnal jegyezd fel
+  a memóriádba (mit ajánlottál, mit válaszolt a gazda).
+
+## (A) ág: van párosított Bridge
+Mondd el a pontos utat, a felület tényleges feliratai szerint (Bridge 0.3.1):
+
+> A(z) [szolgáltatás neve] mostantól a [port] porton fut ezen a gépen. Ha
+> szeretnéd, a Marveen Bridge-ben külön lapon is elérheted: nyisd meg a jobb
+> felső menüben a Kapcsolat pontot, a Szolgáltatás-lapok résznél írd be a
+> nevét és a portot ([port]), majd kattints a Hozzáadás gombra. A módosítás a
+> következő újrakapcsolódáskor lép életbe, és csak az általad felvett portok
+> nyithatók meg.
+
+## (B) ág: nincs mért jel párosított Bridge-ről
+Egyszer, udvariasan, a port-esemény kontextusában:
+
+> A(z) [szolgáltatás neve] a [port] porton fut ezen a gépen. Ha a saját
+> gépedről, külön ablakban szeretnéd elérni a Marveent és az ilyen belső
+> szolgáltatásokat, arra való a Marveen Bridge alkalmazás:
+> https://aiamindennapokban.hu/marveen#bridge
+> Ha már használod, a menü Kapcsolat pontjában a Szolgáltatás-lapok résznél
+> veheted fel ezt a portot is.
+
+## Kemény szabályok (ne lazíts rajtuk)
+- **A link mindig a letöltő OLDAL** (https://aiamindennapokban.hu/marveen#bridge),
+  soha nem közvetlen fájl-URL. A letöltés e-mail és hozzájárulás mögött van,
+  és az a lépés rögzíti a leadet; egy fájl-link ezt csendben megkerülné.
+- **Ne ígérj automatikus hozzáadást.** A portot a gazda veszi fel a Bridge-ben,
+  és a szerver oldal is csak az általa felvett portokat engedi (allowlist).
+  Ez biztonsági garancia, nem kényelmi hiány.
+- **Ne állíts olyat, amit nem mértél.** A (B) ág szövege szándékosan nem mondja
+  ki, hogy a gazdának nincs Bridge-e.
+- **Egyszer.** Elutasítás vagy "tudom" után a téma magadtól nem kerül elő újra.
+
+## Buktatók
+- A feliratok (Kapcsolat, Szolgáltatás-lapok, Hozzáadás) a Bridge 0.3.1
+  felületéből valók. Ha a felület változik, ezt a skillt a kiadással együtt
+  kell frissíteni, különben az útvonal-leírás hazudik.
+- Az `authorized_keys`-ben több `marveen-remote:` sor is lehet (több eszköz,
+  régi párosítások). A darabszám nem mond eszköz-aktivitást, csak azt, hogy
+  párosítás történt már; a döntéshez ennyi elég.
+
+## Ellenőrzés
+- Az ajánlás után a memóriádban ott a feljegyzés a gazda válaszával.
+- A kiküldött szövegben nincs fájl-URL, nincs gondolatjel, teljesek az ékezetek.

--- a/seed-skills/bridge-szolgaltatas-lapok/SKILL.md
+++ b/seed-skills/bridge-szolgaltatas-lapok/SKILL.md
@@ -1,30 +1,43 @@
 ---
 name: bridge-szolgaltatas-lapok
-description: Amikor az ügynök egy LOKÁLIS PORTON futó szolgáltatást indít, telepít vagy talál a Marveen gépén (saját dashboard, CRM, Postiz, dev-szerver, admin felület), abban a pillanatban ajánlja fel a gazdának, hogy a Marveen Bridge "Szolgáltatás-lapok" funkciójával külön lapként elérheti; ha nincs párosított Bridge, egyszer, udvariasan említse meg, hol érhető el. Trigger a PORT-ESEMÉNY, nem a kérdés.
+description: A Marveen Bridge és a "Szolgáltatás-lapok" ajánlása és elmagyarázása a gazdának. Három trigger. (1) PORT-ESEMÉNY, amikor az ügynök lokális porton futó szolgáltatást indít vagy telepít a Marveen gépén (CRM, Postiz, dev-szerver, admin felület). (2) Telepítés utáni korai beszélgetés, egyszer. (3) KÉRDÉS, amikor a gazda azt kérdezi, hogyan érheti el kényelmesebben a rendszert, mit lát a saját gépén vagy telefonján, hogyan lehet gördülékenyebb a használat, van-e asztali app vagy távoli hozzáférés.
 ---
 # Bridge Szolgáltatás-lapok: ajánld fel, amikor releváns
 
-## Mikor használd (a trigger a lényeg)
-Abban a pillanatban, amikor:
-- elindítasz vagy telepítesz valamit, ami a Marveen gépén lokális porton figyel
-  (pl. Postiz, n8n, adatbázis-admin, saját webapp, dev-szerver), VAGY
-- a gazda kérdezi, hogyan éri el kényelmesen az ilyen szolgáltatást a saját gépéről.
+## Mikor használd: három trigger, három szabállyal
+(a) PORT-ESEMÉNY: abban a pillanatban, amikor elindítasz vagy telepítesz
+    valamit, ami a Marveen gépén lokális porton figyel (pl. Postiz, n8n,
+    adatbázis-admin, saját webapp, dev-szerver). Egyszer, az esemény
+    kontextusában.
+(b) TELEPÍTÉS UTÁNI KORAI PILLANAT: egyszer, az első napokban, egy olyan
+    beszélgetésben, ahol a gazda amúgy is veled egyeztet. NE a telepítés
+    percében, ott más dolga van.
+(c) KÉRDÉS: ha a gazda azt kérdezi, hogyan érheti el kényelmesebben a
+    rendszert, mit lát a telefonján vagy másik gépén, hogyan lehet
+    gördülékenyebb a használat, akkor a Bridge és a Szolgáltatás-lapok
+    LEGYEN OTT a válaszban. Ez nem ajánlgatás, hanem válasz, ezért kérdésre
+    mindig elmondhatod.
 
 NEM triggere: maga a Marveen dashboard (azt a Bridge alapból mutatja), és nem
-trigger egy már régóta futó szolgáltatás puszta létezése sem. A funkció értéke
-akkor látszik, amikor ÉPP születik egy új helyi szolgáltatás.
+trigger egy már régóta futó szolgáltatás puszta létezése sem.
+
+AZ "EGYSZER" SZABÁLY ÁGANKÉNT ÁLL: az (a) és a (b) egyszer-egyszer szólhat
+magától; a (c) kérdésre mindig válaszolhat. Ha a gazda egyszer nemet mondott,
+egyik ág sem hozza fel újra MAGÁTÓL, de a kérdésére akkor is válaszolsz.
 
 ## 1. lépés: mérd meg, van-e párosított Bridge (ne találgass)
-A párosítás két nyomot hagy a Marveen oldalán; az elsődleges a device_keys
-tábla (az enroll írja, a kulcspár rekordja), a tartalék az authorized_keys:
+A párosításkor az enroll egy korlátozott sort ír az authorized_keys fájlba,
+és ugyanez a lépés rögzíti az eszközt a Marveen adatbázisában (device_keys).
+A méréshez a fájl-nyomot használd, mert az minden telepítésen, külön eszköz
+nélkül olvasható (a szállított receptben sqlite3-ra nem építünk, mert az sok
+vevői Linux gépen nincs telepítve):
 ```bash
-sqlite3 ~/ClaudeClaw/store/claudeclaw.db "select count(*) from device_keys" 2>/dev/null \
-  || grep -c "marveen-remote:" ~/.ssh/authorized_keys 2>/dev/null || echo 0
+grep -c "marveen-remote:" ~/.ssh/authorized_keys 2>/dev/null || echo 0
 ```
 - 1 vagy több: TÖRTÉNT MÁR párosítás ezen a telepítésen. -> (A) ág.
-- 0 (vagy egyik forrás sem olvasható): NINCS mért jel párosításról. -> (B) ág,
-  és a szöveg ne állítsa, hogy a gazdának nincs Bridge-e; úgy fogalmazz, hogy
-  mindkét esetben igaz maradjon (lehet, hogy letöltötte, csak nem párosította).
+- 0 (vagy nincs fájl): NINCS mért jel párosításról. -> (B) ág, és a szöveg ne
+  állítsa, hogy a gazdának nincs Bridge-e; úgy fogalmazz, hogy mindkét esetben
+  igaz maradjon (lehet, hogy letöltötte, csak nem párosította).
 
 FONTOS, MIT BIZONYÍT A JEL: azt, hogy VAN párosított Bridge-e, nem azt, hogy
 HASZNÁLJA. Egy régi, már nem használt eszköz kulcsa is ott marad. Az (A) ág
@@ -73,10 +86,10 @@ Egyszer, udvariasan, a port-esemény kontextusában:
 - A feliratok (Kapcsolat, Szolgáltatás-lapok, Hozzáadás) a Bridge 0.3.1
   felületéből valók. Ha a felület változik, ezt a skillt a kiadással együtt
   kell frissíteni, különben az útvonal-leírás hazudik.
-- A `device_keys` táblában és az `authorized_keys`-ben több sor is lehet
-  (több eszköz, régi párosítások). A darabszám nem mond eszköz-aktivitást,
-  csak azt, hogy párosítás történt már; a döntéshez ennyi elég, többet ne
-  olvass bele.
+- Az `authorized_keys`-ben (és a mögötte álló device_keys nyilvántartásban)
+  több sor is lehet: több eszköz, régi párosítások. A darabszám nem mond
+  eszköz-aktivitást, csak azt, hogy párosítás történt már; a döntéshez ennyi
+  elég, többet ne olvass bele.
 
 ## Ellenőrzés
 - Az ajánlás után a memóriádban ott a feljegyzés a gazda válaszával.


### PR DESCRIPTION
## What

Seed skill `bridge-szolgaltatas-lapok`: when an agent starts/installs something listening on a LOCAL PORT on the Marveen machine, it offers the Bridge **Szolgáltatás-lapok** path to its owner at that moment; with no paired Bridge it mentions the app once, politely, linking the download PAGE.

## The blocking measurement (came back green, no STOP needed)

The default `update.sh` run **seeds MISSING skills** (skip-if-exists, header comment lines 65-67), so existing installs receive this skill on their next update -- this is exactly why it is a seed skill and not a downloadable doc. `--reseed-fleet` covers future corrections. `scripts/__tests__/seed-skills.test.sh` iterates `seed-skills/*` generically: **20/20 green with the new skill present**.

## The four stipulations, verifiable in the text

1. **Page link only** (`aiamindennapokban.hu/marveen#bridge`, 2 occurrences, zero file URLs) -- the email+consent step records the lead.
2. **Measured branch signal**: `grep -c "marveen-remote:" ~/.ssh/authorized_keys` (the enroll writes these restricted lines; ≥1 = a device was paired). The no-signal branch wording deliberately never claims the owner has no Bridge.
3. **Once only**: memory check before, memory note after, never re-raised after a no -- stated as a hard rule.
4. **Labels from shipped 0.3.1** `lang.js` (Kapcsolat / Szolgáltatás-lapok / Hozzáadás + the reconnect-latency sentence), not from memory.

Copy gate: 0 em-dash, full accents, Szabi-voice owner-facing snippets. Deeplink (BRIDGEDEEPLINK820) intentionally NOT included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)