### PR TITLE
fix(auto-restart): an unanswered inbound question defers a due restart

### DIFF
--- a/src/__tests__/auto-restart.test.ts
+++ b/src/__tests__/auto-restart.test.ts
@@ -4,6 +4,7 @@ import {
   normalizeAutoRestartConfig,
   restartDue,
   dailyDueAtMs,
+  restartBlockedBy,
   DEFAULT_AUTO_RESTART,
 } from '../auto-restart.js'
 
@@ -74,5 +75,22 @@ describe('dailyDueAtMs', () => {
     const midnight = 1_700_000_000_000
     expect(dailyDueAtMs(midnight, 0)).toBe(midnight)
     expect(dailyDueAtMs(midnight, 180)).toBe(midnight + 180 * 60_000) // 03:00
+  })
+})
+
+describe('restartBlockedBy', () => {
+  // Regression guard: paneIsIdle used to be the ONLY pre-restart check, and an
+  // agent waiting on the owner's answer is idle precisely then -- so a due
+  // restart swallowed the pending exchange (for a channel agent even a
+  // "continue" restart is effectively fresh).
+  it('an unanswered inbound question defers even an idle pane', () => {
+    expect(restartBlockedBy({ paneIdle: true, openQuestion: true })).toBe('open-question')
+  })
+  it('a busy pane defers, and wins the ordering over an open question', () => {
+    expect(restartBlockedBy({ paneIdle: false, openQuestion: false })).toBe('busy-pane')
+    expect(restartBlockedBy({ paneIdle: false, openQuestion: true })).toBe('busy-pane')
+  })
+  it('idle pane and no open question proceeds', () => {
+    expect(restartBlockedBy({ paneIdle: true, openQuestion: false })).toBeNull()
   })
 })

--- a/src/auto-restart.ts
+++ b/src/auto-restart.ts
@@ -121,3 +121,21 @@ export function dailyDueAtMs(
 ): number {
   return localMidnightMs + minutesSinceMidnight * 60_000
 }
+
+/**
+ * Why a due restart must still be deferred, or null when it may proceed.
+ * Pure so the invariants are unit-testable:
+ *   - a busy pane defers (never cut off a live turn), and
+ *   - an unanswered inbound question defers -- an idle pane is NOT proof there
+ *     is nothing to lose, because an agent waiting on the owner's answer is
+ *     idle precisely then, and a restart swallows the pending exchange (for a
+ *     channel agent even a "continue" restart is effectively fresh).
+ * Busy-pane wins the ordering: it is the harder invariant (mid-turn cutoff).
+ */
+export function restartBlockedBy(
+  signals: { paneIdle: boolean; openQuestion: boolean },
+): 'busy-pane' | 'open-question' | null {
+  if (!signals.paneIdle) return 'busy-pane'
+  if (signals.openQuestion) return 'open-question'
+  return null
+}

--- a/src/web/auto-restart-runner.ts
+++ b/src/web/auto-restart-runner.ts
@@ -13,7 +13,8 @@ import { MAIN_CHANNELS_SESSION } from './main-agent.js'
 import { respawnMainSessionFresh } from './channel-monitor.js'
 import { paneLooksIdle } from '../pane-state.js'
 import { readAutoRestartConfig } from './auto-restart-store.js'
-import { restartDue, dailyDueAtMs, parseHHMM, mainRestartMechanism, type AutoRestartConfig } from '../auto-restart.js'
+import { restartDue, dailyDueAtMs, parseHHMM, mainRestartMechanism, restartBlockedBy, type AutoRestartConfig } from '../auto-restart.js'
+import { hasOpenInboundQuestion } from '../db.js'
 
 // Drives per-agent scheduled restarts (see src/auto-restart.ts for the why and
 // the pure due-logic). Mirrors the other watcher loops: a 60s sweep, started
@@ -132,8 +133,18 @@ async function checkAgent(name: string, nowMs: number): Promise<void> {
 
   const session = sessionFor(name)
   const host = name === MAIN_AGENT_ID ? null : readAgentRemoteHost(name)
-  if (!paneIsIdle(session, host)) {
-    logger.info({ name, session }, 'auto-restart: due but pane is busy, deferring to next tick')
+  // An agent waiting on the owner's answer is idle precisely then -- so the
+  // idle-guard alone lets a due restart swallow the pending exchange. The
+  // ledger's open-question signal covers that case; a ledger read failure
+  // counts as no-question (same fail-open as the context-restart gate) so a
+  // broken ledger cannot pin restarts forever.
+  const openQuestion = (() => {
+    try { return hasOpenInboundQuestion(name) }
+    catch { return false }
+  })()
+  const blocked = restartBlockedBy({ paneIdle: paneIsIdle(session, host), openQuestion })
+  if (blocked) {
+    logger.info({ name, session, blocked }, 'auto-restart: due but deferred to next tick')
     return
   }
 


### PR DESCRIPTION
## Symptom

The auto-restart runner's only pre-restart check is `paneIsIdle` — but an agent waiting on the owner's answer is idle precisely then. A due scheduled restart therefore swallows the pending exchange: the question-context is gone in the new session, and for a channel agent even a "continue" restart is effectively fresh (`agent-process.ts` never passes `--continue` when a channel is attached). The owner answers into a session that no longer knows what it asked. We have hit exactly this in production use.

## When it broke

Present since the runner's introduction — the idle-guard was always the only check.

## Reproduce (on develop)

An agent with an inbound row in `conversation_log` and no later outbound (i.e. `hasOpenInboundQuestion()` is true), pane idle, restart due → `checkAgent()` restarts, and the open question never gets its answer surfaced in the new session.

## Fix

The signal already exists: `db.ts` ships `hasOpenInboundQuestion()`, documented as "Used by the context-restart gate" — the context-restart-gate runner consumes it, the auto-restart runner never did. This PR:

- folds the two defer conditions into a pure `restartBlockedBy()` helper in `src/auto-restart.ts`, next to the other pure due-logic, and
- consults the ledger's open-question signal in the runner before restarting.

A ledger read failure counts as no-question — the same fail-open choice the context-restart gate makes — so a broken ledger cannot pin restarts forever. Busy-pane keeps priority in the ordering (mid-turn cutoff is the harder invariant).

## Test

The new `restartBlockedBy` cases name the invariants: an unanswered inbound question defers even an idle pane; a busy pane defers and wins the ordering; idle-and-answered proceeds. The 16 existing auto-restart cases pass unchanged; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
