### PR TITLE
fix(heartbeat): DB size is served by the summary endpoint, not re-invented per session (HBDBMERET822)

### DIFF
--- a/src/__tests__/heartbeat-agent-scaffold.test.ts
+++ b/src/__tests__/heartbeat-agent-scaffold.test.ts
@@ -303,7 +303,7 @@ describe('kanban extraction is a shipped one-liner, never an improvised pipe+her
     const out = renderHeartbeatClaudeMd(ID)
     expect(out).toContain(`python3 -c "import json,urllib.request;`)
     expect(out).toContain(`${ID.dashboardOrigin}/api/kanban/heartbeat-summary`)
-    expect(out).toMatch(/COUNTS urgent=%s in_progress=%s waiting=%s planned=%s new_hot_memories_1h=%s waiting_shown=%s/)
+    expect(out).toMatch(/COUNTS urgent=%s in_progress=%s waiting=%s planned=%s new_hot_memories_1h=%s db_size_mb=%s waiting_shown=%s/)
   })
 
   it('the ONLY python3-heredoc mention is the quoted example inside the ban paragraph', () => {

--- a/src/__tests__/heartbeat-db-size.test.ts
+++ b/src/__tests__/heartbeat-db-size.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync, mkdtempSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { initDatabase, getDbFileSizeMb } from '../db.js'
+import { buildHeartbeatSummaryResponse } from '../web/routes/kanban.js'
+
+// HBDBMERET822: the heartbeat's "DB size" line had NO sanctioned source --
+// the scaffold template said `- DB size: <X> MB` and every session re-invented
+// the measurement. Measured drift on 2026-08-22: 09:00 `157 MB`, 14:00 `160M`
+// (du -h shape, different session), 15:00 `0.0 MB` against a real 159 MB.
+// Same family as HBMEMBLIND807/819 and the planned-count fix: a prescription
+// the measured party must re-apply every round is not a mechanism; a number
+// computed server-side has nothing to rewrite. These tests pin three halves:
+// the server-side function measures the OPENED database honestly (null, never
+// 0, when it cannot), the endpoint serves it under counts.*, and the scaffold
+// tells the agent to copy the field and forbids self-measurement.
+
+const ROOT = join(__dirname, '..', '..')
+
+describe('getDbFileSizeMb (server-side, against the OPENED database)', () => {
+  it('reports the real on-disk size of the database it opened', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'hb-dbsize-'))
+    const dbPath = join(dir, 'test.db')
+    initDatabase(dbPath)
+    const reported = getDbFileSizeMb()
+    const real = statSync(dbPath).size / (1024 * 1024)
+    expect(reported).not.toBeNull()
+    // A freshly-initialized schema is small but NOT empty -- the honest value
+    // is the stat of the same file, to one decimal.
+    expect(reported).toBe(Math.round(real * 10) / 10)
+  })
+
+  it(':memory: has no file: null, never a fabricated 0', () => {
+    initDatabase(':memory:')
+    expect(getDbFileSizeMb()).toBeNull()
+  })
+})
+
+describe('the endpoint serves the number under counts.* (truncation-safe surface)', () => {
+  const empty = { urgent: [], in_progress: [], waiting: [] }
+
+  it('db_size_mb rides in counts, inside the first 200 bytes', () => {
+    const json = JSON.stringify(buildHeartbeatSummaryResponse(empty, 0, 0, 159.7))
+    expect(json.slice(0, 200)).toContain('"db_size_mb":159.7')
+  })
+
+  it('null passes through as null -- the builder must not coerce "unknown" into a calm-looking 0', () => {
+    const r = buildHeartbeatSummaryResponse(empty, 0, 0, null)
+    expect(r.counts.db_size_mb).toBeNull()
+    expect(JSON.stringify(r)).toContain('"db_size_mb":null')
+  })
+})
+
+describe('wiring contract: endpoint -> agent, never agent -> du/stat', () => {
+  const KANBAN = readFileSync(join(ROOT, 'src', 'web', 'routes', 'kanban.ts'), 'utf-8')
+  const SCAFFOLD = readFileSync(join(ROOT, 'src', 'web', 'heartbeat-agent-scaffold.ts'), 'utf-8')
+
+  it('the heartbeat-summary handler passes getDbFileSizeMb() into the builder', () => {
+    // Structurally-anchored window (the #1006 review lesson): handler start
+    // marker to its own `return true`, never a window derived from the needle.
+    const start = KANBAN.indexOf("'/api/kanban/heartbeat-summary'")
+    expect(start).toBeGreaterThanOrEqual(0)
+    const end = KANBAN.indexOf('return true', start)
+    expect(end).toBeGreaterThan(start)
+    expect(KANBAN.slice(start, end)).toMatch(/buildHeartbeatSummaryResponse\([\s\S]*getDbFileSizeMb\(\)/)
+  })
+
+  it('the scaffold names counts.db_size_mb as the ONLY source and forbids self-measurement', () => {
+    expect(SCAFFOLD).toMatch(/counts\.db_size_mb/)
+    // The one-line kanban command must surface the number in its measured
+    // output, tolerant of older builds (dict.get, no KeyError).
+    expect(SCAFFOLD).toMatch(/db_size_mb=%s/)
+    expect(SCAFFOLD).toMatch(/c\.get\('db_size_mb'\)/)
+    // The drifted surface itself: the template placeholder with no source.
+    expect(SCAFFOLD).not.toMatch(/DB size: <X> MB/)
+    // Missing/null degrades to "no data", never to a self-run measurement.
+    expect(SCAFFOLD).toMatch(/DB size: nincs adat \(a summary nem adja\)/)
+  })
+})

--- a/src/__tests__/heartbeat-summary-truncation-safe.test.ts
+++ b/src/__tests__/heartbeat-summary-truncation-safe.test.ts
@@ -29,7 +29,7 @@ function bigSummary() {
 
 describe('buildHeartbeatSummaryResponse (pure)', () => {
   it('counts is the FIRST serialized key, so truncated reads lose lists, never numbers', () => {
-    const json = JSON.stringify(buildHeartbeatSummaryResponse(bigSummary(), 2, 305))
+    const json = JSON.stringify(buildHeartbeatSummaryResponse(bigSummary(), 2, 305, 159.7))
     expect(json.startsWith('{"counts":')).toBe(true)
     // The whole counts object must fit well inside any sane read window: the
     // first 200 bytes carry every number even if 99% of the payload is lost.
@@ -42,31 +42,31 @@ describe('buildHeartbeatSummaryResponse (pure)', () => {
   })
 
   it('counts.waiting is the FULL total, never the capped list length (the 2026-08-04 lesson in endpoint form)', () => {
-    const r = buildHeartbeatSummaryResponse(bigSummary(), 0, 305)
+    const r = buildHeartbeatSummaryResponse(bigSummary(), 0, 305, 159.7)
     expect(r.counts.waiting).toBe(280)
     expect(r.waiting.length).toBe(HEARTBEAT_SUMMARY_WAITING_CAP)
     expect(r.waiting_shown).toBe(HEARTBEAT_SUMMARY_WAITING_CAP)
   })
 
   it('the waiting list carries the most recently UPDATED cards', () => {
-    const r = buildHeartbeatSummaryResponse(bigSummary(), 0, 305)
+    const r = buildHeartbeatSummaryResponse(bigSummary(), 0, 305, 159.7)
     // Fixture updated_at grows with the index, so the newest ids are the highest.
     expect(r.waiting[0].id).toBe('W279')
     expect(r.waiting[HEARTBEAT_SUMMARY_WAITING_CAP - 1].id).toBe(`W${280 - HEARTBEAT_SUMMARY_WAITING_CAP}`)
   })
 
   it('every title is truncated server-side; short titles pass through untouched', () => {
-    const r = buildHeartbeatSummaryResponse(bigSummary(), 0, 305)
+    const r = buildHeartbeatSummaryResponse(bigSummary(), 0, 305, 159.7)
     for (const c of [...r.urgent, ...r.waiting]) {
       expect(c.title.length).toBeLessThanOrEqual(HEARTBEAT_SUMMARY_TITLE_MAX + 1) // +1 for the ellipsis
     }
     const small = buildHeartbeatSummaryResponse(
-      { urgent: [card('A', 'rövid cím', 'waiting', 1)], in_progress: [], waiting: [] }, 0, 0)
+      { urgent: [card('A', 'rövid cím', 'waiting', 1)], in_progress: [], waiting: [] }, 0, 0, null)
     expect(small.urgent[0].title).toBe('rövid cím')
   })
 
   it('the payload with 280 huge-titled cards stays small enough to never truncate in practice', () => {
-    const json = JSON.stringify(buildHeartbeatSummaryResponse(bigSummary(), 0, 305))
+    const json = JSON.stringify(buildHeartbeatSummaryResponse(bigSummary(), 0, 305, 159.7))
     // Pre-fix this was ~4.2MB with these fixtures (280 x 15KB); the cap+trunc
     // must keep it in the low KB range.
     expect(json.length).toBeLessThan(10_000)

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,12 +1,16 @@
 import Database from 'better-sqlite3'
 import { join } from 'node:path'
-import { existsSync, mkdirSync, readFileSync, renameSync, chmodSync, openSync, closeSync } from 'node:fs'
+import { existsSync, mkdirSync, readFileSync, renameSync, chmodSync, openSync, closeSync, statSync } from 'node:fs'
 import { STORE_DIR, DB_FILENAME, ALLOWED_CHAT_ID, OLLAMA_URL, APP_TZ } from './config.js'
 import { getEffectiveSettingValue } from './settings-store.js'
 import { logger } from './logger.js'
 import { TOOL_TIMEOUTS } from './tool-timeouts.js'
 
 let db: Database.Database
+// The path the CURRENT handle was opened on (null for ':memory:'). Kept so
+// size reporting measures the database actually being served, not a
+// re-derived default path that an override would silently diverge from.
+let openedDbPath: string | null = null
 
 // Lock the DB file and its sidecars (WAL, SHM, rollback journal) down to
 // owner-only. better-sqlite3 opens the main file with the process umask
@@ -66,6 +70,7 @@ export function initDatabase(dbPathOverride?: string): void {
     }
   }
   db = new Database(dbPath)
+  openedDbPath = isMemory ? null : dbPath
   db.pragma('journal_mode = WAL')
   // Performance pragmas: safe with WAL, applied after journal_mode is set.
   // cache_size: negative value = kibibytes; -65536 → 64 MB page cache.
@@ -2090,6 +2095,32 @@ export const HEARTBEAT_NEW_HOT_MEMORIES_SQL =
 export function countNewHotMemories(agentId: string): number {
   const row = db.prepare(HEARTBEAT_NEW_HOT_MEMORIES_SQL).get(agentId) as { n: number } | undefined
   return row?.n ?? 0
+}
+
+/**
+ * HBDBMERET822: the heartbeat's "DB size" number is computed HERE, server-side,
+ * and served over /api/kanban/heartbeat-summary -- same closure as the kanban
+ * counts and countNewHotMemories above. Before this, the scaffold's template
+ * had a bare `DB size: <X> MB` placeholder with no sanctioned source, so each
+ * session re-invented the measurement: the format drifted round to round
+ * (`158 MB` -> `160M`, a du -h shape) and on 2026-08-22 15:00 the report said
+ * `0.0 MB` against a real 159 MB. A zero here is the dangerous direction --
+ * the metric exists as a GROWTH signal, and a permanent 0.0 does not die
+ * loudly, it just looks calm.
+ *
+ * Returns null (never 0) when the size cannot be measured: for ':memory:'
+ * databases and on stat failure. 0 is a plausible reading; null is not --
+ * the consumer renders it as "nincs adat". Same lesson as the silent
+ * `catch { return 0 }` this replaces in heartbeat.ts collectSystem.
+ */
+export function getDbFileSizeMb(): number | null {
+  if (!openedDbPath) return null
+  try {
+    return Math.round((statSync(openedDbPath).size / (1024 * 1024)) * 10) / 10
+  } catch (err) {
+    logger.warn({ err, dbPath: openedDbPath }, 'DB size stat failed; serving null, not 0')
+    return null
+  }
 }
 
 // --- Agent Messages ---

--- a/src/heartbeat.ts
+++ b/src/heartbeat.ts
@@ -285,7 +285,9 @@ function readClaudeCodeOauthJson(): string | null {
 // --- Data types ---
 
 interface SystemInfo {
-  dbSizeMB: number
+  // null = could not measure. Never 0: the metric is a growth signal, and a
+  // false zero reads as calm, not as failure (HBDBMERET822).
+  dbSizeMB: number | null
   dbWarning: boolean
 }
 
@@ -343,8 +345,9 @@ function collectSystem(): SystemInfo {
     const dbPath = join(STORE_DIR, DB_FILENAME)
     const dbSize = statSync(dbPath).size / (1024 * 1024)
     return { dbSizeMB: Math.round(dbSize * 10) / 10, dbWarning: dbSize > 100 }
-  } catch {
-    return { dbSizeMB: 0, dbWarning: false }
+  } catch (err) {
+    logger.warn({ err }, 'Heartbeat: DB size stat failed; reporting null, not 0')
+    return { dbSizeMB: null, dbWarning: false }
   }
 }
 
@@ -459,7 +462,7 @@ function buildAgentPrompt(data: HeartbeatData): string {
 
   // System -- trusted (our own metrics, no external input).
   prompt += `## Rendszer\n`
-  prompt += `- DB meret: ${data.system.dbSizeMB} MB${data.system.dbWarning ? ' WARNING >100MB!' : ''}\n`
+  prompt += `- DB meret: ${data.system.dbSizeMB === null ? 'nincs adat (stat hiba)' : `${data.system.dbSizeMB} MB${data.system.dbWarning ? ' WARNING >100MB!' : ''}`}\n`
   prompt += `- Aktiv utemezett feladatok: ${data.tasks.count}\n`
   if (data.tasks.nextRun) {
     const nextDate = new Date(data.tasks.nextRun * 1000)

--- a/src/web/heartbeat-agent-scaffold.ts
+++ b/src/web/heartbeat-agent-scaffold.ts
@@ -208,7 +208,7 @@ When you receive the heartbeat prompt:
      as written, do not recompose it:
 
      \`\`\`bash
-     python3 -c "import json,urllib.request; tok=open('${id.storeDir}/.dashboard-token').read().strip(); d=json.load(urllib.request.urlopen(urllib.request.Request('${id.dashboardOrigin}/api/kanban/heartbeat-summary', headers={'Authorization':'Bearer '+tok}))); c=d['counts']; print('COUNTS urgent=%s in_progress=%s waiting=%s planned=%s new_hot_memories_1h=%s waiting_shown=%s' % (c['urgent'],c['in_progress'],c['waiting'],c['planned'],c['new_hot_memories_1h'],d.get('waiting_shown'))); [print('URGENT',x['id'],x['title']) for x in d['urgent']]; [print('WAITING',x['id'],x['title']) for x in d['waiting']]"
+     python3 -c "import json,urllib.request; tok=open('${id.storeDir}/.dashboard-token').read().strip(); d=json.load(urllib.request.urlopen(urllib.request.Request('${id.dashboardOrigin}/api/kanban/heartbeat-summary', headers={'Authorization':'Bearer '+tok}))); c=d['counts']; print('COUNTS urgent=%s in_progress=%s waiting=%s planned=%s new_hot_memories_1h=%s db_size_mb=%s waiting_shown=%s' % (c['urgent'],c['in_progress'],c['waiting'],c['planned'],c['new_hot_memories_1h'],c.get('db_size_mb'),d.get('waiting_shown'))); [print('URGENT',x['id'],x['title']) for x in d['urgent']]; [print('WAITING',x['id'],x['title']) for x in d['waiting']]"
      \`\`\`
 
      The command is ONE line on purpose: it survives copy-paste from any
@@ -303,6 +303,19 @@ When you receive the heartbeat prompt:
      write \`new hot memories (1h): nincs adat (a summary nem adja)\` --
      do not fall back to your own query, and never fill the line with 0.
 
+     HBDBMERET822: the DB size comes from the SAME response: report
+     \`counts.db_size_mb\`. Do NOT measure it yourself -- no \`du\`, no
+     \`ls -l\`, no \`stat\`, no python division, not even a
+     correct-looking one. This line used to be a bare placeholder with
+     no source, and each session re-invented the measurement: the
+     format drifted round to round (\`158 MB\`, then \`160M\` in du -h
+     shape) and on 2026-08-22 15:00 a round reported \`0.0 MB\`
+     against a real 159 MB, right after a restart. A growth signal
+     that reads 0.0 does not die loudly -- nobody misses a zero.
+     If the field is missing or \`None\`/null (older dashboard build,
+     or the server could not stat the file), write
+     \`DB size: nincs adat (a summary nem adja)\` -- never 0.
+
 2. **Format** the result as a single inter-agent message:
 
    \`\`\`
@@ -324,7 +337,7 @@ When you receive the heartbeat prompt:
    - last hour: <N fired, N skipped>
 
    ### Memory / system
-   - DB size: <X> MB
+   - DB size: <counts.db_size_mb> MB
    - new hot memories (1h): <N>
    \`\`\`
 

--- a/src/web/routes/kanban.ts
+++ b/src/web/routes/kanban.ts
@@ -14,6 +14,7 @@ import {
   getHeartbeatKanbanSummary,
   countNewHotMemories,
   countPlannedKanbanCards,
+  getDbFileSizeMb,
 } from '../../db.js'
 import { normalizeKanbanRefs } from '../kanban-ref-normalize.js'
 import { OWNER_NAME, BOT_NAME, MAIN_AGENT_ID, STORE_DIR, WEB_HOST, WEB_PORT, KANBAN_LABEL_COLORS } from '../../config.js'
@@ -139,6 +140,7 @@ export function buildHeartbeatSummaryResponse(
   summary: { urgent: HeartbeatSummaryCard[]; in_progress: HeartbeatSummaryCard[]; waiting: HeartbeatSummaryCard[] },
   newHotMemories1h: number,
   plannedCount: number,
+  dbSizeMb: number | null,
 ) {
   const trunc = (t: string) =>
     t.length > HEARTBEAT_SUMMARY_TITLE_MAX ? t.slice(0, HEARTBEAT_SUMMARY_TITLE_MAX) + '…' : t
@@ -163,6 +165,12 @@ export function buildHeartbeatSummaryResponse(
       // heartbeat agent copies a number instead of running (and rewriting)
       // a query -- see HEARTBEAT_NEW_HOT_MEMORIES_SQL in db.ts.
       new_hot_memories_1h: newHotMemories1h,
+      // HBDBMERET822: without a sanctioned source the agent re-invented this
+      // measurement every session (format drift `158 MB` -> `160M`, then a
+      // false `0.0 MB` against a real 159 MB, 2026-08-22 15:00). null means
+      // "could not measure" and renders as "nincs adat" -- never 0, because
+      // for a growth signal a false zero looks like calm, not like failure.
+      db_size_mb: dbSizeMb,
     },
     urgent: summary.urgent.map(slim),
     waiting: waitingRecent.map(slim),
@@ -201,7 +209,7 @@ export async function tryHandleKanban(ctx: RouteContext): Promise<boolean> {
   // few -- while counts.* always carries the FULL totals. The list is for
   // naming items; the numbers ONLY ever come from counts.
   if (path === '/api/kanban/heartbeat-summary' && method === 'GET') {
-    json(res, buildHeartbeatSummaryResponse(getHeartbeatKanbanSummary(), countNewHotMemories(MAIN_AGENT_ID), countPlannedKanbanCards()))
+    json(res, buildHeartbeatSummaryResponse(getHeartbeatKanbanSummary(), countNewHotMemories(MAIN_AGENT_ID), countPlannedKanbanCards(), getDbFileSizeMb()))
     return true
   }
 


### PR DESCRIPTION
## Mit javít

A heartbeat "DB size" sora eddig forrás nélküli placeholder volt (`- DB size: <X> MB`), így minden session újra-kitalálta a mérést. Mérve 2026-08-22: formátum-drift körről körre (09:00 `157 MB`, 14:00 `160M` du-h alak), majd a 15:00-as kör `0.0 MB`-ot jelentett a valós 159 MB ellen. Növekedés-jelzésnél a hamis nulla a veszélyes irány: nem hangosan hal meg, nyugodt értéknek látszik.

## Hogyan

Ugyanaz a lezárás, mint a HBMEMBLIND819 (#1007) és a planned-count: a szám szerver-oldalon készül, az agens másolja, sosem méri.

- `db.ts`: `getDbFileSizeMb()` a MEGNYITOTT DB útvonalát statolja (init-kor rögzítve, override nem divergál); `:memory:`-re és stat-hibára **null**, soha nem 0.
- heartbeat-summary endpoint: `counts.db_size_mb` (counts-first, truncation-safe felület).
- scaffold: a kanban egysoros extraktor kiadja a mezőt (`dict.get`, régi buildre None, nem KeyError); a memory-bullet tiltja a du/stat/saját mérést; hiányzó/null → "nincs adat", soha nem 0.
- `heartbeat.ts` collectSystem: a néma `catch { return 0 }` logolt null lett, a prompt "nincs adat (stat hiba)"-t ír.

## Bizonyíték

- Teljes suite: **290 fájl, 3908 teszt, zöld** (nem /tmp-gyökerű worktree-ből futtatva).
- Új tesztek: valós méret-visszaolvasás fixture DB ellen (stat ugyanarra a fájlra), null-átfolyás (a builder nem kényszerít 0-t), wiring-kontraktus a handleren (`getDbFileSizeMb()` a builder-hívásban, strukturális ablakkal) és a scaffold-prózán (a driftelt `<X> MB` placeholder tiltva).

Kártya: HBDBMERET822.

🤖 Generated with [Claude Code](https://claude.com/claude-code)