### PR TITLE
fix(ideas): stats row counts the unfiltered set, status narrowing moves client-side

### DIFF
--- a/src/__tests__/ideas-stats-unfiltered.test.ts
+++ b/src/__tests__/ideas-stats-unfiltered.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+// Regression for the first live promote (2026-08-20): the stats row counted the
+// already-filtered list, so under the default "active" filter the "Kanbanban"
+// box showed 0 right after a promote and the item's disappearance from the list
+// read as data loss. The stats must be computed from the unfiltered fetch.
+const appJs = readFileSync(join(__dirname, '../../web/app.js'), 'utf8')
+
+describe('ideas stats count the unfiltered set', () => {
+  it('renderIdeasStats iterates ideasAll, not the display list', () => {
+    const fn = appJs.slice(appJs.indexOf('function renderIdeasStats'))
+    const body = fn.slice(0, fn.indexOf('\n}'))
+    expect(body).toContain('of ideasAll')
+    expect(body).not.toMatch(/for \(const \w+ of ideas\)/)
+  })
+
+  it('loadIdeasPage fetches without a server-side status filter', () => {
+    const fn = appJs.slice(appJs.indexOf('async function loadIdeasPage'))
+    const body = fn.slice(0, fn.indexOf('\n}'))
+    // The status narrowing must happen client-side on ideasAll so the stats
+    // row still sees every status.
+    expect(body).not.toContain("params.set('status'")
+    expect(body).toContain('ideasAll =')
+  })
+})

--- a/web/app.js
+++ b/web/app.js
@@ -14920,6 +14920,7 @@ function renderTuToolStats(data) {
 // Ideas (Ötletláda)
 // ============================================================
 let ideas = []
+let ideasAll = []
 let ideasPromoteId = null
 let ideaEditId = null
 let ideaDetailId = null
@@ -14930,12 +14931,16 @@ async function loadIdeasPage() {
   const statusFilter = document.getElementById('ideaStatusFilter')?.value ?? 'active'
   const categoryFilter = document.getElementById('ideaCategoryFilter')?.value || ''
   const params = new URLSearchParams()
-  // 'active' = new+reviewed, fetched unfiltered then narrowed client-side
-  if (statusFilter && statusFilter !== 'active') params.set('status', statusFilter)
+  // Status narrowing happens client-side on the full fetch: the stats row must
+  // count every status, and a server-side status filter starved it — after the
+  // first promote the "Kanbanban" box showed 0 with the item hidden, which read
+  // as data loss on the first live promote (2026-08-20).
   if (categoryFilter) params.set('category', categoryFilter)
   const [ideasRes, catsRes] = await Promise.all([fetch('/api/ideas?' + params), fetch('/api/ideas/categories')])
-  ideas = await ideasRes.json()
-  if (statusFilter === 'active') ideas = ideas.filter(i => i.status === 'new' || i.status === 'reviewed')
+  ideasAll = await ideasRes.json()
+  if (statusFilter === 'active') ideas = ideasAll.filter(i => i.status === 'new' || i.status === 'reviewed')
+  else if (statusFilter) ideas = ideasAll.filter(i => i.status === statusFilter)
+  else ideas = ideasAll
   const cats = await catsRes.json()
   const catSel = document.getElementById('ideaCategoryFilter')
   if (catSel) {
@@ -14948,7 +14953,7 @@ async function loadIdeasPage() {
 
 function renderIdeasStats() {
   const counts = { new: 0, reviewed: 0, kanban: 0, rejected: 0 }
-  for (const i of ideas) counts[i.status] = (counts[i.status] || 0) + 1
+  for (const i of ideasAll) counts[i.status] = (counts[i.status] || 0) + 1
   const el = document.getElementById('ideasStats')
   if (!el) return
   el.innerHTML = Object.entries(counts).map(([s, n]) =>


### PR DESCRIPTION
## Summary
The idea-box stats row (`renderIdeasStats`) counted the already-filtered display list. Under the default **active (new + reviewed)** filter this means:

- right after a successful **promote to kanban**, the promoted idea vanishes from the list (expected) **and** the "in kanban" stat box shows **0** (wrong) — the promote reads as data loss;
- the "rejected" box is similarly always 0 under the default filter.

Surfaced on our first live promote (2026-08-20); latent since the status filter + lifecycle addition (2aba1fd).

## Fix
`loadIdeasPage` now always fetches the full set (category filter only), keeps it in `ideasAll` for the stats row, and narrows the display list client-side. List behavior itself is unchanged.

## Tests
- New regression test `src/__tests__/ideas-stats-unfiltered.test.ts` (contract-style, same pattern as the other web-asset tests).
- Full suite on this branch vs clean base (`afa2f36`): identical results — 3765 passed; the 20 pre-existing failures (5 files: governance-gates, hook-path-guard, hook-command-quoting, email-send-gate, installer-start-and-fallback) fail identically on the clean base, i.e. machine-dependent, not from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)