### PR TITLE
chore(boundary): .agents/ commercial context stays local, the skeleton ships (APRODMKT822)

### DIFF
--- a/.agents/product-marketing.md.example
+++ b/.agents/product-marketing.md.example
@@ -1,0 +1,56 @@
+# Termék- és marketing-kontextus (sablon)
+
+Másold le `product-marketing.md` néven ugyanebbe a mappába, és töltsd ki a saját
+adataiddal. A kitöltött fájl SZÁNDÉKOSAN nem kerül gitbe (a .gitignore kizárja):
+kereskedelmi adat, ami csak a te telepítésedé. A marketing- és tartalom-skillek
+ebből dolgoznak kérdezés helyett -- minél konkrétabb, annál kevesebbet kérdez
+vissza az ügynök.
+
+## 1. Kik vagyunk, mit árulunk
+
+- [Cég/márka neve, egy mondatos leírás]
+- [Termék 1: mi ez, kinek szól, mi a fő értékígéret]
+- [Termék 2: ...]
+
+## 2. Célközönség
+
+- [Elsődleges szegmens: ki ő, mi fáj neki, hol éred el]
+- [Másodlagos szegmens: ...]
+
+## 3. Aktiváció: az "aha pillanat" termékenként
+
+- [Termék 1: mikor érti meg a felhasználó az értéket -- pl. az első sikeres X után]
+- [Termék 2: ...]
+
+## 4. Konverziós célok felületenként
+
+- [Felület (pl. weboldal, hírlevél, közösség): mi a kívánt következő lépés]
+
+## 5. Árazás és csomagolás
+
+- [Termék / csomag: ár, számlázási mód (nettó/bruttó, havi/éves), mi jár bele]
+- [Kedvezmény-szabályok, ha vannak]
+
+## 6. Csatornák és mérés
+
+- [Élő csatornák és szerepük (pl. hírlevél = megtartás, közösség = aktiválás)]
+- [NEM létező csatornák -- mondd ki, hogy az ügynök ne hivatkozzon rájuk]
+- [Mit mérünk és hol (pl. feliratkozás, vásárlás, aktiváció)]
+
+## 7. Hang és stílus
+
+- [Hangnem, tegezés/magázás, tiltott fordulatok, kötelező formai szabályok]
+
+## 8. TILTOTT MINTÁK -- ez kapu, nem ajánlás
+
+- [Amit az ügynök kimenő anyagban SOHA nem tehet meg (pl. ár-ígéret jóváhagyás
+  nélkül, nem létező funkció említése, más ügyfél adatainak felhasználása)]
+
+## 9. Versenytársak és pozicionálás
+
+- [Versenytárs: miben más a mi termékünk, mit NEM mondunk róluk]
+
+## 10. Mire ne tegyen javaslatot
+
+- [Témák/döntések, amik mindig a tulajdonoshoz mennek (pl. árváltoztatás,
+  új csatorna nyitása, partneri megállapodás)]

--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,11 @@ transcripts/
 
 # Local Netlify folder
 .netlify
+
+# .agents/: az install sajat termek-/marketing-kontextusa -- KERESKEDELMI ADAT
+# (arak, pozicionalas, versenytarsak), SOHA nem mehet a repoba. Tartalom-szintu
+# ignore (".agents/*", nem ".agents/"), mert konyvtar-szintu kizaras utan a
+# fajl-negacio nem hat (ld. 8811abfd, a .claude/settings.json ugyanigy romlott
+# el). A .example vaz viszont kimegy: abbol kap a vevo sajat kontextus-sablont.
+.agents/*
+!.agents/product-marketing.md.example


### PR DESCRIPTION
## Product-boundary guard for .agents/

`.agents/product-marketing.md` (100 lines) holds the install's own commercial data -- every price, the positioning, the competitors. This repo is what the customer clones; before this PR the directory was untracked-but-NOT-ignored, one `git add -A` away from shipping the price list. Same leak class as this morning's settings-template hunk.

### Changes
- **`.gitignore`**: `.agents/*` + `!.agents/product-marketing.md.example` -- content-level ignore on purpose: a directory-level `.agents/` entry kills the negation (the 8811abfd lesson). The trap is real: it bit AGAIN during this change, via a directory-level entry in the shared `.git/info/exclude`, and the example refused to stage until the entry was rewritten content-level.
- **`.agents/product-marketing.md.example`**: the 10-section skeleton (who/what, audience, activation, conversion goals, pricing shape, channels+measurement, voice, FORBIDDEN patterns gate, competitors, no-go topics) with placeholders and zero commercial data -- customers' own agents get a product-context template.

### Evidence
- `git check-ignore -v` both ways: the real file matches `.gitignore:130 .agents/*`; the example matches the `!` negation and `git add` stages it (behavioral proof).
- The prod host got an immediate content-level guard in `.git/info/exclude` so the window between now and the host update is covered.
- Suite: 285 files / 3809 green.
- The example scanned: no prices, no names, no competitor mentions.

Card: APRODMKT822 (Marveen msg 14027).

🤖 Generated with [Claude Code](https://claude.com/claude-code)