### PR TITLE
fix(messages): allow opt-in external system senders on POST /api/mess…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,3 +66,12 @@ HEARTBEAT_CALENDAR_ID=your_calendar_id_or_email
 # settings.json -- that file is tracked, so a local edit blocks the update
 # preflight and is reverted by the next update.
 # MAIN_AGENT_MODEL=claude-opus-5
+
+# Külső (nem flotta-) rendszerek, amelyek feladóként megjelenhetnek a
+# POST /api/messages hívásban. Alapból ÜRES: friss telepítés változatlanul
+# viselkedik. A from-auth kapu regisztrált flotta-ügynököt (agents/<id>/) és a
+# tulajdonost engedi; egy szomszédos RENDSZER (ügykezelő, jegyrendszer), amely
+# csak értesíti az ügynököt, nem rendelkezik ilyen könyvtárral, ezért elutasítva
+# kapna 403-at. Vesszővel elválasztva, a dashboard újraindítása után lép életbe.
+# Ne flotta-ügynököt írj ide -- azok a saját könyvtáruk alapján úgyis átmennek.
+# SYSTEM_SENDER_IDS=cortex

--- a/src/__tests__/system-sender-allowlist.test.ts
+++ b/src/__tests__/system-sender-allowlist.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { parseSystemSenderIds } from '../config.js'
+import { sanitizeAgentIdent } from '../prompt-safety.js'
+
+// POST /api/messages accepts `from` only from registered fleet agents (plus the
+// owner). A neighbouring SYSTEM that merely notifies an agent has no
+// agents/<id>/ directory and was rejected outright; SYSTEM_SENDER_IDS is the
+// opt-in escape hatch. These cover the default (closed) and the normalization
+// symmetry that the surrounding guards depend on.
+describe('parseSystemSenderIds', () => {
+  it('is empty when unset or blank -- a fresh install stays closed', () => {
+    expect(parseSystemSenderIds(undefined, sanitizeAgentIdent).size).toBe(0)
+    expect(parseSystemSenderIds('', sanitizeAgentIdent).size).toBe(0)
+    // A stray separator must not admit the empty id, which would otherwise
+    // match a request whose `from` sanitizes to '' .
+    expect(parseSystemSenderIds(' , ,, ', sanitizeAgentIdent).size).toBe(0)
+  })
+
+  it('parses a comma-separated list and tolerates surrounding whitespace', () => {
+    const s = parseSystemSenderIds('cortex, billing ,ticketing', sanitizeAgentIdent)
+    expect(s.has('cortex')).toBe(true)
+    expect(s.has('billing')).toBe(true)
+    expect(s.has('ticketing')).toBe(true)
+    expect(s.size).toBe(3)
+  })
+
+  it('does not admit a sender that was never listed', () => {
+    const s = parseSystemSenderIds('cortex', sanitizeAgentIdent)
+    expect(s.has('zack')).toBe(false)
+    expect(s.has('cortex-router')).toBe(false)
+  })
+
+  it('normalizes entries with the same function the route matches on', () => {
+    // The route tests sanitizeAgentIdent(from) against this set. If the .env
+    // entry were stored raw, "@cortex." would sit in the set unmatched while a
+    // request sanitizing to "cortex" got rejected -- the asymmetry the
+    // neighbouring coordinator guard exists to prevent.
+    const s = parseSystemSenderIds('@cortex.', sanitizeAgentIdent)
+    expect(s.has(sanitizeAgentIdent('cortex'))).toBe(true)
+    expect(s.has(sanitizeAgentIdent('@cortex.'))).toBe(true)
+  })
+})

--- a/src/config.ts
+++ b/src/config.ts
@@ -142,6 +142,39 @@ export const BOT_NAME = env['BOT_NAME'] ?? 'Marveen'
 // BOT_NAME, behaves exactly as before.
 export const BRAND_NAME = env['BRAND_NAME'] ?? BOT_NAME
 
+// External, non-fleet systems allowed to appear as `from` on POST
+// /api/messages. The from-auth guard there accepts registered fleet agents
+// (agents/<id>/) plus the human owner; a neighbouring SYSTEM that only ever
+// notifies an agent -- a ticketing backend, a case manager -- has no agent
+// directory and would be rejected, even though its call is token-authenticated.
+// Registering it as a fake fleet agent (mkdir agents/<id>/) "works" but has side
+// effects: the id then shows up in agent listings, restart and scheduler logic.
+//
+// Empty by default, so a fresh install behaves exactly as before and no
+// third-party id is baked into the distribution. Comma-separated in .env:
+//   SYSTEM_SENDER_IDS=cortex,billing
+// Read at module load -- adding a sender needs a dashboard restart.
+//
+// This does NOT weaken sender authentication in any meaningful way: the shared
+// dashboard token already lets its holder claim ANY registered fleet agent id
+// (see the from-auth comment in routes/messages.ts). One more claimable id does
+// not change that; the token remains the actual boundary.
+export const SYSTEM_SENDER_IDS = env['SYSTEM_SENDER_IDS'] ?? ''
+
+// Pure parse rule for SYSTEM_SENDER_IDS, so the default (unset => empty set) is
+// provable without a live .env. Entries are normalized with the SAME function
+// the route matches on, keeping this guard symmetric with the coordinator and
+// federation guards next to it -- an .env entry of "@cortex." must not silently
+// fail to match a request that sanitizes to "cortex".
+export function parseSystemSenderIds(raw: string | undefined, normalize: (s: string) => string): Set<string> {
+  return new Set(
+    (raw ?? '')
+      .split(',')
+      .map(s => normalize(s.trim()))
+      .filter(Boolean)
+  )
+}
+
 // Pure resolution rule for BRAND_NAME, so the default (brandEnv unset =>
 // botName) is provable without a live .env. brandEnv is the raw env value
 // (undefined / empty when unset). Mirrors the `env['BRAND_NAME'] ?? BOT_NAME`

