### PR TITLE
fix(ledger): never invent an agent id from a subdirectory cwd

### DIFF
--- a/scripts/__tests__/ledger-agent-id.test.py
+++ b/scripts/__tests__/ledger-agent-id.test.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
 """Test agent_id resolution from the session cwd (scripts/hooks/ledger_lib.py).
 
-Regression guard: a session sitting in a SUBDIRECTORY of the install logged its
-outbound messages under an agent id taken from the directory name. That splits
-the conversation ledger across two identities and makes the reply guard block on
-an already-answered question, because it finds no outbound under the real id.
+Regression guard: a session sitting in a SUBDIRECTORY of the install used to log
+its outbound messages under an agent id INVENTED from the directory name. That
+splits the conversation ledger across two identities and makes the reply guard
+block on an already-answered question, because it finds no outbound under the
+real id. Anything inside the install tree must resolve to the main agent, and a
+cwd outside the tree must never fabricate an id from the directory name.
 
 Run: python3 <thisfile>   Exit 0 = all pass.
 """
@@ -17,6 +19,7 @@ sys.path.insert(0, HOOKS)
 
 INSTALL = os.path.dirname(os.path.dirname(HERE))
 os.environ.setdefault("MAIN_AGENT_ID", "mainagent")
+os.environ.pop("MARVEEN_AGENT_ID", None)
 
 import ledger_lib  # noqa: E402
 
@@ -29,7 +32,7 @@ CASES = [
     ("trailing slash tolerated", INSTALL + "/", MAIN),
     ("agent dir maps to that agent", os.path.join(INSTALL, "agents", "dia"), "dia"),
     ("agent subdir maps to that agent", os.path.join(INSTALL, "agents", "dia", "x", "y"), "dia"),
-    ("outside the install falls back to basename", "/Users/someone/marveen", "marveen"),
+    ("outside the install attributes to the main agent (never invents an id)", "/tmp/someone/marveen", MAIN),
     ("empty cwd falls back to main", "", MAIN),
     ("None cwd falls back to main", None, MAIN),
 ]
@@ -41,6 +44,16 @@ for name, cwd, want in CASES:
     if not ok:
         failed.append(name)
     print(f"  [{'PASS' if ok else 'FAIL'}] {name}: got={got!r} want={want!r}")
+
+# MARVEEN_AGENT_ID lets a launcher name an out-of-tree session explicitly.
+os.environ["MARVEEN_AGENT_ID"] = "explicit-agent"
+got = ledger_lib.agent_id_from_cwd("/tmp/someone/marveen")
+ok = got == "explicit-agent"
+if not ok:
+    failed.append("MARVEEN_AGENT_ID override for out-of-tree cwd")
+print(f"  [{'PASS' if ok else 'FAIL'}] MARVEEN_AGENT_ID override for out-of-tree cwd: "
+      f"got={got!r} want='explicit-agent'")
+os.environ.pop("MARVEEN_AGENT_ID", None)
 
 print()
 if failed:

--- a/scripts/hooks/ledger_lib.py
+++ b/scripts/hooks/ledger_lib.py
@@ -102,9 +102,9 @@ def owner_name():
 
 def agent_id_from_cwd(cwd):
     """Which channel agent is this session? Derived from cwd so the hooks are
-    generic across all three agents and never cross-contaminate:
-      <install>/agents/<id>  -> <id>           (sub-agent: dia, erno-ba, ...)
-      <install>               -> MAIN_AGENT_ID  (the main channels agent)
+    generic across every agent and never cross-contaminate:
+      <install>/agents/<id>[/...]  -> <id>           (a sub-agent)
+      anywhere else in the tree    -> MAIN_AGENT_ID   (the main channels agent)
     """
     cwd = (cwd or "").rstrip("/")
     install = _install_dir().rstrip("/")
@@ -120,9 +120,13 @@ def agent_id_from_cwd(cwd):
         # identities and makes the reply guard block on a question it has
         # already answered, because it finds no outbound under the real id.
         return main_agent_id()
-    # Fallback: last path component (best effort), else main.
-    base = os.path.basename(cwd)
-    return base or main_agent_id()
+    # Outside the install tree: never invent an agent id from the directory name.
+    # The launcher can name the session explicitly via MARVEEN_AGENT_ID; failing
+    # that, attribute to the main agent rather than a bogus basename.
+    env_id = os.environ.get("MARVEEN_AGENT_ID", "").strip()
+    if env_id:
+        return env_id
+    return main_agent_id()
 
 
 def connect():


### PR DESCRIPTION
## Symptom

`agent_id_from_cwd()` in `scripts/hooks/ledger_lib.py` recognised only two cwd shapes — the install root and `<install>/agents/<id>` — and fell through to "last path component" for everything else:

```python
if cwd == install:
    return main_agent_id()
# Fallback: last path component
base = os.path.basename(cwd)
return base or main_agent_id()
```

So a session whose cwd happened to be a **subdirectory** of the install (a scratch dir, a build folder) logged its messages under an agent id **invented from the directory name**.

## When it broke

Present since `agent_id_from_cwd` was introduced with the conversation-continuity ledger — the fallback has always derived an id from the directory basename for any in-tree subdirectory.

## Reproduction

```sh
# main agent id is 'mainagent'; call the resolver with a cwd that is a
# subdirectory of the install:
MAIN_AGENT_ID=mainagent python3 -c "import sys; sys.path.insert(0,'scripts/hooks'); \
import ledger_lib as l; print(l.agent_id_from_cwd(l._install_dir()+'/store/wd'))"
# before: 'wd'         <- a bogus agent id taken from the directory name
# after:  'mainagent'
```

## What the user sees

Two failures downstream of the wrong id:

1. The conversation ledger splits across two identities, degrading replay/handoff.
2. The reply guard finds no outbound logged under the *real* agent id, so it blocks a turn on a question that was in fact already answered.

## Fix

- Anything **inside** the install tree resolves to the main agent (`cwd == install or cwd.startswith(install + os.sep)`).
- A cwd **outside** the tree never fabricates an id from the directory name: a launcher may name the session explicitly via `MARVEEN_AGENT_ID`, otherwise it is attributed to the main agent.
- The `agents/<id>` branch is unchanged.

Includes a regression test (`scripts/__tests__/ledger-agent-id.test.py`) covering in-tree subdirectories, out-of-tree cwd, and the env override.
