### PR TITLE
fix(vault): fail-closed master key handling (VAULTUJKULCS822)

### DIFF
--- a/src/__tests__/vault-master-key.test.ts
+++ b/src/__tests__/vault-master-key.test.ts
@@ -169,3 +169,33 @@ describe('VAULTUJKULCS822: keychain.ts hardening (source scan)', () => {
     expect(src).toMatch(/status === EXIT_ITEM_NOT_FOUND/)
   })
 })
+
+describe('PR #1048 review: corrupt vault.json must not look like an empty vault', () => {
+  it('existing but unparseable vault.json -> VaultKeyError on key decisions (no silent new key)', async () => {
+    writeFileSync(vaultPath, '{ this is not json', { mode: 0o600 })
+    keychainMock.available = true
+    keychainMock.readResult = { status: 'empty', value: null }
+    const v = await freshVault()
+    expect(() => v.setSecret('x', 'X', 'v')).toThrowError(/cannot be read or parsed/)
+    expect(keychainMock.storeCalls).toHaveLength(0)
+  })
+
+  it('corrupt vault.json + present .vault-key -> migration refused, .migrated untouched', async () => {
+    const goodKey = await seedVaultWithSecret()
+    writeFileSync(migratedPath, goodKey + '\n')
+    writeFileSync(vaultPath, '###corrupt###', { mode: 0o600 })
+    keychainMock.available = true
+    const v = await freshVault()
+    expect(() => v.setSecret('x', 'X', 'v')).toThrowError(/cannot be read or parsed/)
+    expect(keychainMock.storeCalls).toHaveLength(0)
+    expect(readFileSync(migratedPath, 'utf-8').trim()).toBe(goodKey)
+  })
+
+  it('MISSING vault.json stays a legitimate first run (key generation allowed)', async () => {
+    keychainMock.available = true
+    keychainMock.readResult = { status: 'empty', value: null }
+    const v = await freshVault()
+    v.setSecret('first', 'First', 'v1')
+    expect(keychainMock.storeCalls).toHaveLength(1)
+  })
+})

