### PR TITLE
fix(channel-monitor): lazily resolve tmux/claude so imports don't throw

### DIFF
--- a/src/__tests__/channel-monitor-resume-recovery.test.ts
+++ b/src/__tests__/channel-monitor-resume-recovery.test.ts
@@ -146,7 +146,7 @@ describe('channel-monitor: periodic detached-claude reap (CB6CF755 durable fix)'
     // Durable fix is wired by calling the SAME reapDetachedChannelClaudes on a
     // throttle inside check() -- NOT a second/parallel reaper implementation.
     expect(src).toMatch(/shouldRunPeriodicReap\(\s*lastDetachedReapAt/)
-    expect(src).toMatch(/reapDetachedChannelClaudes\(\s*{\s*tmuxPath:\s*TMUX\s*}\s*\)/)
+    expect(src).toMatch(/reapDetachedChannelClaudes\(\s*{\s*tmuxPath:\s*tmuxBin\(\)\s*}\s*\)/)
     // throttle interval is a sane slow cadence (minutes, not every 60s tick).
     const m = src.match(/const\s+DETACHED_REAP_INTERVAL_MS\s*=\s*([\d*\s_]+)/)
     expect(m, 'DETACHED_REAP_INTERVAL_MS not found').not.toBeNull()

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync, statSync, writeFileSync, utimesSync } from 'n
 import { hostname } from 'node:os'
 import { join } from 'node:path'
 import { execFileSync, spawn } from 'node:child_process'
-import { resolveFromPath } from '../platform.js'
+import { makeLazyBinResolver } from '../platform.js'
 import { WEB_PORT } from '../config.js'
 import { logger } from '../logger.js'
 import { MAIN_AGENT_ID, SERVICE_ID, BOT_NAME, CHANNEL_PROVIDER, PROJECT_ROOT, RESPAWN_ENABLED } from '../config.js'
@@ -53,8 +53,15 @@ import { decideDownAgentAction, AGENT_MAX_RESTART_ATTEMPTS, parseEtimeToSeconds 
 import { getClaudePidForSession, hasChannelPluginAlive, probeChannelPluginLiveness } from '../channel-coordinator/liveness.js'
 import { getDesiredAgents } from './agent-desired-state.js'
 
-const TMUX = resolveFromPath('tmux')
-const CLAUDE = resolveFromPath('claude')
+// Lazily resolved (see makeLazyBinResolver): a module-level `resolveFromPath`
+// const throws at IMPORT time, so any environment where the binary is not
+// resolvable -- a transient PATH gap, or CI where no `claude` is installed --
+// fails the whole module load and takes every importer down with it. Deferring
+// to first use keeps importing this module side-effect free; the resolution
+// error then surfaces at the call site that actually needs the binary. This
+// mirrors the pattern already used in agent-process.ts.
+const tmuxBin = makeLazyBinResolver('tmux')
+const claudeBin = makeLazyBinResolver('claude')
 
 // How long the agent's claude process has been running. Returns -1 when it
 // cannot be determined, which the restart policy treats as "do not restart".
@@ -397,7 +404,7 @@ async function performStuckInputAction(
           // first (no-op when absent); an Enter on the then-idle prompt is
           // harmless.
           await dismissModelConsentDialogIfPresent(session)
-          execFileSync(TMUX, ['send-keys', '-t', session, 'Enter'], { timeout: 5000 })
+          execFileSync(tmuxBin(), ['send-keys', '-t', session, 'Enter'], { timeout: 5000 })
         }
         submitted = true
         break
@@ -415,7 +422,7 @@ async function performStuckInputAction(
         // Enter must never reach the model consent dialog (its default SWITCHES
         // the model). No-op when the dialog is absent.
         await dismissModelConsentDialogIfPresent(session)
-        execFileSync(TMUX, ['send-keys', '-t', session, 'Enter'], { timeout: 5000 })
+        execFileSync(tmuxBin(), ['send-keys', '-t', session, 'Enter'], { timeout: 5000 })
         submitted = true
         break
       case 'hold':
@@ -705,14 +712,14 @@ export function respawnMainSessionFresh(): void {
     logger.warn({ err }, 'respawnMainSessionFresh: pre-respawn reap failed (continuing)')
   }
   try {
-    reapDetachedChannelClaudes({ tmuxPath: TMUX })
+    reapDetachedChannelClaudes({ tmuxPath: tmuxBin() })
   } catch (err) {
     logger.warn({ err }, 'respawnMainSessionFresh: detached-claude reap failed (continuing)')
   }
   ensureSharedClaudeOnboarded()
 
   const claudeCmd = buildMainSessionRespawnCmd({
-    claudePath: CLAUDE,
+    claudePath: claudeBin(),
     pluginId: provider.pluginId,
     extraPluginIds: readExtraChannelPluginIds(),
     model: readConfiguredMainModel(),
@@ -722,7 +729,7 @@ export function respawnMainSessionFresh(): void {
     isolatedConfigDir: ensureMainAgentIsolatedConfigDir(),
     fleetToken: hasFleetOauthToken(),
   })
-  execFileSync(TMUX, ['respawn-pane', '-k', '-t', MAIN_CHANNELS_SESSION, claudeCmd], { timeout: 15000 })
+  execFileSync(tmuxBin(), ['respawn-pane', '-k', '-t', MAIN_CHANNELS_SESSION, claudeCmd], { timeout: 15000 })
   // Stamp IMMEDIATELY after the respawn, before the scheduling follow-ups.
   // The stamp is a coordination contract, not bookkeeping: five watchers read
   // lastMainRespawnAt() / store/.channel-last-respawn and suppress themselves
@@ -771,7 +778,7 @@ export async function resumeMarveenSession(): Promise<boolean> {
     // spares the live session (this pane) and kills only the leftovers.
     // See project_channels_continue_respawn_leak.
     try {
-      reapDetachedChannelClaudes({ tmuxPath: TMUX })
+      reapDetachedChannelClaudes({ tmuxPath: tmuxBin() })
     } catch (err) {
       logger.warn({ err }, 'resumeMarveenSession: detached-claude reap failed (continuing)')
     }
@@ -782,7 +789,7 @@ export async function resumeMarveenSession(): Promise<boolean> {
     ensureSharedClaudeOnboarded()
 
     const claudeCmd = buildMainSessionRespawnCmd({
-      claudePath: CLAUDE,
+      claudePath: claudeBin(),
       pluginId: provider.pluginId,
       extraPluginIds: readExtraChannelPluginIds(),
       model: readConfiguredMainModel(),
@@ -794,7 +801,7 @@ export async function resumeMarveenSession(): Promise<boolean> {
       isolatedConfigDir: ensureMainAgentIsolatedConfigDir(),
       fleetToken: hasFleetOauthToken(),
     })
-    execFileSync(TMUX, ['respawn-pane', '-k', '-t', MAIN_CHANNELS_SESSION, claudeCmd], { timeout: 15000 })
+    execFileSync(tmuxBin(), ['respawn-pane', '-k', '-t', MAIN_CHANNELS_SESSION, claudeCmd], { timeout: 15000 })
 
     // --continue replays the last conversation. When the prior session is large
     // (>200k tokens) Claude Code opens with a "Resume from summary" modal that
@@ -937,7 +944,7 @@ let marveenLastSessionCreate = 0
 
 export function mainChannelsSessionExists(): boolean {
   try {
-    execFileSync(TMUX, ['has-session', '-t', MAIN_CHANNELS_SESSION], { timeout: 3000 })
+    execFileSync(tmuxBin(), ['has-session', '-t', MAIN_CHANNELS_SESSION], { timeout: 3000 })
     return true
   } catch {
     return false
@@ -995,7 +1002,7 @@ function respawnMarveenSessionFresh(): boolean {
     // Same first-run-picker guard as resumeMarveenSession.
     ensureSharedClaudeOnboarded()
     const claudeCmd = buildMainSessionRespawnCmd({
-      claudePath: CLAUDE,
+      claudePath: claudeBin(),
       pluginId: provider.pluginId,
       extraPluginIds: readExtraChannelPluginIds(),
       model: readConfiguredMainModel(),
@@ -1006,7 +1013,7 @@ function respawnMarveenSessionFresh(): boolean {
       isolatedConfigDir: ensureMainAgentIsolatedConfigDir(),
       fleetToken: hasFleetOauthToken(),
     })
-    execFileSync(TMUX, ['respawn-pane', '-k', '-t', MAIN_CHANNELS_SESSION, claudeCmd], { timeout: 15000 })
+    execFileSync(tmuxBin(), ['respawn-pane', '-k', '-t', MAIN_CHANNELS_SESSION, claudeCmd], { timeout: 15000 })
     logger.warn({ provider: provider.type }, 'Hard restart: marveen session respawned fresh (no --continue)')
     // Re-establish /name on the fresh process (see note in resumeMarveenSession).
     // scheduleIdentitySetup only schedules delayed timers -> fire-and-forget.
@@ -1600,7 +1607,7 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
           } else {
             logger.warn({ session: t.session, agent: label }, 'Session parked in a blocking interactive menu -- sending Escape to recover')
             try {
-              execFileSync(TMUX, ['send-keys', '-t', t.session, 'Escape'], { timeout: 5000 })
+              execFileSync(tmuxBin(), ['send-keys', '-t', t.session, 'Escape'], { timeout: 5000 })
             } catch (err) {
               logger.warn({ err, session: t.session }, 'Menu-recovery Escape failed')
             }
@@ -1849,7 +1856,7 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
     if (shouldRunPeriodicReap(lastDetachedReapAt, Date.now(), DETACHED_REAP_INTERVAL_MS)) {
       lastDetachedReapAt = Date.now()
       try {
-        const reaped = reapDetachedChannelClaudes({ tmuxPath: TMUX })
+        const reaped = reapDetachedChannelClaudes({ tmuxPath: tmuxBin() })
         if (reaped.length > 0) {
           logger.warn({ reaped }, 'channel-monitor: periodic reap removed detached channel-claude orphans')
         }


### PR DESCRIPTION
## Symptom

`src/web/channel-monitor.ts` resolved its external binaries at module scope:

```ts
const TMUX = resolveFromPath('tmux')
const CLAUDE = resolveFromPath('claude')
```

`resolveFromPath` throws when the binary is not on `PATH`, and these run at **import** time. So in any environment where `tmux`/`claude` is not resolvable — a transient `PATH` gap, or CI where no `claude` binary is installed — the whole module fails to load, and every module that transitively imports `channel-monitor.ts` fails with it. At boot that takes the dashboard down; in CI it fails every test that transitively imports the module.

## When it broke

The binaries have been resolved eagerly at module scope since these consts were introduced.

## Reproduction

```sh
# In an environment where `claude` is not on PATH (e.g. a CI runner):
node -e "import('./dist/web/channel-monitor.js')"
# -> throws at import: resolveFromPath('claude') cannot find the binary,
#    so the import itself fails -- not the later call that needs claude.
```

Or run any test that transitively imports `channel-monitor.ts` on a host without `claude` on `PATH`: the module load throws before any test body runs.

## What the user sees

The dashboard fails to start (or CI goes red) because of a binary that is only needed later at runtime, instead of the error surfacing at the actual call site.

## Fix

Use `makeLazyBinResolver` — already exported from `platform.ts` and already used exactly this way in `agent-process.ts`. Resolution is deferred to first use and memoised, so importing the module is side-effect free; if the binary is genuinely missing, the error now surfaces at the call site that needs it. The one source-scan test that pinned the old `tmuxPath: TMUX` identifier is updated to the new `tmuxBin()` form.
