### PR TITLE
fix(outgoing-copy-gate): a quoted span is evidence, not the author's prose (GATEIDEZET822)

### DIFF
--- a/scripts/hooks/outgoing-copy-gate.py
+++ b/scripts/hooks/outgoing-copy-gate.py
@@ -695,9 +695,95 @@ def telegram_gate(tool_input: dict) -> None:
     sys.exit(0)
 
 
-def audit(text: str):
-    """Return a list of human-readable problems."""
+# --- QUOTED SPANS ARE EVIDENCE, NOT PROSE (GATEIDEZET822, 2026-08-22) --------
+# LIVE CASE: the gate blocked the main agent's OWN Telegram message, because the
+# message QUOTED the accent-stripped sentence from the 2026-08-10 incident it was
+# explaining. The gate exists to audit what the AUTHOR wrote; a verbatim quote is
+# not the author's writing, and showing the wrong form is often the entire point
+# of the sentence around it. Quoted spans are therefore masked out of EVERY check
+# (accents, em dash, double hyphen, name, homoglyph).
+#
+# The mask writes SAME-LENGTH spaces on purpose: _hit_context() reports by offset
+# into the same string, so shrinking the text would move every later finding's
+# quoted context off by the removed characters.
+#
+# Two guards keep the exemption from becoming a bypass:
+#   - the same wrong form OUTSIDE the quote still blocks (covered by a test), and
+#   - a finding dropped by masking is written to the gate log, never silent.
+#     A hole nobody knows about protects only until someone steps in it.
+QUOTE_PAIRS = (
+    ("\u201e", "\u201d"),   # Hungarian: low-9 open, right-double close
+    ("\u201c", "\u201d"),   # typographic English
+    ("\u00bb", "\u00ab"),   # Hungarian guillemets (pointing outward)
+    ("\u00ab", "\u00bb"),   # French guillemets
+    ('"', '"'),             # straight double quote
+)
+# No real quotation runs longer than this; the cap stops a stray opening quote
+# from swallowing the rest of the message and disabling the gate wholesale.
+QUOTE_MAX = 1000
+BLOCKQUOTE = re.compile(r"^[ \t]*>[^\n]*$", re.M)
+
+
+def mask_quoted(text: str):
+    """Blank out quoted spans. Returns (masked_text, span_count)."""
+    chars = list(text)
+    n = len(text)
+    spans = 0
+
+    def blank(a, b):
+        for k in range(a, b):
+            if chars[k] != "\n":
+                chars[k] = " "
+
+    # 1. markdown blockquote lines
+    for m in BLOCKQUOTE.finditer(text):
+        blank(m.start(), m.end())
+        spans += 1
+
+    # 2. quote pairs
+    openers = {pair[0]: pair[1] for pair in QUOTE_PAIRS}
+    i = 0
+    while i < n:
+        closer = openers.get(text[i])
+        if closer is None:
+            i += 1
+            continue
+        limit = min(n, i + 1 + QUOTE_MAX)
+        j = text.find(closer, i + 1, limit)
+        if j == -1:
+            i += 1
+            continue
+        # a blank line inside the pair means these are almost certainly two
+        # unrelated quote marks, not one quotation
+        if "\n\n" in text[i:j]:
+            i += 1
+            continue
+        blank(i, j + 1)
+        spans += 1
+        i = j + 1
+
+    return "".join(chars), spans
+
+
+def _log_gate(line: str) -> None:
+    try:
+        log_path = os.path.join(os.path.dirname(_LOCAL_RULES), "outgoing-copy-gate.log")
+        with open(log_path, "a", encoding="utf-8") as fh:
+            fh.write(line if line.endswith("\n") else line + "\n")
+    except OSError:
+        pass
+
+
+def audit(text: str, mask_quotes: bool = True):
+    """Return a list of human-readable problems.
+
+    mask_quotes=False is the raw pass, used ONLY to log what the quote
+    masking dropped. Never gate on it.
+    """
     plain = TAG.sub(" ", text)
+    nspans = 0
+    if mask_quotes:
+        plain, nspans = mask_quoted(plain)
     problems = []
     if EM_DASH in plain:
         problems.append(
@@ -760,6 +846,13 @@ def audit(text: str):
             problems.append(
                 f"MAGYAR SZOVEG GYAKORLATILAG EKEZET NELKUL (ekezet-arany {ratio:.3%}, {letters} betun). "
                 "A szolistam nem talalt konkret talalatot, de az arany onmagaban gepi atirasra utal -- olvasd vissza."
+            )
+    if mask_quotes and nspans:
+        hidden = [p for p in audit(text, mask_quotes=False) if p not in problems]
+        if hidden:
+            _log_gate(
+                f"outgoing-copy-gate: IDEZETBEN kihagyva {len(hidden)} talalat "
+                f"({nspans} idezett szakasz): " + " | ".join(h[:120] for h in hidden)
             )
     return problems
 

--- a/src/__tests__/outgoing-copy-gate-tokens.test.ts
+++ b/src/__tests__/outgoing-copy-gate-tokens.test.ts
@@ -87,3 +87,49 @@ describe('outgoing-copy gate tokenization: a suffix attached to a number is not 
     expect(probs[0]).toContain('a dokumentum es a melleklet')
   })
 })
