### PR TITLE
fix(hooks): widening-proof prefix unpacks at the remaining ledger call sites (HOOKARITAS821)

### DIFF
--- a/scripts/__tests__/hook-arity.test.py
+++ b/scripts/__tests__/hook-arity.test.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Arity-contract guard for hook call sites (HOOKARITAS821).
+
+Class this pins: a hook unpacks a shared-module tuple with FIXED arity, the
+tuple widens in a later change, the unpack raises ValueError outside any
+try/except, the hook dies -- and the harness reads the empty output as "allow"
+or "nothing to do". The telegram-reply-guard was born broken exactly this way
+and blocked nothing for ten days (#898 widened the tuple two minutes before
+#856 shipped the five-name unpack; fixed in #1028).
+
+Two layers:
+  1. Structural: every known cross-boundary call site uses a PREFIX SLICE
+     (oq[:N]), which is widening-proof.
+  2. Behavioral: open_question() keeps working when open_question_with_age()
+     returns a WIDER tuple than today (simulated via monkeypatch).
+
+Run: python3 <thisfile>   Exit 0 = all pass.
+"""
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(os.path.dirname(HERE))
+HOOKS = os.path.join(ROOT, "scripts", "hooks")
+sys.path.insert(0, HOOKS)
+
+failed = []
+
+
+def check(name, ok):
+    print(f"  [{'PASS' if ok else 'FAIL'}] {name}")
+    if not ok:
+        failed.append(name)
+
+
+def src(fname):
+    with open(os.path.join(HOOKS, fname)) as f:
+        return f.read()
+
+
+# --- 1. structural pins: prefix slices at the known call sites --------------
+# The telegram-reply-guard call site is fixed and pinned by #1028 (its own
+# regression test); once both are merged, adding its pin here is a one-liner.
+check("ledger-live-drain unpacks a prefix slice",
+      "= oq[:7]" in src("ledger-live-drain.py"))
+check("ledger-replay unpacks a prefix slice",
+      "= open_q[:6]" in src("ledger-replay.py"))
+check("ledger_lib.open_question unpacks a prefix slice",
+      "= oq[:7]" in src("ledger_lib.py"))
+
+# --- 2. behavioral: a WIDER with_age tuple must not break open_question -----
+import ledger_lib  # noqa: E402
+
+_orig = ledger_lib.open_question_with_age
+try:
+    ledger_lib.open_question_with_age = lambda agent_id: (
+        "111", "42", "szoveg", "2026-08-21T16:00:00Z", 1787300000,
+        "voice", "file-1", "EXTRA-8", "EXTRA-9",
+    )
+    got = ledger_lib.open_question("anyagent")
+    check("open_question survives a 9-wide with_age tuple",
+          got == ("111", "42", "szoveg", "2026-08-21T16:00:00Z", "voice", "file-1"))
+finally:
+    ledger_lib.open_question_with_age = _orig
+
+print()
+if failed:
+    print(f"{len(failed)} FAILED: {failed}", file=sys.stderr)
+    sys.exit(1)
+print("All hook-arity contract tests passed.")

--- a/scripts/hooks/ledger-live-drain.py
+++ b/scripts/hooks/ledger-live-drain.py
@@ -68,7 +68,12 @@ def main():
         sys.exit(0)  # ledger unavailable -> silent no-op
     if not oq:
         sys.exit(0)  # nothing open (none, or already answered)
-    chat_id, message_id, text, ts, created_at, att_kind, att_file_id = oq
+    # Prefix-slice on purpose (HOOKARITAS821): this unpack sits outside the
+    # try above, so a widened open_question_with_age() tuple would kill the
+    # hook with a ValueError -- and a dead drain hook fails OPEN: the unanswered
+    # question is simply never surfaced. The reply guard died exactly this way
+    # for ten days (#1028).
+    chat_id, message_id, text, ts, created_at, att_kind, att_file_id = oq[:7]
 
     # GRACE: skip a fresh inbound the agent may be answering right now.
     try:

--- a/scripts/hooks/ledger-replay.py
+++ b/scripts/hooks/ledger-replay.py
@@ -141,7 +141,11 @@ def _build_output(transcript, open_q, owner):
         "betöltött kontextusból folytass, ne kezdd elölről."
     ]
     if open_q:
-        chat_id, message_id, text, ts, att_kind, att_file_id = open_q
+        # Prefix-slice on purpose (HOOKARITAS821): a widened open_question()
+        # tuple would ValueError here (no try around this frame), the replay
+        # hook would die, and the fresh session would start with NO context --
+        # fail-open, the silence looks like a calm start.
+        chat_id, message_id, text, ts, att_kind, att_file_id = open_q[:6]
         snippet = _snippet(text, _max_snippet())
         parts.append(
             f'NYITOTT KÉRDÉS (még NEM válaszoltad meg): {owner} utolsó üzenete '

--- a/scripts/hooks/ledger_lib.py
+++ b/scripts/hooks/ledger_lib.py
@@ -234,5 +234,9 @@ def open_question(agent_id):
     oq = open_question_with_age(agent_id)
     if not oq:
         return None
-    chat_id, message_id, text, ts, _created_at, att_kind, att_file_id = oq
+    # Prefix-slice on purpose (HOOKARITAS821): if open_question_with_age()
+    # ever widens again, this unpack would ValueError INSIDE ledger_lib, and
+    # every caller that wraps only the open_question() call in try/except
+    # would read the failure as "ledger unavailable" -- fail-open, silently.
+    chat_id, message_id, text, ts, _created_at, att_kind, att_file_id = oq[:7]
     return (chat_id, message_id, text, ts, att_kind, att_file_id)


### PR DESCRIPTION
## HOOKARITAS821: the sweep and the closure

After #1028 (a guard that never blocked because a 5-name unpack met a 7-tuple), the commissioned question: which OTHER hook call sites unpack a shared-module tuple with fixed arity, and is the failure fail-open?

### Sweep result (measured on origin/develop 4000236e, all `scripts/hooks/*.py` unpack sites)
| Call site | Coupling | Today | On widening | Fail direction |
|---|---|---|---|---|
| `ledger-live-drain.py:71` | cross-file (ledger_lib) | 7=7 OK | ValueError outside try -> hook dies | **fail-OPEN**: unanswered question never surfaced |
| `ledger-replay.py:144` | cross-file (ledger_lib) | 6=6 OK | ValueError, no try in frame -> hook dies | **fail-OPEN**: fresh session starts with no context |
| `ledger_lib.py:237` (open_question) | same-module chain root | 7=7 OK | ValueError INSIDE ledger_lib | **fail-OPEN**: callers read it as 'ledger unavailable' |
| skill-usage-capture, progress-watchdog, split/regex/literal sites | same-file callees | OK | visible to the same reviewer | not in class |

### Fix
All three now prefix-slice (`oq[:7]` / `open_q[:6]`) -- the same idiom #1028 shipped for the reply guard, widening-proof by construction. Comments name the fail-open consequence at each site.

### Evidence
- New `scripts/__tests__/hook-arity.test.py`: 4/4 pass -- structural pins on the three sites + behavioral proof that `open_question()` returns the correct 6-tuple even when `open_question_with_age()` is monkeypatched to return 9 elements.
- tsc clean; full vitest suite green (TS untouched, coupling check).
- The reply-guard site itself is fixed and pinned by #1028; once both are merged, adding its pin here is a one-liner (noted in the test).

Card: HOOKARITAS821. Merge order: independent of #1028 (no shared hunks; the guard file is untouched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)