### PR TITLE
fix(context-guard): resume prompt carries the prod-tree constraint (RESPAWNZAJ822)

### DIFF
--- a/src/__tests__/context-guard-resume-prompt.test.ts
+++ b/src/__tests__/context-guard-resume-prompt.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mkdtempSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+// RESPAWNZAJ822/PRODFAAG822 (2026-08-22): a context-guard-restarted session,
+// resumed via inject-resume, branch-switched and committed on the running prod
+// checkout (PR #1036 duplicate). The resume prompt is the ONLY context that
+// session has, so the prod-tree constraint must be present in the prompt text
+// itself -- on EVERY variant (with handoff, without, stale, unmeasurable).
+// This test pins that invariant: a later rewording cannot silently drop it.
+
+const SANDBOX = mkdtempSync(join(tmpdir(), 'resume-prompt-test-'))
+
+vi.mock('../config.js', async (orig) => {
+  const actual = await orig<typeof import('../config.js')>()
+  return { ...actual, MAIN_AGENT_ID: 'marveen', PROJECT_ROOT: SANDBOX, STORE_DIR: join(SANDBOX, 'store') }
+})
+vi.mock('../logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+}))
+vi.mock('../db.js', () => ({ createAgentMessage: vi.fn() }))
+vi.mock('../web/channel-monitor.js', () => ({
+  hardRestartMarveenChannels: vi.fn(() => ({ ok: true })),
+  lastMainRespawnAt: () => null,
+  MARVEEN_POST_RESPAWN_GRACE_MS: 0,
+}))
+vi.mock('../web/stuck-tool-call-watcher.js', () => ({ shouldDeferForRecentRespawn: () => false }))
+vi.mock('../web/agent-process.js', () => ({
+  agentRunState: () => 'stopped',
+  agentSessionName: (n: string) => `agent-${n}`,
+  restartAgentProcess: vi.fn(),
+  capturePane: () => null,
+  sendPromptToSession: vi.fn(),
+  isSessionReadyForPrompt: async () => false,
+}))
+vi.mock('../web/main-agent.js', () => ({ MAIN_CHANNELS_SESSION: 'marveen-channels' }))
+
+const { resumePrompt } = await import('../web/context-guard-runner.js')
+
+const CONSTRAINT = 'NE válts ágat, NE commitolj'
+
+describe('resumePrompt carries the prod-tree constraint on every variant', () => {
+  it('without a handoff', () => {
+    expect(resumePrompt('samu', '/x/HANDOFF.md', false)).toContain(CONSTRAINT)
+  })
+  it('with a fresh handoff', () => {
+    expect(resumePrompt('samu', '/x/HANDOFF.md', true)).toContain(CONSTRAINT)
+  })
+  it('with a stale handoff', () => {
+    expect(resumePrompt('samu', '/x/HANDOFF.md', true, 42)).toContain(CONSTRAINT)
+  })
+  it('with unmeasurable handoff freshness', () => {
+    expect(resumePrompt('samu', '/x/HANDOFF.md', true, 'unknown')).toContain(CONSTRAINT)
+  })
+  it('points at the worktree alternative', () => {
+    expect(resumePrompt('samu', '/x/HANDOFF.md', false)).toContain('worktree')
+  })
+})

--- a/src/__tests__/context-guard-resume-prompt.test.ts
+++ b/src/__tests__/context-guard-resume-prompt.test.ts
@@ -57,3 +57,20 @@ describe('resumePrompt carries the prod-tree constraint on every variant', () =>
     expect(resumePrompt('samu', '/x/HANDOFF.md', false)).toContain('worktree')
   })
 })
