### PR TITLE
feat(governance): kanban-write hard-gate for the heartbeat worker (HBFUTTATOIR824)

### DIFF
--- a/scripts/kanban-write-gate.mjs
+++ b/scripts/kanban-write-gate.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+// PreToolUse hard-gate: the heartbeat worker must not WRITE the kanban board.
+//
+// HBFUTTATOIR824 (2026-08-24): the delegalt-feladat-figyelo skill has said,
+// in capitals, since 2026-08-22: "A FUTTATO A TABLARA NEM IR. SEMMIT." --
+// and nothing enforced it. Three violating writes happened on 2026-08-24
+// alone (MIOFEED824 09:14, AIAMSUBMITSRC820 10:45, KANBANCTXDEAD824 14:43,
+// the last auto-closing a card whose PR was still unreviewed). A rule that
+// lives only in prompt text is the never-installed-guard pattern; this hook
+// is the technical enforcement. Wired ONLY for the heartbeat worker
+// (agentGetsKanbanWriteGate in agent-scaffold.ts) -- every other agent's
+// kanban-first workflow REQUIRES board writes.
+//
+// What is blocked (per command segment, data payloads stripped first):
+//   - SQL writes naming a kanban table (INSERT INTO / UPDATE..SET /
+//     DELETE FROM / REPLACE INTO / DROP TABLE / ALTER TABLE kanban_*),
+//     whatever binary runs them (sqlite3 CLI, python, node). Heredoc SQL
+//     bodies are caught too: the naive segment split turns each body line
+//     into its own segment, and the pattern needs no binary name.
+//   - Write-method calls to the dashboard kanban API (/api/kanban with
+//     -X POST/PUT/PATCH/DELETE or a data flag).
+//
+// What must PASS (the worker's actual duties):
+//   - every kanban READ: sqlite3 SELECT, GET /api/kanban/heartbeat-summary;
+//   - writes to NON-kanban tables (memories, daily log, agent_messages);
+//   - its report messages: a curl -d payload QUOTING SQL-looking text (a
+//     proposed transition) is stripped by stripDataPayloads before matching,
+//     so describing a write is never treated as performing one.
+
+import { readFileSync, realpathSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { splitSegments, stripDataPayloads } from './self-pace-gate.mjs'
+
+// SQL-shaped write patterns anchored on the kanban tables. Anchoring on the
+// verb+table pair (not on the binary name) is what catches heredoc bodies and
+// python/node DB writes with the same rule; prose has to reproduce the exact
+// SQL shape (e.g. "UPDATE kanban_cards SET") to false-positive, and the one
+// place that legitimately quotes such text -- a report payload -- is stripped
+// before matching.
+const KANBAN_SQL_WRITE_PATTERNS = [
+  /\binsert\s+into\s+kanban_\w+/i,
+  /\bupdate\s+kanban_\w+\s+set\b/i,
+  /\bdelete\s+from\s+kanban_\w+/i,
+  /\breplace\s+into\s+kanban_\w+/i,
+  /\bdrop\s+table\s+(?:if\s+exists\s+)?kanban_\w+/i,
+  /\balter\s+table\s+kanban_\w+/i,
+]
+
+// Dashboard kanban API write: the URL plus either an explicit write method or
+// a data flag (curl defaults to POST when -d is present). A plain GET (the
+// heartbeat-summary read) carries neither.
+const KANBAN_API_RX = /\/api\/kanban\b/i
+const WRITE_METHOD_RX = /(?:^|\s)(?:-X|--request)[\s=]*["']?(POST|PUT|PATCH|DELETE)\b/i
+const DATA_FLAG_RX = /(?:^|\s)(?:-d|--data(?:-(?:raw|binary|ascii|urlencode))?|--json|-F|--form)\b/
+
+export function gateDecision(toolName, toolInput) {
+  if (toolName !== 'Bash') return { deny: false }
+  const command = toolInput?.command
+  if (typeof command !== 'string' || command.trim() === '') return { deny: false }
+
+  // Strip data payloads BEFORE segmenting: a report payload legitimately
+  // contains `|` (the jelolt-tetel column separator), and the naive splitter
+  // would cut the quoted -d literal MID-STRING -- the piece carrying the
+  // quoted SQL text would then lack the -d prefix and could never be blanked
+  // (the same `<bar>` trap self-pace-gate documents on splitSegments).
+  const stripped = stripDataPayloads(command)
+  for (const seg of splitSegments(stripped)) {
+    if (KANBAN_SQL_WRITE_PATTERNS.some((rx) => rx.test(seg))) {
+      return { deny: true, reason: 'kanban-sql-write' }
+    }
+    if (KANBAN_API_RX.test(seg) && (WRITE_METHOD_RX.test(seg) || DATA_FLAG_RX.test(seg))) {
+      return { deny: true, reason: 'kanban-api-write' }
+    }
+  }
+  return { deny: false }
+}
+
+const GATE_MSG =
+  'Kanban-iras TILTOTT a heartbeat-futtatonak (HBFUTTATOIR824 hard-gate). A sajat ' +
+  'skilled (delegalt-feladat-figyelo, SCHEDSKIP817 szakasz) szerint a futtato a ' +
+  'tablara nem ir SEMMIT: se statuszt, se kommentet, se cimet, se uj kartyat. ' +
+  'Amit tenni akartal, az JELOLT-TETEL: ird bele a koordinatornak szolo ' +
+  'lelet-uzenetbe (card_id | jelenlegi statusz | javasolt atmenet | evidencia), ' +
+  'es a vegrehajtas a koordinatore. Olvasni tovabbra is szabad (SELECT, GET ' +
+  '/api/kanban/heartbeat-summary).'
+
+function allow() { process.exit(0) }
+
+function deny(reason) {
+  process.stdout.write(JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'deny',
+      permissionDecisionReason: reason,
+    },
+  }))
+  process.exit(0)
+}
+
+function isInvokedDirectly() {
+  try {
+    const self = realpathSync(fileURLToPath(import.meta.url))
+    const entry = process.argv[1] ? realpathSync(process.argv[1]) : ''
+    return self === entry
+  } catch {
+    return false
+  }
+}
+
+if (isInvokedDirectly()) {
+  let payload
+  try {
+    payload = JSON.parse(readFileSync(0, 'utf-8'))
+  } catch {
+    allow() // malformed/empty input must never break the agent's tool calls
+  }
+  const { deny: shouldDeny } = gateDecision(payload?.tool_name, payload?.tool_input)
+  if (shouldDeny) deny(GATE_MSG)
+  allow()
+}

