### PR TITLE
fix(egress): quarantine-reader grants land without a session restart (EGRESSRENDER824)

### DIFF
--- a/scripts/hooks/egress-gate.mjs
+++ b/scripts/hooks/egress-gate.mjs
@@ -19,7 +19,15 @@
 //   - The tool call is HARD-BLOCKED (decision: deny).
 //   - The blocked call is appended to EGRESS_BLOCK_LOG for operator review.
 //   - The operator can approve the URL/domain: add it to store/egress-allowlist.json,
-//     then re-run the WebFetch. No restart required.
+//     then re-run the WebFetch. No restart required for THIS hook (it re-reads
+//     the JSON on every invocation).
+//   - GRANT LATENCY for the quarantine-reader (EGRESSRENDER824): the reader's
+//     own prompt-level list is a RENDERED copy of this JSON, refreshed by a
+//     file-watcher within ~5s of a JSON change and read at the reader's next
+//     SPAWN. A denial from the reader's prompt copy produces NO line in the
+//     block log below (it rejects without a network call) -- if a freshly
+//     granted domain is still refused, wait a few seconds and spawn a new
+//     reader; a session restart is NOT needed.
 //
 // The log is separate from the main Marveen log so operators can grep it
 // independently: `tail -f store/egress-blocked.log`

--- a/src/__tests__/quarantine-reader-render-path.test.ts
+++ b/src/__tests__/quarantine-reader-render-path.test.ts
@@ -16,10 +16,39 @@
 // These tests pin the target path and the watcher's re-render decision.
 
 import { describe, it, expect } from 'vitest'
+import { mkdtempSync, writeFileSync, existsSync, readFileSync, mkdirSync } from 'node:fs'
+import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { homedir } from 'node:os'
-import { quarantineReaderDestDir } from '../web/agent-scaffold.js'
+import {
+  quarantineReaderDestDir,
+  ensureQuarantineReader,
+  watchEgressAllowlistForReaderRender,
+} from '../web/agent-scaffold.js'
 import { PROJECT_ROOT, MAIN_AGENT_ID } from '../config.js'
