### PR TITLE
fix(scaffold): name the .claude-config/skills trap in every agent's CLAUDE.md (SKILLUTCSAPDA822)

### DIFF
--- a/src/__tests__/skills-path-trap-section.test.ts
+++ b/src/__tests__/skills-path-trap-section.test.ts
@@ -1,0 +1,109 @@
+// Functional test for ensureSkillsPathTrapSection() -- mirrors
+// autonomy-section.test.ts. SKILLUTCSAPDA822: the `.claude-config/skills`
+// path IS the shared global dir (symlink), reads as "my own config", and five
+// third-party skills landed fleet-wide through it on 2026-08-22. This proves
+// the warning block actually reaches the agent file on respawn, idempotently.
+import { describe, it, expect, vi } from 'vitest'
+import { mkdtempSync, writeFileSync, readFileSync, mkdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+const tmpRoot = mkdtempSync(join(tmpdir(), 'marveen-skilltrap-test-'))
+
+vi.mock('../config.js', () => ({
+  PROJECT_ROOT: tmpRoot,
+  OWNER_NAME: 'TestOwner',
+  MAIN_AGENT_ID: 'agent-a',
+  BOT_NAME: 'agent-a',
+  CHANNEL_PROVIDER: 'telegram',
+  WEB_PORT: 3420,
+  OWNER_DRIVE_FOLDER: '',
+  DASHBOARD_PUBLIC_URL: '',
+  APP_TZ: 'Europe/Budapest',
+}))
+
+vi.mock('../web/agent-config.js', () => ({
+  agentDir: (name: string) => join(tmpRoot, 'agents', name),
+  agentConfigRoot: () => join(tmpRoot, 'agents'),
+  listAgentNames: () => ['agent-a', 'agent-b'],
+  readAgentCapabilities: () => [],
+}))
+
+vi.mock('../web/atomic-write.js', () => ({
+  atomicWriteFileSync: (path: string, content: string) => writeFileSync(path, content, 'utf-8'),
+}))
+
+const { ensureSkillsPathTrapSection } = await import('../web/agent-scaffold.js')
+
+const MARKER_BEGIN = '<!-- BEGIN GENERATED: skills-path-trap (auto-generated, do not edit by hand) -->'
+const MARKER_END = '<!-- END GENERATED: skills-path-trap -->'
+
+function setup(agentName: string, content: string) {
+  const dir = join(tmpRoot, 'agents', agentName)
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, 'CLAUDE.md'), content, 'utf-8')
+}
+
+function read(agentName: string): string {
+  return readFileSync(join(tmpRoot, 'agents', agentName, 'CLAUDE.md'), 'utf-8')
+}
+
+describe('ensureSkillsPathTrapSection', () => {
+  it('appends the warning block to a CLAUDE.md that lacks it', () => {
+    setup('agent-b', '# Agent B\n\nSome persona.\n')
+    ensureSkillsPathTrapSection('agent-b')
+    const out = read('agent-b')
+    expect(out).toContain(MARKER_BEGIN)
+    expect(out).toContain(MARKER_END)
+    expect(out).toContain('.claude-config/skills')
+    expect(out).toContain('NEM a saját mappád')
+    expect(out).toContain('.claude/skills/')
+    // Existing content untouched.
+    expect(out).toContain('Some persona.')
+  })
+
+  it('is idempotent: a second call changes nothing', () => {
+    setup('agent-b', '# Agent B\n')
+    ensureSkillsPathTrapSection('agent-b')
+    const first = read('agent-b')
+    ensureSkillsPathTrapSection('agent-b')
+    expect(read('agent-b')).toBe(first)
+    // Exactly one block, not stacked.
+    expect(first.split(MARKER_BEGIN).length - 1).toBe(1)
+  })
+
+  it('replaces ONLY the marked block, preserving hand-written text around it', () => {
+    setup('agent-b', `# Agent B\n\n${MARKER_BEGIN}\nRÉGI SZÖVEG\n${MARKER_END}\n\nKézzel írt lábjegyzet.\n`)
+    ensureSkillsPathTrapSection('agent-b')
+    const out = read('agent-b')
+    expect(out).not.toContain('RÉGI SZÖVEG')
+    expect(out).toContain('Kézzel írt lábjegyzet.')
+    expect(out).toContain('.claude-config/skills')
+  })
+
+  it('skips silently when there is no CLAUDE.md', () => {
+    expect(() => ensureSkillsPathTrapSection('agent-nonexistent')).not.toThrow()
+  })
+
+  it('the main agent path targets PROJECT_ROOT/CLAUDE.md', () => {
+    writeFileSync(join(tmpRoot, 'CLAUDE.md'), '# Main\n', 'utf-8')
+    ensureSkillsPathTrapSection('agent-a')
+    const out = readFileSync(join(tmpRoot, 'CLAUDE.md'), 'utf-8')
+    expect(out).toContain(MARKER_BEGIN)
+  })
+})
+
+describe('wiring contracts', () => {
+  it('startAgentProcess calls the ensure on every (re)spawn', () => {
+    const src = readFileSync(join(__dirname, '../../src/web/agent-process.ts'), 'utf-8')
+    const roster = src.indexOf('ensureFleetRosterSection(name)')
+    const trap = src.indexOf('ensureSkillsPathTrapSection(name)')
+    expect(roster).toBeGreaterThan(0)
+    expect(trap).toBeGreaterThan(roster)
+  })
+
+  it('the generated template names the trap inline too', () => {
+    const src = readFileSync(join(__dirname, '../../src/web/agent-scaffold.ts'), 'utf-8')
+    expect(src).toContain('CSAPDA: a .claude-config/skills NEM a tiéd')
+  })
+})

