### PR TITLE
test(hooks): exit-code invariant -- no silent fail-open, no deaf agent

### DIFF
--- a/src/__tests__/hook-exit-code-invariant.test.ts
+++ b/src/__tests__/hook-exit-code-invariant.test.ts
@@ -62,12 +62,7 @@ const HOOKS: HookCase[] = [
 // script -> payload kind -> why the violation is tolerated FOR NOW. The stale
 // check below fails the build once the underlying fix lands, so an entry
 // cannot outlive the bug it excuses.
-const EXPECTED_VIOLATIONS: Record<string, { kind: 'non-dict' | 'bad-stdin'; reason: string }> = {
-  'scripts/hooks/outgoing-copy-gate.py': {
-    kind: 'non-dict',
-    reason: 'crashes with exit 1 on a non-dict tool_input; the fail-closed net ships separately -- delete this entry when it lands',
-  },
-}
+const EXPECTED_VIOLATIONS: Record<string, { kind: 'non-dict' | 'bad-stdin'; reason: string }> = {}
 
 function runHook(h: HookCase, input: string): number {
   try {

--- a/src/__tests__/hook-exit-code-invariant.test.ts
+++ b/src/__tests__/hook-exit-code-invariant.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+// Exit-code invariant for every shipped hook, by event class.
+//
+// Claude Code reads hook exit codes with OPPOSITE failure semantics per event:
+//
+//   - PreToolUse / Stop gates: exit 2 blocks, exit 0 allows -- and exit 1 is a
+//     NON-BLOCKING error: the action proceeds while the gate looks like it ran.
+//     A gate that crashes on malformed input therefore fails OPEN silently
+//     (the outgoing-copy-gate did exactly this: a non-dict tool_input crashed
+//     it with exit 1 and the send ran unchecked).
+//   - UserPromptSubmit (and the replay hooks): ANY non-zero blocks the prompt.
+//     A hook that crashes non-zero on malformed input makes the agent DEAF --
+//     the 2026-07 stale-hook-path incident class.
+//
+// So the invariant is per class: gates must never exit 1; prompt-path hooks
+// must exit 0 on input they cannot understand. This suite feeds every
+// registered hook the two malformed shapes (unparseable stdin, non-dict
+// tool_input) and pins the codes, so a refactor that swaps a guard's failure
+// mode fails CI instead of shipping a silent fail-open or a deaf agent.
+
+const ROOT = join(__dirname, '..', '..')
+const SCRATCH = mkdtempSync(join(tmpdir(), 'hook-exit-inv-'))
+
+const BAD_STDIN = 'this is not json'
+const nonDict = (tool: string) => JSON.stringify({ tool_name: tool, tool_input: ['not-a-dict'] })
+
+interface HookCase {
+  script: string
+  runner: 'python3' | 'node'
+  /** 'gate' = PreToolUse/Stop (exit 1 forbidden); 'prompt' = block-on-nonzero events (must exit 0). */
+  cls: 'gate' | 'prompt'
+  /** tool_name used for the non-dict payload (gates key on it). */
+  tool?: string
+}
+
+const HOOKS: HookCase[] = [
+  // PreToolUse gates
+  { script: 'scripts/hooks/outgoing-copy-gate.py', runner: 'python3', cls: 'gate', tool: 'mcp__x__send_email' },
+  { script: 'scripts/hooks/egress-gate.mjs', runner: 'node', cls: 'gate', tool: 'WebFetch' },
+  { script: 'scripts/email-send-gate.mjs', runner: 'node', cls: 'gate', tool: 'mcp__x__send_email' },
+  { script: 'scripts/self-pace-gate.mjs', runner: 'node', cls: 'gate', tool: 'Bash' },
+  // Stop guard
+  { script: 'scripts/hooks/telegram-reply-guard.py', runner: 'python3', cls: 'gate', tool: 'Stop' },
+  // Prompt-path hooks (UserPromptSubmit / SessionStart / PostToolUse wiring)
+  { script: 'scripts/hooks/staleness-guard.py', runner: 'python3', cls: 'prompt', tool: 'Bash' },
+  { script: 'scripts/hooks/channel-inbox-drain.py', runner: 'python3', cls: 'prompt', tool: 'Bash' },
+  { script: 'scripts/hooks/inbox-drain.py', runner: 'python3', cls: 'prompt', tool: 'Bash' },
+  { script: 'scripts/hooks/telegram-reply-directive.py', runner: 'python3', cls: 'prompt', tool: 'Bash' },
+  { script: 'scripts/hooks/voice-reply-directive.py', runner: 'python3', cls: 'prompt', tool: 'Bash' },
+  { script: 'scripts/hooks/ledger-capture.py', runner: 'python3', cls: 'prompt', tool: 'Bash' },
+  { script: 'scripts/hooks/ledger-replay.py', runner: 'python3', cls: 'prompt', tool: 'Bash' },
+  { script: 'scripts/hooks/taskstate-replay.py', runner: 'python3', cls: 'prompt', tool: 'Bash' },
+  { script: 'scripts/hooks/ledger-outbound.py', runner: 'python3', cls: 'prompt', tool: 'Bash' },
+  { script: 'scripts/hooks/tool-log-capture.py', runner: 'python3', cls: 'prompt', tool: 'Bash' },
+]
+
+// script -> payload kind -> why the violation is tolerated FOR NOW. The stale
+// check below fails the build once the underlying fix lands, so an entry
+// cannot outlive the bug it excuses.
+const EXPECTED_VIOLATIONS: Record<string, { kind: 'non-dict' | 'bad-stdin'; reason: string }> = {
+  'scripts/hooks/outgoing-copy-gate.py': {
+    kind: 'non-dict',
+    reason: 'crashes with exit 1 on a non-dict tool_input; the fail-closed net ships separately -- delete this entry when it lands',
+  },
+}
+
+function runHook(h: HookCase, input: string): number {
+  try {
+    execFileSync(h.runner, [join(ROOT, h.script)], {
+      input,
+      timeout: 15_000,
+      stdio: ['pipe', 'ignore', 'ignore'],
+      // Isolate side-effectful hooks from the checkout's real store.
+      env: { ...process.env, LEDGER_DB_PATH: join(SCRATCH, 'ledger.db') },
+    })
+    return 0
+  } catch (err) {
+    const status = (err as { status?: number }).status
+    return typeof status === 'number' ? status : -1
+  }
+}
+
+function invariantHolds(cls: HookCase['cls'], code: number): boolean {
+  return cls === 'gate' ? code !== 1 : code === 0
+}
+
+describe('hook exit-code invariant (fail-open / deaf-agent guard)', () => {
+  for (const h of HOOKS) {
+    const cases: Array<{ kind: 'bad-stdin' | 'non-dict'; input: string }> = [
+      { kind: 'bad-stdin', input: BAD_STDIN },
+      { kind: 'non-dict', input: nonDict(h.tool ?? 'Bash') },
+    ]
+    for (const c of cases) {
+      const expected = EXPECTED_VIOLATIONS[h.script]
+      const isExcused = expected?.kind === c.kind
+      it(`${h.script} [${h.cls}] on ${c.kind}${isExcused ? ' (excused, fix in flight)' : ''}`, () => {
+        const code = runHook(h, c.input)
+        if (isExcused) {
+          // Stale-excuse check: the moment the fix lands this starts holding,
+          // and the entry must be deleted so the invariant becomes binding.
+          expect(invariantHolds(h.cls, code),
+            `expected violation no longer occurs -- delete the EXPECTED_VIOLATIONS entry for ${h.script}`,
+          ).toBe(false)
+          return
+        }
+        expect(invariantHolds(h.cls, code),
+          h.cls === 'gate'
+            ? `gate exited 1 (non-blocking error): the action would proceed UNCHECKED`
+            : `prompt-path hook exited ${code}: any non-zero here blocks the prompt (deaf agent)`,
+        ).toBe(true)
+      })
+    }
+  }
+
+  it('every expected violation refers to a hook in the matrix', () => {
+    const known = new Set(HOOKS.map((h) => h.script))
+    expect(Object.keys(EXPECTED_VIOLATIONS).filter((s) => !known.has(s))).toEqual([])
+  })
+})

--- a/src/__tests__/hook-registration-completeness.test.ts
+++ b/src/__tests__/hook-registration-completeness.test.ts
@@ -41,10 +41,6 @@ const REGISTRATION_SURFACES = [
 const EXEMPT: Record<string, string> = {
   'ledger_lib.py':
     'shared library imported by the ledger hooks; not itself a hook',
-  'ledger-live-drain.py':
-    'scheduled-task script by design (its docstring says so); the seeded task ships separately -- delete this entry when the scheduled-tasks/ledger-live-drain seed lands',
-  'skill-usage-capture.py':
-    'PostToolUse registration ships separately in the settings template -- delete this entry when it lands',
   'memory-save.sh':
     'legacy: referenced only by a historical rebuild prompt, wired nowhere; kept pending a maintainer decision to remove it',
   'telegram-ack.py':

--- a/src/__tests__/hook-registration-completeness.test.ts
+++ b/src/__tests__/hook-registration-completeness.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest'
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+
+// Registration-completeness lint for scripts/hooks/.
+//
+// The recurring defect class this pins: a hook ships fully unit-tested but is
+// registered NOWHERE, so it never fires in production while its suite stays
+// green -- the reply-guard before #1028 registered its decision logic but not
+// the Stop wiring, skill-usage-capture (#607) captured nothing for six weeks,
+// and the ledger-live-drain never ran while its docs promised a schedule.
+// Each was found by hand. This test finds the next one mechanically: every
+// shipped hook script must be referenced by at least one REGISTRATION surface,
+// or carry an explicit, reasoned exemption below.
+//
+// Two directions are enforced:
+//   - UNWIRED: a hook that is neither registered nor exempted fails the build,
+//     so a new hook cannot ship dead.
+//   - STALE EXEMPTION: an exempted hook that IS now registered fails the
+//     build, so the exemption list cannot rot into a blind spot -- when an
+//     in-flight wiring PR lands, its entry must be deleted here.
+
+const ROOT = join(__dirname, '..', '..')
+const HOOKS_DIR = join(ROOT, 'scripts', 'hooks')
+
+// Everywhere a hook can legitimately be wired into production:
+// the settings template every agent is seeded from, the repo checkout's own
+// project settings, the code-side registrations (agent-scaffold), the two
+// installer scripts, and the seeded scheduled tasks (a script may be driven by
+// a schedule instead of a hook event).
+const REGISTRATION_SURFACES = [
+  'templates/settings.json.template',
+  '.claude/settings.json',
+  'src/web/agent-scaffold.ts',
+  'scripts/install-telegram-progress-hook.sh',
+  'scripts/install-channel-image-hook.sh',
+]
+
+// name -> why it is allowed to be unregistered. Keep every reason concrete;
+// "misc" entries defeat the lint.
+const EXEMPT: Record<string, string> = {
+  'ledger_lib.py':
+    'shared library imported by the ledger hooks; not itself a hook',
+  'ledger-live-drain.py':
+    'scheduled-task script by design (its docstring says so); the seeded task ships separately -- delete this entry when the scheduled-tasks/ledger-live-drain seed lands',
+  'skill-usage-capture.py':
+    'PostToolUse registration ships separately in the settings template -- delete this entry when it lands',
+  'memory-save.sh':
+    'legacy: referenced only by a historical rebuild prompt, wired nowhere; kept pending a maintainer decision to remove it',
+  'telegram-ack.py':
+    'unreferenced anywhere in the repo; dead code kept pending a maintainer decision to remove it',
+}
+
+function registrationCorpus(): string {
+  let corpus = ''
+  for (const rel of REGISTRATION_SURFACES) {
+    const p = join(ROOT, rel)
+    if (existsSync(p)) corpus += readFileSync(p, 'utf-8')
+  }
+  const tasksDir = join(ROOT, 'scheduled-tasks')
+  if (existsSync(tasksDir)) {
+    for (const task of readdirSync(tasksDir)) {
+      const skill = join(tasksDir, task, 'SKILL.md')
+      if (existsSync(skill)) corpus += readFileSync(skill, 'utf-8')
+    }
+  }
+  return corpus
+}
+
+// A reference is a PATH ("/name") or a quoted token ("'name'" / "\"name\"") --
+// never a bare substring, so "channel-inbox-drain.py" cannot satisfy
+// "inbox-drain.py".
+function isRegistered(corpus: string, name: string): boolean {
+  return corpus.includes(`/${name}`) || corpus.includes(`'${name}'`) || corpus.includes(`"${name}"`)
+}
+
+function hookScripts(): string[] {
+  return readdirSync(HOOKS_DIR)
+    .filter((f) => f.endsWith('.py') || f.endsWith('.mjs') || f.endsWith('.sh'))
+    .sort()
+}
+
+describe('hook registration completeness (scripts/hooks/)', () => {
+  const corpus = registrationCorpus()
+
+  it('every shipped hook is registered on some production surface, or reasoned-exempt', () => {
+    const unwired = hookScripts().filter(
+      (name) => !(name in EXEMPT) && !isRegistered(corpus, name),
+    )
+    expect(unwired, `unregistered hooks with no exemption: ${unwired.join(', ')} -- wire them or add a reasoned EXEMPT entry`).toEqual([])
+  })
+
+  it('no exemption has gone stale (an exempted hook that is now registered must drop its entry)', () => {
+    const stale = Object.keys(EXEMPT).filter((name) => isRegistered(corpus, name))
+    expect(stale, `stale exemptions (now registered): ${stale.join(', ')} -- delete their EXEMPT entries`).toEqual([])
+  })
+
+  it('every exemption points at a file that still exists (no ghost entries)', () => {
+    const ghosts = Object.keys(EXEMPT).filter((name) => !existsSync(join(HOOKS_DIR, name)))
+    expect(ghosts).toEqual([])
+  })
+
+  it('the boundary rule rejects substring matches (the channel-inbox-drain trap)', () => {
+    expect(isRegistered('scripts/hooks/channel-inbox-drain.py', 'inbox-drain.py')).toBe(false)
+    expect(isRegistered('scripts/hooks/inbox-drain.py', 'inbox-drain.py')).toBe(true)
+    expect(isRegistered("join(PROJECT_ROOT, 'scripts', 'hooks', 'egress-gate.mjs')", 'egress-gate.mjs')).toBe(true)
+  })
+})

--- a/src/__tests__/json-dup-keys.test.ts
+++ b/src/__tests__/json-dup-keys.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { findDuplicateJsonKeys } from '../web/json-dup-keys.js'
+
+// Duplicate-key lint. JSON.parse keeps only the LAST occurrence of a
+// duplicated key, so a settings.json with two hook-event keys of the same
+// name silently drops every hook in the earlier block: no parse error, no
+// warning, the guards just stop running. Measured cost of this class on a
+// customized install: two guards dead for eight days behind a green-looking
+// config. The evidence exists only in the raw text, so both the detector and
+// this repo lint operate before parsing.
+
+describe('findDuplicateJsonKeys (detector)', () => {
+  it('finds the incident shape: two hook-event keys in the same hooks object', () => {
+    const raw = `{
+      "hooks": {
+        "PreToolUse": [ { "hooks": [ { "command": "guard-a" } ] } ],
+        "Stop":       [ { "hooks": [ { "command": "guard-b" } ] } ],
+        "PreToolUse": [ { "hooks": [ { "command": "guard-c" } ] } ]
+      }
+    }`
+    expect(findDuplicateJsonKeys(raw)).toEqual(['hooks.PreToolUse'])
+    // ...and this is exactly what JSON.parse hides: guard-a is gone.
+    const parsed = JSON.parse(raw) as { hooks: { PreToolUse: unknown[] } }
+    expect(JSON.stringify(parsed.hooks.PreToolUse)).not.toContain('guard-a')
+  })
+
+  it('does not flag the same key name in DIFFERENT objects', () => {
+    const raw = `{"a": {"command": "x"}, "b": {"command": "y"}}`
+    expect(findDuplicateJsonKeys(raw)).toEqual([])
+  })
+
+  it('does not flag repeated keys across sibling array elements', () => {
+    const raw = `{"hooks": [{"type": "command"}, {"type": "command"}]}`
+    expect(findDuplicateJsonKeys(raw)).toEqual([])
+  })
+
+  it('reports array-indexed paths for duplicates inside array elements', () => {
+    const raw = `{"entries": [{"k": 1}, {"k": 1, "k": 2}]}`
+    expect(findDuplicateJsonKeys(raw)).toEqual(['entries[1].k'])
+  })
+
+  it('is not fooled by key-lookalike strings in VALUES or escaped quotes', () => {
+    const raw = `{"cmd": "echo \\"PreToolUse\\": 1", "note": "PreToolUse", "cmd2": "x"}`
+    expect(findDuplicateJsonKeys(raw)).toEqual([])
+  })
+
+  it('handles top-level duplicates and nested duplicates together', () => {
+    const raw = `{"env": {}, "env": {}, "hooks": {"Stop": [], "Stop": []}}`
+    expect(findDuplicateJsonKeys(raw)).toEqual(['env', 'hooks.Stop'])
+  })
+})
+
+describe('shipped JSON settings artifacts carry no duplicate keys', () => {
+  const ROOT = join(__dirname, '..', '..')
+  const ARTIFACTS = [
+    '.claude/settings.json',
+    'templates/settings.json.template',
+  ]
+  for (const rel of ARTIFACTS) {
+    it(rel, () => {
+      const p = join(ROOT, rel)
+      if (!existsSync(p)) return
+      expect(findDuplicateJsonKeys(readFileSync(p, 'utf-8'))).toEqual([])
+    })
+  }
+})

--- a/src/web/agent-scaffold.ts
+++ b/src/web/agent-scaffold.ts
@@ -5,6 +5,8 @@ import { PROJECT_ROOT, OWNER_NAME, MAIN_AGENT_ID, BOT_NAME, CHANNEL_PROVIDER, WE
 import { channelStateDir } from '../channel-provider.js'
 import { runAgent } from '../agent.js'
 import { atomicWriteFileSync } from './atomic-write.js'
+import { findDuplicateJsonKeys } from './json-dup-keys.js'
+import { logger } from '../logger.js'
 import { agentDir, agentConfigRoot, listAgentNames, readAgentCapabilities } from './agent-config.js'
 import { resolveProfilePlaceholders, type ProfileTemplate } from './profiles.js'
 import { sanitizeCapabilityTag, CAPABILITY_TAG_MAX_PER_AGENT } from '../prompt-safety.js'
@@ -216,7 +218,21 @@ export function ensureAgentHooks(name: string): boolean {
   if (!tpl.hooks) return false
   let existing: Record<string, unknown> = {}
   if (existsSync(settingsPath)) {
-    try { existing = JSON.parse(readFileSync(settingsPath, 'utf-8')) } catch { /* overwrite */ }
+    try {
+      const rawExisting = readFileSync(settingsPath, 'utf-8')
+      // JSON.parse keeps only the LAST occurrence of a duplicated key, so a
+      // settings file with two "PreToolUse" (or any hook-event) keys silently
+      // drops every hook in the earlier block -- guards die with no error and
+      // no symptom until the action they gated goes through unchecked. The
+      // evidence only exists in the raw text, so check it BEFORE parsing and
+      // say which paths are affected.
+      const dupKeys = findDuplicateJsonKeys(rawExisting)
+      if (dupKeys.length > 0) {
+        logger.warn({ agent: name, settingsPath, dupKeys },
+          'ensureAgentHooks: duplicate JSON keys in settings -- JSON.parse keeps only the last occurrence, hooks in the earlier block are silently dead')
+      }
+      existing = JSON.parse(rawExisting)
+    } catch { /* overwrite */ }
   }
   const tplHooks = tpl.hooks as Record<string, unknown>
   if (existing.hooks) {

--- a/src/web/json-dup-keys.ts
+++ b/src/web/json-dup-keys.ts
@@ -1,0 +1,99 @@
+// Duplicate-key detector for raw JSON text.
+//
+// Why this exists: JSON.parse silently keeps only the LAST occurrence of a
+// duplicated key. In a settings.json a duplicated hook-event key ("hooks"
+// containing two "PreToolUse" arrays) therefore KILLS every hook in the
+// earlier block -- no parse error, no warning, the guards just stop running.
+// A parsed object cannot reveal this (the evidence is gone by then), so the
+// check has to run on the raw text.
+//
+// The scanner is deliberately small: it tracks object/array nesting, string
+// escapes, and key-vs-value position, and reports each duplicated key with
+// its dotted path (arrays as [i]). It assumes syntactically valid JSON --
+// callers parse the same text anyway, so malformed input surfaces there.
+
+interface ObjFrame { type: 'obj'; keys: Set<string>; path: string; expectKey: boolean }
+interface ArrFrame { type: 'arr'; index: number; path: string }
+type Frame = ObjFrame | ArrFrame
+
+function childPath(stack: Frame[], key?: string): string {
+  const top = stack[stack.length - 1]
+  if (!top) return key ?? ''
+  if (top.type === 'arr') return `${top.path}[${top.index}]`
+  return top.path ? `${top.path}.${key ?? ''}` : (key ?? '')
+}
+
+/**
+ * Dotted paths of every key that appears more than once within the SAME
+ * object, in source order (e.g. `hooks.PreToolUse`). Empty array = clean.
+ */
+export function findDuplicateJsonKeys(raw: string): string[] {
+  const dups: string[] = []
+  const stack: Frame[] = []
+  let pendingKey: string | undefined
+  let i = 0
+  const n = raw.length
+
+  const readString = (): string => {
+    // raw[i] is the opening quote
+    let s = ''
+    i++
+    while (i < n) {
+      const ch = raw[i]
+      if (ch === '\\') { s += raw[i + 1] ?? ''; i += 2; continue }
+      if (ch === '"') { i++; return s }
+      s += ch
+      i++
+    }
+    return s
+  }
+
+  while (i < n) {
+    const ch = raw[i]
+    const top = stack[stack.length - 1]
+    if (ch === '"') {
+      if (top?.type === 'obj' && top.expectKey) {
+        const key = readString()
+        if (top.keys.has(key)) dups.push(top.path ? `${top.path}.${key}` : key)
+        top.keys.add(key)
+        top.expectKey = false
+        pendingKey = key
+      } else {
+        readString() // a string VALUE; discard
+        pendingKey = undefined
+      }
+      continue
+    }
+    if (ch === '{') {
+      const path = childPath(stack, pendingKey)
+      stack.push({ type: 'obj', keys: new Set(), path, expectKey: true })
+      pendingKey = undefined
+      i++
+      continue
+    }
+    if (ch === '[') {
+      const path = childPath(stack, pendingKey)
+      stack.push({ type: 'arr', index: 0, path })
+      pendingKey = undefined
+      i++
+      continue
+    }
+    if (ch === '}' || ch === ']') {
+      stack.pop()
+      i++
+      continue
+    }
+    if (ch === ',') {
+      if (top?.type === 'obj') top.expectKey = true
+      if (top?.type === 'arr') top.index++
+      i++
+      continue
+    }
+    if (ch === ':') {
+      i++
+      continue
+    }
+    i++ // whitespace, literals, numbers
+  }
+  return dups
+}


### PR DESCRIPTION
## What this pins

Claude Code reads hook exit codes with **opposite failure semantics per event**:

- **PreToolUse / Stop gates**: exit 2 blocks, exit 0 allows — and exit 1 is a *non-blocking error*: the action proceeds while the gate looks like it ran. A gate that crashes on malformed input therefore fails **open** silently (the outgoing-copy-gate did exactly this: a non-dict `tool_input` crashed it with exit 1 and the send ran unchecked — see the companion fix PR).
- **UserPromptSubmit and the replay hooks**: *any* non-zero blocks the prompt. The same crash here makes the agent **deaf** — the 2026-07 stale-hook-path incident class.

Nothing pinned either behaviour: each hook's failure mode was true by construction at best. The stakes are lived, not theoretical: on a customized install a config slip once left two guards silently dead for eight days behind green tests — a wrong failure mode has exactly that shape.

## How

The suite feeds every registered hook the two malformed shapes (unparseable stdin, non-dict `tool_input`) and pins the codes per class: gates must never exit 1; prompt-path hooks must exit 0 on input they cannot understand. 15 hooks × 2 shapes, each case named. Side-effectful hooks run against an isolated `LEDGER_DB_PATH`.

The one current violator (outgoing-copy-gate on non-dict input, #1063) is recorded as an EXPECTED violation; a stale-excuse check fails the build the moment that fix lands, so the excuse cannot outlive the bug — the same self-expiring pattern as the registration-completeness lint (#1069). The two PRs merge cleanly in either order.

Part 3 of the meta-lint trio (#1069 registration-completeness, #1070 duplicate-key lint). Together they close the "green tests, dead production behaviour" class from three directions: a hook must be wired, its wiring must survive config merges, and its failure mode must match its event's semantics.

No production code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)