### PR TITLE
fix(channel-monitor): bound the live-poller trust so deafness can't hide

### DIFF
--- a/src/__tests__/channel-deafness-recovery.test.ts
+++ b/src/__tests__/channel-deafness-recovery.test.ts
@@ -4,6 +4,7 @@ import {
   shouldRespawnForStaleKeepalive,
   shouldDeferKeepaliveRespawn,
   shouldRefreshKeepaliveFromInbound,
+  shouldTrustLivePollerOverStaleness,
   lastMainRespawnAt,
   shouldEscalateAfterResume,
   POST_RESUME_GUARD_DELAY_MS,
@@ -252,5 +253,36 @@ describe('B2 cross-path respawn storm prevention', () => {
       msSinceLastRespawn: elapsedSinceKeepaliveRespawn,
       respawnGraceMs: GRACE_MS,
     })).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// DEAFNESS-MASK FIX CONTRACT: a live bun poller is NOT proof the MCP pipe still
+// delivers. The liveness shortcut trusted poller-liveness unconditionally and
+// skipped the respawn, which masked a deafness (live poller, dead pipe) for
+// days. The bounded trust ceiling closes that mask while preserving the trust
+// for normal idle gaps.
+// ---------------------------------------------------------------------------
+describe('shouldTrustLivePollerOverStaleness', () => {
+  const CEILING = 45 * 60 * 1000
+
+  it('trusts a live poller while the keepalive is freshly stale (within ceiling -> idle case)', () => {
+    expect(shouldTrustLivePollerOverStaleness({ keepaliveAgeMs: 20 * 60 * 1000, trustCeilingMs: CEILING })).toBe(true)
+  })
+
+  it('STOPS trusting a live poller once staleness crosses the ceiling (deafness mask closed)', () => {
+    expect(shouldTrustLivePollerOverStaleness({ keepaliveAgeMs: CEILING + 1, trustCeilingMs: CEILING })).toBe(false)
+  })
+
+  it('does not trust at exactly the ceiling (boundary is exclusive)', () => {
+    expect(shouldTrustLivePollerOverStaleness({ keepaliveAgeMs: CEILING, trustCeilingMs: CEILING })).toBe(false)
+  })
+
+  it('trusts liveness when there is no keepalive baseline yet (fresh boot -> never respawn pre-baseline)', () => {
+    expect(shouldTrustLivePollerOverStaleness({ keepaliveAgeMs: null, trustCeilingMs: CEILING })).toBe(true)
+  })
+
+  it('ceiling is comfortably above the 18-min staleness threshold (no idle false-positives)', () => {
+    expect(shouldTrustLivePollerOverStaleness({ keepaliveAgeMs: 18 * 60 * 1000 + 1, trustCeilingMs: CEILING })).toBe(true)
   })
 })

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -1182,6 +1182,18 @@ function maybeRestartWedgedMainChannel(state: StuckInputState): void {
 const KEEPALIVE_FILE = join(PROJECT_ROOT, 'store', '.channel-keepalive')
 const KEEPALIVE_STALE_MS = 18 * 60 * 1000 // ~3 missed 6-min cycles
 const KEEPALIVE_RESPAWN_GRACE_MS = 15 * 60 * 1000 // let a respawned session re-establish the file
+// DEAFNESS-MASK FIX: the liveness shortcut below skips the respawn whenever the
+// bun poller process is alive, treating process-liveness as proof of health.
+// But a live poller only proves the process runs -- NOT that the MCP stdio pipe
+// still DELIVERS. A poller can keep pulling updates while the pipe to the
+// session is deaf, so nothing is delivered for days and no watchdog acts. We
+// still trust a live poller for a BOUNDED window (so a normal quiet idle gap is
+// not respawned), but once the keepalive has been stale past this ceiling a
+// live-but-non-delivering poller reads as deafness and we fall through to the
+// staleness path (still busy-guarded). The ceiling is >2x KEEPALIVE_STALE_MS so
+// it never re-introduces idle false-positives, while bounding a silent deafness
+// to under an hour instead of days.
+const KEEPALIVE_LIVENESS_TRUST_CEILING_MS = 45 * 60 * 1000
 let marveenLastKeepaliveRespawn = 0
 
 /**
@@ -1213,6 +1225,24 @@ export function shouldRespawnForStaleKeepalive(opts: {
   if (opts.keepaliveAgeMs == null) return false
   if (opts.msSinceLastRespawn != null && opts.msSinceLastRespawn < opts.respawnGraceMs) return false
   return opts.keepaliveAgeMs > opts.stalenessThresholdMs
+}
+
+// Pure decision (DEAFNESS-MASK FIX): when the keepalive is stale AND the bun
+// poller is alive, should we TRUST process-liveness and skip the respawn? Only
+// for a bounded window. A live poller proves the process runs, NOT that the MCP
+// pipe still DELIVERS -- a deafness has a live poller and a dead pipe. So we
+// trust liveness while the file is only freshly stale (a normal quiet idle gap),
+// but once staleness crosses the ceiling the poller has delivered nothing for
+// far longer than any idle gap, which reads as deafness -- stop trusting it and
+// let the staleness path decide (its busy-guard still spares a working pane).
+// keepaliveAgeMs == null means no keepalive baseline yet (fresh boot): trust
+// liveness so we never respawn before the first keepalive is written.
+export function shouldTrustLivePollerOverStaleness(opts: {
+  keepaliveAgeMs: number | null
+  trustCeilingMs: number
+}): boolean {
+  if (opts.keepaliveAgeMs == null) return true
+  return opts.keepaliveAgeMs < opts.trustCeilingMs
 }
 
 // SOURCE FIX (2026-06-01): the staleness watchdog's only health signal was the
@@ -1279,8 +1309,17 @@ function checkMainKeepaliveStaleness(): void {
     if (claudePid != null) {
       const provider = getProvider(getMainAgentProvider())
       if (hasChannelPluginAlive(claudePid, provider.type)) {
-        logger.debug({ claudePid, provider: provider.type }, 'Keepalive stale but channel plugin is alive -- skipping respawn')
-        return
+        // A live poller is trusted only while the keepalive is freshly stale.
+        // Past KEEPALIVE_LIVENESS_TRUST_CEILING_MS a live-but-non-delivering
+        // poller reads as deafness, so we do NOT skip -- we fall through to the
+        // staleness path (busy-guarded) instead of staying silent for days.
+        let livenessAgeMs: number | null = null
+        try { livenessAgeMs = Date.now() - statSync(KEEPALIVE_FILE).mtimeMs } catch { livenessAgeMs = null }
+        if (shouldTrustLivePollerOverStaleness({ keepaliveAgeMs: livenessAgeMs, trustCeilingMs: KEEPALIVE_LIVENESS_TRUST_CEILING_MS })) {
+          logger.debug({ claudePid, provider: provider.type, livenessAgeMs }, 'Keepalive stale but channel plugin is alive and within trust ceiling -- skipping respawn')
+          return
+        }
+        logger.warn({ claudePid, provider: provider.type, livenessAgeMs }, 'Keepalive stale beyond liveness-trust ceiling despite a live poller -- treating as possible deafness, not skipping')
       }
     }
   } catch (err) {


### PR DESCRIPTION
## Symptom

`checkMainKeepaliveStaleness` has a liveness shortcut: when the keepalive file is stale but the bun poller process is alive, it skips the respawn, treating process-liveness as proof of health:

```ts
if (hasChannelPluginAlive(claudePid, provider.type)) {
  logger.debug(..., 'Keepalive stale but channel plugin is alive -- skipping respawn')
  return
}
```

A live poller only proves the process runs — **not** that the MCP stdio pipe to the session still *delivers*. A poller can keep pulling updates while the pipe is deaf, so nothing reaches the session. Because the process stays alive, this shortcut skips the respawn indefinitely and the channel stays silent for days with no watchdog action. (We hit exactly this in production: a live poller with a dead pipe, silent for days — this is not a theoretical case.)

## When it broke

Introduced with the liveness shortcut that skips the respawn whenever the poller process is alive; it trusts process-liveness unconditionally, with no upper bound on how long a stale-but-alive state is tolerated.

## Reproduction (unit)

```ts
// freshly stale, poller alive -> trust liveness, skip respawn (normal idle gap)
shouldTrustLivePollerOverStaleness({ keepaliveAgeMs: 20*60*1000, trustCeilingMs: 45*60*1000 })  // true
// stale past the ceiling -> stop trusting; deafness must not hide
shouldTrustLivePollerOverStaleness({ keepaliveAgeMs: 45*60*1000 + 1, trustCeilingMs: 45*60*1000 })  // false
```

## What the user sees

The bot appears to be running (process alive) but delivers nothing for days, and no watchdog recovers it, because the stale keepalive is masked by the live poller.

## Fix

Trust a live poller only within a bounded window. Add `KEEPALIVE_LIVENESS_TRUST_CEILING_MS` (45m, > 2× `KEEPALIVE_STALE_MS` so a normal idle gap is never respawned) and a pure `shouldTrustLivePollerOverStaleness()`. While the keepalive is only freshly stale we still skip (the idle case the shortcut was written for); once staleness crosses the ceiling, a live-but-non-delivering poller reads as deafness and we fall through to the existing staleness path (still busy-guarded), bounding a silent deafness to under an hour instead of days. Adds unit tests for the pure decision.
