### PR TITLE
fix(pr-monitor): strip the .git suffix from the derived repo slug

### DIFF
--- a/scripts/github-pr-monitor.sh
+++ b/scripts/github-pr-monitor.sh
@@ -19,7 +19,13 @@ if [ -z "$REPO" ]; then
   REPO="$(git -C "$INSTALL_DIR" config --get remote.upstream.url 2>/dev/null \
        || git -C "$INSTALL_DIR" config --get remote.origin.url 2>/dev/null || true)"
   # git@host:owner/repo.git and https://host/owner/repo.git both reduce to owner/repo
-  REPO="$(printf '%s' "$REPO" | sed -E 's#^.*[:/]([^/]+/[^/]+?)(\.git)?$#\1#')"
+  # Two passes on purpose: ERE has no lazy quantifier, so `[^/]+?` is NOT
+  # non-greedy here -- it swallows the trailing ".git" and the optional
+  # `(\.git)?` group then matches empty. Measured 2026-08-24: an https
+  # upstream URL yielded "owner/repo.git", and `gh pr list --repo owner/repo.git`
+  # returns an EMPTY list with exit 0, so the monitor reported "nothing to
+  # watch" forever instead of failing loudly. Strip the suffix separately.
+  REPO="$(printf '%s' "$REPO" | sed -E 's#^.*[:/]([^/]+/[^/]+)$#\1#; s#\.git$##')"
 fi
 STATE_FILE="store/.github-pr-monitor-state"
 


### PR DESCRIPTION
`scripts/github-pr-monitor.sh` derives the repo slug from the remote URL, and the expression does not strip the `.git` suffix. ERE has no lazy quantifier, so `[^/]+?` is not non-greedy: it swallows the trailing `.git`, and the optional `(\.git)?` group then matches empty.

**Why this is worth a patch rather than a shrug:** the failure is silent and self-reporting-as-healthy. `gh pr list --repo owner/repo.git` returns an *empty list* with exit 0, not an error. The script takes that as "no open PRs of ours", prints `nothing to watch`, and exits successfully. A monitoring tool that reports success while doing nothing is worse than no monitor, because you believe you are covered.

**Measured here 2026-08-24, both remote forms are affected** whenever the URL carries the suffix, which is what `git clone` produces by default:

```
https://github.com/OWNER/repo.git      old: OWNER/repo.git      new: OWNER/repo
git@github.com:OWNER/repo.git          old: OWNER/repo.git      new: OWNER/repo
https://github.com/OWNER/repo          old: OWNER/repo          new: OWNER/repo
git@github.com:OWNER/repo              old: OWNER/repo          new: OWNER/repo
```

Only a remote without the suffix escapes it. On our fleet host the monitor had never produced a state file at all; after the fix the first run wrote the baseline and both of our open PRs are tracked.

The fix is two sed passes instead of one optional group, plus a comment recording why, so it does not get "simplified" back.

Found while installing the monitor after a change request of yours sat unnoticed on our side for five days. The monitor is exactly the thing that should have caught it, so it seemed worth making sure it actually runs for everyone else too.