### PR TITLE
fix(governance): sub-agent outbound-mail hard-gate keys on command position, not content (SUBGATEPOZ822)

### DIFF
--- a/scripts/email-send-gate.mjs
+++ b/scripts/email-send-gate.mjs
@@ -59,7 +59,12 @@ const SEND_PATTERNS = [
 // Wrapper-shell -c strings recurse; interpreter code-string arguments
 // (python -c / node -e) are scanned for code-level send calls -- code handed
 // to an interpreter IS operation, not content.
-const HEREDOC_RE = /<<-?\s*'?(\w+)'?\n[\s\S]*?\n\1/g
+// Order-independent heredoc stripping (round 3, msg 14286): the rest of
+// the intro line (e.g. a redirect after the marker) is command text and
+// is KEPT -- only the body is cut. Without this, marker-first spellings
+// leaked the body into command position (FP), and dropping the intro
+// would have lost a heredoc-fed real sender (FN).
+const HEREDOC_RE = /(<<-?\s*'?(\w+)'?[^\n]*)\n[\s\S]*?\n\2(?=\s|$)/g
 const ENV_ASSIGN = /^[A-Za-z_][A-Za-z_0-9]*=/
 const SENDER_PROG = /^(sendmail|msmtp|swaks)$/i
 const SENDPY = /^send\.py$/i
@@ -96,7 +101,7 @@ export function maskSubshellMarkers(cmd) {
 // Quote-aware tokenizer -> [[token, ...], ...] per segment. Throws on an
 // unbalanced quote (the caller falls back to the legacy content patterns).
 export function segmentsTokens(cmd) {
-  const s = maskSubshellMarkers(cmd.replace(HEREDOC_RE, ' '))
+  const s = maskSubshellMarkers(cmd.replace(HEREDOC_RE, '$1'))
   const segments = []
   let cur = []
   let tok = ''

--- a/scripts/email-send-gate.mjs
+++ b/scripts/email-send-gate.mjs
@@ -6,6 +6,15 @@
 // Sub-agents may NOT send outbound email; any email must be routed through the
 // main agent (Marveen) for approval -- only Marveen retains email-send.
 //
+// STATED LIMIT (msg 14298): this gate catches the ACCIDENTAL send, not a
+// determined evader. Static analysis of arbitrary interpreter code is
+// undecidable, so a sub-agent CAN send through interpreter code the patterns
+// do not model -- the premise "a sub-agent cannot send outbound" does NOT
+// hold against intent, only against accident. The exec-heuristic below covers
+// the naive shapes (process-spawn plus a known mailer name in one code
+// string) and claims no more. Our sub-agents are not adversaries; if that
+// assumption ever changes, this gate is the wrong tool.
+//
 // Why a hook and not a permissions deny-list: permissive security profiles
 // launch Claude Code with --dangerously-skip-permissions, which BYPASSES the
 // settings.json allow/deny list. A PreToolUse hook runs regardless of
@@ -75,6 +84,12 @@ const WRAPPER_SHELL = /^(sh|bash|zsh|dash)$/i
 const CURLISH = /^(curl|wget|http)$/i
 const RESEND_TARGET = /^(https?:\/\/)?([^/@\s]*\.)?api\.resend\.com(\/|$)/i
 const CODE_SEND = /\bsmtplib\b|SMTP\s*\(|\bsendMail\s*\(|\bsendEmail\b|\bmail\.send\b/i
+// Naive-shape exec heuristic (msg 14298): process-spawn AND a known mailer
+// name together in one interpreter code string. Covers the accidental shapes;
+// see the STATED LIMIT in the header for what it deliberately does not claim.
+const CODE_EXECISH = /\bsubprocess\b|os\.system|\bpopen\b|child_process|\bexec[A-Za-z]*\s*\(|\bspawn[A-Za-z]*\s*\(/i
+const CODE_SENDER_LIT = /sendmail|msmtp|swaks|send\.py/i
+const codeStringSends = (code) => CODE_SEND.test(code) || (CODE_EXECISH.test(code) && CODE_SENDER_LIT.test(code))
 
 // Unquoted newline / backtick / `$(` become segment separators; quoted text is
 // untouched (it is content). Tracks quote state by hand -- no shell involved.
@@ -146,7 +161,7 @@ function segmentIsSend(toksIn, depth) {
   if (PYTHON.test(prog) || NODEISH.test(prog)) {
     for (let i = 0; i < rest.length; i++) {
       if ((rest[i] === '-c' || rest[i] === '-e' || rest[i] === '--eval') &&
-          rest[i + 1] && CODE_SEND.test(rest[i + 1])) return true
+          rest[i + 1] && codeStringSends(rest[i + 1])) return true
     }
   }
   const candidates = [prog]

--- a/scripts/email-send-gate.mjs
+++ b/scripts/email-send-gate.mjs
@@ -19,10 +19,17 @@ import { readFileSync, realpathSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
 
-// Bash command patterns that send mail. Read-only inspection of these tools
-// (e.g. cat'ing the send script) may be caught too -- acceptable: a sub-agent
-// has no legitimate need to invoke them, and the gate fails safe toward
-// blocking only actual send-shaped commands.
+// Bash command patterns that send mail. SUBGATEPOZ822 (2026-08-22): these are
+// no longer the primary trigger -- they matched CONTENT anywhere in the
+// command string, and the header's old premise ("a sub-agent has no
+// legitimate need to invoke these") broke measurably: the developer of the
+// mail tooling IS a sub-agent, and the gate blocked the delivery of the
+// mail-gate fix three times in one afternoon (commit message, PR body,
+// card-comment sqlite write), plus five more content hits across the fleet
+// the same day. The primary trigger is now isSendInvocation() below
+// (command-position analysis); this list remains ONLY as the conservative
+// fallback when a command cannot be tokenized (unbalanced quote) -- on
+// unparseable input the gate behaves exactly as before, never weaker.
 const SEND_PATTERNS = [
   /support-mail\/send\.py/i,
   /\bsend\.py\b/i,
@@ -41,6 +48,122 @@ const SEND_PATTERNS = [
   /\bgraph-mail\b[^\n]*\bsend\b/i,
   /\bsendMail\s*\(/i,
 ]
+
+// --- command-position analysis (SUBGATEPOZ822) ------------------------------
+// Ported from scripts/hooks/outgoing-copy-gate.py (KAPUHATOKOR822, PR #1042,
+// two adversarial rounds): quote-aware tokenization, then the INVOKED program
+// of each pipeline/sequence segment decides. A quoted token keeps its
+// POSITION, so a quoted provider URL in curl argument position still fires
+// (the normal way curl is written), while the same domain inside a quoted -d
+// payload stays content (the target pattern is anchored to the token start).
+// Wrapper-shell -c strings recurse; interpreter code-string arguments
+// (python -c / node -e) are scanned for code-level send calls -- code handed
+// to an interpreter IS operation, not content.
+const HEREDOC_RE = /<<-?\s*'?(\w+)'?\n[\s\S]*?\n\1/g
+const ENV_ASSIGN = /^[A-Za-z_][A-Za-z_0-9]*=/
+const SENDER_PROG = /^(sendmail|msmtp|swaks)$/i
+const SENDPY = /^send\.py$/i
+const PYTHON = /^python3?$/i
+const NODEISH = /^(node|tsx|ts-node|deno|bun|npx)$/i
+const GRAPHMAIL = /^graph-mail(\.ts|\.js)?$/i
+const WRAPPER_SHELL = /^(sh|bash|zsh|dash)$/i
+const CURLISH = /^(curl|wget|http)$/i
+const RESEND_TARGET = /^(https?:\/\/)?([^/@\s]*\.)?api\.resend\.com(\/|$)/i
+const CODE_SEND = /\bsmtplib\b|SMTP\s*\(|\bsendMail\s*\(|\bsendEmail\b|\bmail\.send\b/i
+
+// Unquoted newline / backtick / `$(` become segment separators; quoted text is
+// untouched (it is content). Tracks quote state by hand -- no shell involved.
+export function maskSubshellMarkers(cmd) {
+  let out = ''
+  let q = null
+  for (let i = 0; i < cmd.length; i++) {
+    const ch = cmd[i]
+    if (q) {
+      if (ch === '\\' && q === '"' && i + 1 < cmd.length) { out += cmd[i] + cmd[i + 1]; i++; continue }
+      if (ch === q) q = null
+      out += ch
+      continue
+    }
+    if (ch === "'" || ch === '"') { q = ch; out += ch; continue }
+    if (ch === '\\' && i + 1 < cmd.length) { out += cmd[i] + cmd[i + 1]; i++; continue }
+    if (ch === '\n' || ch === '`') { out += ';'; continue }
+    if (ch === '$' && cmd[i + 1] === '(') { out += ';'; i++; continue }
+    out += ch
+  }
+  return out
+}
+
+// Quote-aware tokenizer -> [[token, ...], ...] per segment. Throws on an
+// unbalanced quote (the caller falls back to the legacy content patterns).
+export function segmentsTokens(cmd) {
+  const s = maskSubshellMarkers(cmd.replace(HEREDOC_RE, ' '))
+  const segments = []
+  let cur = []
+  let tok = ''
+  let hasTok = false
+  let q = null
+  const pushTok = () => { if (hasTok) { cur.push(tok); tok = ''; hasTok = false } }
+  const pushSeg = () => { pushTok(); if (cur.length) { segments.push(cur); cur = [] } }
+  for (let i = 0; i < s.length; i++) {
+    const ch = s[i]
+    if (q) {
+      if (ch === '\\' && q === '"' && i + 1 < s.length) { tok += s[++i]; continue }
+      if (ch === q) { q = null; continue }
+      tok += ch
+      continue
+    }
+    if (ch === "'" || ch === '"') { q = ch; hasTok = true; continue }
+    if (ch === '\\' && i + 1 < s.length) { tok += s[++i]; hasTok = true; continue }
+    if (ch === ' ' || ch === '\t') { pushTok(); continue }
+    if ('|&;()'.includes(ch)) { pushSeg(); continue }
+    tok += ch
+    hasTok = true
+  }
+  if (q) throw new Error('unbalanced quote')
+  pushSeg()
+  return segments
+}
+
+const basename = (t) => t.split('/').pop()
+
+function segmentIsSend(toksIn, depth) {
+  let toks = toksIn
+  while (toks.length && ENV_ASSIGN.test(toks[0])) toks = toks.slice(1)
+  if (!toks.length) return false
+  const prog = basename(toks[0])
+  const rest = toks.slice(1)
+  if (SENDER_PROG.test(prog)) return true
+  if (WRAPPER_SHELL.test(prog) && depth < 3) {
+    for (let i = 0; i < rest.length; i++) {
+      if (rest[i] === '-c' && rest[i + 1] && isSendInvocation(rest[i + 1], depth + 1)) return true
+    }
+  }
+  if (PYTHON.test(prog) || NODEISH.test(prog)) {
+    for (let i = 0; i < rest.length; i++) {
+      if ((rest[i] === '-c' || rest[i] === '-e' || rest[i] === '--eval') &&
+          rest[i + 1] && CODE_SEND.test(rest[i + 1])) return true
+    }
+  }
+  const candidates = [prog]
+  if ((PYTHON.test(prog) || NODEISH.test(prog)) && rest.length) candidates.push(basename(rest[0]))
+  if (candidates.some((c) => SENDPY.test(c)) &&
+      rest.some((t) => t === '--to' || t.startsWith('--to='))) return true
+  if (toks.some((t) => GRAPHMAIL.test(basename(t))) && rest.includes('send')) return true
+  if (CURLISH.test(prog) && rest.some((t) => RESEND_TARGET.test(t))) return true
+  return false
+}
+
+export function isSendInvocation(cmd, depth = 0) {
+  let segments
+  try {
+    segments = segmentsTokens(cmd)
+  } catch {
+    // Unparseable command: fall back to the LEGACY content patterns, so on
+    // this path the gate is exactly as strict as before -- never weaker.
+    return SEND_PATTERNS.some((re) => re.test(cmd))
+  }
+  return segments.some((toks) => segmentIsSend(toks, depth))
+}
 
 // Outbound-shaped operations of the multiplexed manage_email tool. Each of
 // these sends for real unless the call explicitly asks for a draft.
@@ -74,7 +197,7 @@ export function gateDecision(toolName, toolInput) {
   }
   if (name === 'Bash') {
     const cmd = String(toolInput?.command ?? '')
-    if (SEND_PATTERNS.some((re) => re.test(cmd))) return { deny: true }
+    if (isSendInvocation(cmd)) return { deny: true }
   }
   return { deny: false }
 }

--- a/src/__tests__/email-send-gate-scope.test.ts
+++ b/src/__tests__/email-send-gate-scope.test.ts
@@ -68,6 +68,11 @@ describe('gateDecision Bash: POSITIVE CONTROLS -- real send attempts still deny 
     expect(bash(`node -e "require('./src/graph-mail.js').sendMail({to:'a@b.hu'})"`).deny).toBe(true)
   })
 
+  it('heredoc stripping is ORDER-INDEPENDENT: marker-first file-writes stay content, heredoc-FED senders still deny (round 3)', () => {
+    expect(bash(`cat <<'EOF' > /tmp/notes.md\nsendmail --to x@y.hu is how the legacy path worked\nEOF`).deny).toBe(false)
+    expect(bash(`sendmail -t a@b.hu <<'EOF'\ntorzs sora\nEOF`).deny).toBe(true)
+  })
+
   it('an unparseable command falls back to the legacy patterns (never weaker than before)', () => {
     expect(bash(`echo "unbalanced quote and sendmail mentioned`).deny).toBe(true)
     expect(bash(`echo "unbalanced quote, harmless text`).deny).toBe(false)

--- a/src/__tests__/email-send-gate-scope.test.ts
+++ b/src/__tests__/email-send-gate-scope.test.ts
@@ -68,6 +68,13 @@ describe('gateDecision Bash: POSITIVE CONTROLS -- real send attempts still deny 
     expect(bash(`node -e "require('./src/graph-mail.js').sendMail({to:'a@b.hu'})"`).deny).toBe(true)
   })
 
+  it('naive exec-shape in interpreter code denies; exec alone or mailer-name alone does not (msg 14298)', () => {
+    expect(bash(`python3 -c "import subprocess; subprocess.run(['sendmail','-t','a@b.hu'])"`).deny).toBe(true)
+    expect(bash(`node -e "require('child_process').execSync('msmtp a@b.hu < /tmp/m.txt')"`).deny).toBe(true)
+    expect(bash(`python3 -c "import subprocess; subprocess.run(['ls','-la'])"`).deny).toBe(false)
+    expect(bash(`python3 -c "print('a sendmail utvonala regen mas volt')"`).deny).toBe(false)
+  })
+
   it('heredoc stripping is ORDER-INDEPENDENT: marker-first file-writes stay content, heredoc-FED senders still deny (round 3)', () => {
     expect(bash(`cat <<'EOF' > /tmp/notes.md\nsendmail --to x@y.hu is how the legacy path worked\nEOF`).deny).toBe(false)
     expect(bash(`sendmail -t a@b.hu <<'EOF'\ntorzs sora\nEOF`).deny).toBe(true)

--- a/src/__tests__/email-send-gate-scope.test.ts
+++ b/src/__tests__/email-send-gate-scope.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest'
+// @ts-expect-error -- plain .mjs hook script, no types
+import { gateDecision } from '../../scripts/email-send-gate.mjs'
+
+// SUBGATEPOZ822: the gate blocked the DELIVERY of the mail-gate fix three
+// times in one afternoon (commit message, PR body heredoc, card-comment
+// sqlite write) plus five more content hits across the fleet -- all because
+// the old trigger matched send-patterns anywhere in the command string. The
+// old header premise ("a sub-agent has no legitimate need to invoke these")
+// broke: the developer of the mail tooling is a sub-agent. (Writing THIS
+// file was itself blocked by the live gate's old patterns -- the eighth
+// measured false positive of the day.)
+//
+// Per Marveen's strict condition (msg 14282): this is a HARD-deny whose
+// mistakes act outward, so REAL send attempts must keep failing -- the
+// positive controls below are the acceptance bar, not decor.
+describe('gateDecision Bash: content about mail no longer denies (the measured FP classes)', () => {
+  const bash = (command: string) => gateDecision('Bash', { command })
+
+  it('a git commit whose MESSAGE names the mailer binaries passes', () => {
+    expect(bash('git commit -q -m "fix(hooks): sendmail/msmtp/swaks are now matched in program position, send.py needs --to"').deny).toBe(false)
+  })
+
+  it('a PR-create with a heredoc body that documents the send patterns passes', () => {
+    expect(bash(`gh pr create --title "gate fix" --body-file /tmp/b.md <<'EOF'\nthe old trigger matched sendmail and api.resend.com anywhere\nEOF`).deny).toBe(false)
+  })
+
+  it('a card-comment sqlite write quoting the evidence passes', () => {
+    expect(bash(`sqlite3 store/claudeclaw.db "INSERT INTO kanban_comments (card_id, author, content) VALUES ('X','Samu','a send.py es a sendmail mintak a tartalomra tuzeltek')"`).deny).toBe(false)
+  })
+
+  it('an inter-agent message about the mail infrastructure passes', () => {
+    expect(bash(`curl -s -X POST http://localhost:3420/api/messages -d '{"from":"samu","to":"marveen","content":"az api.resend.com kulcs rotalva, a graph-mail send ut tesztelesre var"}'`).deny).toBe(false)
+  })
+
+  it('READING the send tooling passes (cat, grep)', () => {
+    expect(bash('cat scripts/support-mail/send.py').deny).toBe(false)
+    expect(bash('grep -n sendMail scripts/graph-mail.ts').deny).toBe(false)
+  })
+})
+
+describe('gateDecision Bash: POSITIVE CONTROLS -- real send attempts still deny (msg 14282 acceptance bar)', () => {
+  const bash = (command: string) => gateDecision('Bash', { command })
+
+  it('the mail script executed with a recipient denies (python and direct)', () => {
+    expect(bash('python3 scripts/support-mail/send.py --to x@y.hu --subject T --body B').deny).toBe(true)
+    expect(bash('./scripts/support-mail/send.py --to=x@y.hu < /tmp/b.txt').deny).toBe(true)
+  })
+
+  it('the classic mailers deny, also mid-pipeline and behind env prefixes', () => {
+    expect(bash('echo hi | sendmail user@host').deny).toBe(true)
+    expect(bash('SMTP_DEBUG=1 msmtp a@b.hu < /tmp/m.txt').deny).toBe(true)
+    expect(bash('swaks --to a@b.c --server smtp').deny).toBe(true)
+  })
+
+  it('a QUOTED provider URL in curl argument position denies (the normal curl spelling)', () => {
+    expect(bash(`curl -X POST "https://api.resend.com/emails" -d @/tmp/mail.json`).deny).toBe(true)
+    expect(bash(`curl 'https://api.resend.com/emails' -d @/tmp/mail.json`).deny).toBe(true)
+  })
+
+  it('a wrapper shell -c string is analyzed recursively and denies', () => {
+    expect(bash(`bash -c "python3 scripts/support-mail/send.py --to a@b.hu --subject X"`).deny).toBe(true)
+    expect(bash(`sh -c 'echo m | sendmail a@b.hu'`).deny).toBe(true)
+  })
+
+  it('interpreter code-strings that send deny (code handed to an interpreter is operation)', () => {
+    expect(bash(`python3 -c "import smtplib; s = smtplib.SMTP('smtp.x.hu'); s.sendmail('a','b','m')"`).deny).toBe(true)
+    expect(bash(`node -e "require('./src/graph-mail.js').sendMail({to:'a@b.hu'})"`).deny).toBe(true)
+  })
+
+  it('an unparseable command falls back to the legacy patterns (never weaker than before)', () => {
+    expect(bash(`echo "unbalanced quote and sendmail mentioned`).deny).toBe(true)
+    expect(bash(`echo "unbalanced quote, harmless text`).deny).toBe(false)
+  })
+})


### PR DESCRIPTION
## What broke (SUBGATEPOZ822)

Eight measured false positives in ONE day across the fleet: commit messages, PR bodies, sqlite card-comments, inter-agent messages and plain file reads that merely TALKED about the mail tooling. Three of them blocked the delivery of the sibling copy-gate fix (#1042); the eighth blocked writing this change's own test file. The old header premise -- "a sub-agent has no legitimate need to invoke these" -- broke measurably: the developer of the mail tooling is a sub-agent, and content-matching silenced exactly the conversations that maintain the mail path.

## The fix

The Bash branch now uses the command-position analysis proven in the copy-gate over two adversarial review rounds (#1042):

- quote-aware tokenization; unquoted newline / backtick / command substitution become segment separators, quoted text stays content;
- the **invoked program** of each segment decides;
- a **quoted** provider URL in curl argument position still denies (the normal curl spelling -- the round-2 lesson);
- wrapper-shell `-c` strings recurse (depth-capped);
- interpreter code-string arguments (`python -c` / `node -e`) are scanned for code-level outbound calls: code handed to an interpreter is operation, not content;
- an unparseable command (unbalanced quote) falls back to the legacy content patterns, so on that path the gate is exactly as strict as before -- never weaker.

The MCP branches (`send_email`, `manage_email` draft-only) are untouched: they key on tool name and operation, not content.

## Acceptance bar (msg 14282)

This is a HARD-deny whose mistakes act outward, so per the reviewer's condition the **positive controls are the acceptance criterion, not decoration**: every real outbound shape still denies -- the mail script with a recipient (direct and python-invoked), the classic mailers mid-pipeline and behind env prefixes, quoted provider URLs, wrapper-shell and interpreter code-string forms, and the fallback both ways. Pinned in `email-send-gate-scope.test.ts`; the existing `email-send-gate.test.ts` passes unchanged. Full suite 3820/3820 locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
