### PR TITLE
feat(scheduler): Balogh-safe content-match for the parked MAIN input box, time-independent + all decision paths (SCHEDCONTENTMATCH v1+v2)

### DIFF
--- a/src/__tests__/main-scheduled-remnant-clear-v2.test.ts
+++ b/src/__tests__/main-scheduled-remnant-clear-v2.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest'
+
+// SCHEDCONTENTMATCH v2 (2026-08-22). The v1 content-match was live on 2026-08-21
+// and the main box STILL wedged for 78 minutes (07:19:50-08:37:58). Two gaps:
+//   (a) TTL/dispatch coupling -- the authorizing record expired after 15 min (and
+//       a skipIfBusy-dropped tick never dispatched, so nothing was ever recorded);
+//   (b) code-path coverage -- the stuck-input watcher decides the fate of a parked
+//       main box WITHOUT consulting the matcher, and defers it forever as a
+//       "possibly a human draft".
+// v2 closes both: a TIME-INDEPENDENT corpus (the scheduled-task CONFIG prompts on
+// disk + the static SCHEDULED_TASK_PREAMBLE) and the same Balogh-safe gate wired
+// into the watcher path.
+//
+// The Balogh invariant is what every test here guards: ONLY a positive match may
+// clear the main box. A real human/inter-agent reply must NEVER produce a single
+// clearing keystroke, on ANY path.
+
+const h = vi.hoisted(() => {
+  const SEP = '─'.repeat(80)
+  const FOOTER = '  ⏵⏵ bypass permissions on (shift+tab to cycle)'
+  const mkPane = (line: string) => ['', SEP, '❯ ' + line, SEP, FOOTER].join('\n')
+  return { mkPane, pane: '', calls: [] as string[][] }
+})
+
+vi.mock('node:child_process', async (orig) => ({
+  ...(await orig() as object),
+  execFileSync: vi.fn((_file: string, args?: string[]) => {
+    if (Array.isArray(args)) {
+      h.calls.push(args)
+      if (args.includes('capture-pane')) return h.pane
+      // Model a box that actually empties under the clearing keystrokes, so the
+      // post-clear verification inside clearStaleParkedInput sees an empty box
+      // and reports success (a pane that never empties is the "resisted clear"
+      // case, covered by the watcher falling through to restart escalation).
+      if (args.includes('send-keys') && (args.includes('C-u') || args.includes('C-k') || args.includes('C-a'))) {
+        h.pane = h.mkPane('')
+      }
+    }
+    return ''
+  }),
+}))
+vi.mock('../notify.js', () => ({ notifyChannel: vi.fn(async () => {}), notifyTelegram: vi.fn(async () => {}) }))
+
+import {
+  DISPATCHED_PROMPT_TTL_MS,
+  SCHED_MATCH_MIN_LEN,
+  recordDispatchedScheduledPrompt,
+  setScheduledTaskConfigPrompts,
+  matchesDispatchedScheduledPrompt,
+  __resetDispatchedScheduledPromptsForTest,
+} from '../web/dispatched-scheduled-prompts.js'
+import { SCHEDULED_TASK_PREAMBLE } from '../prompt-safety.js'
+import { clearStaleParkedInput } from '../web/agent-process.js'
+import { clearMainParkedScheduledRemnant } from '../web/channel-monitor.js'
+import { MAIN_CHANNELS_SESSION } from '../web/main-agent.js'
+
+let clock = 90_000_000
+const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => clock)
+
+function clearKeystrokes(): string[][] {
+  return h.calls.filter(a => a.includes('send-keys') && (a.includes('C-u') || a.includes('C-k') || a.includes('C-a')))
+}
+
+// A realistic scheduled-task config prompt (the `prompt` field of task-config.json).
+const CONFIG_PROMPT =
+  'Proaktiv level-figyelo heartbeat. Nezd meg a Gmail postafiokot olvasatlan levelekert, ' +
+  'szurd ki a promo/hirlevel feladokat, es a valaszra varo ANTEA-ugyeket vezesd fel a kanban tablara. ' +
+  'Ha nincs erdemi olvasatlan level, maradj csendben.'
+
+beforeEach(() => {
+  h.calls.length = 0
+  __resetDispatchedScheduledPromptsForTest()
+  // Every test starts in a fresh cooldown window and a fresh unwedge episode.
+  clock += 10 * 60 * 1000
+})
+afterAll(() => { nowSpy.mockRestore() })
+
+describe('config-prompt corpus: time-independent match', () => {
+  it('a fragment of a CURRENT config prompt matches with nothing recorded (skipIfBusy-dropped tick)', () => {
+    setScheduledTaskConfigPrompts([CONFIG_PROMPT])
+    const frag = 'szurd ki a promo/hirlevel feladokat, es a valaszra varo ANTEA-ugyeket'
+    expect(matchesDispatchedScheduledPrompt(frag)).toBe(true)
+  })
+
+  it('still matches after the record TTL has elapsed many times over (the 78-minute wedge)', () => {
+    setScheduledTaskConfigPrompts([CONFIG_PROMPT])
+    const frag = 'szurd ki a promo/hirlevel feladokat, es a valaszra varo ANTEA-ugyeket'
+    clock += 10 * DISPATCHED_PROMPT_TTL_MS
+    expect(matchesDispatchedScheduledPrompt(frag)).toBe(true)
+  })
+
+  it('a fragment of the static SCHEDULED_TASK_PREAMBLE matches with an EMPTY corpus and no records', () => {
+    // The dispatched text is PREAMBLE + prefix + wrapped body, so a mid-slice of
+    // the preamble is a substring of NO config prompt (Masha pre-flag 87/1).
+    const frag = SCHEDULED_TASK_PREAMBLE.replace(/\s+/g, ' ').trim().slice(60, 200)
+    expect(frag.length).toBeGreaterThanOrEqual(SCHED_MATCH_MIN_LEN)
+    clock += 10 * DISPATCHED_PROMPT_TTL_MS
+    expect(matchesDispatchedScheduledPrompt(frag)).toBe(true)
+  })
+
+  it('BALOGH: a real reply is not in the corpus -> never matches', () => {
+    setScheduledTaskConfigPrompts([CONFIG_PROMPT])
+    expect(matchesDispatchedScheduledPrompt(
+      'Igen, ird meg Baloghnak hogy a koporsot kedden szallitjuk, es kerd el a szamlazasi adatokat',
+    )).toBe(false)
+  })
+
+  it('MIN_LEN is preserved on the config path: a short fragment can never authorize a clear', () => {
+    setScheduledTaskConfigPrompts([CONFIG_PROMPT])
+    const shortFrag = 'maradj csendben.'
+    expect(shortFrag.length).toBeLessThan(SCHED_MATCH_MIN_LEN)
+    expect(matchesDispatchedScheduledPrompt(shortFrag)).toBe(false)
+  })
+
+  it('the corpus is REPLACED each poll: a deleted task stops authorizing clears', () => {
+    setScheduledTaskConfigPrompts([CONFIG_PROMPT])
+    const frag = 'szurd ki a promo/hirlevel feladokat, es a valaszra varo ANTEA-ugyeket'
+    expect(matchesDispatchedScheduledPrompt(frag)).toBe(true)
+    setScheduledTaskConfigPrompts([])
+    expect(matchesDispatchedScheduledPrompt(frag)).toBe(false)
+  })
+
+  it('a trivially short config prompt is dropped from the corpus', () => {
+    setScheduledTaskConfigPrompts(['heartbeat'])
+    expect(matchesDispatchedScheduledPrompt('heartbeat')).toBe(false)
+  })
+
+  it('the record path survives the raised TTL (2h) and still matches inside it', () => {
+    expect(DISPATCHED_PROMPT_TTL_MS).toBe(2 * 60 * 60 * 1000)
+    const body = '[Utemezett feladat: audit] ' + CONFIG_PROMPT
+    recordDispatchedScheduledPrompt(body)
+    clock += 60 * 60 * 1000 // 1h -- would have expired under the old 15min TTL
+    expect(matchesDispatchedScheduledPrompt(CONFIG_PROMPT.slice(0, 120))).toBe(true)
+  })
+})
+
+describe('entry point A -- clearStaleParkedInput (router janitor / schedule-runner)', () => {
+  it('clears a config-matched remnant that is older than any record TTL', async () => {
+    setScheduledTaskConfigPrompts([CONFIG_PROMPT])
+    clock += 10 * DISPATCHED_PROMPT_TTL_MS
+    h.pane = h.mkPane('Nezd meg a Gmail postafiokot olvasatlan levelekert, szurd ki a promo/hirlevel feladokat')
+    await clearStaleParkedInput(MAIN_CHANNELS_SESSION)
+    expect(clearKeystrokes().length).toBeGreaterThan(0)
+  }, 20_000)
+
+  it('BALOGH: a real parked reply stays escalate-only (not one clearing keystroke)', async () => {
+    setScheduledTaskConfigPrompts([CONFIG_PROMPT])
+    h.pane = h.mkPane('Noemi, a lengyel konzulatus visszairt, hetfon tudjak fogadni a 12 elhunytat')
+    await clearStaleParkedInput(MAIN_CHANNELS_SESSION)
+    expect(clearKeystrokes()).toHaveLength(0)
+  }, 20_000)
+})
+
+describe('entry point B -- stuck-input watcher (channel-monitor human-draft defer)', () => {
+  it('a config-matched remnant is routed to the Balogh-safe clear instead of being deferred', async () => {
+    setScheduledTaskConfigPrompts([CONFIG_PROMPT])
+    clock += 10 * DISPATCHED_PROMPT_TTL_MS
+    h.pane = h.mkPane('es a valaszra varo ANTEA-ugyeket vezesd fel a kanban tablara. Ha nincs erdemi olvasatlan')
+    const cleared = await clearMainParkedScheduledRemnant()
+    expect(cleared).toBe(true)
+    expect(clearKeystrokes().length).toBeGreaterThan(0)
+  }, 20_000)
+
+  it('BALOGH: a human draft is NOT cleared here -- the watcher keeps deferring it', async () => {
+    setScheduledTaskConfigPrompts([CONFIG_PROMPT])
+    h.pane = h.mkPane('Kerlek irj a temetkezesnek hogy a hamvasztas idopontjat tegyek at csutortokre')
+    const cleared = await clearMainParkedScheduledRemnant()
+    expect(cleared).toBe(false)
+    expect(clearKeystrokes()).toHaveLength(0)
+  }, 20_000)
+
+  it('BALOGH: an empty box is a no-op (nothing parked -> nothing to clear)', async () => {
+    h.pane = h.mkPane('')
+    expect(await clearMainParkedScheduledRemnant()).toBe(false)
+    expect(clearKeystrokes()).toHaveLength(0)
+  }, 20_000)
+})

