### PR TITLE
fix(outgoing-copy-gate): a Hungarian suffix attached to a NUMBER is not prose (GATESZAMKOTOJEL821)

### DIFF
--- a/scripts/hooks/outgoing-copy-gate.py
+++ b/scripts/hooks/outgoing-copy-gate.py
@@ -257,6 +257,14 @@ def accent_check_tokens(prose: str):
     out = []
     for m in HYPHEN_WORD.finditer(prose):
         tok = m.group(0)
+        # DIGIT-HYPHEN SUFFIX (429-es, 403-as, 2026-os, 3420-as). HYPHEN_WORD only
+        # admits LETTERS around the hyphen, so a Hungarian suffix attached to a
+        # NUMBER is seen as a standalone word -- and "es" is then read as the
+        # accent-stripped "és". These are not prose words; they carry no accent.
+        # (2026-08-21: the gate blocked a correct message reading "429-es vagy
+        # 403-as". GATEKOTOJEL817 covered letter-hyphen-letter forms, not this one.)
+        if m.start() >= 2 and prose[m.start() - 1] == "-" and prose[m.start() - 2].isdigit():
+            continue
         if "-" not in tok and tok[0].isupper() and not _at_sentence_start(prose, m.start()):
             continue
         out.append((tok.lower(), m.start()))

--- a/src/__tests__/outgoing-copy-gate-tokens.test.ts
+++ b/src/__tests__/outgoing-copy-gate-tokens.test.ts
@@ -62,3 +62,28 @@ describe('outgoing-copy gate tokenization: prose vs identifier (GATEKOTOJEL817/G
     expect(probs[0]).toMatch(/"\.\.\.[^"]*a video nagyon[^"]*\.\.\." @\d+/)
   })
 })
+
+// GATESZAMKOTOJEL821 (2026-08-21): the same prose-vs-identifier class, one step
+// further. HYPHEN_WORD admits only LETTERS around the hyphen, so a Hungarian
+// suffix attached to a NUMBER ("429-es", "2026-os") is tokenized as a bare word
+// -- and "es" then reads as the accent-stripped "és". The gate blocked a correct
+// message about HTTP status codes. A digit before the hyphen is the signal: that
+// token is part of an identifier, not prose.
+describe('outgoing-copy gate tokenization: a suffix attached to a number is not prose (GATESZAMKOTOJEL821)', () => {
+  it('HTTP status codes with Hungarian suffixes pass', () => {
+    expect(auditAccent('A 429-es vagy 403-as hibakód esetén várunk egy kicsit, és köszönöm, hogy szóltál.')).toEqual([])
+  })
+
+  it('a year and a port number with suffixes pass', () => {
+    expect(auditAccent('A 2026-os tervben a 3420-as port marad, és kérlek jelezz, ha nem így van.')).toEqual([])
+  })
+
+  it('a standalone "es" in the same sentence is still caught -- the fix must not widen into a whitelist', () => {
+    // Both halves in one sentence: the suffix on 429 is skipped, the bare word is not.
+    const probs = auditAccent('A 429-es hibakod mellett a dokumentum es a melleklet is megjott, kerlek nezd meg.')
+    expect(probs.length).toBe(1)
+    expect(probs[0]).toContain('es -> és')
+    // the reported occurrence is the standalone one, not the suffix on 429
+    expect(probs[0]).toContain('a dokumentum es a melleklet')
+  })
+})


### PR DESCRIPTION
## What happened

On 2026-08-21 the gate blocked a correct outgoing message whose only sin was naming two HTTP status codes: **"429-es vagy 403-as"**. The reported problem was `es -> és`.

## Why

Same prose-vs-identifier class as GATEKOTOJEL817, one step further out. `HYPHEN_WORD` admits only **letters** around the hyphen, so a Hungarian suffix attached to a **number** is tokenized as a bare standalone word. `429-es` yields the token `es`, which the accent dictionary reads as the accent-stripped `és`.

This is not a rare shape in operational copy:

| written | tokenized as | read as |
|---|---|---|
| `429-es` | `es` | `és` |
| `2026-os` | `os` | — |
| `3420-as` | `as` | — |

None of these are prose words, and none of them carry an accent.

## The change

A digit immediately before the hyphen is the signal that the token belongs to an identifier rather than to a sentence, so the accent tokenizer skips it. Three lines of logic, six lines of why.

## Not a whitelist

The fix stays a **tokenization** rule. A standalone `es` is still reported — a word-exception list would also have passed real errors, which is exactly what GATEKOTOJEL817 warned against.

The test proves both halves in a single sentence: the suffix on `429` is skipped while the bare word four words later is caught. It also asserts on the reported **context**, so a future regression cannot satisfy the test by flagging the wrong occurrence.

## Verification

- `outgoing-copy-gate-tokens.test.ts`: **9/9**. The 6 existing GATEKOTOJEL817 / GATEHYPH816 tests are untouched and green; 3 new cases cover status codes, a year plus a port number, and the standalone control.
- `tsc --noEmit` clean.

Run from a worktree under `$HOME`, per the suite's own live-install guard. Independent of #1039 (different function, no overlapping lines).