### PR TITLE
fix(hooks): outgoing-copy-gate fails closed on a crash instead of exit 1

### DIFF
--- a/scripts/__tests__/outgoing-copy-gate-failclosed.test.py
+++ b/scripts/__tests__/outgoing-copy-gate-failclosed.test.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Exit-code contract of scripts/hooks/outgoing-copy-gate.py on malformed input.
+
+Regression guard: a non-dict tool_input crashed the gate with an unhandled
+AttributeError -> exit 1. PreToolUse treats exit 1 as NON-blocking, so the
+send ran UNCHECKED -- the exact opposite of the email path's fail-closed
+contract. The fix is a top-level fail-closed net: any unexpected crash on the
+email/Bash send paths exits 2 (block), while the telegram path keeps its own
+deliberate fail-open handling (exit 0) and non-send tools stay untouched.
+
+Run: python3 <thisfile>   Exit 0 = all pass.
+"""
+import json
+import os
+import subprocess
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+GATE = os.path.join(os.path.dirname(HERE), "hooks", "outgoing-copy-gate.py")
+
+
+def run_gate(payload) -> int:
+    data = payload if isinstance(payload, str) else json.dumps(payload)
+    proc = subprocess.run(
+        [sys.executable, GATE], input=data.encode(), capture_output=True,
+    )
+    return proc.returncode
+
+
+CASES = [
+    ("email with non-dict tool_input BLOCKS (was: crash, exit 1, send ran unchecked)",
+     {"tool_name": "mcp__x__send_email", "tool_input": ["x"]}, 2),
+    ("Bash with non-dict tool_input BLOCKS (command is uninspectable)",
+     {"tool_name": "Bash", "tool_input": "not-a-dict"}, 2),
+    ("telegram reply with non-dict tool_input stays FAIL-OPEN by design",
+     {"tool_name": "mcp__plugin_telegram_telegram__reply", "tool_input": 42}, 0),
+    ("non-send tool with malformed input passes (the net never widens the gate)",
+     {"tool_name": "Read", "tool_input": ["x"]}, 0),
+    ("unparseable stdin still exits 0 (must not wedge the session)",
+     "this is not json", 0),
+]
+
+failed = []
+for name, payload, want in CASES:
+    got = run_gate(payload)
+    ok = got == want
+    if not ok:
+        failed.append(name)
+    print(f"  [{'PASS' if ok else 'FAIL'}] {name}: exit={got} want={want}")
+
+print()
+if failed:
+    print(f"{len(failed)} FAILED: {failed}", file=sys.stderr)
+    sys.exit(1)
+print("All outgoing-copy-gate fail-closed tests passed.")

--- a/scripts/hooks/outgoing-copy-gate.py
+++ b/scripts/hooks/outgoing-copy-gate.py
@@ -722,4 +722,22 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except SystemExit:
+        raise
+    except Exception as exc:  # noqa: BLE001 -- deliberate blanket: fail-closed net
+        # An unhandled crash exits 1, and PreToolUse treats 1 as NON-blocking,
+        # so the send would run UNCHECKED -- the exact opposite of the email
+        # path's fail-closed contract (e.g. a non-dict tool_input used to
+        # AttributeError inside collect_mcp_body). The telegram path never
+        # reaches here: telegram_gate() catches its own errors and exits 0
+        # (fail-open by design), so this net only ever catches the email/Bash
+        # send paths, where blocking is the safe failure mode.
+        sys.stderr.write(
+            "KIMENO-SZOVEG KAPU: TILTVA, belso hiba a vizsgalat kozben "
+            f"({exc!r}).\n"
+            "Fail-closed: egy vizsgalhatatlan kuldes pont a kaput utne ki. "
+            "Tedd vizsgalhatova a hivast, aztan kuldd ujra.\n"
+        )
+        sys.exit(2)


### PR DESCRIPTION
## Symptom

The outgoing-copy gate's email path promises fail-closed (its own block messages say "Email fail-closed"), but a malformed payload breaks that promise: `main()` reads `tool_input` without an isinstance check, so a non-dict value crashes with an unhandled `AttributeError` inside `collect_mcp_body()`. An unhandled crash exits 1, and PreToolUse treats exit 1 as **non-blocking** — the send runs unchecked, the exact opposite of the contract.

## When it broke

Present since the gate landed in `f96b763` (#983, 2026-08-16).

## Reproduce (on develop)

```
echo '{"tool_name":"mcp__x__send_email","tool_input":["x"]}' \
  | python3 scripts/hooks/outgoing-copy-gate.py; echo $?
# before: AttributeError traceback, exit 1 (send proceeds unchecked)
# after:  "KIMENO-SZOVEG KAPU: TILTVA ...", exit 2 (send blocked)
```

## Fix

A top-level fail-closed net around `main()`: any unexpected exception exits 2 with a clear message instead of 1. Deliberately minimal — one mechanism covers the whole crash class:

- The **telegram path is untouched**: `telegram_gate()` already catches its own errors and exits 0 (fail-open by design — it is the owner's supervision channel), so it never reaches the net.
- **Non-send tools** and **unparseable stdin** keep their exit-0 behaviour; the net never widens the gate.

## Test

`scripts/__tests__/outgoing-copy-gate-failclosed.test.py` pins the exit-code contract case by case: email/Bash malformed → 2, telegram malformed → 0, non-send malformed → 0, bad stdin → 0. The first case fails on current develop (exit 1) and passes with the fix.

This is the same defect class as the fail-open exit-code invariant discussed around #1028: a gate whose decision logic is tested green while its failure mode silently un-gates the action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