--- a/src/__tests__/main-scheduled-remnant-clear.test.ts
+++ b/src/__tests__/main-scheduled-remnant-clear.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest'
+
+// SCHEDCONTENTMATCH (Balogh-safe scheduler-content-match): the main channels box
+// is NEVER auto-cleared for a REAL parked line (a human/inter-agent reply -- the
+// 2026-06-30 "Balogh" near-miss). The one exception: a stranded FRAGMENT of one
+// of OUR OWN dispatched scheduled prompts is provably system-generated text and
+// can never be a real inbound reply, so it is safe to auto-clear instead of
+// silencing the channel unattended. These tests cover (1) the pure content match
+// and (2) that clearStaleParkedInput falls through to the clear path when a
+// recorded remnant is parked, and stays escalate-only when it is not.
+
+const h = vi.hoisted(() => {
+  const SEP = '─'.repeat(80)
+  const FOOTER = '  ⏵⏵ bypass permissions on (shift+tab to cycle)'
+  const mkPane = (line: string) => ['', SEP, '❯ ' + line, SEP, FOOTER].join('\n')
+  return { mkPane, pane: '', calls: [] as string[][] }
+})
+
+vi.mock('node:child_process', async (orig) => ({
+  ...(await orig() as object),
+  execFileSync: vi.fn((_file: string, args?: string[]) => {
+    if (Array.isArray(args)) {
+      h.calls.push(args)
+      if (args.includes('capture-pane')) return h.pane
+    }
+    return ''
+  }),
+}))
+vi.mock('../notify.js', () => ({ notifyChannel: vi.fn(async () => {}), notifyTelegram: vi.fn(async () => {}) }))
+
+import {
+  DISPATCHED_PROMPT_TTL_MS,
+  SCHED_MATCH_MIN_LEN,
+  recordDispatchedScheduledPrompt,
+  matchesDispatchedScheduledPrompt,
+  __resetDispatchedScheduledPromptsForTest,
+} from '../web/dispatched-scheduled-prompts.js'
+import { clearStaleParkedInput } from '../web/agent-process.js'
+import { MAIN_CHANNELS_SESSION } from '../web/main-agent.js'
+
+let clock = 5_000_000
+const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => clock)
+
+function clearKeystrokes(): string[][] {
+  return h.calls.filter(a => a.includes('send-keys') && (a.includes('C-u') || a.includes('C-k') || a.includes('C-a')))
+}
+
+beforeEach(() => {
+  h.calls.length = 0
+  __resetDispatchedScheduledPromptsForTest()
+})
+afterAll(() => { nowSpy.mockRestore() })
+
+describe('matchesDispatchedScheduledPrompt (pure content match)', () => {
+  const BODY = '[Utemezett feladat: reggeli-napindito] Keszits reggeli napindito uzenetet a Telegram csatornan MarkdownV2 formatumban.'
+
+  it('exact recorded body matches', () => {
+    recordDispatchedScheduledPrompt(BODY)
+    expect(matchesDispatchedScheduledPrompt(BODY)).toBe(true)
+  })
+
+  it('a stranded fragment (substring) of a longer recorded body matches', () => {
+    recordDispatchedScheduledPrompt(BODY)
+    const frag = 'Keszits reggeli napindito uzenetet a Telegram csatornan' // >= SCHED_MATCH_MIN_LEN
+    expect(frag.length).toBeGreaterThanOrEqual(SCHED_MATCH_MIN_LEN)
+    expect(matchesDispatchedScheduledPrompt(frag)).toBe(true)
+  })
+
+  it('unrecorded / real-reply text never matches (Balogh case stays untouched)', () => {
+    recordDispatchedScheduledPrompt(BODY)
+    expect(matchesDispatchedScheduledPrompt('Igen, ird meg Baloghnak a valaszt')).toBe(false)
+  })
+
+  it('nothing recorded -> never matches', () => {
+    expect(matchesDispatchedScheduledPrompt(BODY)).toBe(false)
+  })
+
+  it('parked text below SCHED_MATCH_MIN_LEN never matches even if it is a substring', () => {
+    recordDispatchedScheduledPrompt(BODY)
+    const shortFrag = 'Keszits' // < SCHED_MATCH_MIN_LEN chars
+    expect(shortFrag.length).toBeLessThan(SCHED_MATCH_MIN_LEN)
+    expect(matchesDispatchedScheduledPrompt(shortFrag)).toBe(false)
+  })
+
+  it('a body below the record-min-length is ignored (never authorizes a clear)', () => {
+    recordDispatchedScheduledPrompt('too short body') // < 20 chars
+    expect(matchesDispatchedScheduledPrompt('too short body')).toBe(false)
+  })
+
+  it('whitespace is normalized on both sides (newlines/tabs/runs collapse to single spaces)', () => {
+    // Body + matched fragments must clear SCHED_MATCH_MIN_LEN (40) after normalize.
+    recordDispatchedScheduledPrompt('alpha   beta\n\tgamma delta epsilon zeta eta theta iota kappa lambda')
+    expect(matchesDispatchedScheduledPrompt('beta gamma delta epsilon zeta eta theta iota')).toBe(true)
+    expect(matchesDispatchedScheduledPrompt('beta\n\n   gamma\tdelta epsilon zeta eta theta iota')).toBe(true)
+  })
+
+  it('an expired (past TTL) recorded body no longer matches', () => {
+    recordDispatchedScheduledPrompt(BODY)
+    expect(matchesDispatchedScheduledPrompt(BODY)).toBe(true)
+    clock += DISPATCHED_PROMPT_TTL_MS + 1
+    expect(matchesDispatchedScheduledPrompt(BODY)).toBe(false)
+  })
+})
+
+describe('clearStaleParkedInput MAIN box: matched remnant falls through to clear', () => {
+  const REMNANT = 'Reszletes utemezett prompt szoveg amit a boxba gepeltunk es beragadt'
+  const RECORDED = '[Utemezett feladat: audit] ' + REMNANT + ' tovabbi folytatas.'
+
+  it('a parked line that IS a recorded scheduled remnant is cleared (clearing keystrokes fire)', async () => {
+    recordDispatchedScheduledPrompt(RECORDED)
+    h.pane = h.mkPane(REMNANT)
+    await clearStaleParkedInput(MAIN_CHANNELS_SESSION)
+    // Fall-through to the forward-deletion clear path: clearing keystrokes reach
+    // the main box (which upstream escalate-only behavior would NEVER do).
+    expect(clearKeystrokes().length).toBeGreaterThan(0)
+  }, 20_000)
+
+  it('a real reply line that is NOT a recorded remnant stays escalate-only (never a keystroke)', async () => {
+    // Nothing recorded -> the Balogh case: a real parked reply.
+    h.pane = h.mkPane('Igen, ird meg Baloghnak a valaszt most')
+    await clearStaleParkedInput(MAIN_CHANNELS_SESSION)
+    expect(clearKeystrokes()).toHaveLength(0)
+  }, 20_000)
+})

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -53,6 +53,7 @@ import { getSecret } from './vault.js'
 import { resolveOpenRouterModel } from './openrouter-models.js'
 import { reapChannelOrphans, reapDetachedChannelClaudes } from './channel-poller-reap.js'
 import { MAIN_CHANNELS_SESSION } from './main-agent.js'
