### PR TITLE
fix(approvals): closed-loop approval gate -- owner delivery, no self-notify, reachable timeout (APPROVALVAK821)

### DIFF
--- a/src/__tests__/approvals-delivery.test.ts
+++ b/src/__tests__/approvals-delivery.test.ts
@@ -1,0 +1,119 @@
+// APPROVALVAK821: the approval gate was a closed loop -- three independent
+// legs, each silently non-delivering:
+//   (1) creation never sent anything to the owner (telegram_message_id was
+//       only writable via PATCH, which nothing called),
+//   (2) notifyMainAgent delivered the notification back to the REQUESTER
+//       when the requester was the main agent itself,
+//   (3) timeout_at was always NULL (no category carries timeout_minutes and
+//       the request's timeout_seconds was never read), so the sweeper's
+//       'timeout' status was structurally unreachable.
+// These tests pin the fix for all three legs: the pure pieces behaviorally,
+// the wiring as string contracts (house idiom of approvals-prompt-contract).
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+  computeTimeoutAt,
+  buildOwnerApprovalText,
+  DEFAULT_TIMEOUT_MINUTES,
+  MAX_TIMEOUT_SECONDS,
+} from '../web/routes/approvals.js'
+import type { Approval } from '../db.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ROUTE = readFileSync(join(__dirname, '../../src/web/routes/approvals.ts'), 'utf-8')
+const TELEGRAM = readFileSync(join(__dirname, '../../src/web/telegram.ts'), 'utf-8')
+
+const NOW_MS = 1_787_300_000_000
+
+function approval(over: Partial<Approval> = {}): Approval {
+  return {
+    id: 'test-id-1234',
+    agent_id: 'samu',
+    category: 'skill_patch',
+    action_description: 'Skill frissítése a mérési eredmény alapján',
+    action_payload: null,
+    status: 'pending',
+    timeout_at: Math.floor(NOW_MS / 1000) + 3600,
+    telegram_message_id: null,
+    requested_at: Math.floor(NOW_MS / 1000),
+    resolved_at: null,
+    resolved_by: null,
+    ...over,
+  }
+}
+
+describe('computeTimeoutAt (leg 3: the timeout state must be reachable)', () => {
+  const now = Math.floor(NOW_MS / 1000)
+
+  it('the request timeout_seconds wins', () => {
+    expect(computeTimeoutAt('nonexistent-category', 3600, NOW_MS)).toBe(now + 3600)
+  })
+
+  it('caps a timeout past a week (it would equal the old "never")', () => {
+    expect(computeTimeoutAt('x', 10 * 24 * 3600, NOW_MS)).toBe(now + MAX_TIMEOUT_SECONDS)
+  })
+
+  it('ignores junk timeout_seconds and falls through', () => {
+    for (const junk of ['3600', -5, 0, NaN, Infinity, null, undefined, {}]) {
+      expect(computeTimeoutAt('nonexistent-category', junk, NOW_MS)).toBe(now + DEFAULT_TIMEOUT_MINUTES * 60)
+    }
+  })
+
+  it('NEVER returns null: with no param and no category value the default applies', () => {
+    expect(computeTimeoutAt('nonexistent-category', undefined, NOW_MS)).toBe(now + DEFAULT_TIMEOUT_MINUTES * 60)
+  })
+})
+
+describe('buildOwnerApprovalText (leg 1: what the owner reads)', () => {
+  it('carries the id, requester, category and description', () => {
+    const text = buildOwnerApprovalText(approval())
+    expect(text).toContain('samu')
+    expect(text).toContain('skill_patch')
+    expect(text).toContain('Skill frissítése a mérési eredmény alapján')
+    expect(text).toContain('test-id-1234')
+    expect(text).toContain('Jóváhagyások')
+    expect(text).not.toContain('undefined')
+  })
+
+  it('renders the expiry in local (Budapest) time, or "nincs" without one', () => {
+    expect(buildOwnerApprovalText(approval())).toContain('Lejárat: 2026.')
+    expect(buildOwnerApprovalText(approval({ timeout_at: null }))).toContain('Lejárat: nincs')
+  })
+})
+
+describe('wiring contracts on the route source', () => {
+  it('the POST handler notifies the OWNER, not only the main agent', () => {
+    const post = ROUTE.slice(ROUTE.indexOf("path === '/api/approvals' && method === 'POST'"))
+    const owner = post.indexOf('notifyOwner(approval)')
+    const main = post.indexOf('notifyMainAgent(approval)')
+    expect(owner).toBeGreaterThan(0)
+    expect(main).toBeGreaterThan(owner)
+  })
+
+  it('a successful owner send stamps telegram_message_id onto the row', () => {
+    expect(ROUTE).toContain('setApprovalTelegramMessageId(approval.id, messageId)')
+  })
+
+  it('leg 2: the main-agent notify short-circuits when the requester IS the main agent', () => {
+    const fn = ROUTE.slice(ROUTE.indexOf('function notifyMainAgent('))
+    const guard = fn.indexOf('approval.agent_id === MAIN_AGENT_ID')
+    const send = fn.indexOf('createAgentMessage')
+    expect(guard).toBeGreaterThan(0)
+    expect(send).toBeGreaterThan(guard)
+  })
+
+  it('the POST handler reads timeout_seconds from the body', () => {
+    expect(ROUTE).toContain('computeTimeoutAt(category, timeout_seconds)')
+  })
+
+  it('a failed owner send is loud, not silent', () => {
+    expect(ROUTE).toContain('approval owner notification FAILED')
+  })
+
+  it('sendTelegramMessage exposes the message_id for the stamp', () => {
+    expect(TELEGRAM).toContain('Promise<number | null>')
+    expect(TELEGRAM).toContain('message_id')
+  })
+})

