### PR TITLE
fix(hooks): the reply guard never blocks, and cwd can invent an agent id

### DIFF
--- a/scripts/__tests__/ledger-agent-id.test.py
+++ b/scripts/__tests__/ledger-agent-id.test.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Test agent_id resolution from the session cwd (scripts/hooks/ledger_lib.py).
+
+Regression guard: a session sitting in a SUBDIRECTORY of the install logged its
+outbound messages under an agent id taken from the directory name. That splits
+the conversation ledger across two identities and makes the reply guard block on
+an already-answered question, because it finds no outbound under the real id.
+
+Run: python3 <thisfile>   Exit 0 = all pass.
+"""
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+HOOKS = os.path.join(os.path.dirname(HERE), "hooks")
+sys.path.insert(0, HOOKS)
+
+INSTALL = os.path.dirname(os.path.dirname(HERE))
+os.environ.setdefault("MAIN_AGENT_ID", "mainagent")
+
+import ledger_lib  # noqa: E402
+
+MAIN = ledger_lib.main_agent_id()
+
+CASES = [
+    ("install root is the main agent", INSTALL, MAIN),
+    ("subdirectory is STILL the main agent", os.path.join(INSTALL, "store", "some-workdir"), MAIN),
+    ("deep subdirectory is still the main agent", os.path.join(INSTALL, "a", "b", "c"), MAIN),
+    ("trailing slash tolerated", INSTALL + "/", MAIN),
+    ("agent dir maps to that agent", os.path.join(INSTALL, "agents", "dia"), "dia"),
+    ("agent subdir maps to that agent", os.path.join(INSTALL, "agents", "dia", "x", "y"), "dia"),
+    ("outside the install falls back to basename", "/Users/someone/marveen", "marveen"),
+    ("empty cwd falls back to main", "", MAIN),
+    ("None cwd falls back to main", None, MAIN),
+]
+
+failed = []
+for name, cwd, want in CASES:
+    got = ledger_lib.agent_id_from_cwd(cwd)
+    ok = got == want
+    if not ok:
+        failed.append(name)
+    print(f"  [{'PASS' if ok else 'FAIL'}] {name}: got={got!r} want={want!r}")
+
+print()
+if failed:
+    print(f"{len(failed)} FAILED: {failed}", file=sys.stderr)
+    sys.exit(1)
+print("All ledger agent-id tests passed.")

--- a/scripts/hooks/ledger_lib.py
+++ b/scripts/hooks/ledger_lib.py
@@ -112,7 +112,13 @@ def agent_id_from_cwd(cwd):
     if cwd.startswith(agents_root + os.sep):
         rel = cwd[len(agents_root) + 1:]
         return rel.split(os.sep)[0] or main_agent_id()
-    if cwd == install:
+    if cwd == install or cwd.startswith(install + os.sep):
+        # Anywhere else INSIDE the install tree is still the main agent. Without
+        # this, a session whose cwd happens to be a subdirectory (a scratch dir,
+        # a build folder, ...) logs its messages under an agent id invented from
+        # the directory name. That splits the conversation ledger across two
+        # identities and makes the reply guard block on a question it has
+        # already answered, because it finds no outbound under the real id.
         return main_agent_id()
     # Fallback: last path component (best effort), else main.
     base = os.path.basename(cwd)

--- a/scripts/hooks/telegram-reply-guard.py
+++ b/scripts/hooks/telegram-reply-guard.py
@@ -109,7 +109,11 @@ def main():
     if not oq:
         sys.exit(0)  # nothing open, or already answered by a reply-tool call
 
-    chat_id, message_id, text, ts, created_at = oq
+    # open_question_with_age() also returns the inbound's attachment columns.
+    # Take only the prefix this hook needs, so the unpack cannot raise (it sits
+    # outside the try above, so a mismatch would kill the hook and the harness
+    # would read the empty stdout as "allow" -- the guard would never block).
+    chat_id, message_id, text, ts, created_at = oq[:5]
 
     # Pure acknowledgement -> no reply owed.
     if _is_ack(text):


### PR DESCRIPTION
Two related defects in the Stop-hook path. Both reproduce on a clean checkout of `main` (v1.33.0), and the shipped test for the first one is red there.

## 1. The reply guard has never blocked

`scripts/hooks/telegram-reply-guard.py:112` unpacks five values:

```python
chat_id, message_id, text, ts, created_at = oq
```

but `ledger_lib.open_question_with_age()` returns seven — the inbound's `attachment_kind` and `attachment_file_id` are part of the row (`ledger_lib.py:225`).

The unpack sits **outside** the `try/except` above it, so every invocation dies with `ValueError: too many values to unpack (expected 5)`, exits non-zero with empty stdout, and the harness reads that as "allow".

Reproduce on `main`:

```
$ python3 scripts/__tests__/telegram-reply-guard.test.py
3 FAILED: ['unanswered question blocks', 'maxblock #1 blocks', 'maxblock #2 blocks']
```

The effect is quiet, which is the worst part: the rule the hook exists to enforce looks enforced and is not. Fix takes only the prefix the hook needs, so a future column addition cannot wedge it again.

## 2. A subdirectory cwd invents an agent id

`agent_id_from_cwd()` recognises exactly two shapes — the install root and `<install>/agents/<id>` — and falls through to "last path component" for everything else. A session whose cwd happens to be a **subdirectory of the install** (a scratch dir, a build folder) therefore logs its messages under an agent id invented from the directory name.

Observed: a reply sent while the shell sat in `store/<workdir>` landed in `conversation_log` with `agent_id='<workdir>'`.

Two consequences: the conversation ledger splits across two identities (degrading replay/handoff), and — once (1) is fixed — the guard finds no outbound under the real id and blocks a turn on a question that was already answered. That is in fact how this was found: the guard's first working invocation caught it.

Anything inside the install tree now resolves to the main agent. The `agents/<id>` branch still wins for sub-agents including their own subdirectories, and the basename fallback is kept for cwds outside the install.

## Tests

New `scripts/__tests__/ledger-agent-id.test.py`:

| Case | Expect |
|---|---|
| install root | main agent |
| `store/<workdir>` subdirectory | main agent |
| deep subdirectory | main agent |
| trailing slash | main agent |
| `agents/dia` | `dia` |
| `agents/dia/x/y` | `dia` |
| outside the install | basename |
| empty / None | main agent |

All four python contract tests pass on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)