### PR TITLE
fix(approvals): in-band fallback on suppressed owner send + two carded one-liners

### DIFF
--- a/scripts/email-send-gate.mjs
+++ b/scripts/email-send-gate.mjs
@@ -85,8 +85,8 @@ export function gateDecision(toolName, toolInput) {
 export function buildDraftOnlyMsg(ownerName) {
   return (
     'Kimeno email kuldese tiltott (draft-kapu). ' +
-    'Ird meg ugyanezt draft: true kapcsoloval, es szolj ' +
-    `${ownerName}nek, hogy a Gmail piszkozatok kozott varja a jovahagyasat. ` +
+    'Ird meg ugyanezt draft: true kapcsoloval, es jelezd a tulajdonosnak ' +
+    `(${ownerName}), hogy a Gmail piszkozatok kozott varja a jovahagyasat. ` +
     'Csak VERIFIKALT cimre. A kuldes gombot ember nyomja meg.'
   )
 }

--- a/src/__tests__/approvals-delivery.test.ts
+++ b/src/__tests__/approvals-delivery.test.ts
@@ -117,3 +117,21 @@ describe('wiring contracts on the route source', () => {
     expect(TELEGRAM).toContain('message_id')
   })
 })
+
+describe('degraded-delivery fallback (review finding on #1026)', () => {
+  it('every owner-send failure path falls back to an in-band message', () => {
+    const fn = ROUTE.slice(ROUTE.indexOf('function notifyOwner('))
+    for (const reason of ["'no-token'", "'no-owner-chat'", "'send-failed'"]) {
+      expect(fn).toContain(`fallbackInBand(approval, ${reason})`)
+    }
+  })
+
+  it('the fallback is main-requester-only and carries the OWNER_UNREACHED marker', () => {
+    const fn = ROUTE.slice(ROUTE.indexOf('function fallbackInBand('), ROUTE.indexOf('function notifyOwner('))
+    const guard = fn.indexOf('approval.agent_id !== MAIN_AGENT_ID')
+    const send = fn.indexOf('createAgentMessage')
+    expect(guard).toBeGreaterThan(0)
+    expect(send).toBeGreaterThan(guard)
+    expect(fn).toContain('[OWNER_UNREACHED')
+  })
+})

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -1113,7 +1113,13 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
           const stopRes = await stopAgentProcess(name)
           if (stopRes.ok) {
             await delay(2000)
-            gcRestarted = (await startAgentProcess(name)).ok
+            // 'Agent is already running' here means the 60s reconcile sweep
+            // raced us in the stop..start gap and started the agent with the
+            // NEW config (written above, before the stop) -- the end state is
+            // exactly what a restart promises, only the starter differs
+            // (PR1014KONFIG821).
+            const gcStartRes = await startAgentProcess(name)
+            gcRestarted = gcStartRes.ok || gcStartRes.error === 'Agent is already running'
           }
         }
       }
@@ -1211,7 +1217,10 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
         if (stopRes.ok) {
           await delay(2000)
           const startRes = await startAgentProcess(name)
-          restarted = startRes.ok
+          // Same reconcile-race as the GC branch above: an 'already running'
+          // start after our own stop means the agent IS up with the new
+          // provider config (PR1014KONFIG821).
+          restarted = startRes.ok || startRes.error === 'Agent is already running'
         }
       }
     }

--- a/src/web/routes/approvals.ts
+++ b/src/web/routes/approvals.ts
@@ -67,6 +67,31 @@ export function buildOwnerApprovalText(approval: Approval): string {
   ].join('\n')
 }
 
+// When the owner send is suppressed or fails AND the requester is the main
+// agent, there is no in-band signal left at all: the leg-2 short-circuit
+// below skips the main-agent message unconditionally. The old self-notify was
+// useless but VISIBLE -- losing even that would rebuild the closed loop this
+// card documents, one layer deeper (Marveen's review finding on #1026).
+// Everyone else already got the normal main-agent notify, so the fallback is
+// main-requester-only. The marker names the reason so the reader knows this
+// is a degraded delivery, not the normal path.
+function fallbackInBand(approval: Approval, reason: string): void {
+  if (approval.agent_id !== MAIN_AGENT_ID) return
+  try {
+    const content = [
+      `[APPROVAL_REQUEST][OWNER_UNREACHED ${reason}]`,
+      `id=${approval.id}`,
+      `agent=${approval.agent_id}`,
+      `category=${approval.category}`,
+      `action=${approval.action_description}`,
+      `timeout_at=${approval.timeout_at ?? 'null'}`,
+    ].join(' ')
+    createAgentMessage('system', MAIN_AGENT_ID, content)
+  } catch (err) {
+    logger.warn({ err, approvalId: approval.id }, 'approval in-band fallback failed too -- the request is only visible on the dashboard')
+  }
+}
+
 // APPROVALVAK821 (a) -- the request must reach the OWNER, not only the main
 // agent's inter-agent queue. Fire-and-forget on purpose: the POST response
 // must not wait on the Telegram round-trip, and a failed send must not fail
@@ -76,11 +101,13 @@ function notifyOwner(approval: Approval): void {
   void (async () => {
     if (!TELEGRAM_BOT_TOKEN) {
       logger.warn({ approvalId: approval.id }, 'approval owner notification suppressed: no TELEGRAM_BOT_TOKEN')
+      fallbackInBand(approval, 'no-token')
       return
     }
     const ownerChat = resolveOwnerChatId()
     if (!ownerChat) {
       logger.warn({ approvalId: approval.id }, 'approval owner notification suppressed: no owner chat')
+      fallbackInBand(approval, 'no-owner-chat')
       return
     }
     try {
@@ -89,6 +116,7 @@ function notifyOwner(approval: Approval): void {
       logger.info({ approvalId: approval.id, messageId }, 'approval owner notification sent')
     } catch (err) {
       logger.warn({ err, approvalId: approval.id }, 'approval owner notification FAILED -- the request is only visible on the dashboard')
+      fallbackInBand(approval, 'send-failed')
     }
   })()
 }


### PR DESCRIPTION
## Three carded small fixes

### APPROVALVAK821 follow-up (review finding on #1026)
When the owner Telegram send is suppressed (`no-token`, `no-owner-chat`) or fails (`send-failed`), a **main-agent-requested** approval falls back to the inter-agent message with an `[OWNER_UNREACHED <reason>]` marker. Without this, the leg-2 short-circuit left no in-band signal at all -- the old self-notify was useless but visible. Main-requester-only: every other requester already gets the normal main-agent notify.

### PR1014KONFIG821
In the two config-PUT handlers, an `Agent is already running` start after our own stop means the reconcile sweep raced us in the stop..start gap and started the agent with the NEW config (written before the stop). The response now reports `restarted=true` instead of a false negative.

### EMAILKAPUNYELV821
The draft-kapu deny text said `<owner>nek` -- wrong vowel harmony for most Hungarian names (Szabolcsnak, not Szabolcsnek). The wording now inflects a fixed word instead: `jelezd a tulajdonosnak (<owner>)`, correct for every customer install.

### Evidence
- 2 new contract pins: fallback wired on all three failure paths; fallback is main-requester-only and carries the marker.
- Full suite: 284 files / 3807 tests green; typecheck clean.

Cards: APPROVALVAK821 (follow-up), PR1014KONFIG821, EMAILKAPUNYELV821.

🤖 Generated with [Claude Code](https://claude.com/claude-code)