--- a/src/__tests__/vault-master-key.test.ts
+++ b/src/__tests__/vault-master-key.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { tmpdir } from 'node:os'
+
+// VAULTUJKULCS822: the master-key path must FAIL CLOSED. The old code silently
+// generated a REPLACEMENT master key when the keychain did not answer (locked
+// keychain -> retrieve returned null -> "no key, make one"), orphaning every
+// existing secret; and the file->keychain migration renamed over
+// .vault-key.migrated without verifying the file key decrypts vault.json.
+// 2026-08-22 this chain nearly destroyed 49 production secrets.
+
+const here = dirname(fileURLToPath(import.meta.url))
+
+const tmpRoot = vi.hoisted(() => {
+  const { mkdtempSync } = require('node:fs') as typeof import('node:fs')
+  const { tmpdir } = require('node:os') as typeof import('node:os')
+  const { join } = require('node:path') as typeof import('node:path')
+  return mkdtempSync(join(tmpdir(), 'vaultkey-test-'))
+})
+
+const keychainMock = vi.hoisted(() => ({
+  available: true,
+  readResult: { status: 'empty' as 'ok' | 'empty' | 'unavailable', value: null as string | null },
+  storeCalls: [] as string[],
+  storeThrows: false,
+}))
+
+vi.mock('../config.js', () => ({ PROJECT_ROOT: tmpRoot }))
+vi.mock('../web/keychain.js', () => ({
+  isKeychainAvailable: () => keychainMock.available,
+  keychainRetrieveStatus: () => ({ ...keychainMock.readResult }),
+  keychainRetrieve: () => keychainMock.readResult.value,
+  keychainStore: (v: string) => {
+    if (keychainMock.storeThrows) throw new Error('store failed (test)')
+    keychainMock.storeCalls.push(v)
+  },
+  keychainDelete: () => true,
+}))
+
+const storeDir = join(tmpRoot, 'store')
+const vaultPath = join(storeDir, 'vault.json')
+const keyPath = join(storeDir, '.vault-key')
+const migratedPath = join(storeDir, '.vault-key.migrated')
+
+async function freshVault() {
+  vi.resetModules()
+  return await import('../web/vault.js')
+}
+
+function resetStore() {
+  rmSync(storeDir, { recursive: true, force: true })
+  mkdirSync(storeDir, { recursive: true })
+  keychainMock.available = true
+  keychainMock.readResult = { status: 'empty', value: null }
+  keychainMock.storeCalls = []
+  keychainMock.storeThrows = false
+}
+
+beforeEach(resetStore)
+afterEach(() => rmSync(storeDir, { recursive: true, force: true }))
+
+// Helper: build a real vault with one secret using a known key path, then
+// return the working master key material for later manipulation.
+async function seedVaultWithSecret(): Promise<string> {
+  // File mode (non-darwin branch) writes the key next to the vault: simplest
+  // way to create a REAL encrypted entry with a REAL key.
+  keychainMock.available = false
+  const v = await freshVault()
+  v.setSecret('probe', 'Probe secret', 'probe-value-42')
+  const key = readFileSync(keyPath, 'utf-8').trim()
+  expect(key.length).toBeGreaterThan(0)
+  return key
+}
+
+describe('VAULTUJKULCS822: fail-closed master key handling', () => {
+  it('keychain UNAVAILABLE + existing entries -> VaultKeyError, no new key, secrets untouched', async () => {
+    const goodKey = await seedVaultWithSecret()
+    // Move to keychain mode with the key ONLY in the (now unreachable) keychain.
+    rmSync(keyPath, { force: true })
+    keychainMock.available = true
+    keychainMock.readResult = { status: 'unavailable', value: null }
+
+    const v = await freshVault()
+    expect(() => v.getSecret('probe')).toThrowError(/Keychain did not answer/)
+    // No replacement key generated anywhere:
+    expect(keychainMock.storeCalls).toHaveLength(0)
+    expect(existsSync(keyPath)).toBe(false)
+    // The encrypted entry is intact and still opens with the good key later:
+    keychainMock.readResult = { status: 'ok', value: goodKey }
+    const v2 = await freshVault()
+    expect(v2.getSecret('probe')).toBe('probe-value-42')
+  })
+
+  it('keychain EMPTY (answered, no item) + existing entries -> VaultKeyError, no silent generate', async () => {
+    await seedVaultWithSecret()
+    rmSync(keyPath, { force: true })
+    keychainMock.available = true
+    keychainMock.readResult = { status: 'empty', value: null }
+
+    const v = await freshVault()
+    expect(() => v.getSecret('probe')).toThrowError(/refusing to generate a new key/)
+    expect(keychainMock.storeCalls).toHaveLength(0)
+  })
+
+  it('keychain EMPTY + empty vault -> generates and stores a new key (first-run path preserved)', async () => {
+    keychainMock.available = true
+    keychainMock.readResult = { status: 'empty', value: null }
+    const v = await freshVault()
+    v.setSecret('first', 'First', 'v1')
+    expect(keychainMock.storeCalls).toHaveLength(1)
+  })
+
+  it('BOGUS .vault-key + existing entries -> refuses to use/migrate; .migrated is NOT clobbered', async () => {
+    await seedVaultWithSecret()
+    // The real key is "safe" in .migrated (the 2026-08-22 layout)...
+    const goodKey = readFileSync(keyPath, 'utf-8').trim()
+    writeFileSync(migratedPath, goodKey + '\n')
+    // ...and a bogus key sits in .vault-key (what the old silent path produced).
+    writeFileSync(keyPath, Buffer.from('x'.repeat(64)).toString('base64') + '\n')
+    keychainMock.available = true
+
+    const v = await freshVault()
+    expect(() => v.getSecret('probe')).toThrowError(/does not decrypt vault.json/)
+    // The bogus key never reached the keychain and .migrated survived intact:
+    expect(keychainMock.storeCalls).toHaveLength(0)
+    expect(readFileSync(migratedPath, 'utf-8').trim()).toBe(goodKey)
+    expect(existsSync(keyPath)).toBe(true) // no rename happened
+  })
+
+  it('CORRECT .vault-key + existing entries -> verified migration proceeds', async () => {
+    await seedVaultWithSecret()
+    keychainMock.available = true
+    const v = await freshVault()
+    expect(v.getSecret('probe')).toBe('probe-value-42')
+    expect(keychainMock.storeCalls).toHaveLength(1)
+    expect(existsSync(keyPath)).toBe(false)
+    expect(existsSync(migratedPath)).toBe(true)
+  })
+
+  it('non-darwin file mode: missing key file + existing entries -> VaultKeyError', async () => {
+    await seedVaultWithSecret()
+    rmSync(keyPath, { force: true })
+    keychainMock.available = false
+    const v = await freshVault()
+    expect(() => v.getSecret('probe')).toThrowError(/\.vault-key is missing/)
+    expect(existsSync(keyPath)).toBe(false) // no silent regenerate
+  })
+})
+
+describe('VAULTUJKULCS822: keychain.ts hardening (source scan)', () => {
+  // A locked keychain makes `security` block on a GUI prompt forever; every
+  // exec must carry a timeout or the dashboard freezes (measured 48 minutes).
+  it('every execFileSync call in keychain.ts passes a timeout', () => {
+    const src = readFileSync(join(here, '..', 'web', 'keychain.ts'), 'utf-8')
+    const calls = src.split('execFileSync(').slice(1)
+    expect(calls.length).toBeGreaterThanOrEqual(3)
+    for (const c of calls) {
+      // The options object of each call (up to the closing of the call) must
+      // mention the shared timeout constant.
+      expect(c.slice(0, 400)).toMatch(/timeout:\s*SECURITY_TIMEOUT_MS/)
+    }
+  })
+
+  it('retrieve distinguishes item-not-found (exit 44) from unavailable', () => {
+    const src = readFileSync(join(here, '..', 'web', 'keychain.ts'), 'utf-8')
+    expect(src).toMatch(/EXIT_ITEM_NOT_FOUND = 44/)
+    expect(src).toMatch(/status === EXIT_ITEM_NOT_FOUND/)
+  })
+})

