### PR TITLE
fix(hooks): register the skill-usage-capture hook so it actually runs

### DIFF
--- a/src/__tests__/skill-usage-hook-registration.test.ts
+++ b/src/__tests__/skill-usage-hook-registration.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { KNOWN_HOOK_SCRIPTS } from '../web/hook-registration-guard.js'
+
+// The skill-usage-capture hook shipped fully tested (#607) but was registered
+// NOWHERE: templates/settings.json.template never referenced it, so on every
+// scaffolded agent the skill_usage table stayed silently empty while the
+// /skill-usage dashboard and the dream-engine suggestions ran on no data.
+// A hook that only exists on disk is dead code -- these tests pin the wiring,
+// not the (already unit-tested) capture logic.
+
+type Hook = { type?: string; command?: string; timeout?: number }
+type HookEntry = { matcher?: string; hooks?: Hook[] }
+
+const tplPath = join(__dirname, '..', '..', 'templates', 'settings.json.template')
+const tpl = JSON.parse(readFileSync(tplPath, 'utf-8')) as {
+  hooks?: Record<string, HookEntry[]>
+}
+
+function commandsOf(event: string): string[] {
+  return (tpl.hooks?.[event] ?? []).flatMap((e) => (e.hooks ?? []).map((h) => h.command ?? ''))
+}
+
+describe('skill-usage-capture registration', () => {
+  it('the template registers the hook under PostToolUse', () => {
+    const cmds = commandsOf('PostToolUse')
+    expect(cmds.some((c) => c.includes('skill-usage-capture.py'))).toBe(true)
+  })
+
+  it('uses the fail-open wrapper so a missing file never blocks the tool call', () => {
+    const cmd = commandsOf('PostToolUse').find((c) => c.includes('skill-usage-capture.py'))!
+    // Same shape as the other guarded hooks: file-existence test, exec on hit,
+    // exit 0 otherwise. A bare `python3 <path>` would exit 2 after the checkout
+    // moves and a non-zero hook surfaces as an error on every matched tool.
+    expect(cmd).toMatch(/^bash -c '\[ -f [^']*skill-usage-capture\.py \] && exec python3 /)
+    expect(cmd).toMatch(/; exit 0'$/)
+  })
+
+  it('matches only the tools the hook classifies (Skill calls and SKILL.md Reads)', () => {
+    const entry = (tpl.hooks?.PostToolUse ?? []).find((e) =>
+      (e.hooks ?? []).some((h) => (h.command ?? '').includes('skill-usage-capture.py')),
+    )!
+    expect(entry.matcher).toBe('Skill|Read')
+  })
+
+  it('is a known hook script, so the stale-entry pruner may clean it up', () => {
+    // Without this, a stale registration (deleted checkout) would be treated as
+    // FOREIGN by pruneStaleHookEntries and kept forever.
+    expect(KNOWN_HOOK_SCRIPTS).toContain('skill-usage-capture.py')
+  })
+})

--- a/src/web/hook-registration-guard.ts
+++ b/src/web/hook-registration-guard.ts
@@ -37,6 +37,7 @@ export const KNOWN_HOOK_SCRIPTS: readonly string[] = [
   'inbox-drain.py',
   'channel-inbox-drain.py',
   'ledger-capture.py',
+  'skill-usage-capture.py',
 ]
 
 // Path fragment that marks a checkout as an agent worktree. Kept

--- a/templates/settings.json.template
+++ b/templates/settings.json.template
@@ -28,6 +28,18 @@
         ]
       }
     ],
+    "PostToolUse": [
+      {
+        "matcher": "Skill|Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c '[ -f {{PROJECT_ROOT}}/scripts/hooks/skill-usage-capture.py ] && exec python3 {{PROJECT_ROOT}}/scripts/hooks/skill-usage-capture.py; exit 0'",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
     "UserPromptSubmit": [
       {
         "hooks": [


### PR DESCRIPTION
## Symptom

`scripts/hooks/skill-usage-capture.py` shipped in #607 fully unit-tested, but nothing registers it: `templates/settings.json.template` has no `PostToolUse` entry for it and no other registration path references it. A hook that only exists on disk never fires, so on every scaffolded agent the `skill_usage` table stays silently empty while the `/skill-usage` dashboard and the dream-engine skill suggestions run on no data.

## When it broke

Dead since its introduction in `edf0066` (#607, 2026-07-15). The 20/20 green tests cover the pure `_classify()` logic only, which is exactly why the gap stayed invisible: the decision logic is tested, the production wiring is not.

## Reproduce (on develop)

```
grep -c skill-usage-capture templates/settings.json.template   # -> 0
# scaffold an agent, invoke any skill, then:
# SELECT COUNT(*) FROM skill_usage;                            # -> 0
```

## Fix

- Add a `PostToolUse` entry to the settings template, using the same fail-open wrapper as the other guarded hooks (a missing file exits 0 instead of surfacing an error on every matched tool call) and a `Skill|Read` matcher so the hook only runs for the two events it classifies.
- `ensureAgentHooks()` already merges missing template events into every agent's settings at startup, so this backfills the existing fleet with no manual step.
- Add the script to `KNOWN_HOOK_SCRIPTS` so `pruneStaleHookEntries()` treats a stale registration as ours (prunable) rather than foreign (kept forever).

## Test

`src/__tests__/skill-usage-hook-registration.test.ts` pins the wiring, not the capture logic, naming each invariant: registered under `PostToolUse`, fail-open command shape, `Skill|Read` matcher, present in `KNOWN_HOOK_SCRIPTS`.

Verified: `tsc --noEmit` clean; full vitest 3937 passed, the single failure (`channels-never-started-backoff`) is the known root-environment case (chmod-based unwritable-store setup does not bind under root) and fails identically on a pristine develop checkout.

## Known follow-up (out of scope)

The hook's private `_agent_id_from_cwd()` copy still derives an agent id from the cwd basename for unrecognised paths, the same class as #1057. Worth aligning once that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
