### PR TITLE
test(gates): shared-case conformance binds the two mail-gate implementations (SUBGATEPOZ822)

### DIFF
--- a/scripts/email-send-gate.mjs
+++ b/scripts/email-send-gate.mjs
@@ -59,7 +59,12 @@ const SEND_PATTERNS = [
 // Wrapper-shell -c strings recurse; interpreter code-string arguments
 // (python -c / node -e) are scanned for code-level send calls -- code handed
 // to an interpreter IS operation, not content.
-const HEREDOC_RE = /<<-?\s*'?(\w+)'?\n[\s\S]*?\n\1/g
+// Order-independent heredoc stripping (round 3, msg 14286): the rest of
+// the intro line (e.g. a redirect after the marker) is command text and
+// is KEPT -- only the body is cut. Without this, marker-first spellings
+// leaked the body into command position (FP), and dropping the intro
+// would have lost a heredoc-fed real sender (FN).
+const HEREDOC_RE = /(<<-?\s*'?(\w+)'?[^\n]*)\n[\s\S]*?\n\2(?=\s|$)/g
 const ENV_ASSIGN = /^[A-Za-z_][A-Za-z_0-9]*=/
 const SENDER_PROG = /^(sendmail|msmtp|swaks)$/i
 const SENDPY = /^send\.py$/i
@@ -96,7 +101,7 @@ export function maskSubshellMarkers(cmd) {
 // Quote-aware tokenizer -> [[token, ...], ...] per segment. Throws on an
 // unbalanced quote (the caller falls back to the legacy content patterns).
 export function segmentsTokens(cmd) {
-  const s = maskSubshellMarkers(cmd.replace(HEREDOC_RE, ' '))
+  const s = maskSubshellMarkers(cmd.replace(HEREDOC_RE, '$1'))
   const segments = []
   let cur = []
   let tok = ''

--- a/scripts/email-send-gate.mjs
+++ b/scripts/email-send-gate.mjs
@@ -6,6 +6,15 @@
 // Sub-agents may NOT send outbound email; any email must be routed through the
 // main agent (Marveen) for approval -- only Marveen retains email-send.
 //
+// STATED LIMIT (msg 14298): this gate catches the ACCIDENTAL send, not a
+// determined evader. Static analysis of arbitrary interpreter code is
+// undecidable, so a sub-agent CAN send through interpreter code the patterns
+// do not model -- the premise "a sub-agent cannot send outbound" does NOT
+// hold against intent, only against accident. The exec-heuristic below covers
+// the naive shapes (process-spawn plus a known mailer name in one code
+// string) and claims no more. Our sub-agents are not adversaries; if that
+// assumption ever changes, this gate is the wrong tool.
+//
 // Why a hook and not a permissions deny-list: permissive security profiles
 // launch Claude Code with --dangerously-skip-permissions, which BYPASSES the
 // settings.json allow/deny list. A PreToolUse hook runs regardless of
@@ -75,6 +84,12 @@ const WRAPPER_SHELL = /^(sh|bash|zsh|dash)$/i
 const CURLISH = /^(curl|wget|http)$/i
 const RESEND_TARGET = /^(https?:\/\/)?([^/@\s]*\.)?api\.resend\.com(\/|$)/i
 const CODE_SEND = /\bsmtplib\b|SMTP\s*\(|\bsendMail\s*\(|\bsendEmail\b|\bmail\.send\b/i
+// Naive-shape exec heuristic (msg 14298): process-spawn AND a known mailer
+// name together in one interpreter code string. Covers the accidental shapes;
+// see the STATED LIMIT in the header for what it deliberately does not claim.
+const CODE_EXECISH = /\bsubprocess\b|os\.system|\bpopen\b|child_process|\bexec[A-Za-z]*\s*\(|\bspawn[A-Za-z]*\s*\(/i
+const CODE_SENDER_LIT = /sendmail|msmtp|swaks|send\.py/i
+const codeStringSends = (code) => CODE_SEND.test(code) || (CODE_EXECISH.test(code) && CODE_SENDER_LIT.test(code))
 
 // Unquoted newline / backtick / `$(` become segment separators; quoted text is
 // untouched (it is content). Tracks quote state by hand -- no shell involved.
@@ -146,7 +161,7 @@ function segmentIsSend(toksIn, depth) {
   if (PYTHON.test(prog) || NODEISH.test(prog)) {
     for (let i = 0; i < rest.length; i++) {
       if ((rest[i] === '-c' || rest[i] === '-e' || rest[i] === '--eval') &&
-          rest[i + 1] && CODE_SEND.test(rest[i + 1])) return true
+          rest[i + 1] && codeStringSends(rest[i + 1])) return true
     }
   }
   const candidates = [prog]

--- a/scripts/email-send-gate.mjs
+++ b/scripts/email-send-gate.mjs
@@ -19,10 +19,17 @@ import { readFileSync, realpathSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
 
-// Bash command patterns that send mail. Read-only inspection of these tools
-// (e.g. cat'ing the send script) may be caught too -- acceptable: a sub-agent
-// has no legitimate need to invoke them, and the gate fails safe toward
-// blocking only actual send-shaped commands.
+// Bash command patterns that send mail. SUBGATEPOZ822 (2026-08-22): these are
+// no longer the primary trigger -- they matched CONTENT anywhere in the
+// command string, and the header's old premise ("a sub-agent has no
+// legitimate need to invoke these") broke measurably: the developer of the
+// mail tooling IS a sub-agent, and the gate blocked the delivery of the
+// mail-gate fix three times in one afternoon (commit message, PR body,
+// card-comment sqlite write), plus five more content hits across the fleet
+// the same day. The primary trigger is now isSendInvocation() below
+// (command-position analysis); this list remains ONLY as the conservative
+// fallback when a command cannot be tokenized (unbalanced quote) -- on
+// unparseable input the gate behaves exactly as before, never weaker.
 const SEND_PATTERNS = [
   /support-mail\/send\.py/i,
   /\bsend\.py\b/i,
@@ -41,6 +48,122 @@ const SEND_PATTERNS = [
   /\bgraph-mail\b[^\n]*\bsend\b/i,
   /\bsendMail\s*\(/i,
 ]
+
+// --- command-position analysis (SUBGATEPOZ822) ------------------------------
+// Ported from scripts/hooks/outgoing-copy-gate.py (KAPUHATOKOR822, PR #1042,
+// two adversarial rounds): quote-aware tokenization, then the INVOKED program
+// of each pipeline/sequence segment decides. A quoted token keeps its
+// POSITION, so a quoted provider URL in curl argument position still fires
+// (the normal way curl is written), while the same domain inside a quoted -d
+// payload stays content (the target pattern is anchored to the token start).
+// Wrapper-shell -c strings recurse; interpreter code-string arguments
+// (python -c / node -e) are scanned for code-level send calls -- code handed
+// to an interpreter IS operation, not content.
+const HEREDOC_RE = /<<-?\s*'?(\w+)'?\n[\s\S]*?\n\1/g
+const ENV_ASSIGN = /^[A-Za-z_][A-Za-z_0-9]*=/
+const SENDER_PROG = /^(sendmail|msmtp|swaks)$/i
+const SENDPY = /^send\.py$/i
+const PYTHON = /^python3?$/i
+const NODEISH = /^(node|tsx|ts-node|deno|bun|npx)$/i
+const GRAPHMAIL = /^graph-mail(\.ts|\.js)?$/i
+const WRAPPER_SHELL = /^(sh|bash|zsh|dash)$/i
+const CURLISH = /^(curl|wget|http)$/i
+const RESEND_TARGET = /^(https?:\/\/)?([^/@\s]*\.)?api\.resend\.com(\/|$)/i
+const CODE_SEND = /\bsmtplib\b|SMTP\s*\(|\bsendMail\s*\(|\bsendEmail\b|\bmail\.send\b/i
+
+// Unquoted newline / backtick / `$(` become segment separators; quoted text is
+// untouched (it is content). Tracks quote state by hand -- no shell involved.
+export function maskSubshellMarkers(cmd) {
+  let out = ''
+  let q = null
+  for (let i = 0; i < cmd.length; i++) {
+    const ch = cmd[i]
+    if (q) {
+      if (ch === '\\' && q === '"' && i + 1 < cmd.length) { out += cmd[i] + cmd[i + 1]; i++; continue }
+      if (ch === q) q = null
+      out += ch
+      continue
+    }
+    if (ch === "'" || ch === '"') { q = ch; out += ch; continue }
+    if (ch === '\\' && i + 1 < cmd.length) { out += cmd[i] + cmd[i + 1]; i++; continue }
+    if (ch === '\n' || ch === '`') { out += ';'; continue }
+    if (ch === '$' && cmd[i + 1] === '(') { out += ';'; i++; continue }
+    out += ch
+  }
+  return out
+}
+
+// Quote-aware tokenizer -> [[token, ...], ...] per segment. Throws on an
+// unbalanced quote (the caller falls back to the legacy content patterns).
+export function segmentsTokens(cmd) {
+  const s = maskSubshellMarkers(cmd.replace(HEREDOC_RE, ' '))
+  const segments = []
+  let cur = []
+  let tok = ''
+  let hasTok = false
+  let q = null
+  const pushTok = () => { if (hasTok) { cur.push(tok); tok = ''; hasTok = false } }
+  const pushSeg = () => { pushTok(); if (cur.length) { segments.push(cur); cur = [] } }
+  for (let i = 0; i < s.length; i++) {
+    const ch = s[i]
+    if (q) {
+      if (ch === '\\' && q === '"' && i + 1 < s.length) { tok += s[++i]; continue }
+      if (ch === q) { q = null; continue }
+      tok += ch
+      continue
+    }
+    if (ch === "'" || ch === '"') { q = ch; hasTok = true; continue }
+    if (ch === '\\' && i + 1 < s.length) { tok += s[++i]; hasTok = true; continue }
+    if (ch === ' ' || ch === '\t') { pushTok(); continue }
+    if ('|&;()'.includes(ch)) { pushSeg(); continue }
+    tok += ch
+    hasTok = true
+  }
+  if (q) throw new Error('unbalanced quote')
+  pushSeg()
+  return segments
+}
+
+const basename = (t) => t.split('/').pop()
+
+function segmentIsSend(toksIn, depth) {
+  let toks = toksIn
+  while (toks.length && ENV_ASSIGN.test(toks[0])) toks = toks.slice(1)
+  if (!toks.length) return false
+  const prog = basename(toks[0])
+  const rest = toks.slice(1)
+  if (SENDER_PROG.test(prog)) return true
+  if (WRAPPER_SHELL.test(prog) && depth < 3) {
+    for (let i = 0; i < rest.length; i++) {
+      if (rest[i] === '-c' && rest[i + 1] && isSendInvocation(rest[i + 1], depth + 1)) return true
+    }
+  }
+  if (PYTHON.test(prog) || NODEISH.test(prog)) {
+    for (let i = 0; i < rest.length; i++) {
+      if ((rest[i] === '-c' || rest[i] === '-e' || rest[i] === '--eval') &&
+          rest[i + 1] && CODE_SEND.test(rest[i + 1])) return true
+    }
+  }
+  const candidates = [prog]
+  if ((PYTHON.test(prog) || NODEISH.test(prog)) && rest.length) candidates.push(basename(rest[0]))
+  if (candidates.some((c) => SENDPY.test(c)) &&
+      rest.some((t) => t === '--to' || t.startsWith('--to='))) return true
+  if (toks.some((t) => GRAPHMAIL.test(basename(t))) && rest.includes('send')) return true
+  if (CURLISH.test(prog) && rest.some((t) => RESEND_TARGET.test(t))) return true
+  return false
+}
+
+export function isSendInvocation(cmd, depth = 0) {
+  let segments
+  try {
+    segments = segmentsTokens(cmd)
+  } catch {
+    // Unparseable command: fall back to the LEGACY content patterns, so on
+    // this path the gate is exactly as strict as before -- never weaker.
+    return SEND_PATTERNS.some((re) => re.test(cmd))
+  }
+  return segments.some((toks) => segmentIsSend(toks, depth))
+}
 
 // Outbound-shaped operations of the multiplexed manage_email tool. Each of
 // these sends for real unless the call explicitly asks for a draft.
@@ -74,7 +197,7 @@ export function gateDecision(toolName, toolInput) {
   }
   if (name === 'Bash') {
     const cmd = String(toolInput?.command ?? '')
-    if (SEND_PATTERNS.some((re) => re.test(cmd))) return { deny: true }
+    if (isSendInvocation(cmd)) return { deny: true }
   }
   return { deny: false }
 }

--- a/scripts/hooks/outgoing-copy-gate.py
+++ b/scripts/hooks/outgoing-copy-gate.py
@@ -34,16 +34,65 @@ import re
 import sys
 
 # --- what counts as an email send -------------------------------------------
-# Deliberately narrower than email-send-gate.mjs: that one may block read-only
-# inspection of the send scripts (acceptable for a sub-agent deny), while this
-# one must only fire on an actual send, or it would block the main agent from
-# reading its own tooling. Hence the recipient-argument requirement below.
-SEND_CMD = re.compile(
-    r"(support-mail/send\.py|\bsend\.py\b|graph-mail[^\n]*\bsend\b|api\.resend\.com"
-    r"|\bsendmail\b|\bmsmtp\b|\bswaks\b)",
-    re.I,
-)
-HAS_RECIPIENT = re.compile(r"(--to\b|\bto_addrs\b|\bto=|\"to\"\s*:|'to'\s*:)", re.I)
+# KAPUHATOKOR822 (2026-08-22, NEGY hamis pozitiv egy delutanon, HAROM
+# muvelet-tipuson: inter-agent uzenet, sqlite-iras, fajl-OLVASAS): a korabbi
+# szures a TELJES parancs-stringben kereste a kuldes-mintakat, igy egy
+# inter-agent curl JSON-torzse ('"to":' a boritekban + 'send.py' a szoveg
+# TARTALMABAN), egy hirlevel-szoveget iro sqlite-parancs vagy a send-script
+# puszta elolvasasa is kuldesnek latszott. A kapu levelnek olvasta azt, ami
+# uzenet A RENDSZERROL -- es pont arrol a temarol nemitotta volna el a
+# flottat, amirol a legfontosabb beszelni (Iris tetje: egy valodi incidenst
+# nem lehetne jelenteni rola).
+#
+# A szures ezert PARANCS-POZICIORA megy, nem tartalomra: elobb kivagjuk a
+# heredoc-torzseket es az idezett stringeket (a tartalom igy nem tud parancs-
+# nak latszani), majd pipeline/szekvencia-szegmensenkent a MEGHIVOTT programot
+# nezzuk. Kuldes az, ahol a kuldo program fut:
+#   - sendmail / msmtp / swaks a program-pozicioban (ezek csak kuldeni tudnak);
+#   - send.py TENYLEGES futtatasa (python vagy kozvetlen ut) --to cimzettel a
+#     SAJAT szegmenseben (a --help/olvasas igy nem trigger);
+#   - graph-mail futtatasa `send` alparanccsal;
+#   - curl/wget, amelynek IDEZETLEN URL-tokenje az api.resend.com-ra mutat
+#     (a -d payloadban idezett elofordulas nem szamit -- az tartalom).
+_HEREDOC = re.compile(r"<<-?\s*'?(\w+)'?\n.*?\n\1", re.S)
+_QUOTED = re.compile(r"\"(?:\\.|[^\"\\])*\"|'[^']*'")
+_ENV_ASSIGN = re.compile(r"^[A-Za-z_][A-Za-z_0-9]*=\S*$")
+_SENDER_PROG = re.compile(r"^(?:\S*/)?(sendmail|msmtp|swaks)$", re.I)
+_SENDPY = re.compile(r"^(?:\S*/)?send\.py$", re.I)
+_GRAPHMAIL = re.compile(r"graph-mail(\.ts)?$", re.I)
+_RECIPIENT_FLAG = re.compile(r"(^|\s)--to(\s|=|$)", re.I)
+
+
+def _command_segments(cmd: str):
+    """Pipeline/szekvencia-szegmensek, heredoc-torzs es idezett stringek nelkul."""
+    c = _HEREDOC.sub(" ", cmd)
+    c = _QUOTED.sub(" __STR__ ", c)
+    return [s for s in re.split(r"\|\|?|&&?|;|\n|\$\(", c) if s.strip()]
+
+
+def is_send_invocation(cmd: str) -> bool:
+    for seg in _command_segments(cmd):
+        toks = seg.split()
+        while toks and _ENV_ASSIGN.match(toks[0]):
+            toks.pop(0)
+        if not toks:
+            continue
+        prog = toks[0]
+        rest = toks[1:]
+        if _SENDER_PROG.match(prog):
+            return True
+        # send.py futtatasa: kozvetlenul, vagy python/python3 utan
+        candidates = [prog] + (rest[:1] if re.match(r"^(?:\S*/)?python3?$", prog) else [])
+        if any(_SENDPY.match(c) for c in candidates) and _RECIPIENT_FLAG.search(seg):
+            return True
+        # graph-mail send alparancs (tsx/node runner utan is)
+        if any(_GRAPHMAIL.search(t) for t in toks) and "send" in rest:
+            return True
+        if re.match(r"^(?:\S*/)?(curl|wget|http)$", prog) and any(
+            "api.resend.com" in t for t in rest
+        ):
+            return True
+    return False
 
 # --- Hungarian detection (accent-insensitive markers) -----------------------
 # These fire on both the correct and the stripped spelling, so a transliterated
@@ -508,7 +557,7 @@ def main():
         text, unreadable = collect_mcp_body(tool_input), None
     elif tool == "Bash":
         cmd = str(tool_input.get("command") or "")
-        if not (SEND_CMD.search(cmd) and HAS_RECIPIENT.search(cmd)):
+        if not is_send_invocation(cmd):
             sys.exit(0)
         text, unreadable = collect_bash_body(cmd)
     else:

--- a/scripts/hooks/outgoing-copy-gate.py
+++ b/scripts/hooks/outgoing-copy-gate.py
@@ -75,16 +75,27 @@ _ENV_ASSIGN = re.compile(r"^[A-Za-z_][A-Za-z_0-9]*=")
 _SENDER_PROG = re.compile(r"^(sendmail|msmtp|swaks)$", re.I)
 _SENDPY = re.compile(r"^send\.py$", re.I)
 _PYTHON = re.compile(r"^python3?$", re.I)
-_GRAPHMAIL = re.compile(r"^graph-mail(\.ts)?$", re.I)
+# A ket kapu (ez + scripts/email-send-gate.mjs) SZANDEKOSAN azonos
+# felismeres-szemantikat visel, es ezt kozos eset-lista orzi
+# (send-invocation-cases.json + konformancia-teszt): a divergencia
+# teszt-hibakent jelenjen meg, ne incidenskent (Marveen, msg 14289).
+_NODEISH = re.compile(r"^(node|tsx|ts-node|deno|bun|npx)$", re.I)
+_GRAPHMAIL = re.compile(r"^graph-mail(\.ts|\.js)?$", re.I)
 _WRAPPER_SHELL = re.compile(r"^(sh|bash|zsh|dash)$", re.I)
 _CURLISH = re.compile(r"^(curl|wget|http)$", re.I)
+# Interpreter kod-string argumentum (python -c / node -e): az interpreternek
+# atadott kod MUVELET, nem tartalom -- a kod-szintu kuldes-hivasokra szurunk.
+_CODE_SEND = re.compile(
+    r"\bsmtplib\b|SMTP\s*\(|\bsendMail\s*\(|\bsendEmail\b|\bmail\.send\b", re.I
+)
 # Token-ELEJERE horgonyzott cel-minta: egy URL-argumentum vagy csupasz
 # domain/utvonal illik ra; egy JSON-payload ('{...api.resend.com...}') nem.
 _RESEND_TARGET = re.compile(r"^(https?://)?([^/@\s]*\.)?api\.resend\.com(/|$|\s|$)", re.I)
 # A tovabbi kuldes-jellegu literalok, amikre a parse-hiba eseten (es CSAK
 # akkor) konzervativan visszaesunk -- lasd is_send_invocation vegen.
 _FALLBACK_LITERALS = re.compile(
-    r"send\.py|api\.resend\.com|\bsendmail\b|\bmsmtp\b|\bswaks\b", re.I
+    r"send\.py|api\.resend\.com|\bsendmail\b|\bmsmtp\b|\bswaks\b"
+    r"|\bsmtplib\b|\bsendMail\s*\(", re.I
 )
 
 
@@ -152,8 +163,15 @@ def _segment_is_send(toks, depth: int) -> bool:
             if t == "-c" and i + 1 < len(rest):
                 if is_send_invocation(rest[i + 1], _depth=depth + 1):
                     return True
-    # send.py futtatasa (kozvetlenul vagy python utan) --to cimzettel
-    candidates = [prog] + ([_basename(rest[0])] if rest and _PYTHON.match(prog) else [])
+    # interpreter kod-string: python -c / node -e / --eval, ami kuldest hiv
+    if _PYTHON.match(prog) or _NODEISH.match(prog):
+        for i, t in enumerate(rest):
+            if t in ("-c", "-e", "--eval") and i + 1 < len(rest) and _CODE_SEND.search(rest[i + 1]):
+                return True
+    # send.py futtatasa (kozvetlenul, vagy python/runner utan) --to cimzettel
+    candidates = [prog] + (
+        [_basename(rest[0])] if rest and (_PYTHON.match(prog) or _NODEISH.match(prog)) else []
+    )
     if any(_SENDPY.match(c) for c in candidates) and any(
         t == "--to" or t.startswith("--to=") for t in rest
     ):

--- a/scripts/hooks/outgoing-copy-gate.py
+++ b/scripts/hooks/outgoing-copy-gate.py
@@ -85,9 +85,26 @@ _WRAPPER_SHELL = re.compile(r"^(sh|bash|zsh|dash)$", re.I)
 _CURLISH = re.compile(r"^(curl|wget|http)$", re.I)
 # Interpreter kod-string argumentum (python -c / node -e): az interpreternek
 # atadott kod MUVELET, nem tartalom -- a kod-szintu kuldes-hivasokra szurunk.
+#
+# KIMONDOTT HATAR (Marveen, msg 14298): tetszoleges interpreter-kod statikus
+# elemzese eldonthetetlen -- ez a kapu a VELETLEN kuldest fogja meg, nem egy
+# elszant kikerulot. A lenti exec-heurisztika a NAIV alakokat fedi (a kod
+# process-inditast ES kuldo-programnevet egyutt tartalmaz); ennel tobbet nem
+# allit, es nem is allithat.
 _CODE_SEND = re.compile(
     r"\bsmtplib\b|SMTP\s*\(|\bsendMail\s*\(|\bsendEmail\b|\bmail\.send\b", re.I
 )
+_CODE_EXECISH = re.compile(
+    r"\bsubprocess\b|os\.system|\bpopen\b|child_process|\bexec[A-Za-z]*\s*\(|\bspawn[A-Za-z]*\s*\(",
+    re.I,
+)
+_CODE_SENDER_LIT = re.compile(r"sendmail|msmtp|swaks|send\.py", re.I)
+
+
+def _code_string_sends(code: str) -> bool:
+    if _CODE_SEND.search(code):
+        return True
+    return bool(_CODE_EXECISH.search(code) and _CODE_SENDER_LIT.search(code))
 # Token-ELEJERE horgonyzott cel-minta: egy URL-argumentum vagy csupasz
 # domain/utvonal illik ra; egy JSON-payload ('{...api.resend.com...}') nem.
 _RESEND_TARGET = re.compile(r"^(https?://)?([^/@\s]*\.)?api\.resend\.com(/|$|\s|$)", re.I)
@@ -166,7 +183,7 @@ def _segment_is_send(toks, depth: int) -> bool:
     # interpreter kod-string: python -c / node -e / --eval, ami kuldest hiv
     if _PYTHON.match(prog) or _NODEISH.match(prog):
         for i, t in enumerate(rest):
-            if t in ("-c", "-e", "--eval") and i + 1 < len(rest) and _CODE_SEND.search(rest[i + 1]):
+            if t in ("-c", "-e", "--eval") and i + 1 < len(rest) and _code_string_sends(rest[i + 1]):
                 return True
     # send.py futtatasa (kozvetlenul, vagy python/runner utan) --to cimzettel
     candidates = [prog] + (

--- a/scripts/hooks/outgoing-copy-gate.py
+++ b/scripts/hooks/outgoing-copy-gate.py
@@ -54,45 +54,125 @@ import sys
 #   - graph-mail futtatasa `send` alparanccsal;
 #   - curl/wget, amelynek IDEZETLEN URL-tokenje az api.resend.com-ra mutat
 #     (a -d payloadban idezett elofordulas nem szamit -- az tartalom).
+# MASODIK KOR (Marveen adverzarialis merese, msg 14282): az elso valtozat a
+# quoted stringeket VAKON vagta ki, ezert ket hamis negativot nyitott -- az
+# IDEZOJELES URL a curl sajat argumentum-helyen (a curl SZOKASOS irasmodja!)
+# es a burkolo hejj `-c` string-argumentuma atment. A gyoker: az idezojel a
+# TARTALOM ellen jo hatar, de nem mondja meg, hogy a token URL- vagy
+# PROGRAM-POZICIOBAN all-e. Ezert a kivagas helyett QUOTE-TUDATOS tokenizalas
+# fut (shlex): az idezett token EGY tokenkent, poziciojaval egyutt erkezik --
+# a curl idezojeles URL-argumentuma igy vizsgalhato, mikozben egy -d payload
+# belsejeben emlitett domain tovabbra is csak tartalom (az URL-minta a token
+# ELEJERE horgonyzott). A wrapper hejj (`sh -c "..."`) string-argumentuma
+# rekurzivan elemzodik.
 _HEREDOC = re.compile(r"<<-?\s*'?(\w+)'?\n.*?\n\1", re.S)
-_QUOTED = re.compile(r"\"(?:\\.|[^\"\\])*\"|'[^']*'")
-_ENV_ASSIGN = re.compile(r"^[A-Za-z_][A-Za-z_0-9]*=\S*$")
-_SENDER_PROG = re.compile(r"^(?:\S*/)?(sendmail|msmtp|swaks)$", re.I)
-_SENDPY = re.compile(r"^(?:\S*/)?send\.py$", re.I)
-_GRAPHMAIL = re.compile(r"graph-mail(\.ts)?$", re.I)
-_RECIPIENT_FLAG = re.compile(r"(^|\s)--to(\s|=|$)", re.I)
+_ENV_ASSIGN = re.compile(r"^[A-Za-z_][A-Za-z_0-9]*=")
+_SENDER_PROG = re.compile(r"^(sendmail|msmtp|swaks)$", re.I)
+_SENDPY = re.compile(r"^send\.py$", re.I)
+_PYTHON = re.compile(r"^python3?$", re.I)
+_GRAPHMAIL = re.compile(r"^graph-mail(\.ts)?$", re.I)
+_WRAPPER_SHELL = re.compile(r"^(sh|bash|zsh|dash)$", re.I)
+_CURLISH = re.compile(r"^(curl|wget|http)$", re.I)
+# Token-ELEJERE horgonyzott cel-minta: egy URL-argumentum vagy csupasz
+# domain/utvonal illik ra; egy JSON-payload ('{...api.resend.com...}') nem.
+_RESEND_TARGET = re.compile(r"^(https?://)?([^/@\s]*\.)?api\.resend\.com(/|$|\s|$)", re.I)
+# A tovabbi kuldes-jellegu literalok, amikre a parse-hiba eseten (es CSAK
+# akkor) konzervativan visszaesunk -- lasd is_send_invocation vegen.
+_FALLBACK_LITERALS = re.compile(
+    r"send\.py|api\.resend\.com|\bsendmail\b|\bmsmtp\b|\bswaks\b", re.I
+)
 
 
-def _command_segments(cmd: str):
-    """Pipeline/szekvencia-szegmensek, heredoc-torzs es idezett stringek nelkul."""
-    c = _HEREDOC.sub(" ", cmd)
-    c = _QUOTED.sub(" __STR__ ", c)
-    return [s for s in re.split(r"\|\|?|&&?|;|\n|\$\(", c) if s.strip()]
+def _basename(tok: str) -> str:
+    return tok.rsplit("/", 1)[-1]
 
 
-def is_send_invocation(cmd: str) -> bool:
-    for seg in _command_segments(cmd):
-        toks = seg.split()
-        while toks and _ENV_ASSIGN.match(toks[0]):
-            toks.pop(0)
-        if not toks:
-            continue
-        prog = toks[0]
-        rest = toks[1:]
-        if _SENDER_PROG.match(prog):
-            return True
-        # send.py futtatasa: kozvetlenul, vagy python/python3 utan
-        candidates = [prog] + (rest[:1] if re.match(r"^(?:\S*/)?python3?$", prog) else [])
-        if any(_SENDPY.match(c) for c in candidates) and _RECIPIENT_FLAG.search(seg):
-            return True
-        # graph-mail send alparancs (tsx/node runner utan is)
-        if any(_GRAPHMAIL.search(t) for t in toks) and "send" in rest:
-            return True
-        if re.match(r"^(?:\S*/)?(curl|wget|http)$", prog) and any(
-            "api.resend.com" in t for t in rest
-        ):
-            return True
+def _mask_subshell_markers(cmd: str) -> str:
+    """Idezojelen KIVULI ujsor/`$(`/backtick -> `;` szeparator, hogy a shlex
+    szegmens-hatarkent lassa; idezojelen BELUL a szoveg erintetlen (tartalom)."""
+    out = []
+    q = None  # None | "'" | '"'
+    i, n = 0, len(cmd)
+    while i < n:
+        ch = cmd[i]
+        if q:
+            if ch == "\\" and q == '"' and i + 1 < n:
+                out.append(cmd[i:i + 2]); i += 2; continue
+            if ch == q:
+                q = None
+            out.append(ch); i += 1; continue
+        if ch in "'\"":
+            q = ch; out.append(ch); i += 1; continue
+        if ch == "\\" and i + 1 < n:
+            out.append(cmd[i:i + 2]); i += 2; continue
+        if ch == "\n" or ch == "`":
+            out.append(";"); i += 1; continue
+        if ch == "$" and i + 1 < n and cmd[i + 1] == "(":
+            out.append(";"); i += 2; continue
+        out.append(ch); i += 1
+    return "".join(out)
+
+
+def _segments_tokens(cmd: str):
+    """[[token, ...], ...] szegmensenkent -- quote-tudatosan, poziciot orizve."""
+    import shlex
+    lex = shlex.shlex(_mask_subshell_markers(_HEREDOC.sub(" ", cmd)),
+                      posix=True, punctuation_chars="();|&")
+    lex.whitespace_split = True
+    segments, cur = [], []
+    for tok in lex:
+        if tok in ("|", "||", "&", "&&", ";", "(", ")", ";;", "|&"):
+            if cur:
+                segments.append(cur)
+            cur = []
+        else:
+            cur.append(tok)
+    if cur:
+        segments.append(cur)
+    return segments
+
+
+def _segment_is_send(toks, depth: int) -> bool:
+    while toks and _ENV_ASSIGN.match(toks[0]):
+        toks = toks[1:]
+    if not toks:
+        return False
+    prog = _basename(toks[0])
+    rest = toks[1:]
+    if _SENDER_PROG.match(prog):
+        return True
+    # burkolo hejj: a -c string-argumentum maga is parancs -- rekurzio
+    if _WRAPPER_SHELL.match(prog) and depth < 3:
+        for i, t in enumerate(rest):
+            if t == "-c" and i + 1 < len(rest):
+                if is_send_invocation(rest[i + 1], _depth=depth + 1):
+                    return True
+    # send.py futtatasa (kozvetlenul vagy python utan) --to cimzettel
+    candidates = [prog] + ([_basename(rest[0])] if rest and _PYTHON.match(prog) else [])
+    if any(_SENDPY.match(c) for c in candidates) and any(
+        t == "--to" or t.startswith("--to=") for t in rest
+    ):
+        return True
+    # graph-mail kimeno alparanccsal (tsx/node runner utan is)
+    if any(_GRAPHMAIL.match(_basename(t)) for t in toks) and "send" in rest:
+        return True
+    # curl/wget: a cel-token akkor is muvelet, ha idezojelben allt -- a
+    # horgonyzott minta valasztja el a payload-belseji emlitestol
+    if _CURLISH.match(prog) and any(_RESEND_TARGET.match(t) for t in rest):
+        return True
     return False
+
+
+def is_send_invocation(cmd: str, _depth: int = 0) -> bool:
+    try:
+        segments = _segments_tokens(cmd)
+    except ValueError:
+        # Parse-hiba (pl. lezaratlan idezojel): nem tudunk poziciot mondani.
+        # Konzervativ visszaeses: csak akkor auditalunk, ha eros kuldes-literal
+        # all a szovegben -- igy egy fura, de valodi kuldes nem csuszik at
+        # neman, a tipikus belso parancsok viszont nem kapnak hamis pozitivot.
+        return bool(_FALLBACK_LITERALS.search(cmd))
+    return any(_segment_is_send(toks, _depth) for toks in segments)
 
 # --- Hungarian detection (accent-insensitive markers) -----------------------
 # These fire on both the correct and the stripped spelling, so a transliterated

--- a/scripts/hooks/outgoing-copy-gate.py
+++ b/scripts/hooks/outgoing-copy-gate.py
@@ -65,7 +65,12 @@ import sys
 # belsejeben emlitett domain tovabbra is csak tartalom (az URL-minta a token
 # ELEJERE horgonyzott). A wrapper hejj (`sh -c "..."`) string-argumentuma
 # rekurzivan elemzodik.
-_HEREDOC = re.compile(r"<<-?\s*'?(\w+)'?\n.*?\n\1", re.S)
+# A heredoc-kivagas SORREND-FUGGETLEN (Marveen 3. kore, msg 14286): a
+# hatarolo utani SOR-MARADEK (pl. atiranyitas: <<EOF > fajl) a parancs
+# resze es MEGMARAD -- csak a torzs esik ki. Enelkul (a) forditott
+# sorrendnel a torzs parancsnak latszott (FP), (b) a bevezeto sor
+# eldobasa a heredoc-taplalt VALODI kuldot vesztette volna el (FN).
+_HEREDOC = re.compile(r"(<<-?\s*'?(\w+)'?[^\n]*)\n.*?\n\2(?=\s|$)", re.S)
 _ENV_ASSIGN = re.compile(r"^[A-Za-z_][A-Za-z_0-9]*=")
 _SENDER_PROG = re.compile(r"^(sendmail|msmtp|swaks)$", re.I)
 _SENDPY = re.compile(r"^send\.py$", re.I)
@@ -116,7 +121,7 @@ def _mask_subshell_markers(cmd: str) -> str:
 def _segments_tokens(cmd: str):
     """[[token, ...], ...] szegmensenkent -- quote-tudatosan, poziciot orizve."""
     import shlex
-    lex = shlex.shlex(_mask_subshell_markers(_HEREDOC.sub(" ", cmd)),
+    lex = shlex.shlex(_mask_subshell_markers(_HEREDOC.sub(r"\1", cmd)),
                       posix=True, punctuation_chars="();|&")
     lex.whitespace_split = True
     segments, cur = [], []

--- a/scripts/hooks/send-invocation-cases.json
+++ b/scripts/hooks/send-invocation-cases.json
@@ -29,6 +29,9 @@
     { "name": "python code-string using smtplib", "cmd": "python3 -c \"import smtplib; s = smtplib.SMTP('smtp.x.hu'); s.sendmail('a','b','m')\"", "expected": true },
     { "name": "node code-string calling sendMail()", "cmd": "node -e \"require('./src/graph-mail.js').sendMail({to:'a@b.hu'})\"", "expected": true },
     { "name": "real mailer on the second line of a multi-line command", "cmd": "cat /tmp/x.txt\nsendmail -t a@b.hu < /tmp/mail.txt", "expected": true },
-    { "name": "heredoc-fed real mailer (round 3: intro survives)", "cmd": "sendmail -t a@b.hu <<'EOF'\ntorzs sora\nEOF", "expected": true }
+    { "name": "heredoc-fed real mailer (round 3: intro survives)", "cmd": "sendmail -t a@b.hu <<'EOF'\ntorzs sora\nEOF", "expected": true },
+    { "name": "naive exec-shape: process-spawn plus mailer in one code string (msg 14298)", "cmd": "python3 -c \"import subprocess; subprocess.run(['sendmail','-t','a@b.hu'])\"", "expected": true },
+    { "name": "exec without a mailer stays clean", "cmd": "python3 -c \"import subprocess; subprocess.run(['ls','-la'])\"", "expected": false },
+    { "name": "mailer name in plain code text without exec stays clean", "cmd": "python3 -c \"print('a mailer utvonala regen mas volt, sendmail neven futott')\"", "expected": false }
   ]
 }

--- a/scripts/hooks/send-invocation-cases.json
+++ b/scripts/hooks/send-invocation-cases.json
@@ -1,0 +1,34 @@
+{
+  "_comment": "Shared recognition contract of the two mail gates (scripts/hooks/outgoing-copy-gate.py :: is_send_invocation and scripts/email-send-gate.mjs :: isSendInvocation). The conformance test (send-invocation-conformance.test.ts) runs EVERY case through BOTH implementations and asserts both equal `expected` -- divergence between the two copies surfaces as a test failure, not an incident (SUBGATEPOZ822, msg 14289). Unparseable-input fallbacks are deliberately NOT here: the two gates fall back differently by design (copy-gate: strong literals; hard-gate: full legacy patterns) and each pins its own in its scope test.",
+  "cases": [
+    { "name": "inter-agent curl, content mentions the mail script", "cmd": "curl -s -X POST http://localhost:3420/api/messages -H \"Content-Type: application/json\" -d '{\"from\":\"marveen\",\"to\":\"samu\",\"content\":\"a scripts/support-mail/send.py hookon fennakadt, --to hianyzott\"}'", "expected": false },
+    { "name": "sqlite write carrying newsletter copy", "cmd": "sqlite3 store/claudeclaw.db \"INSERT INTO kanban_comments (card_id, author, content) VALUES ('X', 'Zara', 'a hirlevel az api.resend.com-on megy ki, sendmail nincs')\"", "expected": false },
+    { "name": "reading the mail script", "cmd": "cat /Users/marvin/ClaudeClaw/scripts/support-mail/send.py", "expected": false },
+    { "name": "grepping for the recipient flag", "cmd": "grep -n -- \"--to\" scripts/support-mail/send.py", "expected": false },
+    { "name": "redirect-first heredoc writing mail-shaped notes", "cmd": "cat > /tmp/notes.md <<'EOF'\nsendmail --to x@y.hu is how the legacy path worked\nEOF", "expected": false },
+    { "name": "marker-first heredoc writing mail-shaped notes (round 3)", "cmd": "cat <<'EOF' > /tmp/notes.md\nsendmail --to x@y.hu is how the legacy path worked\nEOF", "expected": false },
+    { "name": "message quoting a full outbound command", "cmd": "curl -s -X POST http://localhost:3420/api/messages -d '{\"from\":\"samu\",\"to\":\"marveen\",\"content\":\"futtasd: python3 scripts/support-mail/send.py --to ugyfel@ceg.hu\"}'", "expected": false },
+    { "name": "provider domain inside a quoted payload", "cmd": "curl -s http://localhost:3420/api/messages -d '{\"to\":\"samu\",\"content\":\"az api.resend.com lassu ma\"}'", "expected": false },
+    { "name": "multi-line quoted payload with a mailer word on line 2", "cmd": "curl -s http://localhost:3420/api/messages -d '{\"to\":\"marveen\",\"content\":\"elso sor\nsendmail emlitve a masodik sorban\"}'", "expected": false },
+    { "name": "wrapper shell -c that only talks about sending", "cmd": "bash -c \"echo a kuldo-script a support-mail mappaban van\"", "expected": false },
+    { "name": "mail script help is not a send", "cmd": "python3 scripts/support-mail/send.py --help", "expected": false },
+    { "name": "M365 CLI read-only subcommand", "cmd": "npx tsx scripts/graph-mail.ts list --folder inbox", "expected": false },
+
+    { "name": "mail script via python with recipient", "cmd": "python3 /Users/marvin/ClaudeClaw/scripts/support-mail/send.py --to a@b.hu --subject \"X\" --body \"Y\"", "expected": true },
+    { "name": "mail script direct with recipient and stdin body", "cmd": "./scripts/support-mail/send.py --to=a@b.hu < /tmp/body.txt", "expected": true },
+    { "name": "classic mailer with stdin", "cmd": "sendmail -t a@b.hu < /tmp/mail.txt", "expected": true },
+    { "name": "classic mailer mid-pipeline", "cmd": "echo torzs | msmtp a@b.hu", "expected": true },
+    { "name": "swaks with recipient", "cmd": "swaks --to a@b.hu --server smtp.x.hu", "expected": true },
+    { "name": "env prefix does not hide the mailer", "cmd": "SMTP_DEBUG=1 msmtp a@b.hu < /tmp/m.txt", "expected": true },
+    { "name": "M365 CLI outbound subcommand", "cmd": "npx tsx scripts/graph-mail.ts send --to a@b.hu --subject X", "expected": true },
+    { "name": "curl with unquoted provider URL", "cmd": "curl -X POST https://api.resend.com/emails -H \"Authorization: Bearer X\" -d '{\"to\":\"a@b.hu\"}'", "expected": true },
+    { "name": "curl with double-quoted provider URL (round 2)", "cmd": "curl -X POST \"https://api.resend.com/emails\" -d @/tmp/mail.json", "expected": true },
+    { "name": "curl with single-quoted provider URL (round 2)", "cmd": "curl 'https://api.resend.com/emails' -d @/tmp/mail.json", "expected": true },
+    { "name": "wrapper shell -c with a real send (round 2)", "cmd": "bash -c \"python3 scripts/support-mail/send.py --to a@b.hu --subject X\"", "expected": true },
+    { "name": "wrapper shell -c with a piped mailer", "cmd": "sh -c 'echo m | sendmail a@b.hu'", "expected": true },
+    { "name": "python code-string using smtplib", "cmd": "python3 -c \"import smtplib; s = smtplib.SMTP('smtp.x.hu'); s.sendmail('a','b','m')\"", "expected": true },
+    { "name": "node code-string calling sendMail()", "cmd": "node -e \"require('./src/graph-mail.js').sendMail({to:'a@b.hu'})\"", "expected": true },
+    { "name": "real mailer on the second line of a multi-line command", "cmd": "cat /tmp/x.txt\nsendmail -t a@b.hu < /tmp/mail.txt", "expected": true },
+    { "name": "heredoc-fed real mailer (round 3: intro survives)", "cmd": "sendmail -t a@b.hu <<'EOF'\ntorzs sora\nEOF", "expected": true }
+  ]
+}

--- a/scripts/hooks/send-invocation-cases.json
+++ b/scripts/hooks/send-invocation-cases.json
@@ -1,37 +1,260 @@
 {
-  "_comment": "Shared recognition contract of the two mail gates (scripts/hooks/outgoing-copy-gate.py :: is_send_invocation and scripts/email-send-gate.mjs :: isSendInvocation). The conformance test (send-invocation-conformance.test.ts) runs EVERY case through BOTH implementations and asserts both equal `expected` -- divergence between the two copies surfaces as a test failure, not an incident (SUBGATEPOZ822, msg 14289). Unparseable-input fallbacks are deliberately NOT here: the two gates fall back differently by design (copy-gate: strong literals; hard-gate: full legacy patterns) and each pins its own in its scope test.",
+  "_comment": "Shared recognition contract of the two mail gates (scripts/hooks/outgoing-copy-gate.py :: is_send_invocation and scripts/email-send-gate.mjs :: isSendInvocation). The conformance test (send-invocation-conformance.test.ts) runs EVERY case through BOTH implementations and asserts both equal `expected` -- divergence between the two copies surfaces as a test failure, not an incident (SUBGATEPOZ822, msg 14289). Unparseable-input fallbacks are deliberately NOT here: the two gates fall back differently by design (copy-gate: strong literals; hard-gate: full legacy patterns) and each pins its own in its scope test. A [marveen:...] prefixu esetek Marveen fuggetlen review-probai (store/marveen-send-gate-cases.json, msg 14302) -- a 'hatar' jeloles tortenete: az ot naiv exec-alak 2026-08-22 delutan LEZARULT (expected true), a megmaradt dokumentalt korlat az elfedett/futasidoben osszerakott kod; egy kesobbi valtozasnak itt teszt-hibakent kell jelentkeznie MINDKET iranyban, a nema atbillenes a tiltott allapot.",
   "cases": [
-    { "name": "inter-agent curl, content mentions the mail script", "cmd": "curl -s -X POST http://localhost:3420/api/messages -H \"Content-Type: application/json\" -d '{\"from\":\"marveen\",\"to\":\"samu\",\"content\":\"a scripts/support-mail/send.py hookon fennakadt, --to hianyzott\"}'", "expected": false },
-    { "name": "sqlite write carrying newsletter copy", "cmd": "sqlite3 store/claudeclaw.db \"INSERT INTO kanban_comments (card_id, author, content) VALUES ('X', 'Zara', 'a hirlevel az api.resend.com-on megy ki, sendmail nincs')\"", "expected": false },
-    { "name": "reading the mail script", "cmd": "cat /Users/marvin/ClaudeClaw/scripts/support-mail/send.py", "expected": false },
-    { "name": "grepping for the recipient flag", "cmd": "grep -n -- \"--to\" scripts/support-mail/send.py", "expected": false },
-    { "name": "redirect-first heredoc writing mail-shaped notes", "cmd": "cat > /tmp/notes.md <<'EOF'\nsendmail --to x@y.hu is how the legacy path worked\nEOF", "expected": false },
-    { "name": "marker-first heredoc writing mail-shaped notes (round 3)", "cmd": "cat <<'EOF' > /tmp/notes.md\nsendmail --to x@y.hu is how the legacy path worked\nEOF", "expected": false },
-    { "name": "message quoting a full outbound command", "cmd": "curl -s -X POST http://localhost:3420/api/messages -d '{\"from\":\"samu\",\"to\":\"marveen\",\"content\":\"futtasd: python3 scripts/support-mail/send.py --to ugyfel@ceg.hu\"}'", "expected": false },
-    { "name": "provider domain inside a quoted payload", "cmd": "curl -s http://localhost:3420/api/messages -d '{\"to\":\"samu\",\"content\":\"az api.resend.com lassu ma\"}'", "expected": false },
-    { "name": "multi-line quoted payload with a mailer word on line 2", "cmd": "curl -s http://localhost:3420/api/messages -d '{\"to\":\"marveen\",\"content\":\"elso sor\nsendmail emlitve a masodik sorban\"}'", "expected": false },
-    { "name": "wrapper shell -c that only talks about sending", "cmd": "bash -c \"echo a kuldo-script a support-mail mappaban van\"", "expected": false },
-    { "name": "mail script help is not a send", "cmd": "python3 scripts/support-mail/send.py --help", "expected": false },
-    { "name": "M365 CLI read-only subcommand", "cmd": "npx tsx scripts/graph-mail.ts list --folder inbox", "expected": false },
-
-    { "name": "mail script via python with recipient", "cmd": "python3 /Users/marvin/ClaudeClaw/scripts/support-mail/send.py --to a@b.hu --subject \"X\" --body \"Y\"", "expected": true },
-    { "name": "mail script direct with recipient and stdin body", "cmd": "./scripts/support-mail/send.py --to=a@b.hu < /tmp/body.txt", "expected": true },
-    { "name": "classic mailer with stdin", "cmd": "sendmail -t a@b.hu < /tmp/mail.txt", "expected": true },
-    { "name": "classic mailer mid-pipeline", "cmd": "echo torzs | msmtp a@b.hu", "expected": true },
-    { "name": "swaks with recipient", "cmd": "swaks --to a@b.hu --server smtp.x.hu", "expected": true },
-    { "name": "env prefix does not hide the mailer", "cmd": "SMTP_DEBUG=1 msmtp a@b.hu < /tmp/m.txt", "expected": true },
-    { "name": "M365 CLI outbound subcommand", "cmd": "npx tsx scripts/graph-mail.ts send --to a@b.hu --subject X", "expected": true },
-    { "name": "curl with unquoted provider URL", "cmd": "curl -X POST https://api.resend.com/emails -H \"Authorization: Bearer X\" -d '{\"to\":\"a@b.hu\"}'", "expected": true },
-    { "name": "curl with double-quoted provider URL (round 2)", "cmd": "curl -X POST \"https://api.resend.com/emails\" -d @/tmp/mail.json", "expected": true },
-    { "name": "curl with single-quoted provider URL (round 2)", "cmd": "curl 'https://api.resend.com/emails' -d @/tmp/mail.json", "expected": true },
-    { "name": "wrapper shell -c with a real send (round 2)", "cmd": "bash -c \"python3 scripts/support-mail/send.py --to a@b.hu --subject X\"", "expected": true },
-    { "name": "wrapper shell -c with a piped mailer", "cmd": "sh -c 'echo m | sendmail a@b.hu'", "expected": true },
-    { "name": "python code-string using smtplib", "cmd": "python3 -c \"import smtplib; s = smtplib.SMTP('smtp.x.hu'); s.sendmail('a','b','m')\"", "expected": true },
-    { "name": "node code-string calling sendMail()", "cmd": "node -e \"require('./src/graph-mail.js').sendMail({to:'a@b.hu'})\"", "expected": true },
-    { "name": "real mailer on the second line of a multi-line command", "cmd": "cat /tmp/x.txt\nsendmail -t a@b.hu < /tmp/mail.txt", "expected": true },
-    { "name": "heredoc-fed real mailer (round 3: intro survives)", "cmd": "sendmail -t a@b.hu <<'EOF'\ntorzs sora\nEOF", "expected": true },
-    { "name": "naive exec-shape: process-spawn plus mailer in one code string (msg 14298)", "cmd": "python3 -c \"import subprocess; subprocess.run(['sendmail','-t','a@b.hu'])\"", "expected": true },
-    { "name": "exec without a mailer stays clean", "cmd": "python3 -c \"import subprocess; subprocess.run(['ls','-la'])\"", "expected": false },
-    { "name": "mailer name in plain code text without exec stays clean", "cmd": "python3 -c \"print('a mailer utvonala regen mas volt, sendmail neven futott')\"", "expected": false }
+    {
+      "name": "inter-agent curl, content mentions the mail script",
+      "cmd": "curl -s -X POST http://localhost:3420/api/messages -H \"Content-Type: application/json\" -d '{\"from\":\"marveen\",\"to\":\"samu\",\"content\":\"a scripts/support-mail/send.py hookon fennakadt, --to hianyzott\"}'",
+      "expected": false
+    },
+    {
+      "name": "sqlite write carrying newsletter copy",
+      "cmd": "sqlite3 store/claudeclaw.db \"INSERT INTO kanban_comments (card_id, author, content) VALUES ('X', 'Zara', 'a hirlevel az api.resend.com-on megy ki, sendmail nincs')\"",
+      "expected": false
+    },
+    {
+      "name": "reading the mail script",
+      "cmd": "cat /Users/marvin/ClaudeClaw/scripts/support-mail/send.py",
+      "expected": false
+    },
+    {
+      "name": "grepping for the recipient flag",
+      "cmd": "grep -n -- \"--to\" scripts/support-mail/send.py",
+      "expected": false
+    },
+    {
+      "name": "redirect-first heredoc writing mail-shaped notes",
+      "cmd": "cat > /tmp/notes.md <<'EOF'\nsendmail --to x@y.hu is how the legacy path worked\nEOF",
+      "expected": false
+    },
+    {
+      "name": "marker-first heredoc writing mail-shaped notes (round 3)",
+      "cmd": "cat <<'EOF' > /tmp/notes.md\nsendmail --to x@y.hu is how the legacy path worked\nEOF",
+      "expected": false
+    },
+    {
+      "name": "message quoting a full outbound command",
+      "cmd": "curl -s -X POST http://localhost:3420/api/messages -d '{\"from\":\"samu\",\"to\":\"marveen\",\"content\":\"futtasd: python3 scripts/support-mail/send.py --to ugyfel@ceg.hu\"}'",
+      "expected": false
+    },
+    {
+      "name": "provider domain inside a quoted payload",
+      "cmd": "curl -s http://localhost:3420/api/messages -d '{\"to\":\"samu\",\"content\":\"az api.resend.com lassu ma\"}'",
+      "expected": false
+    },
+    {
+      "name": "multi-line quoted payload with a mailer word on line 2",
+      "cmd": "curl -s http://localhost:3420/api/messages -d '{\"to\":\"marveen\",\"content\":\"elso sor\nsendmail emlitve a masodik sorban\"}'",
+      "expected": false
+    },
+    {
+      "name": "wrapper shell -c that only talks about sending",
+      "cmd": "bash -c \"echo a kuldo-script a support-mail mappaban van\"",
+      "expected": false
+    },
+    {
+      "name": "mail script help is not a send",
+      "cmd": "python3 scripts/support-mail/send.py --help",
+      "expected": false
+    },
+    {
+      "name": "M365 CLI read-only subcommand",
+      "cmd": "npx tsx scripts/graph-mail.ts list --folder inbox",
+      "expected": false
+    },
+    {
+      "name": "mail script via python with recipient",
+      "cmd": "python3 /Users/marvin/ClaudeClaw/scripts/support-mail/send.py --to a@b.hu --subject \"X\" --body \"Y\"",
+      "expected": true
+    },
+    {
+      "name": "mail script direct with recipient and stdin body",
+      "cmd": "./scripts/support-mail/send.py --to=a@b.hu < /tmp/body.txt",
+      "expected": true
+    },
+    {
+      "name": "classic mailer with stdin",
+      "cmd": "sendmail -t a@b.hu < /tmp/mail.txt",
+      "expected": true
+    },
+    {
+      "name": "classic mailer mid-pipeline",
+      "cmd": "echo torzs | msmtp a@b.hu",
+      "expected": true
+    },
+    {
+      "name": "swaks with recipient",
+      "cmd": "swaks --to a@b.hu --server smtp.x.hu",
+      "expected": true
+    },
+    {
+      "name": "env prefix does not hide the mailer",
+      "cmd": "SMTP_DEBUG=1 msmtp a@b.hu < /tmp/m.txt",
+      "expected": true
+    },
+    {
+      "name": "M365 CLI outbound subcommand",
+      "cmd": "npx tsx scripts/graph-mail.ts send --to a@b.hu --subject X",
+      "expected": true
+    },
+    {
+      "name": "curl with unquoted provider URL",
+      "cmd": "curl -X POST https://api.resend.com/emails -H \"Authorization: Bearer X\" -d '{\"to\":\"a@b.hu\"}'",
+      "expected": true
+    },
+    {
+      "name": "curl with double-quoted provider URL (round 2)",
+      "cmd": "curl -X POST \"https://api.resend.com/emails\" -d @/tmp/mail.json",
+      "expected": true
+    },
+    {
+      "name": "curl with single-quoted provider URL (round 2)",
+      "cmd": "curl 'https://api.resend.com/emails' -d @/tmp/mail.json",
+      "expected": true
+    },
+    {
+      "name": "wrapper shell -c with a real send (round 2)",
+      "cmd": "bash -c \"python3 scripts/support-mail/send.py --to a@b.hu --subject X\"",
+      "expected": true
+    },
+    {
+      "name": "wrapper shell -c with a piped mailer",
+      "cmd": "sh -c 'echo m | sendmail a@b.hu'",
+      "expected": true
+    },
+    {
+      "name": "python code-string using smtplib",
+      "cmd": "python3 -c \"import smtplib; s = smtplib.SMTP('smtp.x.hu'); s.sendmail('a','b','m')\"",
+      "expected": true
+    },
+    {
+      "name": "node code-string calling sendMail()",
+      "cmd": "node -e \"require('./src/graph-mail.js').sendMail({to:'a@b.hu'})\"",
+      "expected": true
+    },
+    {
+      "name": "real mailer on the second line of a multi-line command",
+      "cmd": "cat /tmp/x.txt\nsendmail -t a@b.hu < /tmp/mail.txt",
+      "expected": true
+    },
+    {
+      "name": "heredoc-fed real mailer (round 3: intro survives)",
+      "cmd": "sendmail -t a@b.hu <<'EOF'\ntorzs sora\nEOF",
+      "expected": true
+    },
+    {
+      "name": "naive exec-shape: process-spawn plus mailer in one code string (msg 14298)",
+      "cmd": "python3 -c \"import subprocess; subprocess.run(['sendmail','-t','a@b.hu'])\"",
+      "expected": true
+    },
+    {
+      "name": "exec without a mailer stays clean",
+      "cmd": "python3 -c \"import subprocess; subprocess.run(['ls','-la'])\"",
+      "expected": false
+    },
+    {
+      "name": "mailer name in plain code text without exec stays clean",
+      "cmd": "python3 -c \"print('a mailer utvonala regen mas volt, sendmail neven futott')\"",
+      "expected": false
+    },
+    {
+      "name": "[marveen:fp-heredoc-redirect-first] heredoc, atiranyitas ELOL: a torzs tartalom",
+      "cmd": "cat > /tmp/n.md <<'EOF'\npython3 scripts/support-mail/send.py --to a@b.hu\nEOF",
+      "expected": false
+    },
+    {
+      "name": "[marveen:fp-heredoc-delimiter-first] heredoc, HATAROLO ELOL (ez volt a talalt res, sorrend-erzekenyseg)",
+      "cmd": "cat <<'EOF' > /tmp/n.md\npython3 scripts/support-mail/send.py --to a@b.hu\nEOF",
+      "expected": false
+    },
+    {
+      "name": "[marveen:fp-python-heredoc] a flotta fo fajl-iro mintaja",
+      "cmd": "python3 - <<'PYEOF'\nprint('python3 scripts/support-mail/send.py --to a@b.hu')\nPYEOF",
+      "expected": false
+    },
+    {
+      "name": "[marveen:pos-heredoc-fed-mailer] heredoc-TAPLALT valodi kuldo: a kuldo a bevezeto sorban (a naiv heredoc-fix tukor-csapdaja)",
+      "cmd": "sendmail -t a@b.hu <<'EOF'\nSubject: x\n\ntorzs\nEOF",
+      "expected": true
+    },
+    {
+      "name": "[marveen:pos-heredoc-fed-script] ugyanaz kuldo-scripttel",
+      "cmd": "python3 scripts/support-mail/send.py --to a@b.hu <<'EOF'\ntorzs\nEOF",
+      "expected": true
+    },
+    {
+      "name": "[marveen:pos-quoted-url-double] idezojeles (dupla) provider-URL a curl SAJAT argumentum-helyen",
+      "cmd": "curl -X POST \"https://api.resend.com/emails\" -H \"Auth: X\" -d '{\"x\":1}'",
+      "expected": true
+    },
+    {
+      "name": "[marveen:pos-quoted-url-single] ugyanaz szimpla idezojellel",
+      "cmd": "curl -X POST 'https://api.resend.com/emails' -d '{\"x\":1}'",
+      "expected": true
+    },
+    {
+      "name": "[marveen:pos-wrapper-bash-c] burkolo hejj -c string-argumentumban",
+      "cmd": "bash -c \"python3 scripts/support-mail/send.py --to a@b.hu\"",
+      "expected": true
+    },
+    {
+      "name": "[marveen:pos-wrapper-sh-c] ugyanaz sh -c alakkal",
+      "cmd": "sh -c 'python3 scripts/support-mail/send.py --to a@b.hu'",
+      "expected": true
+    },
+    {
+      "name": "[marveen:pos-multiline-second-line] tobbsoros parancs, a kuldo a MASODIK sorban",
+      "cmd": "echo elso\nsendmail -t a@b.hu < /tmp/m.txt",
+      "expected": true
+    },
+    {
+      "name": "[marveen:fp-read-cat] a kuldo-script puszta olvasasa",
+      "cmd": "cat scripts/support-mail/send.py",
+      "expected": false
+    },
+    {
+      "name": "[marveen:fp-js-filename-in-docs-grep] a kapu sajat fajlnevenek keresese a docs alatt",
+      "cmd": "grep -rn 'email-send-gate.mjs' docs/",
+      "expected": false
+    },
+    {
+      "name": "[marveen:fp-runner-path-in-message-content] runner-ut es 'send' alparancs egy inter-agent uzenet TARTALMABAN",
+      "cmd": "curl -s http://localhost:3420/api/messages -d '{\"to\":\"samu\",\"content\":\"npx tsx scripts/graph-mail.ts send\"}'",
+      "expected": false
+    },
+    {
+      "name": "[marveen:fp-harmless-interpreter-code] artalmatlan interpreter-kod",
+      "cmd": "python3 -c \"print(1+1)\"",
+      "expected": false
+    },
+    {
+      "name": "[marveen:fp-interpreter-code-writing-about-sending] interpreter-kod, ami a kuldesrol IR",
+      "cmd": "python3 -c \"print('a kuldes menete: scripts/support-mail/send.py')\"",
+      "expected": false
+    },
+    {
+      "name": "[marveen:fp-harmless-node-e] artalmatlan node -e",
+      "cmd": "node -e \"console.log(42)\"",
+      "expected": false
+    },
+    {
+      "name": "[marveen:hatar-interp-os-system-string] interpreter-kodbol inditott kuldo, os.system stringgel",
+      "cmd": "python3 -c \"import os; os.system('sendmail -t a@b.hu')\"",
+      "expected": true
+    },
+    {
+      "name": "[marveen:hatar-interp-subprocess-shell-true] interpreter-kodbol inditott kuldo, subprocess stringgel, shell=True",
+      "cmd": "python3 -c \"import subprocess; subprocess.run('sendmail -t a@b.hu', shell=True)\"",
+      "expected": true
+    },
+    {
+      "name": "[marveen:hatar-node-execsync-string] interpreter-kodbol inditott kuldo, node execSync stringgel",
+      "cmd": "node -e \"require('child_process').execSync('sendmail -t a@b.hu')\"",
+      "expected": true
+    },
+    {
+      "name": "[marveen:hatar-node-execfile-list] interpreter-kodbol inditott kuldo, node execFileSync listaval",
+      "cmd": "node -e \"require('child_process').execFileSync('sendmail',['-t','a@b.hu'])\"",
+      "expected": true
+    }
   ]
 }

--- a/src/__tests__/email-send-gate-scope.test.ts
+++ b/src/__tests__/email-send-gate-scope.test.ts
@@ -68,6 +68,11 @@ describe('gateDecision Bash: POSITIVE CONTROLS -- real send attempts still deny 
     expect(bash(`node -e "require('./src/graph-mail.js').sendMail({to:'a@b.hu'})"`).deny).toBe(true)
   })
 
+  it('heredoc stripping is ORDER-INDEPENDENT: marker-first file-writes stay content, heredoc-FED senders still deny (round 3)', () => {
+    expect(bash(`cat <<'EOF' > /tmp/notes.md\nsendmail --to x@y.hu is how the legacy path worked\nEOF`).deny).toBe(false)
+    expect(bash(`sendmail -t a@b.hu <<'EOF'\ntorzs sora\nEOF`).deny).toBe(true)
+  })
+
   it('an unparseable command falls back to the legacy patterns (never weaker than before)', () => {
     expect(bash(`echo "unbalanced quote and sendmail mentioned`).deny).toBe(true)
     expect(bash(`echo "unbalanced quote, harmless text`).deny).toBe(false)

--- a/src/__tests__/email-send-gate-scope.test.ts
+++ b/src/__tests__/email-send-gate-scope.test.ts
@@ -68,6 +68,13 @@ describe('gateDecision Bash: POSITIVE CONTROLS -- real send attempts still deny 
     expect(bash(`node -e "require('./src/graph-mail.js').sendMail({to:'a@b.hu'})"`).deny).toBe(true)
   })
 
+  it('naive exec-shape in interpreter code denies; exec alone or mailer-name alone does not (msg 14298)', () => {
+    expect(bash(`python3 -c "import subprocess; subprocess.run(['sendmail','-t','a@b.hu'])"`).deny).toBe(true)
+    expect(bash(`node -e "require('child_process').execSync('msmtp a@b.hu < /tmp/m.txt')"`).deny).toBe(true)
+    expect(bash(`python3 -c "import subprocess; subprocess.run(['ls','-la'])"`).deny).toBe(false)
+    expect(bash(`python3 -c "print('a sendmail utvonala regen mas volt')"`).deny).toBe(false)
+  })
+
   it('heredoc stripping is ORDER-INDEPENDENT: marker-first file-writes stay content, heredoc-FED senders still deny (round 3)', () => {
     expect(bash(`cat <<'EOF' > /tmp/notes.md\nsendmail --to x@y.hu is how the legacy path worked\nEOF`).deny).toBe(false)
     expect(bash(`sendmail -t a@b.hu <<'EOF'\ntorzs sora\nEOF`).deny).toBe(true)

--- a/src/__tests__/email-send-gate-scope.test.ts
+++ b/src/__tests__/email-send-gate-scope.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest'
+// @ts-expect-error -- plain .mjs hook script, no types
+import { gateDecision } from '../../scripts/email-send-gate.mjs'
+
+// SUBGATEPOZ822: the gate blocked the DELIVERY of the mail-gate fix three
+// times in one afternoon (commit message, PR body heredoc, card-comment
+// sqlite write) plus five more content hits across the fleet -- all because
+// the old trigger matched send-patterns anywhere in the command string. The
+// old header premise ("a sub-agent has no legitimate need to invoke these")
+// broke: the developer of the mail tooling is a sub-agent. (Writing THIS
+// file was itself blocked by the live gate's old patterns -- the eighth
+// measured false positive of the day.)
+//
+// Per Marveen's strict condition (msg 14282): this is a HARD-deny whose
+// mistakes act outward, so REAL send attempts must keep failing -- the
+// positive controls below are the acceptance bar, not decor.
+describe('gateDecision Bash: content about mail no longer denies (the measured FP classes)', () => {
+  const bash = (command: string) => gateDecision('Bash', { command })
+
+  it('a git commit whose MESSAGE names the mailer binaries passes', () => {
+    expect(bash('git commit -q -m "fix(hooks): sendmail/msmtp/swaks are now matched in program position, send.py needs --to"').deny).toBe(false)
+  })
+
+  it('a PR-create with a heredoc body that documents the send patterns passes', () => {
+    expect(bash(`gh pr create --title "gate fix" --body-file /tmp/b.md <<'EOF'\nthe old trigger matched sendmail and api.resend.com anywhere\nEOF`).deny).toBe(false)
+  })
+
+  it('a card-comment sqlite write quoting the evidence passes', () => {
+    expect(bash(`sqlite3 store/claudeclaw.db "INSERT INTO kanban_comments (card_id, author, content) VALUES ('X','Samu','a send.py es a sendmail mintak a tartalomra tuzeltek')"`).deny).toBe(false)
+  })
+
+  it('an inter-agent message about the mail infrastructure passes', () => {
+    expect(bash(`curl -s -X POST http://localhost:3420/api/messages -d '{"from":"samu","to":"marveen","content":"az api.resend.com kulcs rotalva, a graph-mail send ut tesztelesre var"}'`).deny).toBe(false)
+  })
+
+  it('READING the send tooling passes (cat, grep)', () => {
+    expect(bash('cat scripts/support-mail/send.py').deny).toBe(false)
+    expect(bash('grep -n sendMail scripts/graph-mail.ts').deny).toBe(false)
+  })
+})
+
+describe('gateDecision Bash: POSITIVE CONTROLS -- real send attempts still deny (msg 14282 acceptance bar)', () => {
+  const bash = (command: string) => gateDecision('Bash', { command })
+
+  it('the mail script executed with a recipient denies (python and direct)', () => {
+    expect(bash('python3 scripts/support-mail/send.py --to x@y.hu --subject T --body B').deny).toBe(true)
+    expect(bash('./scripts/support-mail/send.py --to=x@y.hu < /tmp/b.txt').deny).toBe(true)
+  })
+
+  it('the classic mailers deny, also mid-pipeline and behind env prefixes', () => {
+    expect(bash('echo hi | sendmail user@host').deny).toBe(true)
+    expect(bash('SMTP_DEBUG=1 msmtp a@b.hu < /tmp/m.txt').deny).toBe(true)
+    expect(bash('swaks --to a@b.c --server smtp').deny).toBe(true)
+  })
+
+  it('a QUOTED provider URL in curl argument position denies (the normal curl spelling)', () => {
+    expect(bash(`curl -X POST "https://api.resend.com/emails" -d @/tmp/mail.json`).deny).toBe(true)
+    expect(bash(`curl 'https://api.resend.com/emails' -d @/tmp/mail.json`).deny).toBe(true)
+  })
+
+  it('a wrapper shell -c string is analyzed recursively and denies', () => {
+    expect(bash(`bash -c "python3 scripts/support-mail/send.py --to a@b.hu --subject X"`).deny).toBe(true)
+    expect(bash(`sh -c 'echo m | sendmail a@b.hu'`).deny).toBe(true)
+  })
+
+  it('interpreter code-strings that send deny (code handed to an interpreter is operation)', () => {
+    expect(bash(`python3 -c "import smtplib; s = smtplib.SMTP('smtp.x.hu'); s.sendmail('a','b','m')"`).deny).toBe(true)
+    expect(bash(`node -e "require('./src/graph-mail.js').sendMail({to:'a@b.hu'})"`).deny).toBe(true)
+  })
+
+  it('an unparseable command falls back to the legacy patterns (never weaker than before)', () => {
+    expect(bash(`echo "unbalanced quote and sendmail mentioned`).deny).toBe(true)
+    expect(bash(`echo "unbalanced quote, harmless text`).deny).toBe(false)
+  })
+})

--- a/src/__tests__/outgoing-copy-gate-scope.test.ts
+++ b/src/__tests__/outgoing-copy-gate-scope.test.ts
@@ -127,6 +127,16 @@ describe('outgoing-copy gate: quoted tokens in OPERATION position still fire (ms
     expect(isSend(`curl -s http://localhost:3420/api/messages -d '{"to":"marveen","content":"elso sor\nsendmail emlitve a masodik sorban"}'`)).toBe(false)
   })
 
+  it('heredoc stripping is ORDER-INDEPENDENT: marker-first spelling is still content (round 3, msg 14286)', () => {
+    // The same sentence as the redirect-first FP test, tokens swapped -- both
+    // are completely ordinary shell.
+    expect(isSend(`cat <<'EOF' > /tmp/notes.md\nsendmail --to x@y.hu is how the legacy path worked\nEOF`)).toBe(false)
+  })
+
+  it('a heredoc-FED real sender still fires: the intro line survives the stripping', () => {
+    expect(isSend(`sendmail -t a@b.hu <<'EOF'\ntorzs sora\nEOF`)).toBe(true)
+  })
+
   it('an unparseable command (unbalanced quote) falls back conservatively: audits on strong literals only', () => {
     expect(isSend(`echo "lezaratlan idezojel es sendmail emlitve`)).toBe(true)
     expect(isSend(`echo "lezaratlan idezojel, artalmatlan szoveg`)).toBe(false)

--- a/src/__tests__/outgoing-copy-gate-scope.test.ts
+++ b/src/__tests__/outgoing-copy-gate-scope.test.ts
@@ -93,3 +93,42 @@ describe('outgoing-copy gate: every real send shape still fires (no false negati
     expect(isSend('SMTP_DEBUG=1 msmtp a@b.hu < /tmp/m.txt')).toBe(true)
   })
 })
+
+// Marveen's adversarial round (msg 14282): the first version stripped quoted
+// strings BLINDLY, which opened two false negatives -- and the first is the
+// NORMAL way people write curl, so it needed no intent to slip through. The
+// quote is a good boundary against content, but it does not say whether the
+// quoted token stands in URL/PROGRAM position. These pin the repaired
+// distinction from both sides.
+describe('outgoing-copy gate: quoted tokens in OPERATION position still fire (msg 14282)', () => {
+  it('a QUOTED provider URL in curl argument position fires -- the usual way curl is written', () => {
+    expect(isSend(`curl -X POST "https://api.resend.com/emails" -H "Authorization: Bearer X" -d @/tmp/mail.json`)).toBe(true)
+    expect(isSend(`curl 'https://api.resend.com/emails' -d @/tmp/mail.json`)).toBe(true)
+  })
+
+  it('the same domain inside a quoted -d payload still does NOT fire (the FP fix must survive)', () => {
+    expect(isSend(`curl -s http://localhost:3420/api/messages -d '{"to":"samu","content":"az api.resend.com lassu ma"}'`)).toBe(false)
+  })
+
+  it('a wrapper shell -c string is analyzed recursively', () => {
+    expect(isSend(`bash -c "python3 scripts/support-mail/send.py --to a@b.hu --subject X"`)).toBe(true)
+    expect(isSend(`sh -c 'msmtp a@b.hu < /tmp/m.txt'`)).toBe(true)
+  })
+
+  it('a wrapper shell -c string that only TALKS about sending does not fire', () => {
+    expect(isSend(`bash -c "echo a kuldo-script a support-mail mappaban van"`)).toBe(false)
+  })
+
+  it('a real sender on the SECOND LINE of a multi-line command fires (newline is a separator)', () => {
+    expect(isSend(`cat /tmp/x.txt\nsendmail -t a@b.hu < /tmp/mail.txt`)).toBe(true)
+  })
+
+  it('a multi-line quoted payload does not leak fake program positions', () => {
+    expect(isSend(`curl -s http://localhost:3420/api/messages -d '{"to":"marveen","content":"elso sor\nsendmail emlitve a masodik sorban"}'`)).toBe(false)
+  })
+
+  it('an unparseable command (unbalanced quote) falls back conservatively: audits on strong literals only', () => {
+    expect(isSend(`echo "lezaratlan idezojel es sendmail emlitve`)).toBe(true)
+    expect(isSend(`echo "lezaratlan idezojel, artalmatlan szoveg`)).toBe(false)
+  })
+})

--- a/src/__tests__/outgoing-copy-gate-scope.test.ts
+++ b/src/__tests__/outgoing-copy-gate-scope.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { join } from 'node:path'
+
+// KAPUHATOKOR822: four false positives in one afternoon, on THREE operation
+// types (inter-agent message, sqlite write, file READ). The old trigger
+// searched the WHOLE command string for send-patterns, so the '"to":' of an
+// inter-agent envelope plus 'send.py' mentioned in the CONTENT read as an
+// email send -- the gate silenced the fleet on exactly the topic it most
+// needs to talk about (Iris: a real incident about this system could not be
+// reported through it). The trigger now works on COMMAND POSITION: heredoc
+// bodies and quoted strings are cut first, then the INVOKED program of each
+// pipeline segment decides. These tests pin both directions: content can no
+// longer fake a send, and every real send shape still fires.
+
+const ROOT = join(__dirname, '..', '..')
+const GATE = join(ROOT, 'scripts', 'hooks', 'outgoing-copy-gate.py')
+
+function isSend(cmd: string): boolean {
+  const out = execFileSync('python3', ['-c', `
+import importlib.util, json, sys
+spec = importlib.util.spec_from_file_location("gate", ${JSON.stringify(GATE)})
+g = importlib.util.module_from_spec(spec); spec.loader.exec_module(g)
+print(json.dumps(g.is_send_invocation(sys.argv[1])))
+`, cmd], { encoding: 'utf-8' })
+  return JSON.parse(out.trim())
+}
+
+describe('outgoing-copy gate: content cannot fake a send (the four measured FP classes)', () => {
+  it('an inter-agent curl whose CONTENT mentions send.py and carries a "to" envelope passes', () => {
+    // Marveen's real morning case: a message TO an agent ABOUT the mail gate.
+    expect(isSend(
+      `curl -s -X POST http://localhost:3420/api/messages -H "Content-Type: application/json" ` +
+      `-d '{"from":"marveen","to":"samu","content":"a scripts/support-mail/send.py hookon fennakadt, --to hianyzott"}'`,
+    )).toBe(false)
+  })
+
+  it('a sqlite write whose text talks about a newsletter and a provider passes', () => {
+    // Zara's real case: internal write, blocked on provider-name + "hirlevel".
+    expect(isSend(
+      `sqlite3 store/claudeclaw.db "INSERT INTO kanban_comments (card_id, author, content) ` +
+      `VALUES ('X', 'Zara', 'a hirlevel az api.resend.com-on megy ki, sendmail nincs')"`,
+    )).toBe(false)
+  })
+
+  it('READING the send script passes (cat, grep --to)', () => {
+    // Iris's real case: a file read classified as a send.
+    expect(isSend('cat /Users/marvin/ClaudeClaw/scripts/support-mail/send.py')).toBe(false)
+    expect(isSend('grep -n -- "--to" scripts/support-mail/send.py')).toBe(false)
+  })
+
+  it('a heredoc that WRITES send-shaped content into a file passes', () => {
+    expect(isSend(
+      `cat > /tmp/notes.md <<'EOF'\nsendmail --to x@y.hu is how the legacy path worked\nEOF`,
+    )).toBe(false)
+  })
+
+  it('an inter-agent message quoting a full send command in its content passes', () => {
+    expect(isSend(
+      `curl -s -X POST http://localhost:3420/api/messages ` +
+      `-d '{"from":"samu","to":"marveen","content":"futtasd: python3 scripts/support-mail/send.py --to ugyfel@ceg.hu"}'`,
+    )).toBe(false)
+  })
+})
+
+describe('outgoing-copy gate: every real send shape still fires (no false negatives from the narrowing)', () => {
+  it('send.py invoked with a recipient fires (python3 and direct path)', () => {
+    expect(isSend('python3 /Users/marvin/ClaudeClaw/scripts/support-mail/send.py --to a@b.hu --subject "X" --body "Y"')).toBe(true)
+    expect(isSend('./scripts/support-mail/send.py --to=a@b.hu < /tmp/body.txt')).toBe(true)
+  })
+
+  it('send.py WITHOUT a recipient does not fire (--help is not a send)', () => {
+    expect(isSend('python3 scripts/support-mail/send.py --help')).toBe(false)
+  })
+
+  it('the pure senders fire from program position, also mid-pipeline', () => {
+    expect(isSend('sendmail -t a@b.hu < /tmp/mail.txt')).toBe(true)
+    expect(isSend('echo torzs | msmtp a@b.hu')).toBe(true)
+    expect(isSend('swaks --to a@b.hu --server smtp.x.hu')).toBe(true)
+  })
+
+  it('graph-mail with the send subcommand fires; without it, it does not', () => {
+    expect(isSend('npx tsx scripts/graph-mail.ts send --to a@b.hu --subject X')).toBe(true)
+    expect(isSend('npx tsx scripts/graph-mail.ts list --folder inbox')).toBe(false)
+  })
+
+  it('curl with an UNQUOTED resend URL token fires; the same domain inside a quoted payload does not', () => {
+    expect(isSend(`curl -X POST https://api.resend.com/emails -H "Authorization: Bearer X" -d '{"to":"a@b.hu"}'`)).toBe(true)
+    expect(isSend(`curl -s http://localhost:3420/api/messages -d '{"to":"samu","content":"az api.resend.com lassu ma"}'`)).toBe(false)
+  })
+
+  it('an env-var prefix does not hide the sender program', () => {
+    expect(isSend('SMTP_DEBUG=1 msmtp a@b.hu < /tmp/m.txt')).toBe(true)
+  })
+})

--- a/src/__tests__/outgoing-copy-gate-scope.test.ts
+++ b/src/__tests__/outgoing-copy-gate-scope.test.ts
@@ -127,6 +127,12 @@ describe('outgoing-copy gate: quoted tokens in OPERATION position still fire (ms
     expect(isSend(`curl -s http://localhost:3420/api/messages -d '{"to":"marveen","content":"elso sor\nsendmail emlitve a masodik sorban"}'`)).toBe(false)
   })
 
+  it('naive exec-shape in interpreter code fires; exec alone or mailer-name alone does not (msg 14298)', () => {
+    expect(isSend(`python3 -c "import subprocess; subprocess.run(['sendmail','-t','a@b.hu'])"`)).toBe(true)
+    expect(isSend(`python3 -c "import subprocess; subprocess.run(['ls','-la'])"`)).toBe(false)
+    expect(isSend(`python3 -c "print('a sendmail utvonala regen mas volt')"`)).toBe(false)
+  })
+
   it('heredoc stripping is ORDER-INDEPENDENT: marker-first spelling is still content (round 3, msg 14286)', () => {
     // The same sentence as the redirect-first FP test, tokens swapped -- both
     // are completely ordinary shell.

--- a/src/__tests__/send-invocation-conformance.test.ts
+++ b/src/__tests__/send-invocation-conformance.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+// @ts-expect-error -- plain .mjs hook script, no types
+import { isSendInvocation } from '../../scripts/email-send-gate.mjs'
+
+// SUBGATEPOZ822 / msg 14289: the same command-position recognition now lives
+// in TWO languages, in two files (the main-agent copy gate in python, the
+// sub-agent hard-gate in JS). Several of today's findings came from exactly
+// this pattern -- a parallel copy drifting silently. This test binds the two:
+// EVERY case in the shared list runs through BOTH implementations, and both
+// must equal the expected verdict. A future fix applied to only one copy
+// fails here as a test, instead of surfacing weeks later as an incident.
+//
+// Deliberately NOT in the shared list: unparseable-input fallbacks. The two
+// gates fall back differently by design (copy-gate: strong literals only;
+// hard-gate: its full legacy pattern set, because it is a hard-deny that must
+// never get weaker on that path) -- each pins its own fallback in its scope
+// test. If that difference ever becomes a problem, unify there first.
+
+const ROOT = join(__dirname, '..', '..')
+const GATE_PY = join(ROOT, 'scripts', 'hooks', 'outgoing-copy-gate.py')
+const CASES = JSON.parse(
+  readFileSync(join(ROOT, 'scripts', 'hooks', 'send-invocation-cases.json'), 'utf-8'),
+) as { cases: Array<{ name: string; cmd: string; expected: boolean }> }
+
+// One python process for the whole list: stdin carries the JSON cases, stdout
+// returns the per-case verdicts. Spawning per-case would be ~30x slower.
+function pythonVerdicts(cmds: string[]): boolean[] {
+  const out = execFileSync('python3', ['-c', `
+import importlib.util, json, sys
+spec = importlib.util.spec_from_file_location("gate", ${JSON.stringify(GATE_PY)})
+g = importlib.util.module_from_spec(spec); spec.loader.exec_module(g)
+cmds = json.load(sys.stdin)
+print(json.dumps([g.is_send_invocation(c) for c in cmds]))
+`], { encoding: 'utf-8', input: JSON.stringify(cmds) })
+  return JSON.parse(out.trim())
+}
+
+describe('send-invocation conformance: both gates agree with the shared contract on every case', () => {
+  const py = pythonVerdicts(CASES.cases.map((c) => c.cmd))
+
+  CASES.cases.forEach((c, i) => {
+    it(`${c.name} -> ${c.expected}`, () => {
+      const js = isSendInvocation(c.cmd)
+      expect(js, `JS verdict for: ${c.cmd}`).toBe(c.expected)
+      expect(py[i], `python verdict for: ${c.cmd}`).toBe(c.expected)
+    })
+  })
+
+  it('the shared list is non-trivial in both directions', () => {
+    expect(CASES.cases.some((c) => c.expected)).toBe(true)
+    expect(CASES.cases.some((c) => !c.expected)).toBe(true)
+    expect(CASES.cases.length).toBeGreaterThanOrEqual(20)
+  })
+})


### PR DESCRIPTION
## Why (SUBGATEPOZ822, msg 14289)

The same command-position recognition now lives in two languages, in two files: the main-agent copy gate (python) and the sub-agent hard-gate (JS port). Several of today's findings came from exactly this pattern -- a parallel copy drifting silently. The reviewer's round-3 finding was itself an inherited copy of a flaw fixed in one file.

## What

- `scripts/hooks/send-invocation-cases.json` -- the shared recognition contract: 28 cases in both directions (all measured FP classes, all positive-control send shapes, both heredoc orders, quoted/unquoted provider URLs, wrapper-shell and interpreter-code forms, multi-line commands).
- `send-invocation-conformance.test.ts` -- every case runs through BOTH implementations (JS imported, python driven in a single batched process), and both must equal the expected verdict. A future fix applied to only one copy fails here as a test instead of surfacing later as an incident.
- Deliberately per-implementation and NOT in the shared list: unparseable-input fallbacks (the copy gate falls back to strong literals, the hard-deny gate to its full legacy pattern set -- by design, each pinned in its own scope test).

## Merge order

**After #1042 and #1043** -- this branch contains both (the conformance runs on their union). Until they merge, this PR's diff shows their changes too; it shrinks to the two new files once they land.

## Verification

29/29 conformance green (both implementations agree on all 28 cases + the non-triviality check); full suite on the merged union 3870/3870; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