--- a/src/__tests__/kanban-write-gate.test.ts
+++ b/src/__tests__/kanban-write-gate.test.ts
@@ -1,0 +1,119 @@
+// HBFUTTATOIR824: the heartbeat worker's skill has forbidden kanban writes in
+// prompt text since 2026-08-22 ("A FUTTATO A TABLARA NEM IR. SEMMIT.") with
+// zero enforcement -- three violating writes on 2026-08-24 alone, one
+// auto-closing a card whose PR was still unreviewed. This gate is the
+// technical enforcement: a PreToolUse hook wired ONLY for the heartbeat
+// worker, blocking SQL and dashboard-API writes to the kanban tables while
+// every read (and every report that merely QUOTES SQL-looking text in a data
+// payload) passes.
+
+import { describe, it, expect } from 'vitest'
+// @ts-expect-error -- plain .mjs hook script, no types
+import { gateDecision } from '../../scripts/kanban-write-gate.mjs'
+import {
+  agentGetsKanbanWriteGate,
+  injectKanbanWriteGate,
+} from '../web/agent-scaffold.js'
+import { MAIN_AGENT_ID, HEARTBEAT_AGENT_ID } from '../config.js'
+
+const bash = (command: string) => gateDecision('Bash', { command })
+
+describe('kanban-write-gate gateDecision: SQL writes (known positives)', () => {
+  it('denies a direct sqlite3 UPDATE of kanban_cards (the 14:43 incident shape)', () => {
+    expect(
+      bash(`sqlite3 store/claudeclaw.db "UPDATE kanban_cards SET status='done', updated_at=unixepoch() WHERE id='KANBANCTXDEAD824'"`).deny
+    ).toBe(true)
+  })
+  it('denies INSERT INTO kanban_comments', () => {
+    expect(
+      bash(`sqlite3 store/claudeclaw.db "INSERT INTO kanban_comments (card_id, author, content, created_at) VALUES ('X', 'heartbeat', 'auto-close', unixepoch())"`).deny
+    ).toBe(true)
+  })
+  it('denies heredoc SQL: the write verb sits on its own body line', () => {
+    expect(
+      bash(`sqlite3 store/claudeclaw.db << 'EOF'\nUPDATE kanban_cards SET status='done' WHERE id='X';\nEOF`).deny
+    ).toBe(true)
+  })
+  it('denies a python-driven kanban write (no sqlite3 CLI token anywhere)', () => {
+    expect(
+      bash(`python3 -c "import sqlite3; c=sqlite3.connect('store/claudeclaw.db'); c.execute('DELETE FROM kanban_cards WHERE id=?', ('X',)); c.commit()"`).deny
+    ).toBe(true)
+  })
+  it('denies DROP/ALTER on kanban tables', () => {
+    expect(bash(`sqlite3 db "DROP TABLE IF EXISTS kanban_comments"`).deny).toBe(true)
+    expect(bash(`sqlite3 db "ALTER TABLE kanban_cards ADD COLUMN x TEXT"`).deny).toBe(true)
+  })
+})
+
+describe('kanban-write-gate gateDecision: dashboard API writes', () => {
+  it('denies POST to /api/kanban', () => {
+    expect(
+      bash(`curl -s -X POST http://localhost:3420/api/kanban/cards -H "Authorization: Bearer $TOK" -d '{"title":"x"}'`).deny
+    ).toBe(true)
+  })
+  it('denies a data-flag call to /api/kanban even without explicit -X (curl defaults to POST)', () => {
+    expect(
+      bash(`curl -s http://localhost:3420/api/kanban/comments --data '{"card_id":"X"}'`).deny
+    ).toBe(true)
+  })
+})
+
+describe('kanban-write-gate gateDecision: the worker duties that MUST pass', () => {
+  it('allows sqlite3 SELECT over kanban tables (the measuring read)', () => {
+    expect(
+      bash(`sqlite3 store/claudeclaw.db "SELECT id, status, substr(title,1,50) FROM kanban_cards WHERE archived_at IS NULL AND status IN ('in_progress','waiting')"`).deny
+    ).toBe(false)
+  })
+  it('allows the scaffolded GET of /api/kanban/heartbeat-summary', () => {
+    expect(
+      bash(`python3 -c "import json,urllib.request; tok=open('store/.dashboard-token').read().strip(); d=json.load(urllib.request.urlopen(urllib.request.Request('http://localhost:3420/api/kanban/heartbeat-summary', headers={'Authorization':'Bearer '+tok})))"`).deny
+    ).toBe(false)
+  })
+  it('allows writes to NON-kanban tables (memories, daily log)', () => {
+    expect(
+      bash(`sqlite3 store/claudeclaw.db "INSERT INTO memories (agent_id, content) VALUES ('heartbeat', 'x')"`).deny
+    ).toBe(false)
+  })
+  it('allows the report message even when its payload QUOTES SQL-looking text', () => {
+    // The worker's core duty: a jelolt-tetel message to the coordinator whose
+    // CONTENT describes a proposed write. stripDataPayloads blanks the -d
+    // literal, so describing a write is never treated as performing one.
+    expect(
+      bash(`curl -s -X POST http://localhost:3420/api/messages -H "Content-Type: application/json" -d '{"from":"heartbeat","to":"marveen","content":"NYERSANYAG: X kartya | waiting | javasolt: UPDATE kanban_cards SET status=done | evidencia msg 123"}'`).deny
+    ).toBe(false)
+  })
+  it('allows plain non-kanban commands', () => {
+    expect(bash('date && git status').deny).toBe(false)
+  })
+  it('ignores non-Bash tools', () => {
+    expect(gateDecision('Write', { file_path: '/x', content: 'UPDATE kanban_cards SET' }).deny).toBe(false)
+  })
+})
+
+describe('kanban-write-gate wiring', () => {
+  it('gates the heartbeat worker and NOBODY else', () => {
+    expect(agentGetsKanbanWriteGate(HEARTBEAT_AGENT_ID)).toBe(true)
+    expect(agentGetsKanbanWriteGate(MAIN_AGENT_ID)).toBe(false)
+    // Every normal sub-agent's kanban-first workflow requires board writes.
+    expect(agentGetsKanbanWriteGate('samu')).toBe(false)
+    expect(agentGetsKanbanWriteGate('geri')).toBe(false)
+  })
+  it('injects idempotently: respawn re-runs never accumulate duplicates', () => {
+    const settings: Record<string, unknown> = {}
+    injectKanbanWriteGate(settings)
+    injectKanbanWriteGate(settings)
+    const ptu = (settings.hooks as Record<string, unknown[]>).PreToolUse
+    const mine = ptu.filter((e) => JSON.stringify(e).includes('kanban-write-gate.mjs'))
+    expect(mine.length).toBe(1)
+    expect((mine[0] as { matcher: string }).matcher).toBe('Bash')
+  })
+  it('keeps other PreToolUse entries intact', () => {
+    const settings: Record<string, unknown> = {
+      hooks: { PreToolUse: [{ matcher: 'WebFetch', hooks: [{ type: 'command', command: 'x/egress-gate.mjs' }] }] },
+    }
+    injectKanbanWriteGate(settings)
+    const ptu = (settings.hooks as Record<string, unknown[]>).PreToolUse
+    expect(ptu.length).toBe(2)
+    expect(JSON.stringify(ptu[0])).toContain('egress-gate.mjs')
+  })
+})