+import { matchesDispatchedScheduledPrompt } from './dispatched-scheduled-prompts.js'
 import { notifyChannel } from '../notify.js'
 
 // Lazy so a transient PATH gap at import time (e.g. the 04:00 auto-update
@@ -2217,7 +2218,14 @@ export async function clearStaleParkedInput(session: string, host: string | null
   //     notifyChannel direct to the owner (pure HTTP, does not touch the box)
   //     with the CONCRETE manual fix -- a message actionable in seconds, not
   //     "something is wrong".
-  if (session === MAIN_CHANNELS_SESSION) {
+  // SCHEDCONTENTMATCH (Balogh-safe scheduler-content-match, 2026-08-19): the
+  // main box is NEVER auto-cleared for a REAL parked line -- but a stranded
+  // fragment of one of OUR OWN dispatched scheduled prompts is provably
+  // system-generated text (never a real inbound reply), so it is SAFE to clear
+  // instead of silencing the channel unattended overnight. Only a parked line
+  // that is a substring of a recently-recorded dispatched scheduled body
+  // qualifies; anything else keeps the escalate-only behavior 100% unchanged.
+  if (session === MAIN_CHANNELS_SESSION && !matchesDispatchedScheduledPrompt(parked)) {
     const fails = (prev && prev.sig === parked ? prev.fails : 0) + 1
     let escalated = !!(prev && prev.sig === parked && prev.escalated)
     const stage = decideMainParkedEscalation(fails, escalated)
@@ -2238,6 +2246,15 @@ export async function clearStaleParkedInput(session: string, host: string | null
     }
     unwedgeAttempts.set(key, { last: nowMs, sig: parked, fails, escalated })
     return false
+  }
+  if (session === MAIN_CHANNELS_SESSION) {
+    // Reached only when the matched-remnant guard above let the main box fall
+    // through: this is our own dispatched scheduled prompt stranded in the box,
+    // safe to clear via the SAME forward-deletion path the sub-agents use.
+    logger.info(
+      { session, parked: parked.slice(0, 60) },
+      'message-router: main-agent parked input matched a dispatched scheduled prompt -- auto-clearing stale remnant (Balogh-safe)',
+    )
   }
 
   // Forward deletion, budgeted by the visible row count -- see the rationale and

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -14,6 +14,7 @@ import {
   capturePane,
   captureParkedInputView,
   clearInputBuffer,
+  clearStaleParkedInput,
   dismissResumeSummaryModalIfPresent,
   dismissModelConsentDialogIfPresent,
   stampFableOverageConsentSharedRoots,
@@ -43,6 +44,7 @@ import {
   type StuckInputActionFacts,
 } from '../pane-state.js'
 import { MAIN_CHANNELS_SESSION, MAIN_CHANNELS_PLIST } from './main-agent.js'
+import { matchesDispatchedScheduledPrompt } from './dispatched-scheduled-prompts.js'
 import { notifyChannel } from '../notify.js'
 import { getProvider, channelStateDir, readChannelToken, type ChannelProviderType } from '../channel-provider.js'
 import { attemptChannelMcpReconnect } from './channel-mcp-reconnect.js'
@@ -1113,6 +1115,30 @@ export function hardRestartMarveenChannels(): { ok: boolean; error?: string } {
   return { ok: false, error: 'hard restart failed: tmux respawn-pane failed' }
 }
 
+// SCHEDCONTENTMATCH v2 (2026-08-22): the stuck-input watcher is the OTHER path
+// that decides the fate of a parked main box, and it never consulted the
+// content-match. Its soft recovery has no move for a plain (non-<channel>) parked
+// line on the main session -> 'hold', and the restart guard then defers it as
+// "possibly a human draft" (a mid-slice remnant carries no machine-origin prefix).
+// That is exactly how the 2026-08-21 wedge stood for 78 minutes with the v1 fix
+// already live. A parked line that is provably a fragment of one of our OWN
+// scheduled prompts is system-generated text that can never be a real inbound
+// reply, so hand it to the SAME Balogh-safe clear path (clearStaleParkedInput
+// independently re-captures, re-confirms stability and re-checks the match before
+// touching anything). Returns true when the box was cleared.
+// Balogh invariant: ONLY a positive match diverts; every other parked line keeps
+// the unchanged defer/escalate behaviour below.
+export async function clearMainParkedScheduledRemnant(): Promise<boolean> {
+  const view = captureParkedInputView(MAIN_CHANNELS_SESSION)
+  const parked = view != null ? parkedInputText(view) : null
+  if (parked == null || !matchesDispatchedScheduledPrompt(parked)) return false
+  logger.warn(
+    { session: MAIN_CHANNELS_SESSION, parked: parked.slice(0, 60) },
+    'Stuck-input watcher: parked main input matched a scheduled prompt -- routing to the Balogh-safe auto-clear instead of deferring as a possible human draft',
+  )
+  return await clearStaleParkedInput(MAIN_CHANNELS_SESSION)
+}
+
 // Escalate a main channel input that survived the full soft recovery to a hard
 // restart (respawn-pane). Driven by the pure decideStuckInputRestart; this
 // wrapper owns the I/O + counters. Called once per monitor tick right after the
@@ -1618,10 +1644,18 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
     // only when the captured block looks COMPLETE -- a truncated capture stays
     // on Enter rather than risk a partial re-inject to the wrong chat_id.
     mainStuckInput = await recoverStuckInputForSession(MAIN_CHANNELS_SESSION, mainStuckInput, MAIN_STUCK_THRESHOLDS, false)
-    // Reliable backstop: if the soft recovery is exhausted and the input is
-    // STILL parked, the TUI is hard-wedged -- escalate to a respawn-pane (the
-    // automated form of the manual `systemctl restart channels`). Rate-limited.
-    maybeRestartWedgedMainChannel(mainStuckInput)
+    // SCHEDCONTENTMATCH v2: before the restart/defer decision, give a parked line
+    // that is provably our OWN scheduled prompt the Balogh-safe auto-clear (see
+    // clearMainParkedScheduledRemnant). A cleared box ends the episode, so reset
+    // the tracker and skip the restart escalation for this tick.
+    if (mainStuckInput.parkedSig !== null && await clearMainParkedScheduledRemnant()) {
+      mainStuckInput = { parkedSig: null, firstSeenAt: null, lastRecoverAt: null, attempts: 0 }
+    } else {
+      // Reliable backstop: if the soft recovery is exhausted and the input is
+      // STILL parked, the TUI is hard-wedged -- escalate to a respawn-pane (the
+      // automated form of the manual `systemctl restart channels`). Rate-limited.
+      maybeRestartWedgedMainChannel(mainStuckInput)
+    }
     // Same recovery for every running sub-agent session: a parked channel
     // message wedges a sub-agent ("nem válaszol") exactly as it would the main
     // session. Per-session state lives in agentStuckInput; drop it once the

--- a/src/web/dispatched-scheduled-prompts.ts
+++ b/src/web/dispatched-scheduled-prompts.ts
@@ -12,11 +12,17 @@
 // never inbound channel messages, never inter-agent messages. A parked line that
 // is not a substring of a recorded body must never match.
 
-// Recently dispatched scheduled prompt bodies live at most this long. A stranded
-// remnant is cleared within seconds/minutes of the dispatch that produced it, so
-// a short TTL keeps the match window tight and prevents a long-past body from
-// authorizing a clear of some unrelated later parked line.
-export const DISPATCHED_PROMPT_TTL_MS = 15 * 60 * 1000 // 15 minutes
+import { SCHEDULED_TASK_PREAMBLE } from '../prompt-safety.js'
+
+// Recently dispatched scheduled prompt bodies live at most this long.
+//
+// SCHEDCONTENTMATCH v2 (2026-08-22): raised 15min -> 2h after a 78-minute main-box
+// wedge (2026-08-21 07:19-08:37) whose remnant fell out of the 15-minute window
+// long before anything looked at it. The TTL is no longer a correctness boundary:
+// the time-INDEPENDENT config-prompt corpus below now decides the same matches on
+// its own, so the record path is a fast path/optimization (it also covers the
+// pre-check-prefixed body, which the raw config prompt does not contain).
+export const DISPATCHED_PROMPT_TTL_MS = 2 * 60 * 60 * 1000 // 2 hours
 
 // Ring-buffer capacity: a handful of scheduled tasks can dispatch in a short
 // burst; 32 is comfortably above any realistic in-flight count while staying
@@ -43,6 +49,42 @@ interface RecordedPrompt {
 }
 
 const recorded: RecordedPrompt[] = []
+
+// SCHEDCONTENTMATCH v2: the TIME-INDEPENDENT half of the corpus -- the scheduled
+// task CONFIG prompt bodies currently on disk, refreshed by the schedule runner
+// on every poll. Two gaps in the record-only design made the 2026-08-21 wedge
+// survive 78 minutes:
+//   (a) TTL: a wedge can stand for hours; the record that authorized clearing it
+//       expired long before anyone looked.
+//   (b) skipIfBusy=true ticks are dropped BEFORE dispatch, so a body that never
+//       dispatched was never recorded -- yet its text can still strand in the box
+//       from an earlier attempt.
+// A config prompt is the same class of text as a dispatched body: operator-authored
+// system text (SKILL.md on disk / the bearer-gated schedule editor), NEVER an
+// inbound channel or inter-agent message. Matching against it is therefore exactly
+// as Balogh-safe as matching a record, and it holds regardless of elapsed time or
+// process restarts (the set is re-read from disk each poll).
+let configPrompts: string[] = []
+
+// The dispatched text is SCHEDULED_TASK_PREAMBLE + prefix + wrapScheduledTask(body),
+// so a fragment sliced out of the PREAMBLE is not a substring of any raw config
+// prompt. The preamble is a static, operator-owned system constant, so it belongs
+// in the time-independent corpus permanently (Masha adversarial pre-flag 87/1).
+const STATIC_SYSTEM_CORPUS = [normalize(SCHEDULED_TASK_PREAMBLE)].filter(t => t.length >= MIN_RECORD_LEN)
+
+// Replace the config-prompt corpus with the CURRENT scheduled-task prompt bodies.
+// Called by the schedule runner each poll cycle with `task.prompt` for every task
+// it just read from disk -- deliberately injected rather than read here, so this
+// module stays IO-free and trivially testable. Bodies shorter than MIN_RECORD_LEN
+// carry no signal and are dropped.
+export function setScheduledTaskConfigPrompts(prompts: string[]): void {
+  const next: string[] = []
+  for (const p of prompts) {
+    const norm = normalize(p)
+    if (norm.length >= MIN_RECORD_LEN) next.push(norm)
+  }
+  configPrompts = next
+}
 
 // Trim, then collapse every run of internal whitespace (incl. newlines/tabs) to
 // a single space. Applied identically to recorded bodies and to the parked text
@@ -75,9 +117,11 @@ export function recordDispatchedScheduledPrompt(body: string): void {
   }
 }
 
-// True iff the parked text is a substring of some non-expired recorded scheduled
-// body (catching a stranded FRAGMENT of a longer dispatched prompt). The parked
-// text must clear SCHED_MATCH_MIN_LEN after normalization to be eligible.
+// True iff the parked text is a substring of (a) some non-expired recorded
+// dispatched body, or (b) a CURRENT scheduled-task config prompt / the static
+// scheduled-task preamble -- catching a stranded FRAGMENT of a longer scheduled
+// prompt however long it has been standing. The parked text must clear
+// SCHED_MATCH_MIN_LEN after normalization to be eligible.
 export function matchesDispatchedScheduledPrompt(parked: string): boolean {
   const norm = normalize(parked)
   if (norm.length < SCHED_MATCH_MIN_LEN) return false
@@ -86,10 +130,22 @@ export function matchesDispatchedScheduledPrompt(parked: string): boolean {
   for (const rec of recorded) {
     if (rec.body.includes(norm)) return true
   }
+  // Time-independent half: the scheduled-task CONFIG prompts on disk plus the
+  // static scheduled-task preamble. No TTL applies here -- an hours-old wedge
+  // whose text is provably one of our own scheduled bodies is still provably
+  // ours, and the Balogh invariant is unchanged (only a POSITIVE match ever
+  // authorizes a clear; everything else keeps the escalate-only behaviour).
+  for (const body of configPrompts) {
+    if (body.includes(norm)) return true
+  }
+  for (const body of STATIC_SYSTEM_CORPUS) {
+    if (body.includes(norm)) return true
+  }
   return false
 }
 
 // Test-only: clear all recorded state so each test starts from a clean buffer.
 export function __resetDispatchedScheduledPromptsForTest(): void {
   recorded.length = 0
+  configPrompts = []
 }

--- a/src/web/dispatched-scheduled-prompts.ts
+++ b/src/web/dispatched-scheduled-prompts.ts
@@ -1,0 +1,95 @@
+// SCHEDCONTENTMATCH (Balogh-safe scheduler-content-match): a bounded, in-memory
+// record of the scheduled-task prompt BODIES we recently typed into a session's
+// input box. Its ONLY consumer is clearStaleParkedInput's MAIN_CHANNELS_SESSION
+// branch, which normally NEVER auto-clears the main box (a parked line could be
+// a real human/inter-agent reply -- the 2026-06-30 "Balogh" near-miss). The one
+// exception this module enables: when a stranded parked line on the main box is
+// provably a fragment of one of OUR OWN dispatched scheduled prompts, it is
+// system-generated text that can NEVER be a real inbound reply, so it is SAFE to
+// auto-clear instead of silencing the channel unattended overnight.
+//
+// Hard invariant: ONLY scheduled-task prompt bodies are ever recorded here --
+// never inbound channel messages, never inter-agent messages. A parked line that
+// is not a substring of a recorded body must never match.
+
+// Recently dispatched scheduled prompt bodies live at most this long. A stranded
+// remnant is cleared within seconds/minutes of the dispatch that produced it, so
+// a short TTL keeps the match window tight and prevents a long-past body from
+// authorizing a clear of some unrelated later parked line.
+export const DISPATCHED_PROMPT_TTL_MS = 15 * 60 * 1000 // 15 minutes
+
+// Ring-buffer capacity: a handful of scheduled tasks can dispatch in a short
+// burst; 32 is comfortably above any realistic in-flight count while staying
+// bounded (no unbounded growth from a hot-looping runner).
+const DISPATCHED_PROMPT_CAP = 32
+
+// A recorded body shorter than this carries no signal -- ignore it so trivial
+// or empty prompts can never authorize a clear.
+const MIN_RECORD_LEN = 20
+
+// The normalized PARKED text must be at least this long to be eligible to match.
+// A REAL stranded wedge remnant is long (hundreds of chars -- a mid-slice of a
+// full scheduled envelope), so a high floor loses none of them; it only removes
+// the risk that a SHORT parked line (e.g. a brief real inbound reply, 12-39
+// chars) coincidentally lands as a substring of some long recorded body. In the
+// rare event a genuinely short scheduled remnant strands, it simply gets the
+// safe default (escalate-only) instead of an auto-clear -- never the reverse.
+// (Masha adversarial-review hardening, 2026-08-19: raised 12 -> 40.)
+export const SCHED_MATCH_MIN_LEN = 40
+
+interface RecordedPrompt {
+  body: string // normalized
+  at: number // Date.now() at record time
+}
+
+const recorded: RecordedPrompt[] = []
+
+// Trim, then collapse every run of internal whitespace (incl. newlines/tabs) to
+// a single space. Applied identically to recorded bodies and to the parked text
+// so a multi-line prompt that gets re-wrapped in the input box still matches.
+function normalize(text: string): string {
+  return text.trim().replace(/\s+/g, ' ')
+}
+
+function pruneExpired(now: number): void {
+  // Drop everything past its TTL. Entries are appended in time order, so all
+  // expired ones sit at the front; splice them off in one pass.
+  let firstLive = 0
+  while (firstLive < recorded.length && now - recorded[firstLive]!.at > DISPATCHED_PROMPT_TTL_MS) {
+    firstLive++
+  }
+  if (firstLive > 0) recorded.splice(0, firstLive)
+}
+
+// Record a scheduled-task prompt body that is about to be (or has just been)
+// typed into a session's input box. Call with the SAME text that gets typed.
+export function recordDispatchedScheduledPrompt(body: string): void {
+  const norm = normalize(body)
+  if (norm.length < MIN_RECORD_LEN) return
+  const now = Date.now()
+  pruneExpired(now)
+  recorded.push({ body: norm, at: now })
+  // Keep the buffer bounded: drop the oldest overflow entries.
+  if (recorded.length > DISPATCHED_PROMPT_CAP) {
+    recorded.splice(0, recorded.length - DISPATCHED_PROMPT_CAP)
+  }
+}
+
+// True iff the parked text is a substring of some non-expired recorded scheduled
+// body (catching a stranded FRAGMENT of a longer dispatched prompt). The parked
+// text must clear SCHED_MATCH_MIN_LEN after normalization to be eligible.
+export function matchesDispatchedScheduledPrompt(parked: string): boolean {
+  const norm = normalize(parked)
+  if (norm.length < SCHED_MATCH_MIN_LEN) return false
+  const now = Date.now()
+  pruneExpired(now)
+  for (const rec of recorded) {
+    if (rec.body.includes(norm)) return true
+  }
+  return false
+}
+
+// Test-only: clear all recorded state so each test starts from a clean buffer.
+export function __resetDispatchedScheduledPromptsForTest(): void {
+  recorded.length = 0
+}

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -47,7 +47,7 @@ import {
   clearStaleParkedInput,
 } from './agent-process.js'
 import { MAIN_CHANNELS_SESSION } from './main-agent.js'
-import { recordDispatchedScheduledPrompt } from './dispatched-scheduled-prompts.js'
+import { recordDispatchedScheduledPrompt, setScheduledTaskConfigPrompts } from './dispatched-scheduled-prompts.js'
 import { sendTelegramMessage } from './telegram.js'
 import { runCommandTask } from './command-task.js'
 import { decideQuotaAction, type QuotaWorkClass } from '../quota-gate.js'
@@ -1172,6 +1172,14 @@ export function startScheduleRunner(): NodeJS.Timeout {
     tickRunning = true
     try {
     const tasks = listScheduledTasks()
+    // SCHEDCONTENTMATCH v2 (2026-08-22): refresh the TIME-INDEPENDENT half of the
+    // Balogh-safe content-match corpus from the tasks we just read off disk. A
+    // stranded main-box remnant can then be recognised as our own system text
+    // hours later -- and even for a tick that was dropped by skipIfBusy before it
+    // ever dispatched (so nothing was recorded). Config prompts are operator-
+    // authored, never inbound message text, so this cannot widen the match to a
+    // real reply.
+    setScheduledTaskConfigPrompts(tasks.map(t => t.prompt))
     const now = Date.now()
     // Scan the real interval elapsed since the previous tick (30 min on the
     // first tick), not a fixed 60s window -- a late/dropped tick must not let a

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -47,6 +47,7 @@ import {
   clearStaleParkedInput,
 } from './agent-process.js'
 import { MAIN_CHANNELS_SESSION } from './main-agent.js'
+import { recordDispatchedScheduledPrompt } from './dispatched-scheduled-prompts.js'
 import { sendTelegramMessage } from './telegram.js'
 import { runCommandTask } from './command-task.js'
 import { decideQuotaAction, type QuotaWorkClass } from '../quota-gate.js'
@@ -712,6 +713,13 @@ async function attemptFireTask(
       SCHEDULED_TASK_PREAMBLE + '\n' +
       prefix.trimEnd() + '\n\n' +
       wrapScheduledTask(`scheduled-task:${task.name}`, taskBody)
+    // SCHEDCONTENTMATCH (Balogh-safe): record the EXACT text we are about to
+    // type into the box, so that if a fragment of it later strands as a parked
+    // line on the main channels box, clearStaleParkedInput can recognise it as
+    // our own system-generated remnant and auto-clear it (instead of silencing
+    // the channel unattended). Recorded here, right at the dispatch, so the
+    // recorded body is byte-identical to what lands in the input box.
+    recordDispatchedScheduledPrompt(fullPrompt)
     // forceSend skips the busy-state check above; it must also skip the
     // pre-flight wait-until-idle gate inside sendPromptToSession, otherwise a
     // task aimed at a long-busy session would block on the 12s idle wait every


### PR DESCRIPTION
## Mit javit

A fo channels input-boxa (`marveen-channels`) beragadt szoveggel NEMITETTE a csatornat: minden bejovo uzenet pendingben allt, felugyelet nelkul akar orakon at. A doboz szandekosan SOHA nem torlodik automatikusan, mert egy parkolt sor lehet valodi ember-valasz (2026-06-30 "Balogh" near-miss), ezert eddig csak eszkalacio volt.

Ket commit, ugyanaz a sag:

**c721093 (v1)** bevezeti a Balogh-safe content-matchet: egy parkolt sor, ami provably a SAJAT dispatchelt scheduled promptunk fragmentuma, rendszer-szoveg (sosem lehet valodi bejovo valasz), tehat biztonsagosan torolheto. Bounded (32), TTL-es ring buffer a dispatchelt bodykrol; `clearStaleParkedInput` MAIN-aga csak POZITIV matchnel esik at a torlo utra. `SCHED_MATCH_MIN_LEN=40`.

**385aadd (v2)** azert kellett, mert v1 ELESBEN VOLT 2026-08-21-en, es a fo doboz megis beragadt 78 percre (07:19:50-08:37:58). Ket res:

1. **Ido- es dispatch-fuggoseg.** Az egyetlen korpusz egy 15 perces ring buffer volt: egy tobb oras wedge tulel minden rekordot, a `skipIfBusy`-val eldobott tick pedig sosem dispatchel, tehat sosem rekordolodik. Uj: `setScheduledTaskConfigPrompts()` tartja az AKTUALIS scheduled-task config prompt bodykat (a schedule-runner minden pollnal frissiti, lemezrol), plusz allandoan a korpuszban a statikus `SCHEDULED_TASK_PREAMBLE`. Ez a fel idofuggetlen es restart-tulelo; a TTL 15p -> 2h emeles mar csak a rekord-gyorsut optimalizacioja (a pre-check prefixelt bodyt csak az fedi).

2. **Kod-ut lefedettseg.** A `clearStaleParkedInput` gate-elve volt, de nem az donti el ELOSZOR egy parkolt MAIN doboz sorsat. A stuck-input watcher soft recovery-jenek nincs lepese egy sima (nem `<channel>`) parkolt sorra -> `hold`, majd a restart-guard "esetleg emberi piszkozat" cimen deferalja, orokre. A `channel-monitor` most lefuttatja a `clearMainParkedScheduledRemnant()`-et a soft recovery UTAN es a restart-eszkalacio ELOTT: POZITIV matchnel atadja a dobozt ugyanannak a Balogh-safe torlo utnak (ami maga is ujra-captureol, ujra-stabilitast ellenoriz es ujra-matchel: dupla gate), sikertelen torles eseten valtozatlanul a restart-backstopra esik at.

## Miert Balogh-safe

A korpuszban KIZAROLAG operator-altal irt rendszer-szoveg van: dispatchelt scheduled bodyk, a lemezen levo scheduled-task config promptok (SKILL.md / bearer-gated schedule editor) es a statikus preamble. Bejovo channel- vagy inter-agent uzenet SOHA nem kerul bele. A `MIN_LEN=40` floor mindharom agon el. Csak POZITIV match divertal; minden mas parkolt sor viselkedese valtozatlan (defer/eszkalacio). 2026-08-21-i audit: egyetlen scheduled-task config prompt sem agyaz be verbatim bejovo/pelda uzenet-mintat.

## Tesztek

- `main-scheduled-remnant-clear.test.ts` (10, v1) es `main-scheduled-remnant-clear-v2.test.ts` (13, uj): config-match ures rekord-bufferrel (skipIfBusy-eldobott tick), match a TTL tizszereset meghaladva (a 78 perces wedge), preamble-fragment match ures korpusszal, korpusz-csere pollonkent, MIN_LEN floor, es MINDKET belepesi pont: matchelt remnant -> CLEAR, valodi human draft -> SOHA egyetlen torlo billentyu sem.
- Teljes suite: 3745 passed (4 elore letezo, nem kapcsolodo bukas: installer bash ERR-trap sorszamok, memory-performance Ollama timeout).
- `develop`-pal (93870499) osszefesulve kulon ellenorizve: tiszta auto-merge, `tsc --noEmit` zold, es a `#1008` (RIASZTASZAJ819, ugyanaz a watcher) tesztjeivel egyutt 33 teszt zold.

## Review

Adverszarialis paper-review + fuggetlen tesztfuttatas: zold (masha, 2026-08-22). Ket nem-blokkolo eszrevetel: match-uton 2-3 pane-capture (bounded, csak parkolt inputnal), es valodi human draftnal a valtozatlan restart-backstop respawn-olhat (pre-v2 viselkedes, nem regresszio).

Eles ota (2026-08-22 08:53) dashboard-only cutoverrel fut a rendszeren.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