--- a/src/web.ts
+++ b/src/web.ts
@@ -13,7 +13,7 @@ import { isBlockedCrossOriginWrite, originMatchesServedHost } from './web/csrf-o
 import { json } from './web/http-helpers.js'
 import { detectLanIp } from './web/network-info.js'
 import { AGENTS_BASE_DIR, listAgentNames } from './web/agent-config.js'
-import { ensureAgentHooks, ensureAgentStalenessHook, ensureEgressGate, ensureGovernanceGateCommands, ensureQuarantineReader, ensureDefaultScheduledTasks, agentSettingsPath, ensureAutonomySection } from './web/agent-scaffold.js'
+import { ensureAgentHooks, ensureAgentStalenessHook, ensureEgressGate, ensureGovernanceGateCommands, ensureQuarantineReader, ensureDefaultScheduledTasks, agentSettingsPath, ensureAutonomySection, ensureSkillsPathTrapSection } from './web/agent-scaffold.js'
 import { shouldRegisterHooks, pruneStaleHooksFromSettingsFile } from './web/hook-registration-guard.js'
 import { refreshMarveenBotUsername } from './web/telegram.js'
 import { startMessageRouter } from './web/message-router.js'
@@ -481,6 +481,7 @@ export function startWebServer(port = 3420): http.Server {
   if (!webOnly) {
     ensureFederationClaudeMdSection()
     ensureAutonomySection(MAIN_AGENT_ID)
+    ensureSkillsPathTrapSection(MAIN_AGENT_ID)
   }
 
   // Backfill the PreCompact hook into existing agents' settings.json so the

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -47,7 +47,7 @@ import { CHANNEL_PROVIDER, MAIN_AGENT_ID, STORE_DIR, PROJECT_ROOT, SUBAGENT_INBO
 import { getEffectiveSettingValue } from '../settings-store.js'
 import { loadProfileTemplate } from './profiles.js'
 import { resolveAgentSecurityProfile } from './agent-team.js'
-import { writeAgentSettingsFromProfile, ensureFleetRosterSection, ensureAutonomySection } from './agent-scaffold.js'
+import { writeAgentSettingsFromProfile, ensureFleetRosterSection, ensureAutonomySection, ensureSkillsPathTrapSection } from './agent-scaffold.js'
 import { schedulePluginUnlockAfterRespawn } from './channel-plugin-unlock.js'
 import { getSecret } from './vault.js'
 import { resolveOpenRouterModel } from './openrouter-models.js'
@@ -1122,6 +1122,7 @@ export async function startAgentProcess(name: string, opts: { fresh?: boolean } 
     writeAgentSettingsFromProfile(name, profile)
     ensureFleetRosterSection(name)
     ensureAutonomySection(name)
+    ensureSkillsPathTrapSection(name)
     // A sub-agent must load ONLY its own channel plugin. The user-scope
     // enabledPlugins would otherwise make EVERY sub-agent spawn a telegram
     // (and slack/discord) poller that falls back to the main agent's bot

--- a/src/web/agent-scaffold.ts
+++ b/src/web/agent-scaffold.ts
@@ -1040,6 +1040,62 @@ export function ensureFleetRosterSection(name: string): void {
   atomicWriteFileSync(claudeMdPath, updated)
 }
 
+// SKILLUTCSAPDA822: the near-identical `.claude-config/skills` path IS the
+// shared global directory (a symlink to ~/.claude/skills, single-copy
+// distribution -- deliberate, see skills-symlink-single-copy), and the
+// skill-run base directory even DISPLAYS that path. An agent writing "its
+// own" skill there writes to the whole fleet, and nothing says so. Measured
+// 2026-08-22: five third-party marketing skills landed in the shared dir and
+// only luck caught them. The symlink stays; the fix is naming the trap in
+// every agent's CLAUDE.md, idempotently, on every respawn.
+const SKILLS_TRAP_BEGIN = '<!-- BEGIN GENERATED: skills-path-trap (auto-generated, do not edit by hand) -->'
+const SKILLS_TRAP_END = '<!-- END GENERATED: skills-path-trap -->'
+const SKILLS_TRAP_BLOCK_RE = new RegExp(
+  `${SKILLS_TRAP_BEGIN.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}[\\s\\S]*?${SKILLS_TRAP_END.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`,
+)
+
+function buildSkillsPathTrapBody(): string {
+  return [
+    '## Skill-útvonal csapda (KÖTELEZŐ elolvasni skill-írás előtt)',
+    '',
+    'A `.claude-config/skills` NEM a saját mappád: symlink a globális',
+    '`~/.claude/skills`-re, tehát ami oda kerül, az a TELJES flottánál megjelenik',
+    '-- akkor is, ha a skill-futtatás base directory-ja ezt az utat mutatja.',
+    'A saját, csak neked szóló vagy kipróbálatlan külső skill a munkakönyvtárad',
+    '`.claude/skills/` mappájába megy. A globálisba írás tudatos, flotta-szintű',
+    'döntés legyen, ne alapértelmezés.',
+  ].join('\n')
+}
+
+// Same five-rule idempotency contract as ensureFleetRosterSection /
+// ensureAutonomySection; called on every startAgentProcess() so existing
+// agents receive the warning automatically on respawn.
+export function ensureSkillsPathTrapSection(name: string): void {
+  const claudeMdPath = name === MAIN_AGENT_ID
+    ? join(PROJECT_ROOT, 'CLAUDE.md')
+    : join(agentDir(name), 'CLAUDE.md')
+  if (!existsSync(claudeMdPath)) return
+
+  const block = `${SKILLS_TRAP_BEGIN}\n${buildSkillsPathTrapBody()}\n${SKILLS_TRAP_END}`
+
+  let existing: string
+  try {
+    existing = readFileSync(claudeMdPath, 'utf-8')
+  } catch {
+    return
+  }
+
+  let updated: string
+  if (SKILLS_TRAP_BLOCK_RE.test(existing)) {
+    updated = existing.replace(SKILLS_TRAP_BLOCK_RE, block)
+  } else {
+    updated = existing.trimEnd() + '\n\n' + block + '\n'
+  }
+
+  if (updated === existing) return
+  atomicWriteFileSync(claudeMdPath, updated)
+}
+
 export async function generateClaudeMd(name: string, description: string, model: string): Promise<string> {
   // Distribution-safe default-drive line: only emit a concrete folder when this
   // install has one configured (OWNER_DRIVE_FOLDER). A fresh install with no
@@ -1112,6 +1168,7 @@ Te egy önfejlesztő ágens vagy. A munkád során tanulsz, és újrafelhasznál
 ### Skill-ek helye
 - Globális: ~/.claude/skills/ (minden ágens számára elérhető)
 - Egyéni: a te munkakönyvtárad .claude/skills/ mappája
+- CSAPDA: a .claude-config/skills NEM a tiéd -- az a globális mappa symlinken át; saját skill a .claude/skills alá menjen
 
 ### Automatikus skill generálás
 Komplex feladatok után (5+ tool hívás, hiba utáni recovery, user korrekció, többlépéses workflow) automatikusan hozz létre SKILL.md fájlt:


### PR DESCRIPTION
## SKILLUTCSAPDA822: the preventive layer

`.claude-config/skills` reads as "my own config" but IS the shared global dir (symlink to `~/.claude/skills`, deliberate single-copy distribution -- measured 2026-08-04, same inode everywhere), and the skill-run base directory even displays that path. Five third-party skills landed fleet-wide through this on 2026-08-22, caught by luck.

Per the agreed split (msg 14043/14051): the detective layer (name-list diff in dream-engine's skill bucket) is Marveen's; this PR is the preventive layer.

### Changes
- **`ensureSkillsPathTrapSection()`**: idempotent anchored block (five-rule contract mirroring the autonomy/fleet-roster sections) appended to every agent's CLAUDE.md on every `startAgentProcess()` + at server boot for the main agent. Existing agents get it on their next respawn -- no manual migration, and no "guard that only future agents would see".
- **Template**: the generated skill section names the trap inline (`CSAPDA: a .claude-config/skills NEM a tiéd...`).

### Evidence
- 7 new tests: append / idempotent (single block, byte-identical second run) / replaces only the marked block preserving hand-written text / silent skip without CLAUDE.md / main-agent path targets PROJECT_ROOT -- plus 2 wiring contracts (call site after fleet-roster; template line present).
- Full suite green; typecheck clean.

Card: SKILLUTCSAPDA822.

🤖 Generated with [Claude Code](https://claude.com/claude-code)