--- a/src/db.ts
+++ b/src/db.ts
@@ -3393,6 +3393,14 @@ export function resolveApproval(id: string, status: 'approved' | 'rejected' | 't
   `).run(status, now, resolvedBy, telegramMessageId ?? null, id).changes > 0
 }
 
+// The CREATE path stamps the owner-notification message id onto the row
+// (APPROVALVAK821): until this existed, telegram_message_id was only writable
+// through resolveApproval, so a pending request could never carry it.
+export function setApprovalTelegramMessageId(id: string, telegramMessageId: number): boolean {
+  return db.prepare('UPDATE approvals SET telegram_message_id = ? WHERE id = ?')
+    .run(telegramMessageId, id).changes > 0
+}
+
 export function listApprovals(opts: {
   agent_id?: string
   category?: string

--- a/src/web/routes/approvals.ts
+++ b/src/web/routes/approvals.ts
@@ -1,40 +1,107 @@
 import { randomUUID } from 'node:crypto'
 import { readFileSync, existsSync } from 'node:fs'
 import { join } from 'node:path'
-import { PROJECT_ROOT, MAIN_AGENT_ID } from '../../config.js'
+import { PROJECT_ROOT, MAIN_AGENT_ID, TELEGRAM_BOT_TOKEN } from '../../config.js'
 import {
   createApproval, getApproval, resolveApproval, listApprovals, expireTimedOutApprovals,
-  createAgentMessage,
+  createAgentMessage, setApprovalTelegramMessageId,
   type Approval,
 } from '../../db.js'
 import { logger } from '../../logger.js'
 import { readBody, json } from '../http-helpers.js'
+import { resolveOwnerChatId } from '../../owner-chat.js'
+import { sendTelegramMessage } from '../telegram.js'
 import type { RouteContext } from './types.js'
 
 const AUTONOMY_CONFIG_PATH = join(PROJECT_ROOT, 'store', 'autonomy-config.json')
 
-interface AutonomyCategory {
-  key: string
-  timeout_minutes?: number | null
-}
+// APPROVALVAK821: a pending approval with timeout_at NULL can never reach the
+// 'timeout' status -- the sweeper's WHERE clause skips it forever, so an
+// unanswered request leaves the asking agent polling into eternity. No
+// category carried timeout_minutes in any real install, which made the state
+// STRUCTURALLY unreachable. Every request therefore gets a timeout: the
+// caller's explicit timeout_seconds wins, then the category's
+// timeout_minutes, then this default.
+export const DEFAULT_TIMEOUT_MINUTES = 1440
+// Cap: a timeout past a week is indistinguishable from the old "never".
+export const MAX_TIMEOUT_SECONDS = 7 * 24 * 3600
 
-interface AutonomyConfig {
-  categories: AutonomyCategory[]
-}
-
-function getTimeoutAt(category: string): number | null {
+function readCategoryTimeoutMinutes(category: string): number | null {
   try {
     if (!existsSync(AUTONOMY_CONFIG_PATH)) return null
-    const config = JSON.parse(readFileSync(AUTONOMY_CONFIG_PATH, 'utf-8')) as AutonomyConfig
+    const config = JSON.parse(readFileSync(AUTONOMY_CONFIG_PATH, 'utf-8')) as {
+      categories: { key: string; timeout_minutes?: number | null }[]
+    }
     const cat = config.categories.find(c => c.key === category)
     if (!cat || cat.timeout_minutes == null) return null
-    return Math.floor(Date.now() / 1000) + cat.timeout_minutes * 60
+    return cat.timeout_minutes
   } catch {
     return null
   }
 }
 
+// Pure + exported for tests. `timeoutSeconds` is the request-body value as
+// received (unknown): the scaffolded agent instructions have always told
+// agents to send timeout_seconds, but the old handler never read it.
+export function computeTimeoutAt(category: string, timeoutSeconds: unknown, nowMs: number = Date.now()): number {
+  const now = Math.floor(nowMs / 1000)
+  if (typeof timeoutSeconds === 'number' && Number.isFinite(timeoutSeconds) && timeoutSeconds > 0) {
+    return now + Math.min(Math.floor(timeoutSeconds), MAX_TIMEOUT_SECONDS)
+  }
+  const catMinutes = readCategoryTimeoutMinutes(category)
+  if (catMinutes != null && catMinutes > 0) return now + catMinutes * 60
+  return now + DEFAULT_TIMEOUT_MINUTES * 60
+}
+
+// Owner-facing Telegram text. Pure + exported for tests. Plain text (no
+// markdown escaping concerns), proper accents: this is outgoing copy.
+export function buildOwnerApprovalText(approval: Approval): string {
+  const expires = approval.timeout_at
+    ? new Date(approval.timeout_at * 1000).toLocaleString('hu-HU', { timeZone: 'Europe/Budapest' })
+    : 'nincs'
+  return [
+    `[JÓVÁHAGYÁS KELL] ${approval.agent_id} | ${approval.category}`,
+    approval.action_description,
+    `Lejárat: ${expires}`,
+    `Döntés: Dashboard -> Jóváhagyások (id: ${approval.id})`,
+  ].join('\n')
+}
+
+// APPROVALVAK821 (a) -- the request must reach the OWNER, not only the main
+// agent's inter-agent queue. Fire-and-forget on purpose: the POST response
+// must not wait on the Telegram round-trip, and a failed send must not fail
+// the request -- but it must be LOUD in the logs, because a silently
+// undelivered approval is exactly the closed loop this fixes.
+function notifyOwner(approval: Approval): void {
+  void (async () => {
+    if (!TELEGRAM_BOT_TOKEN) {
+      logger.warn({ approvalId: approval.id }, 'approval owner notification suppressed: no TELEGRAM_BOT_TOKEN')
+      return
+    }
+    const ownerChat = resolveOwnerChatId()
+    if (!ownerChat) {
+      logger.warn({ approvalId: approval.id }, 'approval owner notification suppressed: no owner chat')
+      return
+    }
+    try {
+      const messageId = await sendTelegramMessage(TELEGRAM_BOT_TOKEN, ownerChat, buildOwnerApprovalText(approval))
+      if (messageId != null) setApprovalTelegramMessageId(approval.id, messageId)
+      logger.info({ approvalId: approval.id, messageId }, 'approval owner notification sent')
+    } catch (err) {
+      logger.warn({ err, approvalId: approval.id }, 'approval owner notification FAILED -- the request is only visible on the dashboard')
+    }
+  })()
+}
+
 function notifyMainAgent(approval: Approval): void {
+  // APPROVALVAK821 (b): when the requester IS the main agent, this used to
+  // deliver the notification back to the requester itself -- which counted as
+  // "notified" while no human ever saw it. The owner Telegram above is the
+  // real notification; a self-addressed message is noise that hides the gap.
+  if (approval.agent_id === MAIN_AGENT_ID) {
+    logger.info({ approvalId: approval.id }, 'approval main-agent notify skipped: requester is the main agent (owner is notified on Telegram)')
+    return
+  }
   try {
     const content = [
       `[APPROVAL_REQUEST]`,
@@ -67,7 +134,7 @@ export async function tryHandleApprovals(ctx: RouteContext): Promise<boolean> {
 
   // POST /api/approvals -- create new approval request
   if (path === '/api/approvals' && method === 'POST') {
-    let body: { agent_id?: unknown; category?: unknown; action_description?: unknown; action_payload?: unknown }
+    let body: { agent_id?: unknown; category?: unknown; action_description?: unknown; action_payload?: unknown; timeout_seconds?: unknown }
     try {
       body = JSON.parse((await readBody(req)).toString())
     } catch {
@@ -75,7 +142,7 @@ export async function tryHandleApprovals(ctx: RouteContext): Promise<boolean> {
       return true
     }
 
-    const { agent_id, category, action_description, action_payload } = body
+    const { agent_id, category, action_description, action_payload, timeout_seconds } = body
     if (typeof agent_id !== 'string' || !agent_id.trim()) {
       json(res, { error: 'agent_id is required' }, 400)
       return true
@@ -94,7 +161,7 @@ export async function tryHandleApprovals(ctx: RouteContext): Promise<boolean> {
     }
 
     const id = randomUUID()
-    const timeout_at = getTimeoutAt(category)
+    const timeout_at = computeTimeoutAt(category, timeout_seconds)
     const approval = createApproval({
       id,
       agent_id: agent_id.trim(),
@@ -104,6 +171,7 @@ export async function tryHandleApprovals(ctx: RouteContext): Promise<boolean> {
       timeout_at,
     })
 
+    notifyOwner(approval)
     notifyMainAgent(approval)
     logger.info({ id, agent_id, category }, 'Approval request created')
     json(res, approval, 201)

--- a/src/web/telegram.ts
+++ b/src/web/telegram.ts
@@ -119,7 +119,7 @@ export async function refreshMarveenBotUsername(): Promise<void> {
   } catch { /* offline; cache stays stale */ }
 }
 
-export async function sendTelegramMessage(token: string, chatId: string, text: string): Promise<void> {
+export async function sendTelegramMessage(token: string, chatId: string, text: string): Promise<number | null> {
   // Test-run marking happens HERE too, not only in notifyChannel: this path
   // reads its token from .env FILES (schedule-runner alerts), so blanking
   // CHANNEL_TOKEN/CHANNEL_CHAT_ID in a test's environment does not stop it.
@@ -136,6 +136,15 @@ export async function sendTelegramMessage(token: string, chatId: string, text: s
   if (!resp.ok) {
     const body = await resp.text().catch(() => '')
     throw new Error(`Telegram API ${resp.status}: ${body.slice(0, 200)}`)
+  }
+  // Some callers need the message id back (the approval gate stamps it onto
+  // the request row so the decision UI can reference the exact message). A
+  // malformed success body is not a send failure -- return null, never throw.
+  try {
+    const data = await resp.json() as { result?: { message_id?: number } }
+    return typeof data.result?.message_id === 'number' ? data.result.message_id : null
+  } catch {
+    return null
   }
 }
 


### PR DESCRIPTION
## APPROVALVAK821: the approval gate was a closed loop

16 level-2 requests sat pending for three days; three independent legs were silently dead (measured by Marveen, msg 13949). This PR fixes all three:

### (a) Owner delivery
Creation now sends a Telegram message to the owner (`resolveOwnerChatId()` + `TELEGRAM_BOT_TOKEN`, the same pattern the schedule-runner alerts use) and stamps the returned `message_id` onto the row (`setApprovalTelegramMessageId`, new). `sendTelegramMessage` now returns `Promise<number | null>` (message_id parsed best-effort; existing callers ignore the return value, no behavior change for them). Fire-and-forget: the POST response does not wait on the Telegram round-trip, but a failed OR suppressed send logs loudly -- a silently undelivered approval is exactly the bug class.

### (b) Self-notify
`notifyMainAgent` short-circuits when the requester IS the main agent. It used to deliver the notification back to the requester itself, which counted as "notified" while no human ever saw it -- this alone would have made the bug visible three days ago.

### (c) Reachable timeout
`computeTimeoutAt` never returns null: request `timeout_seconds` (finally destructured -- the scaffolded agent instructions have always told agents to send it) > category `timeout_minutes` > 1440-minute default, capped at 7 days. The per-minute sweeper therefore actually expires rows; the `timeout` status is reachable.

### Evidence
- 12 new tests: `computeTimeoutAt` precedence/cap/junk-input/never-null behaviorally; owner text content (id, requester, category, description, Budapest-local expiry, no `undefined`); wiring as string contracts (owner-notify before main-notify, message_id stamp, self-notify guard order, loud failure, telegram return type).
- Full suite: 284 files / 3805 tests green in the worktree.
- Typecheck clean.

### Deploy notes
- The 16 stuck requests are data -- this fix does not retro-notify them. Batch-decide them once deployed (per msg 13949).
- Live effect needs the dashboard restart (standard host-update flow). The owner-notification live proof belongs to the deploy round: one real level-2 request must land in the owner's Telegram with the row's `telegram_message_id` set.

Card: APPROVALVAK821.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