--- a/src/web/keychain.ts
+++ b/src/web/keychain.ts
@@ -5,8 +5,49 @@ const SECURITY = '/usr/bin/security'
 const SERVICE = 'com.marveen.vault'
 const ACCOUNT = 'master-key'
 
+// A locked keychain makes `security` pop a GUI unlock prompt and block
+// indefinitely; without a timeout that freezes the whole dashboard (measured
+// 2026-08-22: 48-minute HTTP outage from exactly this, VAULTKEY822). The
+// timeout turns a hung call into a loud 'unavailable' instead.
+const SECURITY_TIMEOUT_MS = 5000
+
+// errSecItemNotFound: the keychain ANSWERED and the item does not exist.
+// Everything else (timeout, locked keychain, auth failure) means the keychain
+// did not answer -- callers must treat that as unavailable, never as "no key".
+const EXIT_ITEM_NOT_FOUND = 44
+
 export function isKeychainAvailable(): boolean {
+  // Platform gate only. Whether the keychain actually answers is decided by
+  // keychainRetrieveStatus() at each decision point -- a platform check alone
+  // said "available" on a locked keychain and enabled the silent key swap
+  // (VAULTUJKULCS822).
   return platform() === 'darwin'
+}
+
+export type KeychainReadStatus = 'ok' | 'empty' | 'unavailable'
+export interface KeychainReadResult {
+  status: KeychainReadStatus
+  value: string | null
+}
+
+export function keychainRetrieveStatus(): KeychainReadResult {
+  try {
+    const out = execFileSync(SECURITY, [
+      'find-generic-password',
+      '-s', SERVICE,
+      '-a', ACCOUNT,
+      '-w',
+    ], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'], timeout: SECURITY_TIMEOUT_MS })
+    const value = out.trim()
+    return value ? { status: 'ok', value } : { status: 'empty', value: null }
+  } catch (err: any) {
+    if (err?.status === EXIT_ITEM_NOT_FOUND) return { status: 'empty', value: null }
+    return { status: 'unavailable', value: null }
+  }
+}
+
+export function keychainRetrieve(): string | null {
+  return keychainRetrieveStatus().value
 }
 
 export function keychainStore(value: string): void {
@@ -17,21 +58,7 @@ export function keychainStore(value: string): void {
     '-a', ACCOUNT,
     '-w', value,
     '-A',
-  ], { stdio: ['ignore', 'ignore', 'ignore'] })
-}
-
-export function keychainRetrieve(): string | null {
-  try {
-    const out = execFileSync(SECURITY, [
-      'find-generic-password',
-      '-s', SERVICE,
-      '-a', ACCOUNT,
-      '-w',
-    ], { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] })
-    return out.trim() || null
-  } catch {
-    return null
-  }
+  ], { stdio: ['ignore', 'ignore', 'ignore'], timeout: SECURITY_TIMEOUT_MS })
 }
 
 export function keychainDelete(): boolean {
@@ -40,7 +67,7 @@ export function keychainDelete(): boolean {
       'delete-generic-password',
       '-s', SERVICE,
       '-a', ACCOUNT,
-    ], { stdio: ['ignore', 'ignore', 'ignore'] })
+    ], { stdio: ['ignore', 'ignore', 'ignore'], timeout: SECURITY_TIMEOUT_MS })
     return true
   } catch {
     return false

--- a/src/web/vault.ts
+++ b/src/web/vault.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path'
 import { randomBytes, createCipheriv, createDecipheriv, scryptSync } from 'node:crypto'
 import { PROJECT_ROOT } from '../config.js'
 import { atomicWriteFileSync } from './atomic-write.js'
-import { isKeychainAvailable, keychainStore, keychainRetrieve } from './keychain.js'
+import { isKeychainAvailable, keychainStore, keychainRetrieveStatus } from './keychain.js'
 import { logger } from '../logger.js'
 
 const VAULT_PATH = join(PROJECT_ROOT, 'store', 'vault.json')
@@ -27,22 +27,91 @@ interface VaultStore {
   entries: VaultEntry[]
 }
 
+// Thrown when the master key cannot be established SAFELY. Callers surface it
+// as a loud error -- generating a replacement key here would silently orphan
+// every existing secret (VAULTUJKULCS822: 49 secrets nearly lost 2026-08-22).
+export class VaultKeyError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'VaultKeyError'
+  }
+}
+
+function vaultEntryCount(): number {
+  try {
+    const store = JSON.parse(readFileSync(VAULT_PATH, 'utf-8'))
+    return Array.isArray(store?.entries) ? store.entries.length : 0
+  } catch {
+    return 0
+  }
+}
+
+// True iff the candidate master key decrypts the vault (trial-decrypts the
+// first entry; an empty vault is opened by any key by definition).
+function keyOpensVault(master: Buffer): boolean {
+  let entry: VaultEntry | undefined
+  try {
+    const store = JSON.parse(readFileSync(VAULT_PATH, 'utf-8'))
+    entry = store?.entries?.[0]
+  } catch {
+    return true
+  }
+  if (!entry) return true
+  try {
+    decryptWithKey(master, entry.encrypted)
+    return true
+  } catch {
+    return false
+  }
+}
+
 function getMasterKey(): Buffer {
+  const entryCount = vaultEntryCount()
+
   if (isKeychainAvailable()) {
     if (existsSync(VAULT_KEY_PATH)) {
       const fileKey = readFileSync(VAULT_KEY_PATH, 'utf-8').trim()
+      const fileKeyBuf = Buffer.from(fileKey, 'base64')
+      // A wrong .vault-key (e.g. one produced by the old silent-generate path)
+      // must never reach the Keychain and must never clobber .vault-key.migrated
+      // -- in the 2026-08-22 incident .migrated held the ONLY good copy of the
+      // real key, and this rename was one step from destroying it.
+      if (!keyOpensVault(fileKeyBuf)) {
+        throw new VaultKeyError(
+          'store/.vault-key does not decrypt vault.json -- refusing to use or migrate it. ' +
+          'Restore the correct master key (check store/.vault-key.migrated and backups).'
+        )
+      }
       try {
         keychainStore(fileKey)
         renameSync(VAULT_KEY_PATH, VAULT_KEY_MIGRATED)
-        logger.info('Vault master key migrated from file to macOS Keychain')
+        logger.info('Vault master key migrated from file to macOS Keychain (verified against vault.json first)')
       } catch (err: any) {
         logger.warn({ err: err.message }, 'Keychain migration failed, keeping file-based key')
       }
-      return Buffer.from(fileKey, 'base64')
+      return fileKeyBuf
     }
 
-    const existing = keychainRetrieve()
-    if (existing) return Buffer.from(existing, 'base64')
+    const read = keychainRetrieveStatus()
+    if (read.status === 'ok') return Buffer.from(read.value as string, 'base64')
+
+    if (read.status === 'unavailable') {
+      // Locked keychain / timeout / auth failure: the key may well EXIST, we
+      // just cannot read it. Generating a replacement here is exactly the bug
+      // that nearly destroyed 49 secrets -- fail closed instead.
+      throw new VaultKeyError(
+        'macOS Keychain did not answer (locked keychain?) -- refusing to continue. ' +
+        'Unlock the login keychain and retry. No new master key was generated.'
+      )
+    }
+
+    // status === 'empty': the keychain ANSWERED and there is no item.
+    if (entryCount > 0) {
+      throw new VaultKeyError(
+        `vault.json holds ${entryCount} entr(y/ies) but no master key exists in the Keychain or key file -- ` +
+        'refusing to generate a new key (it would silently orphan every secret). Restore the key from backup.'
+      )
+    }
 
     const newKey = randomBytes(64).toString('base64')
     try {
@@ -56,6 +125,12 @@ function getMasterKey(): Buffer {
   }
 
   if (!existsSync(VAULT_KEY_PATH)) {
+    if (entryCount > 0) {
+      throw new VaultKeyError(
+        `vault.json holds ${entryCount} entr(y/ies) but store/.vault-key is missing -- ` +
+        'refusing to generate a new key. Restore the key file from backup.'
+      )
+    }
     const key = randomBytes(64).toString('base64')
     atomicWriteFileSync(VAULT_KEY_PATH, key, { mode: 0o600 })
   }
@@ -77,8 +152,7 @@ function encrypt(plaintext: string): string {
   return Buffer.concat([salt, iv, tag, encrypted]).toString('base64')
 }
 
-function decrypt(packed: string): string {
-  const master = getMasterKey()
+function decryptWithKey(master: Buffer, packed: string): string {
   const buf = Buffer.from(packed, 'base64')
   const salt = buf.subarray(0, SALT_LENGTH)
   const iv = buf.subarray(SALT_LENGTH, SALT_LENGTH + IV_LENGTH)
@@ -88,6 +162,10 @@ function decrypt(packed: string): string {
   const decipher = createDecipheriv(ALGORITHM, key, iv)
   decipher.setAuthTag(tag)
   return decipher.update(ciphertext) + decipher.final('utf-8')
+}
+
+function decrypt(packed: string): string {
+  return decryptWithKey(getMasterKey(), packed)
 }
 
 function readVault(): VaultStore {

--- a/src/web/vault.ts
+++ b/src/web/vault.ts
@@ -37,28 +37,35 @@ export class VaultKeyError extends Error {
   }
 }
 
-function vaultEntryCount(): number {
+// Strict loader for KEY DECISIONS: a missing vault.json is a legitimate
+// first run (empty), but an EXISTING-yet-unreadable one must never be treated
+// as empty -- that would re-open the silent-new-key class through a corrupted
+// or permission-broken file (PR #1048 review finding).
+function loadVaultEntriesForKeyCheck(): VaultEntry[] {
+  if (!existsSync(VAULT_PATH)) return []
   try {
     const store = JSON.parse(readFileSync(VAULT_PATH, 'utf-8'))
-    return Array.isArray(store?.entries) ? store.entries.length : 0
-  } catch {
-    return 0
+    if (!Array.isArray(store?.entries)) throw new Error('entries is not an array')
+    return store.entries
+  } catch (err: any) {
+    throw new VaultKeyError(
+      'store/vault.json exists but cannot be read or parsed -- refusing master-key decisions ' +
+      `on a possibly corrupted vault (${err.message}). Repair or restore vault.json first.`
+    )
   }
+}
+
+function vaultEntryCount(): number {
+  return loadVaultEntriesForKeyCheck().length
 }
 
 // True iff the candidate master key decrypts the vault (trial-decrypts the
 // first entry; an empty vault is opened by any key by definition).
 function keyOpensVault(master: Buffer): boolean {
-  let entry: VaultEntry | undefined
+  const entries = loadVaultEntriesForKeyCheck()
+  if (!entries.length) return true
   try {
-    const store = JSON.parse(readFileSync(VAULT_PATH, 'utf-8'))
-    entry = store?.entries?.[0]
-  } catch {
-    return true
-  }
-  if (!entry) return true
-  try {
-    decryptWithKey(master, entry.encrypted)
+    decryptWithKey(master, entries[0].encrypted)
     return true
   } catch {
     return false


### PR DESCRIPTION
## Mit javit

A 2026-08-22-i VAULTKEY822 incidens KOD-OLDALI oka: a vault csendben UJ mesterkulcsot generalt, amikor a zarolt kulcskarika miatt nem erte el a valodit -- 49 titok valt volna visszafejthetetlenne, es ugyanez a kod megy ki a telepitovel az ugyfelekhez, ahol nincs .vault-key.migrated tartalek.

## Negy javitott hibapont

1. **Statusz-differencialt keychain-olvasas**: `keychainRetrieveStatus()` megkulonbozteti az `empty`-t (a keychain VALASZOLT, exit 44 = errSecItemNotFound) az `unavailable`-tol (timeout/zarolt/auth-hiba). A regi `null` mindkettot jelentette -- ez volt a csendes kulcs-csere triggere.
2. **Fail-closed generalas**: ha a vault.json-ban VAN bejegyzes, uj mesterkulcs generalasa TILOS -- `VaultKeyError` hangos hibaval (keychain-unavailable eseten mindig; empty+entries eseten is). Ures vaultnal a first-run viselkedes valtozatlan.
3. **Verifikalt migracio**: a .vault-key -> Keychain migracio ELOTT probafejtes a vault.json elso bejegyzesen; hamis kulcs sosem eri el a Keychaint es sosem irja felul a .vault-key.migrated-et (az incidensnel az tartotta az EGYETLEN jo kulcsot).
4. **Timeout minden security(1) hivason**: zarolt kulcskarikanal a GUI-prompt eddig VEGTELEN fuggest okozott (48 perces dashboard-kieses merve); most 5s timeout utan hangos `unavailable`.

## Bizonyitek

- Typecheck: tiszta (tsc 5.9.3, 0 hiba).
- Teljes suite: **292 fajl / 3923 teszt zold** a worktree-ben (nem /tmp-gyokerbol).
- 8 uj teszt, **mutacios kontrollal**: a csendes-generalas visszaengedese PONTOSAN a ket guard-tesztet buktatja (2 failed / 6 passed), a fix visszaallitasa utan 8/8 zold.
- Forras-szken teszt: minden execFileSync timeout-tal fut + az exit-44 megkulonboztetes jelen van.

## Kikotes (kartya)

Biztonsagi/adat-integritas javitas a vevoi uton -- **NEM autonom merge**, Marveen dont. Ha ma mergelodik developre, keddig a hermesen soakol.

Kartya: VAULTUJKULCS822. Bemenet: Boni elemzese (msg 14414), Iris kod-diagnozisa, Marveen forras-visszamerese (msg 14521).

🤖 Generated with [Claude Code](https://claude.com/claude-code)