--- a/src/web/routes/messages.ts
+++ b/src/web/routes/messages.ts
@@ -12,7 +12,7 @@ import { logger } from '../../logger.js'
 import { COORDINATOR_AGENT_ID } from '../../channel-coordinator/ingest.js'
 import { sanitizeAgentIdent } from '../../prompt-safety.js'
 import { isKnownAgent } from '../agent-config.js'
-import { OWNER_NAME } from '../../config.js'
+import { OWNER_NAME, SYSTEM_SENDER_IDS, parseSystemSenderIds } from '../../config.js'
 import { readBody, json, jsonMaybeGzip } from '../http-helpers.js'
 import { normalizeKanbanRefs } from '../kanban-ref-normalize.js'
 import { parseQualifiedId, formatQualifiedId } from '../federation/address.js'
@@ -42,6 +42,9 @@ export function shouldNotifyDelegator(fromAgent: string, toAgent: string, conten
   if (content.startsWith(COMPLETION_REPORT_PREFIX)) return false
   return true
 }
+
+// Frozen at module load, like the config constant it derives from.
+const SYSTEM_SENDERS = parseSystemSenderIds(SYSTEM_SENDER_IDS, sanitizeAgentIdent)
 
 export async function tryHandleMessages(ctx: RouteContext): Promise<boolean> {
   const { req, res, path, method, url } = ctx
@@ -99,8 +102,17 @@ export async function tryHandleMessages(ctx: RouteContext): Promise<boolean> {
     // "unknown agent". The owner is not a fleet agent (no agents/<id>/ dir), so
     // isKnownAgent alone rejects it. Match on the router's normalization to stay
     // symmetric with the other guards above.
+    //
+    // Neighbouring SYSTEMS are legitimate senders too, on the same reasoning as
+    // the owner: they are token-authenticated and only notify an agent, but they
+    // have no agents/<id>/ directory. Opt-in via SYSTEM_SENDER_IDS in .env
+    // (empty by default). Without this, such a system silently loses its push
+    // channel the moment this guard ships -- observed here: an external case
+    // manager pushed 4182 messages, then every call 403'd for nine days while
+    // its fail-soft caller logged nothing.
     const isOwnerSender = sanitizeAgentIdent(from) === sanitizeAgentIdent(OWNER_NAME)
-    if (!isOwnerSender && !isKnownAgent(sanitizeAgentIdent(from))) {
+    const isSystemSender = SYSTEM_SENDERS.has(sanitizeAgentIdent(from))
+    if (!isOwnerSender && !isSystemSender && !isKnownAgent(sanitizeAgentIdent(from))) {
       logger.warn({ from: from.trim(), to: to.trim() }, 'Rejected /api/messages POST from unregistered agent')
       json(res, { error: `unknown agent '${from.trim()}' -- from must be a registered fleet agent id` }, 403)
       return true


### PR DESCRIPTION
…ages

The from-auth guard accepts a `from` claim only from registered fleet agents (agents/<id>/) plus the human owner. A neighbouring SYSTEM that only notifies an agent -- a case manager, a ticketing backend -- has no agent directory, so its token-authenticated call is rejected with 403.

This is silent by construction: such callers are typically fail-soft, so the push channel dies without anyone noticing. On this install an external case manager had pushed 4182 messages, then every call 403'd for nine days; it surfaced only when someone tried to send one by hand. Nothing stopped -- a 5-minute pull cron was the fallback -- but the push-driven chain control it was designed around did not work at all in the meantime.

Registering such a system as a fake fleet agent (mkdir agents/<id>/) does clear the guard, but has side effects: the id then appears in agent listings, restart and scheduler logic.

Add SYSTEM_SENDER_IDS, a comma-separated opt-in allowlist. Empty by default, so a fresh install behaves exactly as before and no third-party id ships in the distribution. Entries are normalized with sanitizeAgentIdent -- the same function the route matches on -- keeping this guard symmetric with the coordinator and federation guards beside it.

This does not weaken sender authentication in any meaningful way: the shared dashboard token already lets its holder claim any registered fleet agent id, as the from-auth comment itself notes. The token remains the actual boundary; one more claimable id does not move it.

<!--
  HU + EN. Töltsd ki minden szakaszt. / Fill in every section.
  A jelölőnégyzeteket így pipáld: [x]  /  Tick a box like this: [x]
-->

## A változtatás típusa / Type of change

- [ ] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

<!-- HU: Foglald össze, milyen problémát old meg a PR és milyen technikai megközelítést alkalmaztál.
     EN: Summarize what problem this PR solves and the technical approach you took. -->

## Kapcsolódó issue / Related issue

Closes #

## Ellenőrzőlista / Checklist

- [ ] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [ ] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
- [ ] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [ ] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).

## Titok-kapu / Secret gate

A `secret-gate` CI-job a valodi kapu. A lokalis pre-commit hook csak gyors
elorejelzes, es `--no-verify`-jal megkerulheto -- ne tekintsd elegnek.
The `secret-gate` CI job is the real gate; the local pre-commit hook is a fast
preview and can be skipped with `--no-verify`, so it is not sufficient on its own.

- [ ] Nincs a valtoztatasban bizonyitek-/artefaktum-mappa, titok-alaku string vagy idezett csatorna-uzenet.
      / No evidence or artifact directory, secret-shaped string, or quoted channel message in this change.