--- a/src/config.ts
+++ b/src/config.ts
@@ -231,6 +231,10 @@ export function brandSlug(raw: string): string {
 // (NFKD + ASCII + lowercase dashes). Older installs without this env var
 // fall back to "marveen" so nothing breaks when upgrading in place.
 export const MAIN_AGENT_ID = env['MAIN_AGENT_ID'] ?? 'marveen'
+// The hidden heartbeat worker's agent id. Lives here (not in
+// heartbeat-agent-scaffold) so agent-scaffold can key gates on it without an
+// import cycle: heartbeat-agent-scaffold already imports agent-scaffold.
+export const HEARTBEAT_AGENT_ID = 'heartbeat'
 
 // Identifier the OS service manager uses for the main agent's units (launchd
 // label com.<id>.channels / com.<id>.dashboard, systemd <id>-channels, etc.).

--- a/src/web/agent-scaffold.ts
+++ b/src/web/agent-scaffold.ts
@@ -1,7 +1,7 @@
 import { readFileSync, writeFileSync, existsSync, mkdirSync, copyFileSync, readdirSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 import { homedir } from 'node:os'
-import { PROJECT_ROOT, OWNER_NAME, MAIN_AGENT_ID, BOT_NAME, CHANNEL_PROVIDER, WEB_PORT, OWNER_DRIVE_FOLDER, APP_TZ, DASHBOARD_PUBLIC_URL, STORE_DIR } from '../config.js'
+import { PROJECT_ROOT, OWNER_NAME, MAIN_AGENT_ID, HEARTBEAT_AGENT_ID, BOT_NAME, CHANNEL_PROVIDER, WEB_PORT, OWNER_DRIVE_FOLDER, APP_TZ, DASHBOARD_PUBLIC_URL, STORE_DIR } from '../config.js'
 import { channelStateDir } from '../channel-provider.js'
 import { runAgent } from '../agent.js'
 import { atomicWriteFileSync } from './atomic-write.js'
@@ -364,6 +364,7 @@ export function writeAgentSettingsFromProfile(name: string, profile: ProfileTemp
   // covered by the self-pace block + the #0 CLAUDE.md doctrine.
   if (agentGetsEmailGate(name)) injectEmailSendGate(existing)
   if (agentGetsGovernanceGates(name)) injectSelfPaceGate(existing)
+  if (agentGetsKanbanWriteGate(name)) injectKanbanWriteGate(existing)
   injectEgressGate(existing)
   atomicWriteFileSync(settingsPath, JSON.stringify(existing, null, 2))
 }
@@ -456,6 +457,39 @@ export function injectSelfPaceGate(existing: Record<string, unknown>): void {
   const prev = Array.isArray(hooks.PreToolUse) ? (hooks.PreToolUse as unknown[]) : []
   hooks.PreToolUse = [
     ...prev.filter((e) => !JSON.stringify(e).includes('self-pace-gate.mjs')),
+    entry,
+  ]
+}
+
+// Which agents are subject to the kanban-write gate: ONLY the hidden heartbeat
+// worker (HBFUTTATOIR824). Its skill has forbidden board writes in prompt text
+// since 2026-08-22 ("A FUTTATO A TABLARA NEM IR. SEMMIT.") with zero
+// enforcement -- three violating writes on 2026-08-24 alone, one auto-closing
+// a card whose PR was unreviewed. Every OTHER agent's kanban-first workflow
+// REQUIRES board writes, so this must never widen to the general sub-agent
+// population. Pure + exported so both directions are unit-testable.
+export function agentGetsKanbanWriteGate(name: string): boolean {
+  return name === HEARTBEAT_AGENT_ID
+}
+
+// Idempotently wire the kanban-write-gate PreToolUse hook (blocks SQL and
+// dashboard-API writes to the kanban tables; reads pass). Same shape + dedupe
+// discipline as injectEmailSendGate. Bash-only matcher: the write routes are
+// sqlite3 / python / curl invocations, all of which arrive as Bash commands.
+export function injectKanbanWriteGate(existing: Record<string, unknown>): void {
+  const hooks = (existing.hooks && typeof existing.hooks === 'object'
+    ? existing.hooks
+    : (existing.hooks = {})) as Record<string, unknown>
+  const command = hookCommand(join(PROJECT_ROOT, 'scripts', 'kanban-write-gate.mjs'))
+  // Registration guard: a /tmp or missing path must never enter shared settings.
+  if (isUnsafeHookCommand(command)) return
+  const entry = {
+    matcher: 'Bash',
+    hooks: [{ type: 'command', command, timeout: 10 }],
+  }
+  const prev = Array.isArray(hooks.PreToolUse) ? (hooks.PreToolUse as unknown[]) : []
+  hooks.PreToolUse = [
+    ...prev.filter((e) => !JSON.stringify(e).includes('kanban-write-gate.mjs')),
     entry,
   ]
 }

--- a/src/web/heartbeat-agent-scaffold.ts
+++ b/src/web/heartbeat-agent-scaffold.ts
@@ -41,6 +41,7 @@ import {
   OWNER_NAME,
   BOT_NAME,
   MAIN_AGENT_ID,
+  HEARTBEAT_AGENT_ID,
   WEB_PORT,
   HEARTBEAT_CALENDAR_ACCOUNT,
   APP_TZ,
@@ -50,7 +51,7 @@ import { resolveDashboardOrigin } from './agent-scaffold.js'
 import { logger } from '../logger.js'
 import { CHANNEL_PLUGIN_IDS } from './plugin-ids.js'
 
-const HEARTBEAT_AGENT_NAME = 'heartbeat'
+const HEARTBEAT_AGENT_NAME = HEARTBEAT_AGENT_ID
 const HEARTBEAT_AGENT_DIR = join(PROJECT_ROOT, 'agents', HEARTBEAT_AGENT_NAME)
 
 // Channel plugins MUST be explicitly disabled in the agent's


### PR DESCRIPTION
## What

A new PreToolUse hard-gate (`scripts/kanban-write-gate.mjs`) wired **only** for the hidden heartbeat worker: blocks SQL writes naming a kanban table and write-method calls to `/api/kanban`, while every read and every non-kanban write passes.

## Why

The delegalt-feladat-figyelo skill has said, in capitals, since 2026-08-22: *"A FUTTATO A TABLARA NEM IR. SEMMIT."* — and nothing enforced it. Three violating writes happened on 2026-08-24 alone (MIOFEED824 09:14, AIAMSUBMITSRC820 10:45, KANBANCTXDEAD824 14:43 — the last auto-closed a card whose PR was still unreviewed). Per the card, the fix must be technical, not more skill text.

## The fourth incident — while this PR sat in review

At **15:28:33 the runner auto-closed HBFUTTATOIR824 itself** — the very card commissioning this gate — from Samu's "PR ready for review" message, while #1060 was `OPEN/CLEAN` with its merge scheduled after the release freeze. The delivery existed; the work did not. Marveen reopened it at 15:30:04. That makes **four violating writes in one day** (09:14:28, 10:45:06, 14:43:34, 15:28:33) against a prohibition that has stood in the skill, verbatim and in capitals, since 2026-08-22.

A rule that overrides even the card ordering its own enforcement is not a rule — it is a sign on the wall. This is why the fix is a PreToolUse hook and not more prompt text.

**Merge ordering request (Marveen, msg 15126): this PR merges FIRST after the freeze.** #1056 and #1059 lose nothing by waiting an hour; every respawn without this gate extends a four-times-proven failure.

## Design

- **Predicate**: `agentGetsKanbanWriteGate(name) === (name === HEARTBEAT_AGENT_ID)`. Every other agent's kanban-first workflow REQUIRES board writes — the gate must never widen. Both directions unit-tested.
- **Verb+table anchoring** (`INSERT INTO kanban_`, `UPDATE kanban_* SET`, …), no binary names: heredoc SQL bodies and python/node DB writes are caught by the same rule; `SELECT` and writes to other tables pass.
- **Reports quoting SQL pass**: `stripDataPayloads` runs on the WHOLE command before segmenting. The jelolt-tetel column separator is `|`, and the naive splitter would cut a quoted `-d` literal mid-string — the exact `<bar>` trap documented inside self-pace-gate. Describing a write is never treated as performing one.
- **No import cycle**: `HEARTBEAT_AGENT_ID` moves to `config.ts` (heartbeat-agent-scaffold already imports agent-scaffold).
- Same idempotent injector shape + dedupe discipline as the email/self-pace/egress gates; re-applied on every spawn, so it survives respawns and reaches the worker on its next context-guard restart.

## Evidence

- 16 new tests: the 14:43 incident shape as known positive; the scaffolded heartbeat-summary GET, an SQL-quoting report payload, and non-kanban writes as known negatives; injector idempotence + preservation of other hooks.
- E2E stdin probe: deny JSON on the incident command, clean exit on the SELECT.
- Full suite **3951/3951**, `tsc --noEmit` exit 0.

## Merge timing

Freeze-compliant: PR now, merge after today's release (develop = 8fa255c0 at branch time). The running worker picks the hook up on its next respawn (settings regenerate on spawn).

Card: HBFUTTATOIR824

🤖 Generated with [Claude Code](https://claude.com/claude-code)