+
+const TEMPLATE = `---
+name: quarantine-reader
+---
+
+## Domain restriction
+
+Only fetch URLs from these approved domains. Reject all others:
+- \`status.anthropic.com\`
+
+For any other domain, return the error shape.
+`
+
+function tmpSetup() {
+  const root = mkdtempSync(join(tmpdir(), 'qr-render-'))
+  const tplPath = join(root, 'quarantine-reader.md')
+  writeFileSync(tplPath, TEMPLATE)
+  const destDir = join(root, 'dest', '.claude', 'agents')
+  const legacyPath = join(root, 'legacy', 'quarantine-reader.md')
+  const storeDir = join(root, 'store')
+  mkdirSync(storeDir, { recursive: true })
+  return { root, tplPath, destDir, legacyPath, storeDir }
+}
 
 describe('quarantineReaderDestDir (EGRESSRENDER824 target path)', () => {
   it('the MAIN agent copy goes to PROJECT scope, never the user scope', () => {
@@ -35,5 +64,110 @@ describe('quarantineReaderDestDir (EGRESSRENDER824 target path)', () => {
     const dest = quarantineReaderDestDir('samu')
     expect(dest).toContain(join('agents', 'samu', '.claude', 'agents'))
     expect(dest.startsWith(join(homedir(), '.claude', 'agents'))).toBe(false)
+  })
+})
+
+describe('ensureQuarantineReader legacy cleanup (order: write first, remove after)', () => {
+  it('removes the legacy user-scope copy only once the project copy is on disk', () => {
+    const { tplPath, destDir, legacyPath, storeDir } = tmpSetup()
+    mkdirSync(join(legacyPath, '..'), { recursive: true })
+    writeFileSync(legacyPath, 'stale user-scope copy')
+
+    const wrote = ensureQuarantineReader(MAIN_AGENT_ID, { tplPath, destDir, legacyPath, storeDir })
+
+    expect(wrote).toBe(true)
+    // The project copy exists AND the legacy copy is gone -- never neither.
+    expect(existsSync(join(destDir, 'quarantine-reader.md'))).toBe(true)
+    expect(existsSync(legacyPath)).toBe(false)
+  })
+
+  it('an up-to-date project copy still clears a lingering legacy file (returns false)', () => {
+    const { tplPath, destDir, legacyPath, storeDir } = tmpSetup()
+    // First render establishes the current project copy.
+    expect(ensureQuarantineReader(MAIN_AGENT_ID, { tplPath, destDir, legacyPath, storeDir })).toBe(true)
+    // A legacy file reappears (e.g. an old install script re-created it).
+    mkdirSync(join(legacyPath, '..'), { recursive: true })
+    writeFileSync(legacyPath, 'resurrected stale copy')
+
+    const wrote = ensureQuarantineReader(MAIN_AGENT_ID, { tplPath, destDir, legacyPath, storeDir })
+
+    expect(wrote).toBe(false) // content unchanged -> no rewrite ...
+    expect(existsSync(legacyPath)).toBe(false) // ... but the legacy is still cleared
+  })
+
+  it('a sub-agent run never touches the legacy path', () => {
+    const { tplPath, destDir, legacyPath, storeDir } = tmpSetup()
+    mkdirSync(join(legacyPath, '..'), { recursive: true })
+    writeFileSync(legacyPath, 'not mine to delete')
+    ensureQuarantineReader('samu', { tplPath, destDir, legacyPath, storeDir })
+    expect(existsSync(legacyPath)).toBe(true)
+  })
+})
+
+describe('watchEgressAllowlistForReaderRender (the re-render decision)', () => {
+  it('a JSON change re-renders MAIN + every listed agent and reports which were written', async () => {
+    const { storeDir } = tmpSetup()
+    const allowlistPath = join(storeDir, 'egress-allowlist.json')
+    writeFileSync(allowlistPath, JSON.stringify({ quarantine_domains: [] }))
+
+    const ensured: string[] = []
+    const reported: string[][] = []
+    const stop = watchEgressAllowlistForReaderRender(
+      () => ['samu', 'geri'],
+      (agents) => reported.push(agents),
+      {
+        storeDir,
+        intervalMs: 20,
+        ensure: (name) => {
+          ensured.push(name)
+          // 'geri' simulates an already-up-to-date copy: rendered=false, so it
+          // must be ensured but NOT reported as written.
+          return name !== 'geri'
+        },
+      },
+    )
+    try {
+      // Let the poller take its baseline, then change the file.
+      await new Promise((r) => setTimeout(r, 60))
+      writeFileSync(allowlistPath, JSON.stringify({ quarantine_domains: ['supabase.com'] }))
+      await new Promise((r) => setTimeout(r, 250))
+    } finally {
+      stop()
+    }
+
+    expect(ensured).toContain(MAIN_AGENT_ID)
+    expect(ensured).toContain('samu')
+    expect(ensured).toContain('geri')
+    expect(reported.length).toBeGreaterThan(0)
+    expect(reported[0]).toEqual([MAIN_AGENT_ID, 'samu'])
+  })
+
+  it('one agent throwing does not stop the rest (per-agent best effort)', async () => {
+    const { storeDir } = tmpSetup()
+    const allowlistPath = join(storeDir, 'egress-allowlist.json')
+    writeFileSync(allowlistPath, JSON.stringify({ quarantine_domains: [] }))
+
+    const ensured: string[] = []
+    const stop = watchEgressAllowlistForReaderRender(
+      () => ['bad', 'good'],
+      undefined,
+      {
+        storeDir,
+        intervalMs: 20,
+        ensure: (name) => {
+          if (name === 'bad') throw new Error('one bad agent dir')
+          ensured.push(name)
+          return true
+        },
+      },
+    )
+    try {
+      await new Promise((r) => setTimeout(r, 60))
+      writeFileSync(allowlistPath, JSON.stringify({ quarantine_domains: ['example.org'] }))
+      await new Promise((r) => setTimeout(r, 250))
+    } finally {
+      stop()
+    }
+    expect(ensured).toContain('good')
   })
 })

--- a/src/__tests__/quarantine-reader-render-path.test.ts
+++ b/src/__tests__/quarantine-reader-render-path.test.ts
@@ -1,0 +1,39 @@
+// EGRESSRENDER824: an operator grant typed into store/egress-allowlist.json
+// silently never reached the quarantine-reader, and the denial looked exactly
+// like a legitimate block (prompt-level rejection, no network call, nothing in
+// egress-blocked.log). Two independent causes, both measured 2026-08-24 with
+// positive AND negative controls:
+//
+//   1. TARGET PATH: the main agent's rendered copy went to the USER scope
+//      (~/.claude/agents), which the runtime caches at session start. A
+//      PROJECT-scoped copy is read from disk at each sub-agent spawn -- the
+//      fleet agents were already project-scoped, which is why their grants
+//      landed without restart while the main agent's did not.
+//   2. RENDER TRIGGER: the copies were rendered only at scaffold time, so a
+//      JSON edit between boots reached the HOOK (live read) but not the
+//      PROMPT copies.
+//
+// These tests pin the target path and the watcher's re-render decision.
+
+import { describe, it, expect } from 'vitest'
+import { join } from 'node:path'
+import { homedir } from 'node:os'
+import { quarantineReaderDestDir } from '../web/agent-scaffold.js'
+import { PROJECT_ROOT, MAIN_AGENT_ID } from '../config.js'
+
+describe('quarantineReaderDestDir (EGRESSRENDER824 target path)', () => {
+  it('the MAIN agent copy goes to PROJECT scope, never the user scope', () => {
+    const dest = quarantineReaderDestDir(MAIN_AGENT_ID)
+    expect(dest).toBe(join(PROJECT_ROOT, '.claude', 'agents'))
+    // The load-bearing negative: the old location must be gone for good. A
+    // user-scoped definition is cached at session start, so a grant written
+    // there waits for a full session restart -- the measured failure.
+    expect(dest.startsWith(join(homedir(), '.claude'))).toBe(false)
+  })
+
+  it('sub-agent copies stay project-scoped under their own agent dir', () => {
+    const dest = quarantineReaderDestDir('samu')
+    expect(dest).toContain(join('agents', 'samu', '.claude', 'agents'))
+    expect(dest.startsWith(join(homedir(), '.claude', 'agents'))).toBe(false)
+  })
+})

--- a/src/web.ts
+++ b/src/web.ts
@@ -519,6 +519,10 @@ export function startWebServer(port = 3420): http.Server {
       // EGRESSRENDER824: a grant added to store/egress-allowlist.json must
       // reach the reader PROMPT copies without waiting for the next boot --
       // the egress-gate hook reads the JSON live, the prompt copies do not.
+      // DELIBERATELY inside the hookDecision.register branch: a worktree /
+      // sandbox instance must not start re-rendering the shared agent
+      // definitions any more than it may register hooks -- the same isolation
+      // rule that guards the settings writes above guards this watcher.
       watchEgressAllowlistForReaderRender(listAgentNames, (agents) =>
         logger.info({ agents }, 'quarantine-reader definitions re-rendered after egress-allowlist.json change'))
       if (pruned.length) logger.info({ pruned }, 'Stale hook entries pruned from agent settings.json')

--- a/src/web.ts
+++ b/src/web.ts
@@ -13,7 +13,7 @@ import { isBlockedCrossOriginWrite, originMatchesServedHost } from './web/csrf-o
 import { json } from './web/http-helpers.js'
 import { detectLanIp } from './web/network-info.js'
 import { AGENTS_BASE_DIR, listAgentNames } from './web/agent-config.js'
-import { ensureAgentHooks, ensureAgentStalenessHook, ensureEgressGate, ensureGovernanceGateCommands, ensureQuarantineReader, ensureDefaultScheduledTasks, agentSettingsPath, ensureAutonomySection, ensureSkillsPathTrapSection } from './web/agent-scaffold.js'
+import { ensureAgentHooks, ensureAgentStalenessHook, ensureEgressGate, ensureGovernanceGateCommands, ensureQuarantineReader, watchEgressAllowlistForReaderRender, ensureDefaultScheduledTasks, agentSettingsPath, ensureAutonomySection, ensureSkillsPathTrapSection } from './web/agent-scaffold.js'
 import { shouldRegisterHooks, pruneStaleHooksFromSettingsFile } from './web/hook-registration-guard.js'
 import { refreshMarveenBotUsername } from './web/telegram.js'
 import { startMessageRouter } from './web/message-router.js'
@@ -516,6 +516,11 @@ export function startWebServer(port = 3420): http.Server {
         if (ensureGovernanceGateCommands(agentName)) govPatched.push(agentName)
         ensureQuarantineReader(agentName)
       }
+      // EGRESSRENDER824: a grant added to store/egress-allowlist.json must
+      // reach the reader PROMPT copies without waiting for the next boot --
+      // the egress-gate hook reads the JSON live, the prompt copies do not.
+      watchEgressAllowlistForReaderRender(listAgentNames, (agents) =>
+        logger.info({ agents }, 'quarantine-reader definitions re-rendered after egress-allowlist.json change'))
       if (pruned.length) logger.info({ pruned }, 'Stale hook entries pruned from agent settings.json')
       if (patched.length) logger.info({ patched }, 'PreCompact hook backfilled into agent settings.json')
       if (stalePatched.length) logger.info({ patched: stalePatched }, 'staleness-guard UserPromptSubmit hook backfilled into agent settings.json')

--- a/src/web/agent-scaffold.ts
+++ b/src/web/agent-scaffold.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync, existsSync, mkdirSync, copyFileSync, readdirSync, statSync, rmSync, watchFile } from 'node:fs'
+import { readFileSync, writeFileSync, existsSync, mkdirSync, copyFileSync, readdirSync, statSync, rmSync, watchFile, unwatchFile } from 'node:fs'
 import { join } from 'node:path'
 import { homedir } from 'node:os'
 import { PROJECT_ROOT, OWNER_NAME, MAIN_AGENT_ID, BOT_NAME, CHANNEL_PROVIDER, WEB_PORT, OWNER_DRIVE_FOLDER, APP_TZ, DASHBOARD_PUBLIC_URL, STORE_DIR } from '../config.js'
@@ -738,33 +738,42 @@ export function quarantineReaderDestDir(name: string): string {
   return join(agentDir(name), '.claude', 'agents')
 }
 
-export function ensureQuarantineReader(name: string): boolean {
-  const tplPath = join(PROJECT_ROOT, 'templates', 'sub-agents', 'quarantine-reader.md')
+// The optional `paths` override exists for tests only: it lets the whole
+// render-write-cleanup sequence run inside a tmp directory, so the legacy
+// removal ORDER is assertable without touching the real homedir.
+export function ensureQuarantineReader(
+  name: string,
+  paths?: { tplPath?: string; destDir?: string; legacyPath?: string; storeDir?: string },
+): boolean {
+  const tplPath = paths?.tplPath ?? join(PROJECT_ROOT, 'templates', 'sub-agents', 'quarantine-reader.md')
   if (!existsSync(tplPath)) return false
-  const destDir = quarantineReaderDestDir(name)
+  const destDir = paths?.destDir ?? quarantineReaderDestDir(name)
   mkdirSync(destDir, { recursive: true })
   const destPath = join(destDir, 'quarantine-reader.md')
   let rendered: string
   try {
-    rendered = renderQuarantineReader(readFileSync(tplPath, 'utf-8'), quarantineReaderDomains())
+    rendered = renderQuarantineReader(readFileSync(tplPath, 'utf-8'), quarantineReaderDomains(paths?.storeDir))
   } catch {
     return false
   }
-  // Legacy cleanup: the main agent's copy used to live in the USER scope,
-  // where the session-start cache made it permanently stale. Remove it once
-  // the project-scoped copy is in place -- a leftover user-scope file would
-  // keep shadowing nothing (project scope wins) but would mislead the next
-  // person debugging the gate.
-  if (name === MAIN_AGENT_ID) {
-    try { rmSync(join(homedir(), '.claude', 'agents', 'quarantine-reader.md'), { force: true }) } catch { /* best effort */ }
-  }
+  let upToDate = false
   if (existsSync(destPath)) {
     try {
-      if (readFileSync(destPath, 'utf-8') === rendered) return false
-    } catch { /* fall through to re-write */ }
+      upToDate = readFileSync(destPath, 'utf-8') === rendered
+    } catch { /* unreadable -> treat as stale, re-write below */ }
   }
-  writeFileSync(destPath, rendered)
-  return true
+  if (!upToDate) writeFileSync(destPath, rendered)
+  // Legacy cleanup, deliberately AFTER the project-scoped copy is guaranteed
+  // on disk (either it was already current, or the line above just wrote it):
+  // there must be no window in which NEITHER copy exists. The user-scope copy
+  // is the pre-EGRESSRENDER824 location, cached at session start and therefore
+  // permanently stale -- a leftover would shadow nothing (project scope wins)
+  // but would mislead the next person debugging the gate.
+  if (name === MAIN_AGENT_ID) {
+    const legacyPath = paths?.legacyPath ?? join(homedir(), '.claude', 'agents', 'quarantine-reader.md')
+    try { rmSync(legacyPath, { force: true }) } catch { /* best effort */ }
+  }
+  return !upToDate
 }
 
 // EGRESSRENDER824 (b): a grant typed into store/egress-allowlist.json used to
@@ -775,20 +784,28 @@ export function ensureQuarantineReader(name: string): boolean {
 // closes the gap: any change to the JSON re-renders every deployed reader
 // copy. fs.watchFile (mtime polling) rather than fs.watch: it survives the
 // file being replaced (editors/atomic writes) and needs no debounce.
+// `opts` exists for tests: a tmp storeDir + a short poll interval + an
+// injected ensure() make the re-render decision assertable in milliseconds
+// without touching real agent directories. Production callers pass none of it.
+// Returns a stop function (unwatchFile) so a test can end the poll.
 export function watchEgressAllowlistForReaderRender(
   listAgents: () => string[],
   onRendered?: (agents: string[]) => void,
-): void {
-  const allowlistPath = join(STORE_DIR, 'egress-allowlist.json')
-  watchFile(allowlistPath, { interval: 5000 }, () => {
+  opts?: { storeDir?: string; intervalMs?: number; ensure?: (name: string) => boolean },
+): () => void {
+  const allowlistPath = join(opts?.storeDir ?? STORE_DIR, 'egress-allowlist.json')
+  const ensure = opts?.ensure ?? ((name: string) => ensureQuarantineReader(name))
+  const listener = () => {
     const rendered: string[] = []
     for (const name of [MAIN_AGENT_ID, ...listAgents()]) {
       try {
-        if (ensureQuarantineReader(name)) rendered.push(name)
+        if (ensure(name)) rendered.push(name)
       } catch { /* per-agent best effort: one bad dir must not stop the rest */ }
     }
     if (rendered.length) onRendered?.(rendered)
-  })
+  }
+  watchFile(allowlistPath, { interval: opts?.intervalMs ?? 5000 }, listener)
+  return () => unwatchFile(allowlistPath, listener)
 }
 
 // Copy the repo's `scheduled-tasks/<task>/task-config.json` to the

--- a/src/web/agent-scaffold.ts
+++ b/src/web/agent-scaffold.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync, existsSync, mkdirSync, copyFileSync, readdirSync, statSync } from 'node:fs'
+import { readFileSync, writeFileSync, existsSync, mkdirSync, copyFileSync, readdirSync, statSync, rmSync, watchFile } from 'node:fs'
 import { join } from 'node:path'
 import { homedir } from 'node:os'
 import { PROJECT_ROOT, OWNER_NAME, MAIN_AGENT_ID, BOT_NAME, CHANNEL_PROVIDER, WEB_PORT, OWNER_DRIVE_FOLDER, APP_TZ, DASHBOARD_PUBLIC_URL, STORE_DIR } from '../config.js'
@@ -721,15 +721,27 @@ export function ensureGovernanceGateCommands(name: string): boolean {
 // disappeared on 2026-07-30. Now the owner's domains are an INPUT to the
 // render, so a re-render preserves the decision instead of erasing it.
 // Returns true if the file was written, false if already up-to-date.
+// Where an agent's deployed quarantine-reader definition lives. PROJECT scope
+// for EVERY agent, the main agent included -- and that word is load-bearing
+// (EGRESSRENDER824, measured 2026-08-24 with positive AND negative controls):
+// the Claude Code runtime reads a PROJECT-scoped agent definition from disk at
+// each sub-agent SPAWN, but caches a USER-scoped (~/.claude/agents) one at
+// session start. The main agent's copy used to go to the user scope, so an
+// operator-approved domain only reached its reader after a full session
+// restart -- and the denial came from the stale prompt copy, without any
+// network call, so nothing ever landed in store/egress-blocked.log. Writing
+// the main agent's copy into PROJECT_ROOT/.claude/agents makes a grant
+// effective at the NEXT reader spawn, no restart. Pure + exported so the
+// target-path guarantee is unit-testable.
+export function quarantineReaderDestDir(name: string): string {
+  if (name === MAIN_AGENT_ID) return join(PROJECT_ROOT, '.claude', 'agents')
+  return join(agentDir(name), '.claude', 'agents')
+}
+
 export function ensureQuarantineReader(name: string): boolean {
   const tplPath = join(PROJECT_ROOT, 'templates', 'sub-agents', 'quarantine-reader.md')
   if (!existsSync(tplPath)) return false
-  let destDir: string
-  if (name === MAIN_AGENT_ID) {
-    destDir = join(homedir(), '.claude', 'agents')
-  } else {
-    destDir = join(agentDir(name), '.claude', 'agents')
-  }
+  const destDir = quarantineReaderDestDir(name)
   mkdirSync(destDir, { recursive: true })
   const destPath = join(destDir, 'quarantine-reader.md')
   let rendered: string
@@ -738,6 +750,14 @@ export function ensureQuarantineReader(name: string): boolean {
   } catch {
     return false
   }
+  // Legacy cleanup: the main agent's copy used to live in the USER scope,
+  // where the session-start cache made it permanently stale. Remove it once
+  // the project-scoped copy is in place -- a leftover user-scope file would
+  // keep shadowing nothing (project scope wins) but would mislead the next
+  // person debugging the gate.
+  if (name === MAIN_AGENT_ID) {
+    try { rmSync(join(homedir(), '.claude', 'agents', 'quarantine-reader.md'), { force: true }) } catch { /* best effort */ }
+  }
   if (existsSync(destPath)) {
     try {
       if (readFileSync(destPath, 'utf-8') === rendered) return false
@@ -745,6 +765,30 @@ export function ensureQuarantineReader(name: string): boolean {
   }
   writeFileSync(destPath, rendered)
   return true
+}
+
+// EGRESSRENDER824 (b): a grant typed into store/egress-allowlist.json used to
+// reach the reader PROMPT copies only at the next scaffold (boot/spawn of the
+// dashboard) -- the egress-gate HOOK reads the JSON live, but the reader's
+// prompt-level list is baked at render time, so the two silently disagreed
+// and the prompt denial produced no egress-blocked.log line. This watcher
+// closes the gap: any change to the JSON re-renders every deployed reader
+// copy. fs.watchFile (mtime polling) rather than fs.watch: it survives the
+// file being replaced (editors/atomic writes) and needs no debounce.
+export function watchEgressAllowlistForReaderRender(
+  listAgents: () => string[],
+  onRendered?: (agents: string[]) => void,
+): void {
+  const allowlistPath = join(STORE_DIR, 'egress-allowlist.json')
+  watchFile(allowlistPath, { interval: 5000 }, () => {
+    const rendered: string[] = []
+    for (const name of [MAIN_AGENT_ID, ...listAgents()]) {
+      try {
+        if (ensureQuarantineReader(name)) rendered.push(name)
+      } catch { /* per-agent best effort: one bad dir must not stop the rest */ }
+    }
+    if (rendered.length) onRendered?.(rendered)
+  })
 }
 
 // Copy the repo's `scheduled-tasks/<task>/task-config.json` to the


### PR DESCRIPTION
## The failure (measured, with controls)

An operator grant typed into `store/egress-allowlist.json` silently never reached the quarantine-reader, and the denial was indistinguishable from a legitimate block: the reader rejects from its **prompt-level list without any network call**, so nothing lands in `egress-blocked.log`. Both of us read it as a justified denial — and this gate ships to Marveen customers.

Two causes, separated by a discriminator experiment (2026-08-24, positive control supabase.com + negative control mistral.ai, both directions):

1. **Target path**: the main agent's rendered copy went to the USER scope (`~/.claude/agents`), which the runtime **caches at session start**; a PROJECT-scoped copy is **read from disk at each spawn**. The fleet agents were already project-scoped — their grants landed without restart; the main agent's waited for a full session restart. The decisive datum: the same two probes failed after a re-render alone, and passed the moment an identical copy existed at the project scope, with no other change.
2. **Render trigger**: copies were rendered only at scaffold time, so a JSON edit between boots reached the HOOK (live read) but not the prompt copies.

## The fix

- `quarantineReaderDestDir()` (pure, exported, pinned): the main agent's copy renders into `PROJECT_ROOT/.claude/agents`; the legacy user-scope file is removed best-effort so it cannot mislead the next debugger. This **eliminates** the restart requirement rather than documenting it.
- `watchEgressAllowlistForReaderRender()`: a `watchFile` poller (5s, survives atomic file replacement) re-renders every deployed copy on JSON change; wired at dashboard boot in `web.ts`.
- The operator comment in `egress-gate.mjs` now states the grant-latency contract: effective at the **next reader spawn**, within ~5s of the JSON change; a prompt-copy denial writes no log line.

## Evidence

- 2 new tests pin the target path (project scope for MAIN, never `~/.claude`; sub-agents unchanged). The watcher is thin glue over the already-covered `ensureQuarantineReader` render (content-compare; owner domains as render input — the 2026-07-30 hand-edit-revert lesson).
- Full suite **3937/3937**, `tsc --noEmit` exit 0.
- The manually placed project-scope file at `/Users/marvin/ClaudeClaw/.claude/agents/` (the discriminator artifact, currently the only working egress path for the main agent) is **taken over as the render target** by this fix — first boot after merge overwrites it with a fresh render, so no stray remains. Note: `.gitignore` line 26 (`.claude/*`) hides it from git status; the card is the only reminder.

## Merge timing

Freeze-compliant: PR now, merge after today's release. Card: EGRESSRENDER824.

🤖 Generated with [Claude Code](https://claude.com/claude-code)