### PR TITLE
fix(ledger): ship the ledger-live-drain scheduled task the docs promise

### DIFF
--- a/scheduled-tasks/ledger-live-drain/SKILL.md
+++ b/scheduled-tasks/ledger-live-drain/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: ledger-live-drain
+description: 2 percenként ellenőrzi, maradt-e megválaszolatlan bejövő üzenet a beszélgetés-ledgerben, és ha igen, felszínre hozza, hogy a futó session válaszoljon rá respawn nélkül
+---
+
+Futtasd le csendben:
+
+```bash
+python3 {{PROJECT_ROOT}}/scripts/hooks/ledger-live-drain.py
+```
+
+- Ha a kimenet ÜRES: minden bejövő meg van válaszolva. NE csinálj és NE írj semmit, maradj csendben.
+- Ha a kimenet egy `OPEN_QUESTION chat_id=... message_id=...` blokk: az egy korábban elveszett, még megválaszolatlan bejövő üzenet ebből a csatornából. Olvasd el a blokk szövegét, és válaszolj rá MOST a szokásos csatorna-válasz eszközzel (a blokkban szereplő chat_id-ra), ugyanúgy, mintha most érkezett volna.
+
+A script determinisztikus és biztonságos: 60 másodpercnél frissebb kérdést nem hoz fel (nem szól bele éppen készülő válaszba), és ugyanazt az üzenetet csak egyszer hozza felszínre.

--- a/scheduled-tasks/ledger-live-drain/task-config.json
+++ b/scheduled-tasks/ledger-live-drain/task-config.json
@@ -1,0 +1,8 @@
+{
+  "schedule": "*/2 * * * *",
+  "agent": "marveen",
+  "enabled": true,
+  "type": "heartbeat",
+  "skipIfBusy": true,
+  "createdAt": 1787580000
+}

--- a/src/__tests__/ledger-live-drain-task-seed.test.ts
+++ b/src/__tests__/ledger-live-drain-task-seed.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+// docs/conversation-continuity.md promises that ledger-live-drain.py is "run
+// every ~2 min by the ledger-live-drain scheduled task" -- but no such task was
+// ever shipped: scheduled-tasks/ only seeded dream-engine, memoria-heartbeat
+// and reggeli-napindito, so the drain NEVER ran and the mid-session deafness
+// gap it exists to close stayed open. Same dead-feature class as the
+// skill-usage-capture registration gap: tested logic, zero production wiring.
+// These tests pin the promise to the seed.
+
+const ROOT = join(__dirname, '..', '..')
+const TASK_DIR = join(ROOT, 'scheduled-tasks', 'ledger-live-drain')
+
+describe('ledger-live-drain scheduled-task seed', () => {
+  it('the task the docs promise is actually shipped', () => {
+    expect(existsSync(join(TASK_DIR, 'task-config.json'))).toBe(true)
+    expect(existsSync(join(TASK_DIR, 'SKILL.md'))).toBe(true)
+  })
+
+  it('config parses, is enabled, and runs on the ~2-minute cadence the docs state', () => {
+    const cfg = JSON.parse(readFileSync(join(TASK_DIR, 'task-config.json'), 'utf-8'))
+    expect(cfg.enabled).toBe(true)
+    expect(cfg.schedule).toBe('*/2 * * * *')
+    // Seeded for the main agent; copyTaskConfigWithAgentRewrite() rewrites this
+    // to the install's MAIN_AGENT_ID, but only when the field is a string.
+    expect(typeof cfg.agent).toBe('string')
+  })
+
+  it('the prompt invokes the drain script via the placeholder the seeder resolves', () => {
+    const skill = readFileSync(join(TASK_DIR, 'SKILL.md'), 'utf-8')
+    expect(skill).toContain('{{PROJECT_ROOT}}/scripts/hooks/ledger-live-drain.py')
+  })
+
+  it('the drain script the task invokes exists', () => {
+    expect(existsSync(join(ROOT, 'scripts', 'hooks', 'ledger-live-drain.py'))).toBe(true)
+  })
+})


### PR DESCRIPTION
## Symptom

`docs/conversation-continuity.md` states that `ledger-live-drain.py` is "run every ~2 min by the `ledger-live-drain` scheduled task in the live session" — but no such task was ever shipped. `scheduled-tasks/` seeds only `dream-engine`, `memoria-heartbeat` and `reggeli-napindito`, and nothing else references the drain, so it **never ran**: the mid-session deafness gap it exists to close (a message captured by `ledger-capture.py` while the running session is deaf stays unanswered until the next respawn) stayed open, while the drain's own logic sat fully covered by the 34-case conversation-ledger suite.

Same dead-feature class as the skill-usage-capture registration gap (#1062): tested decision logic, zero production wiring.

## When it broke

Dead since the drain's introduction — the scheduled task the docs describe was never part of any commit.

## Reproduce (on develop)

```
ls scheduled-tasks/
# dream-engine  memoria-heartbeat  reggeli-napindito
# -- no drain task, while docs/conversation-continuity.md:41-42 promises one
```

## Fix

Seed `scheduled-tasks/ledger-live-drain/` (SKILL.md + task-config.json, `*/2 * * * *`, heartbeat, skipIfBusy). `ensureDefaultScheduledTasks()` copies it on startup with the placeholder substitution and agent-name rewrite it already applies to the other seeds, so existing installs pick it up with no manual step. The prompt keeps the drain's contract: stay silent when the script prints nothing; answer the surfaced `OPEN_QUESTION` block when it does. The SKILL.md follows the seeded tasks' existing language convention.

## Test

`src/__tests__/ledger-live-drain-task-seed.test.ts` pins the promise to the seed, case by case: the task is shipped, enabled, on the documented ~2-minute cadence, the prompt invokes the script via the `{{PROJECT_ROOT}}` placeholder the seeder resolves, and the script it invokes exists. The first case fails on current develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
