### PR TITLE
fix(hooks): skill-usage-capture uses the shared agent-id resolver

### DIFF
--- a/scripts/__tests__/skill-usage-capture.test.py
+++ b/scripts/__tests__/skill-usage-capture.test.py
@@ -136,6 +136,24 @@ class TestAgentIdFromCwd(unittest.TestCase):
         cwd_with_slash = os.path.join(install, "agents", "agent-a") + "/"
         self.assertEqual(self._call(cwd_with_slash), "agent-a")
 
+    # Regression guards for the drifted-private-copy bug: the hook used to
+    # carry its own resolver that missed the install-subdirectory case and
+    # invented an agent id from the cwd basename, so skill_usage rows were
+    # attributed to a directory name instead of a real agent.
+
+    def test_delegates_to_the_shared_ledger_resolver(self):
+        import sys as _sys
+        _sys.path.insert(0, os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "hooks"))
+        import ledger_lib
+        self.assertIs(hook._agent_id_from_cwd, ledger_lib.agent_id_from_cwd)
+
+    def test_install_subdir_is_main_agent_not_directory_name(self):
+        install = self._install()
+        cwd = os.path.join(install, "store", "some-workdir")
+        # The drifted copy returned "some-workdir" here.
+        self.assertNotEqual(self._call(cwd), "some-workdir")
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/scripts/hooks/skill-usage-capture.py
+++ b/scripts/hooks/skill-usage-capture.py
@@ -24,6 +24,15 @@ import json
 import urllib.request
 import urllib.error
 
+# Agent identity comes from the ledger library -- ONE resolver for every hook.
+# This file used to carry its own _agent_id_from_cwd() copy, which drifted:
+# it missed the install-subdirectory case (only `cwd == install` mapped to the
+# main agent) and kept the basename fallback, so skill_usage rows got an agent
+# id INVENTED from the directory name. A drifted private copy is exactly how
+# that class of bug survives -- delegate instead of duplicating.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import ledger_lib  # noqa: E402
+
 
 def _install_dir() -> str:
     here = os.path.dirname(os.path.abspath(__file__))
@@ -52,37 +61,9 @@ def _dashboard_token() -> str:
         return ""
 
 
-def _main_agent_id() -> str:
-    v = os.environ.get("MAIN_AGENT_ID")
-    if v and v.strip():
-        return v.strip()
-    try:
-        with open(os.path.join(_install_dir(), ".env")) as f:
-            for line in f:
-                if line.startswith("MAIN_AGENT_ID="):
-                    return line.split("=", 1)[1].strip()
-    except Exception:
-        pass
-    return "marveen"
-
-
-def _agent_id_from_cwd(cwd: str) -> str:
-    """Derive agent_id from the session working directory.
-
-    <install>/agents/<id>  -> <id>       (sub-agent: zack, rick, ...)
-    <install>               -> MAIN_AGENT_ID
-    """
-    cwd = (cwd or "").rstrip("/")
-    install = _install_dir().rstrip("/")
-    agents_root = os.path.join(install, "agents")
-    if cwd.startswith(agents_root + os.sep):
-        rel = cwd[len(agents_root) + 1:]
-        seg = rel.split(os.sep)[0]
-        return seg if seg else _main_agent_id()
-    if cwd == install:
-        return _main_agent_id()
-    base = os.path.basename(cwd)
-    return base if base else _main_agent_id()
+# Kept as a module-level name so callers and tests address ONE symbol; the
+# implementation is the shared resolver, not a local copy.
+_agent_id_from_cwd = ledger_lib.agent_id_from_cwd
 
 
 # ~/.claude/skills/<name>/SKILL.md  (expand ~ for the running user)


### PR DESCRIPTION
## Symptom

`scripts/hooks/skill-usage-capture.py` carries its own private copy of `_agent_id_from_cwd()`, and the copy drifted from the ledger's resolver: it maps only the EXACT install root to the main agent (any install subdirectory falls through) and keeps the basename fallback, so `skill_usage` rows get an agent id **invented from the directory name**. This is the follow-up announced in #1062, and the same defect class as #1057 — a second, independently drifting copy of the cwd→agent-id rule.

## When it broke

Present since the hook's introduction in `edf0066` (#607, 2026-07-15). It becomes user-visible once the hook is registered (#1062): the telemetry then records rows under fabricated agent ids.

## Reproduce (on develop)

```
MAIN_AGENT_ID=mainagent python3 -c "import importlib.util as u;\
s=u.spec_from_file_location('h','scripts/hooks/skill-usage-capture.py');\
m=u.module_from_spec(s);s.loader.exec_module(m);\
print(m._agent_id_from_cwd(m._install_dir()+'/store/wd'))"
# before: 'wd'         (invented from the directory name)
# after:  'mainagent'
```

## Fix

Delete the copy and delegate to `ledger_lib.agent_id_from_cwd` — one resolver for every hook, so the semantics cannot drift again. The module keeps the `_agent_id_from_cwd` name as an alias, so callers and tests address one symbol.

Composition either way: with #1057 this automatically picks up the never-invent-from-basename rule for out-of-tree cwds; without it, it still fixes the install-subdirectory attribution immediately.

## Test

Two new cases pin the invariants by name: the alias IS the ledger resolver (delegation cannot silently revert to a copy), and an install subdirectory is never attributed to its directory name. The 20 existing `_classify()`/resolution cases pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
