### PR TITLE
refactor(kanban): remove never-wired full-board context dump (KANBANCTXDEAD824)

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -1702,12 +1702,6 @@ export function listKanbanCards(): KanbanCard[] {
     .all() as KanbanCard[]
 }
 
-export function listKanbanCardsSummary(): { status: string; title: string; assignee: string | null; priority: string; id: string }[] {
-  return db
-    .prepare("SELECT id, title, status, assignee, priority FROM kanban_cards WHERE archived_at IS NULL ORDER BY status, sort_order ASC")
-    .all() as any[]
-}
-
 export function getKanbanCard(id: string): KanbanCard | undefined {
   return db.prepare('SELECT rowid AS seq, * FROM kanban_cards WHERE id = ?').get(id) as KanbanCard | undefined
 }

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -10,7 +10,6 @@ import {
   pruneAuditLogs,
   pruneTokenUsage,
   getMemoriesForChat,
-  listKanbanCardsSummary,
   type Memory,
 } from './db.js'
 import { runAgent } from './agent.js'
@@ -103,35 +102,13 @@ export async function buildMemoryContext(
   return `[Memoria kontextus]\n${lines.join('\n')}`
 }
 
-const STATUS_HU: Record<string, string> = {
-  planned: 'Tervezett',
-  in_progress: 'Folyamatban',
-  waiting: 'Várakozik',
-  done: 'Kész',
-}
-
-const PRIORITY_HU: Record<string, string> = {
-  urgent: '🔴',
-  high: '🟠',
-  normal: '⚪',
-  low: '🔵',
-}
-
-export function buildKanbanContext(): string {
-  const cards = listKanbanCardsSummary()
-  if (cards.length === 0) return ''
-
-  const grouped: Record<string, string[]> = {}
-  for (const c of cards) {
-    const key = STATUS_HU[c.status] ?? c.status
-    if (!grouped[key]) grouped[key] = []
-    const assignee = c.assignee ? ` (${c.assignee})` : ''
-    grouped[key].push(`  ${PRIORITY_HU[c.priority] ?? '⚪'} ${c.title}${assignee} [${c.id}]`)
-  }
-
-  const lines = Object.entries(grouped).map(([status, items]) => `${status}:\n${items.join('\n')}`)
-  return `[Kanban tabla]\n${lines.join('\n')}`
-}
+// buildKanbanContext used to live here: it rendered EVERY unarchived card's
+// FULL title into a [Kanban tabla] block (no limit, no truncation -- ~1 MB of
+// titles on the live board, KANBANCTXDEAD824). Nothing ever called it, in src,
+// dist or any plugin. Removed rather than fixed: an unbounded full-board dump
+// is the wrong contract for agent context, and whoever wires kanban context in
+// the future should start from the heartbeat-summary shape (counts first,
+// titles truncated server-side -- see buildHeartbeatSummaryResponse).
 
 export async function saveConversationTurn(
   chatId: string,


### PR DESCRIPTION
## What

Removes `buildKanbanContext()` (src/memory.ts) and its only dependency `listKanbanCardsSummary()` (src/db.ts).

## Why

The function rendered EVERY unarchived card's FULL title into a `[Kanban tabla]` block — no limit, no truncation. On the live board that is 822 cards / ~0.96 MB of titles (max single title 16,428 chars). Had it ever run against a 200k-token window it would have overflowed it several times over.

It never ran: verified **zero callers** in `src/`, `dist/` (the running build) and all plugins. The mechanism claim "the kanban table is injected into every agent message" is refuted at the wiring step — the scary SQL exists but is dead code.

Removed rather than hardened: an unbounded full-board dump is the wrong contract for agent context. A tombstone comment points any future kanban-context work at the heartbeat-summary shape (counts first, server-side title truncation, HBKANBANDRIFT819 / #1010).

## Evidence

- `grep -rn 'buildKanbanContext' src/ dist/ ~/.claude/plugins` → only the definition, no call site
- `tsc --noEmit`: exit 0
- Full suite: **3935/3935** (293 files) on this branch

Card: KANBANCTXDEAD824

🤖 Generated with [Claude Code](https://claude.com/claude-code)