+
+// GATEIDEZET822 (2026-08-22): the gate blocked its OWN outgoing message because
+// the message QUOTED the accent-stripped sentence from the incident it was
+// explaining. The gate audits the author's own prose; a verbatim quote is not
+// the author's writing, and showing the wrong form is often the whole point.
+// Quoted spans are therefore masked out of every check -- but the masking must
+// not become a bypass: the same wrong form in the author's own sentence still
+// blocks, and a masked-away finding is written to the gate log, never silent.
+function auditAll(text: string): string[] {
+  const out = execFileSync('python3', ['-c', `
+import importlib.util, json, sys
+spec = importlib.util.spec_from_file_location("gate", ${JSON.stringify(GATE)})
+g = importlib.util.module_from_spec(spec); spec.loader.exec_module(g)
+print(json.dumps(g.audit(sys.argv[1])))
+`, text], { encoding: 'utf-8' })
+  return JSON.parse(out.trim())
+}
+
+describe('outgoing-copy gate: quoted spans are the author\'s evidence, not the author\'s prose (GATEIDEZET822)', () => {
+  it('an accent-stripped sentence inside Hungarian quotes passes', () => {
+    expect(auditAll('A tegnapi levélben ez ment ki: „itt van a licenckulcsod es a telepito”. Ezt javítottuk, köszönjük a jelzést.')).toEqual([])
+  })
+
+  it('the same accent-stripped words in the author\'s own sentence still fail', () => {
+    const probs = auditAll('Itt van a licenckulcsod es a telepito, kerlek jelezz ha megjott, koszonom.')
+    expect(probs.some((p) => p.includes('HIANYZO EKEZETEK'))).toBe(true)
+  })
+
+  it('straight double quotes mask too', () => {
+    expect(auditAll('A hibás alak, amit kerülünk: "es a telepito". Helyesen és a telepítő.')).toEqual([])
+  })
+
+  it('a markdown blockquote line is masked', () => {
+    expect(auditAll('A panasz szövege így szólt:\n> a felulet nem mukodik es nem jon valasz\n\nEzt kivizsgáljuk, köszönjük a jelzést.')).toEqual([])
+  })
+
+  it('an unclosed quote does not swallow the rest of the message', () => {
+    const probs = auditAll('Idézem: „ez a mondat sosem zárul le, es a telepito hibas maradt, kerlek nezd meg.')
+    expect(probs.some((p) => p.includes('HIANYZO EKEZETEK'))).toBe(true)
+  })
+
+  it('a paragraph break inside a quote pair cancels the masking', () => {
+    const probs = auditAll('Idézem: „első rész\n\nes a telepito hibas maradt, kerlek nezd meg” vége.')
+    expect(probs.some((p) => p.includes('HIANYZO EKEZETEK'))).toBe(true)
+  })
+})


### PR DESCRIPTION
## What happened

The gate blocked the main agent's **own** outgoing message, because that message quoted the accent-stripped sentence from the 2026-08-10 incident it was explaining to the owner. Observed live on 2026-08-22: the reply came back rejected with `HIANYZO EKEZETEK, 2 szo`, pointing at words that existed only inside the quotation marks.

## Why that is a defect, not a strict gate

The gate audits what the **author** wrote. A verbatim quote is not the author's writing, and showing the wrong form is frequently the entire reason the sentence exists. The same applies to a complaint pasted from a customer, a log line, or a name someone else spelled wrong: "correcting" quoted text would be an error, not a fix.

## The change

Quoted spans are masked before every check (accents, em dash, double hyphen, name rules, homoglyphs). Recognised: Hungarian `„…”`, typographic `“…”`, straight `"…"`, both guillemet directions, and markdown blockquote lines.

## Keeping the exemption from becoming a bypass

- **Same-length mask.** `_hit_context()` reports findings by offset into the same string, so shrinking the text would shift every later finding's quoted context. The mask writes spaces, not deletions.
- **Outside the quote still blocks.** A wrong form that appears in the author's own sentence is reported even if it is also quoted elsewhere. Without this, quoting a bad word once would disable the check for it. Covered by a test.
- **The skip is not silent.** A finding dropped by masking is written to the gate log with its text, so an unexpectedly permissive run is auditable afterwards.

Two guards bound the masking itself, both tested: a 1000-character cap so a stray opening quote cannot swallow the rest of the message, and a paragraph break inside a pair cancels it (two unrelated quote marks, not one quotation).

## Verification

- `outgoing-copy-gate-tokens.test.ts`: **12/12**. The 6 existing GATEKOTOJEL817 / GATEHYPH816 tests are untouched and green; 6 new cases cover quoted accents, the outside-the-quote case, straight quotes, blockquote lines, an unclosed quote, and the paragraph-break cancel.
- `tsc --noEmit` clean.
- 10 live hook runs against a real `gmail_send_email` payload. Blocks: a name in the author's prose, missing accents, an em dash, and the mixed case. Passes: quoted names, quoted accent-stripped text, a blockquote line, and a clean letter.

Run from a worktree under `$HOME`, per the suite's own live-install guard.