+
+// Review msg 14197: the main agent's channel is the OWNER's Telegram, and
+// session meta must never go there (standing owner preference; a 3am status
+// notice went out exactly this way on 2026-08-05). The closing line is
+// therefore agent-dependent, and this pins BOTH directions so a rewording
+// cannot re-point the main agent at the owner's channel.
+describe('resumePrompt closing line is agent-dependent', () => {
+  it('main agent (mocked MAIN_AGENT_ID=marveen): no channel notice, transcript line instead', () => {
+    const p = resumePrompt('marveen', '/x/HANDOFF.md', true)
+    expect(p).not.toContain('jelezz a csatornádon')
+    expect(p).toContain('transzkript')
+    expect(p).toContain(CONSTRAINT)
+  })
+  it('sub-agent: channel notice stays (their channel is the inter-agent queue)', () => {
+    expect(resumePrompt('samu', '/x/HANDOFF.md', true)).toContain('jelezz a csatornádon')
+  })
+})

--- a/src/web/context-guard-runner.ts
+++ b/src/web/context-guard-runner.ts
@@ -178,6 +178,12 @@ export function resumePrompt(
     base + source +
     `Utána ellenőrizd a kanban tábládat (in_progress kártyák, assignee=${name}) és a hot memóriáidat, ` +
     `és FOLYTASD a megkezdett munkát magadtól. Ne kezdd elölről ami a handoff szerint már kész. ` +
+    // RESPAWNZAJ822/PRODFAAG822: a fresh session acting on a resume goal is
+    // exactly the actor that branch-switched and committed on the live prod
+    // tree (2026-08-22 10:10, PR #1036 duplicate). The constraint must ride in
+    // the resume prompt itself -- it is the ONLY context the fresh session has.
+    `KORLÁT: a futó prod fán (a repo fő checkoutján) NE válts ágat, NE commitolj és NE nyiss belőle PR-t ` +
+    `-- ha repo-munka kell, használj worktree-t (git worktree add). ` +
     `Röviden jelezz a csatornádon, hogy friss kontextussal folytatod.`
   )
 }

--- a/src/web/context-guard-runner.ts
+++ b/src/web/context-guard-runner.ts
@@ -184,7 +184,14 @@ export function resumePrompt(
     // the resume prompt itself -- it is the ONLY context the fresh session has.
     `KORLÁT: a futó prod fán (a repo fő checkoutján) NE válts ágat, NE commitolj és NE nyiss belőle PR-t ` +
     `-- ha repo-munka kell, használj worktree-t (git worktree add). ` +
-    `Röviden jelezz a csatornádon, hogy friss kontextussal folytatod.`
+    // The main agent's channel is the OWNER's channel (Telegram), and session
+    // meta must never go there (standing owner preference; a 3am status
+    // notice measured on 2026-08-05, review msg 14197). Sub-agents' channel
+    // is the inter-agent queue, where the notice belongs. This prompt is the
+    // fresh session's ONLY rule set, so the split must live here.
+    (name === MAIN_AGENT_ID
+      ? `Zárásul egyetlen transzkript-sorban rögzítsd, hogy friss kontextussal folytatod -- a csatornádra (a gazda Telegramjára) session-meta NEM mehet ki.`
+      : `Röviden jelezz a csatornádon, hogy friss kontextussal folytatod.`)
   )
 }
 


### PR DESCRIPTION
## What (RESPAWNZAJ822 / PRODFAAG822)

The 2026-08-22 10:10 incident chain (measured on both cards): context-guard restarted a 100%-saturated session, the inject-resume gave it a goal with no other context, and the fresh session branch-switched, committed and opened a duplicate PR (#1036) on the running prod checkout.

The resume prompt is the ONLY context that session has, so the standing "no branch-ops on the prod tree" rule now rides in the prompt itself, on every variant (no handoff / fresh / stale / unmeasurable freshness).

## Test

`context-guard-resume-prompt.test.ts` pins the invariant on all four prompt variants plus the worktree pointer; a later rewording cannot silently drop the constraint. 77/77 green on the three context-guard test files; `npm run typecheck` clean.

## Defense-in-depth context

This PR is the third layer of the same class:
1. Host-local `.git/hooks/pre-commit` on the prod checkout BLOCKS commits (installed + verified today; override: `MARVEEN_PROD_COMMIT_OK=1`).
2. Host-local `post-checkout` hook ALERTS on a branch switch (git cannot block checkouts).
3. This prompt line prevents the attempt from forming in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
