### PR TITLE
fix(web): offer Ollama models in the new-agent wizard too

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -2713,6 +2713,7 @@ function resetWizard() {
   agentDesc.value = ''
   agentModel.value = 'inherit'
   loadAvailableModels()
+  loadOllamaModels()
   selectedAvatar = null
   selectedAvatarFile = null
   document.querySelectorAll('#avatarGrid .avatar-grid-item').forEach(i => i.classList.remove('selected'))
@@ -3946,19 +3947,33 @@ function switchAgentTab(tab) {
 
 // === Settings save buttons ===
 async function loadOllamaModels() {
-  const group = document.getElementById('ollamaModelGroup')
-  if (!group) return
-  group.innerHTML = ''
+  // Two optgroups, mirroring loadAvailableModels(): one in the agent edit panel
+  // and one in the new-agent wizard. getElementById returns a single node, so
+  // the earlier single-group version could only ever reach the edit panel --
+  // the wizard had no local-model option at all.
+  const groups = [
+    document.getElementById('ollamaModelGroup'),
+    document.getElementById('agentModelOllamaGroup'),
+  ]
+  let models = []
   try {
     const res = await fetch('/api/ollama/models')
-    const models = await res.json()
+    if (res.ok) models = await res.json()
+  } catch { /* Ollama not reachable -- fall through with an empty list */ }
+  if (!Array.isArray(models)) models = []
+  for (const group of groups) {
+    if (!group) continue
+    group.innerHTML = ''
+    // Hide rather than show an empty group, matching loadAvailableModels().
+    if (models.length === 0) { group.style.display = 'none'; continue }
+    group.style.display = ''
     for (const m of models) {
       const opt = document.createElement('option')
       opt.value = m.name
       opt.textContent = `${m.name} (${m.size})`
       group.appendChild(opt)
     }
-  } catch { /* Ollama not available */ }
+  }
 }
 
 // Populates the DeepSeek optgroups in both the wizard and the agent edit
@@ -12380,6 +12395,7 @@ populateAvatarGrid()
 loadMemAgents()
 loadOverview()
 loadAvailableModels()
+loadOllamaModels()
 {
   const onbClose = document.getElementById('onboardingClose')
   if (onbClose) onbClose.addEventListener('click', dismissOnboarding)

--- a/web/index.html
+++ b/web/index.html
@@ -2228,6 +2228,8 @@
               </optgroup>
               <optgroup label="🔀 OpenRouter - kézi" id="agentModelOpenrouterManualGroup" style="display:none">
               </optgroup>
+              <optgroup label="🏠 Ollama (lokális)" id="agentModelOllamaGroup" style="display:none">
+              </optgroup>
             </select>
           </div>
           <div class="form-group">


### PR DESCRIPTION
The "Ollama (lokális)" optgroup existed only in the agent EDIT panel, so a local model could not be picked when creating an agent -- only by creating it on some other model first and then editing it. The backend was already ready: /api/ollama/models returns the catalog and agent-process.ts has the isOllama branch that points ANTHROPIC_BASE_URL at OLLAMA_URL.

Root cause is historical. 96b063f ("v1.5: Ollama local models for agents", 2026-04-09) added a single optgroup and wired loadOllamaModels() into the edit-panel render, at a time when both #agentModel and #editAgentModel already existed. Three weeks later 559d2b0 (DeepSeek, #57) established the pattern this UI has used since: one optgroup per select, with distinct ids, populated together. OpenRouter followed it; Ollama was never brought in line.

This aligns Ollama with that pattern:
  - add #agentModelOllamaGroup to the wizard select
  - loadOllamaModels() fills both groups and hides them when the list is empty, matching loadAvailableModels()
  - call it from resetWizard() and from Init, where loadAvailableModels() is already called -- previously its only call site was the edit-panel render, so the wizard group would have stayed empty even once it existed

Committed-on: susi

<!--
  HU + EN. Töltsd ki minden szakaszt. / Fill in every section.
  A jelölőnégyzeteket így pipáld: [x]  /  Tick a box like this: [x]
-->

## A változtatás típusa / Type of change

- [ ] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

<!-- HU: Foglald össze, milyen problémát old meg a PR és milyen technikai megközelítést alkalmaztál.
     EN: Summarize what problem this PR solves and the technical approach you took. -->

## Kapcsolódó issue / Related issue

Closes #

## Ellenőrzőlista / Checklist

- [ ] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [ ] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
- [ ] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [ ] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).

## Titok-kapu / Secret gate

A `secret-gate` CI-job a valodi kapu. A lokalis pre-commit hook csak gyors
elorejelzes, es `--no-verify`-jal megkerulheto -- ne tekintsd elegnek.
The `secret-gate` CI job is the real gate; the local pre-commit hook is a fast
preview and can be skipped with `--no-verify`, so it is not sufficient on its own.

- [ ] Nincs a valtoztatasban bizonyitek-/artefaktum-mappa, titok-alaku string vagy idezett csatorna-uzenet.
      / No evidence or artifact directory, secret-shaped string, or quoted channel message in this change.
