### PR TITLE
fix(notify): do not guess the sender when there is no tmux pane

### DIFF
--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -38,7 +38,17 @@ fi
 # reader can see who it came from. Distribution-safe: the main agent id is read
 # from .env (default marveen), no hardcoded names.
 SENDER=""
-SESS=$(tmux display-message -p '#S' 2>/dev/null)
+# Only ask tmux who we are when we are actually INSIDE a tmux pane. Detached
+# callers -- cron, systemd, a plain ssh shell -- have no session, but
+# `tmux display-message -p '#S'` still answers happily with whatever session the
+# server most recently touched. That mislabels a cron- or systemd-fired system
+# alert as coming from an arbitrary agent, which is worse than no attribution: it
+# points the reader at an uninvolved agent while a system alert is in flight.
+# No pane -> no claim about the sender; the message goes out as the main agent.
+SESS=""
+if [ -n "${TMUX:-}" ]; then
+  SESS=$(tmux display-message -p '#S' 2>/dev/null)
+fi
 case "$SESS" in
   agent-*)
     SENDER="${SESS#agent-}"


### PR DESCRIPTION
## Symptom

`notify.sh` sends on the main bot token, so it derives the calling agent from the tmux session name to prefix the message with who it came from. It queried tmux unconditionally:

```sh
SESS=$(tmux display-message -p '#S' 2>/dev/null)
```

`tmux display-message` answers even when the caller is **not** inside a pane — it returns whatever session the tmux server most recently touched. So every detached caller (cron, systemd, a plain ssh shell) gets attributed to an arbitrary agent. A cron-fired system alert went out prefixed with an uninvolved agent's name, which is worse than no attribution: it points the reader at the wrong agent while a system alert is in flight.

## When it broke

Introduced with the sender-prefix feature; the attribution has queried tmux unconditionally since then.

## Reproduction

```sh
tmux new-session -d -s agent-foo      # any 'agent-*' session exists
# now, from a plain shell OUTSIDE any pane ($TMUX unset):
MAIN_AGENT_ID=marveen scripts/notify.sh 'system alert'
# -> the message is prefixed as coming from 'Foo', though nobody sent it;
#    the sender is just the session the tmux server last touched.
```

## What the user sees

A system/cron alert appears to come from a random agent that had nothing to do with it.

## Fix

Only ask tmux for the session when `$TMUX` shows we are actually inside a pane; otherwise make no claim about the sender and send as the main agent. One guard, no behavior change for in-pane callers.
