### PR TITLE
fix(scheduler): make delivery + system alerts provider-aware, not Telegram-only

### DIFF
--- a/src/__tests__/channel-provider-send-timeout.test.ts
+++ b/src/__tests__/channel-provider-send-timeout.test.ts
@@ -1,0 +1,80 @@
+// Every provider sendMessage must carry a deadline. The scheduler's
+// pending-retry alert stamps `alert_sent_at` BEFORE the send and clears it
+// only on a thrown error (schedule-runner sendPendingRetryAlert), so a socket
+// that never answers would pin the stamp forever and silence that alert for
+// good. These tests pin that the deadline is actually wired in -- a timeout
+// that is configured but never attached to the request is the exact
+// regression this guards against.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { EventEmitter } from 'node:events'
+import { TOOL_TIMEOUTS } from '../tool-timeouts.js'
+
+// `import https from 'node:https'` -> the mock must provide `default`.
+const httpsRequest = vi.fn()
+vi.mock('node:https', () => ({ default: { request: (...a: unknown[]) => httpsRequest(...a) } }))
+
+const { getProvider } = await import('../channel-provider.js')
+
+/** Minimal stand-in for http.ClientRequest: events + the methods the code calls. */
+class FakeRequest extends EventEmitter {
+  write = vi.fn()
+  end = vi.fn()
+  destroy = vi.fn((err?: Error) => { if (err) this.emit('error', err) })
+}
+
+describe('telegram sendMessage deadline', () => {
+  let req: FakeRequest
+  let opts: { timeout?: number } | undefined
+
+  beforeEach(() => {
+    req = new FakeRequest()
+    httpsRequest.mockImplementation((_url: string, o: { timeout?: number }) => { opts = o; return req })
+  })
+  afterEach(() => { httpsRequest.mockReset(); opts = undefined })
+
+  it('passes the TOOL_TIMEOUTS.telegram deadline to https.request', async () => {
+    const pending = getProvider('telegram').sendMessage('tok', '1', 'hi')
+    expect(opts?.timeout).toBe(TOOL_TIMEOUTS['telegram'])
+    // Let the request "complete" so the promise settles.
+    const cb = httpsRequest.mock.calls[0][2] as (res: EventEmitter & { statusCode: number; resume: () => void }) => void
+    const res = Object.assign(new EventEmitter(), { statusCode: 200, resume: () => {} })
+    cb(res)
+    await expect(pending).resolves.toBeUndefined()
+  })
+
+  it('a socket timeout destroys the request and REJECTS -- never hangs the caller', async () => {
+    const pending = getProvider('telegram').sendMessage('tok', '1', 'hi')
+    req.emit('timeout')
+    expect(req.destroy).toHaveBeenCalledTimes(1)
+    await expect(pending).rejects.toThrow(/timed out/)
+  })
+})
+
+describe('slack / discord sendMessage deadline', () => {
+  const realFetch = globalThis.fetch
+  let init: RequestInit | undefined
+
+  beforeEach(() => {
+    init = undefined
+    globalThis.fetch = vi.fn(async (_url: string | URL | Request, i?: RequestInit) => {
+      init = i
+      return new Response(JSON.stringify({ ok: true }), { status: 200 })
+    }) as typeof fetch
+  })
+  afterEach(() => { globalThis.fetch = realFetch })
+
+  it('slack: chat.postMessage carries an AbortSignal', async () => {
+    await getProvider('slack').sendMessage('xoxb', 'C0000000001', 'hi')
+    expect(init?.signal).toBeInstanceOf(AbortSignal)
+  })
+
+  it('discord: the channel message POST carries an AbortSignal', async () => {
+    await getProvider('discord').sendMessage('tok', '123', 'hi')
+    expect(init?.signal).toBeInstanceOf(AbortSignal)
+  })
+
+  it('an aborted fetch surfaces as a rejection with no HTTP status (classified transient upstream)', async () => {
+    globalThis.fetch = vi.fn(async () => { throw new DOMException('The operation was aborted', 'TimeoutError') }) as typeof fetch
+    await expect(getProvider('slack').sendMessage('xoxb', 'C0000000001', 'hi')).rejects.toThrow(/aborted/)
+  })
+})

--- a/src/__tests__/channel-provider.test.ts
+++ b/src/__tests__/channel-provider.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, afterAll } from 'vitest'
 import {
   getProvider,
   getProviderType,
@@ -216,5 +216,77 @@ describe('checkTelegramTokenBusy', () => {
     expect(src).toMatch(/checkTelegramTokenBusy\(botToken\.trim\(\)\)/)
     expect(src).toMatch(/botToken\.trim\(\) !== currentToken/)
     expect(src.indexOf('checkTelegramTokenBusy(botToken')).toBeGreaterThan(src.indexOf('findBotTokenDuplicate'))
+  })
+})
+
+// readChannelToken is the single parser behind the scheduler-alert token
+// fallback (marveen/.env -> channel .env), agentHasChannel/hasChannel and ten
+// other call sites. Its regex used to be unanchored, so a commented-out
+// `# SLACK_BOT_TOKEN=old` in marveen/.env matched first and shadowed the live
+// token in the channel .env -- exactly the fallback the alert path relies on
+// after a token rotation.
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { readChannelToken } from '../channel-provider.js'
+
+describe('readChannelToken (anchored, whole-line match)', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'read-channel-token-'))
+  const envFile = (body: string): string => {
+    const p = join(dir, `${Math.random().toString(36).slice(2)}.env`)
+    writeFileSync(p, body)
+    return p
+  }
+  afterAll(() => rmSync(dir, { recursive: true, force: true }))
+
+  it('reads the provider key from a plain line, tolerating indentation and CRLF', () => {
+    expect(readChannelToken('slack', envFile('SLACK_BOT_TOKEN=xoxb-live\n'))).toBe('xoxb-live')
+    expect(readChannelToken('telegram', envFile('  TELEGRAM_BOT_TOKEN=111:live  \r\n'))).toBe('111:live')
+  })
+
+  it('ignores a commented-out key (a dead token must not shadow the fallback)', () => {
+    expect(readChannelToken('slack', envFile('# SLACK_BOT_TOKEN=xoxb-dead\n'))).toBeNull()
+    expect(readChannelToken('slack', envFile('# SLACK_BOT_TOKEN=xoxb-dead\nSLACK_BOT_TOKEN=xoxb-live\n'))).toBe('xoxb-live')
+    expect(readChannelToken('slack', envFile('SLACK_BOT_TOKEN=xoxb-live\n# SLACK_BOT_TOKEN=xoxb-dead\n'))).toBe('xoxb-live')
+  })
+
+  it('ignores a key that merely ends with the provider key', () => {
+    expect(readChannelToken('telegram', envFile('OLD_TELEGRAM_BOT_TOKEN=111:old\n'))).toBeNull()
+    expect(readChannelToken('telegram', envFile('OLD_TELEGRAM_BOT_TOKEN=111:old\nTELEGRAM_BOT_TOKEN=222:live\n'))).toBe('222:live')
+  })
+
+  it('does not confuse SLACK_APP_TOKEN with SLACK_BOT_TOKEN', () => {
+    expect(readChannelToken('slack', envFile('SLACK_APP_TOKEN=xapp-1\n'))).toBeNull()
+    // Neither of these two pins the anchor: on the unanchored regex both were
+    // already null (`SLACK_APP_TOKEN` and `SLACK_BOT_TOKEN_OLD` contain no
+    // `SLACK_BOT_TOKEN=` substring). They guard naming drift. The case that
+    // DOES pin it is `OLD_TELEGRAM_BOT_TOKEN=` above -- a key ENDING with ours.
+    expect(readChannelToken('slack', envFile('SLACK_BOT_TOKEN_OLD=xoxb-old\n'))).toBeNull()
+  })
+
+  it('ignores a comment written without a space after the hash', () => {
+    // `sed -i 's/^KEY=/#KEY=/'` -- the form an operator actually produces when
+    // disabling a token by hand, and the one measured on the live install.
+    expect(readChannelToken('telegram', envFile('#TELEGRAM_BOT_TOKEN=111:dead\n'))).toBeNull()
+    expect(readChannelToken('telegram', envFile('#TELEGRAM_BOT_TOKEN=111:dead\nTELEGRAM_BOT_TOKEN=222:live\n'))).toBe('222:live')
+    expect(readChannelToken('telegram', envFile('   # TELEGRAM_BOT_TOKEN=111:dead\n'))).toBeNull()
+  })
+
+  it('an empty value is not a token, so the caller falls through to the next location', () => {
+    // Documents behaviour rather than guarding the anchor (`(.+)` already
+    // refused an empty value before the fix): resolveSchedulerAlertToken
+    // chains marveen/.env || channel .env, and a key left with no value must
+    // not win that chain.
+    expect(readChannelToken('telegram', envFile('TELEGRAM_BOT_TOKEN=\n'))).toBeNull()
+    expect(readChannelToken('telegram', envFile('TELEGRAM_BOT_TOKEN=\nTELEGRAM_BOT_TOKEN=222:live\n'))).toBe('222:live')
+  })
+
+  it('a commented-out presence key no longer counts as a configured channel', () => {
+    // hasChannel/agentHasChannel use the same reader for creds-based providers.
+    expect(readChannelToken('googlechat', envFile('# GOOGLECHAT_PROJECT_ID=p1\n'))).toBeNull()
+    expect(readChannelToken('googlechat', envFile('GOOGLECHAT_PROJECT_ID=p1\n'))).toBe('p1')
+  })
+
+  it('missing file -> null', () => {
+    expect(readChannelToken('slack', join(dir, 'nope.env'))).toBeNull()
   })
 })

--- a/src/__tests__/owner-chat.test.ts
+++ b/src/__tests__/owner-chat.test.ts
@@ -12,7 +12,7 @@
 // out to fail. These tests assert BOTH halves, because they are different
 // claims: that a real id gets through, AND that the placeholder never does.
 import { describe, expect, it } from 'vitest'
-import { normalizeChatId, resolveOwnerChatId } from '../owner-chat.js'
+import { normalizeChatId, resolveOwnerChatId, configuredOwnerChatFor } from '../owner-chat.js'
 
 const REAL = '1268077055'
 
@@ -95,5 +95,31 @@ describe('resolveOwnerChatId', () => {
       expect(got, `${JSON.stringify(body)} + env=${JSON.stringify(env)}`).not.toBe('0')
       expect(got).toBeNull()
     }
+  })
+})
+
+// SLACKAWARE: the scheduler alerts resolve the owner for the MAIN agent's
+// provider. The configured half must come from the provider's own .env key --
+// a Slack install routinely keeps a stale numeric Telegram id in
+// ALLOWED_CHAT_ID, and feeding that to chat.postMessage is a permanent
+// channel_not_found (stamp kept, alert dead after one warn).
+describe('configuredOwnerChatFor', () => {
+  const env = { allowedChatId: REAL, channelChatId: 'C0000000001' }
+
+  it('telegram keeps ALLOWED_CHAT_ID (existing installs unchanged)', () => {
+    expect(configuredOwnerChatFor('telegram', env)).toBe(REAL)
+  })
+
+  it('every other provider uses its own CHANNEL_CHAT_ID, never the Telegram id', () => {
+    for (const p of ['slack', 'discord', 'googlechat', 'teams'] as const) {
+      expect(configuredOwnerChatFor(p, env), p).toBe('C0000000001')
+    }
+  })
+
+  it('a stale Telegram ALLOWED_CHAT_ID on a Slack install does not leak into the owner chat', () => {
+    // The reported hazard, end to end: SLACK_CHANNEL_ID unset, ALLOWED_CHAT_ID
+    // still numeric from an earlier Telegram setup, slack/access.json paired.
+    const configured = configuredOwnerChatFor('slack', { allowedChatId: REAL, channelChatId: '' })
+    expect(resolveOwnerChatId(reader({ allowFrom: ['U0000000001'] }), configured, 'slack')).toBe('U0000000001')
   })
 })

--- a/src/__tests__/owner-chat.test.ts
+++ b/src/__tests__/owner-chat.test.ts
@@ -70,6 +70,18 @@ describe('resolveOwnerChatId', () => {
     expect(resolveOwnerChatId(reader({ allowFrom: [], groups: { '-100999': {} } }), '0')).toBe('-100999')
   })
 
+  it('falls back to a Slack channel binding (`channels` map) when there is no DM entry', () => {
+    // Slack access.json keeps channel bindings under `channels`, not `groups`
+    // (routes/agents.ts channel-request approval writes access.channels[id]).
+    // A main agent bound only to a channel must still have an owner chat for
+    // the scheduler alerts, the same way chatIdFromAccessConfig resolves the
+    // task-prompt delivery.
+    expect(resolveOwnerChatId(reader({ allowFrom: [], channels: { C0000000001: {} } }), '', 'slack')).toBe('C0000000001')
+    // The DM allowlist still wins over any channel, and groups over channels.
+    expect(resolveOwnerChatId(reader({ allowFrom: ['U0000000001'], channels: { C0000000001: {} } }), '', 'slack')).toBe('U0000000001')
+    expect(resolveOwnerChatId(reader({ allowFrom: [], groups: { '-100999': {} }, channels: { C0000000001: {} } }), '')).toBe('-100999')
+  })
+
   it('returns null when this install genuinely has no owner chat', () => {
     // Null is a real answer, not a failure: callers must SKIP the send. The
     // alternative -- passing "0" on -- is what produced silent 400s.

--- a/src/__tests__/pending-retries.test.ts
+++ b/src/__tests__/pending-retries.test.ts
@@ -3,6 +3,7 @@ import {
   shouldSendAlert,
   toPendingRetryView,
   classifyTelegramSendError,
+  classifySendError,
   ALERT_THRESHOLD_MS,
 } from '../pending-retries.js'
 
@@ -128,5 +129,40 @@ describe('classifyTelegramSendError', () => {
     expect(classifyTelegramSendError('Telegram API 401: Unauthorized')).toBe('permanent')
     expect(classifyTelegramSendError('Telegram API 403: Forbidden: bot was blocked by the user')).toBe('permanent')
     expect(classifyTelegramSendError('Telegram API 404: Not Found')).toBe('permanent')
+  })
+})
+
+// SLACKAWARE: the scheduler alerts now go over whatever channel the main agent
+// is bound to, so the classifier must recognise Slack's two error shapes too.
+// classifyTelegramSendError is a backward-compatible alias of classifySendError.
+describe('classifySendError (Slack shapes)', () => {
+  it('is the same function as the legacy classifyTelegramSendError alias', () => {
+    expect(classifySendError).toBe(classifyTelegramSendError)
+  })
+
+  it('treats Slack HTTP 429/5xx as transient, other 4xx as permanent', () => {
+    expect(classifySendError('Slack API HTTP 429')).toBe('transient')
+    expect(classifySendError('Slack API HTTP 503')).toBe('transient')
+    expect(classifySendError('Slack API HTTP 400')).toBe('permanent')
+    expect(classifySendError('Slack API HTTP 403')).toBe('permanent')
+  })
+
+  it('treats Slack rate-limit / server error codes as transient', () => {
+    expect(classifySendError('Slack API error: ratelimited')).toBe('transient')
+    expect(classifySendError('Slack API error: rate_limited')).toBe('transient')
+    expect(classifySendError('Slack API error: internal_error')).toBe('transient')
+    expect(classifySendError('Slack API error: service_unavailable')).toBe('transient')
+  })
+
+  it('treats Slack config error codes as permanent (no 60s spin)', () => {
+    expect(classifySendError('Slack API error: channel_not_found')).toBe('permanent')
+    expect(classifySendError('Slack API error: not_in_channel')).toBe('permanent')
+    expect(classifySendError('Slack API error: invalid_auth')).toBe('permanent')
+    expect(classifySendError('Slack API error: token_revoked')).toBe('permanent')
+    expect(classifySendError('Slack API error: is_archived')).toBe('permanent')
+  })
+
+  it('treats a bare Slack network failure (no status/code) as transient', () => {
+    expect(classifySendError('fetch failed')).toBe('transient')
   })
 })

--- a/src/__tests__/pending-retries.test.ts
+++ b/src/__tests__/pending-retries.test.ts
@@ -166,3 +166,23 @@ describe('classifySendError (Slack shapes)', () => {
     expect(classifySendError('fetch failed')).toBe('transient')
   })
 })
+
+// Discord is a valid CHANNEL_PROVIDER for the alert path too (channelDeliveryName,
+// resolveSchedulerAlertToken). discordProvider.sendMessage throws
+// "Discord API <status>: <body>"; without its own branch every 4xx fell
+// through the "no recognized prefix" default as transient and respun each tick.
+describe('classifySendError (Discord shapes)', () => {
+  it('treats Discord HTTP 429/5xx as transient, other 4xx as permanent', () => {
+    expect(classifySendError('Discord API 429: rate limited')).toBe('transient')
+    expect(classifySendError('Discord API 502: bad gateway')).toBe('transient')
+    expect(classifySendError('Discord API 401: {"message":"401: Unauthorized"}')).toBe('permanent')
+    expect(classifySendError('Discord API 403: {"message":"Missing Access"}')).toBe('permanent')
+    expect(classifySendError('Discord API 404: {"message":"Unknown Channel"}')).toBe('permanent')
+  })
+
+  it('does not confuse a status-looking number inside the body with the status', () => {
+    // The status is the number right after the prefix; the body may carry
+    // its own codes (Discord echoes "401: Unauthorized" in the JSON).
+    expect(classifySendError('Discord API 503: {"code":40001}')).toBe('transient')
+  })
+})

--- a/src/__tests__/schedule-runner-bound-channel.test.ts
+++ b/src/__tests__/schedule-runner-bound-channel.test.ts
@@ -1,0 +1,87 @@
+// Behavioural guard for resolveBoundChannel, the function the provider-aware
+// scheduled-task delivery hangs on. The source-contract tests in
+// schedule-runner-bound-chatid.test.ts pin the call shape; this one pins what
+// actually happens on disk: the access.json is read from the agent's OWN
+// provider subdir (<agentDir>/.claude/channels/<provider>/access.json), and a
+// missing binding yields {chatId: null} -- never a guess, never the other
+// provider's file. Measured on the live CHANNEL_PROVIDER=slack install before
+// the fix: telegram/access.json was read unconditionally, was absent, and every
+// scheduled task shipped with no delivery instruction.
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+// The mock factories are hoisted but run lazily, on the dynamic import below,
+// so they can safely read this module-level state.
+const h = {
+  tmpRoot: mkdtempSync(join(tmpdir(), 'bound-channel-')),
+  provider: 'telegram' as 'telegram' | 'slack' | 'discord',
+}
+
+// Only agentDir is redirected: the sub-agent path must land in the tmp root.
+vi.mock('../web/agent-config.js', async (importOriginal) => {
+  const real = await importOriginal<typeof import('../web/agent-config.js')>()
+  return { ...real, agentDir: (name: string) => join(h.tmpRoot, 'agents', name) }
+})
+
+// Only resolveAgentProvider is redirected: it is the per-agent provider the
+// test flips between cases.
+vi.mock('../web/agent-process.js', async (importOriginal) => {
+  const real = await importOriginal<typeof import('../web/agent-process.js')>()
+  return { ...real, resolveAgentProvider: () => h.provider }
+})
+
+const { resolveBoundChannel } = await import('../web/schedule-runner.js')
+
+const AGENT = 'zara'
+
+function writeAccess(provider: string, body: unknown): void {
+  const dir = join(h.tmpRoot, 'agents', AGENT, '.claude', 'channels', provider)
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, 'access.json'), JSON.stringify(body))
+}
+
+beforeEach(() => {
+  rmSync(join(h.tmpRoot, 'agents'), { recursive: true, force: true })
+  h.provider = 'telegram'
+})
+afterAll(() => rmSync(h.tmpRoot, { recursive: true, force: true }))
+
+describe('resolveBoundChannel (sub-agent, on-disk access.json)', () => {
+  it('a Slack-bound agent resolves from slack/access.json, not telegram/', () => {
+    h.provider = 'slack'
+    writeAccess('slack', { allowFrom: ['U0000000001'] })
+    // A stale Telegram binding next to it must not win.
+    writeAccess('telegram', { allowFrom: ['1268077055'] })
+    expect(resolveBoundChannel(AGENT)).toEqual({ provider: 'slack', chatId: 'U0000000001' })
+  })
+
+  it('a Telegram-bound agent resolves from telegram/access.json (unchanged behaviour)', () => {
+    writeAccess('telegram', { allowFrom: ['1268077055'] })
+    writeAccess('slack', { allowFrom: ['U0000000001'] })
+    expect(resolveBoundChannel(AGENT)).toEqual({ provider: 'telegram', chatId: '1268077055' })
+  })
+
+  it('a Slack agent bound only to a channel resolves the channel id', () => {
+    h.provider = 'slack'
+    writeAccess('slack', { allowFrom: [], channels: { C0000000001: {} } })
+    expect(resolveBoundChannel(AGENT)).toEqual({ provider: 'slack', chatId: 'C0000000001' })
+  })
+
+  it('no access.json for the agent\'s provider -> chatId null, provider still reported', () => {
+    h.provider = 'slack'
+    // Only the OTHER provider's file exists: that is the pre-fix live shape
+    // inverted, and it must not be borrowed.
+    writeAccess('telegram', { allowFrom: ['1268077055'] })
+    expect(resolveBoundChannel(AGENT)).toEqual({ provider: 'slack', chatId: null })
+  })
+
+  it('an empty or corrupt access.json is a config gap, not a default', () => {
+    writeAccess('telegram', { allowFrom: [], groups: {} })
+    expect(resolveBoundChannel(AGENT)).toEqual({ provider: 'telegram', chatId: null })
+    const dir = join(h.tmpRoot, 'agents', AGENT, '.claude', 'channels', 'telegram')
+    writeFileSync(join(dir, 'access.json'), 'not json')
+    expect(resolveBoundChannel(AGENT)).toEqual({ provider: 'telegram', chatId: null })
+  })
+})

--- a/src/__tests__/schedule-runner-bound-chatid.test.ts
+++ b/src/__tests__/schedule-runner-bound-chatid.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
-import { chatIdFromAccessConfig } from '../web/schedule-runner.js'
+import { chatIdFromAccessConfig, channelDeliveryName } from '../web/schedule-runner.js'
 
 // Regression guard for 2026-07-27 (Zara report, Marveen diagnosis): the
 // scheduled-task prompt prefix carried a "chat_id: 0" sentinel from a
@@ -25,6 +25,17 @@ describe('chatIdFromAccessConfig (pure core)', () => {
     expect(chatIdFromAccessConfig({ allowFrom: [], groups: { '-100123': {} } })).toBe('-100123')
   })
 
+  it('falls back to the Slack channels map when no DM entry exists', () => {
+    // Slack access.json uses `channels`, not `groups` -- the same helper must
+    // cover it so a Slack-bound agent with only a channel (no DM allowlist)
+    // still resolves a deliverable id.
+    expect(chatIdFromAccessConfig({ allowFrom: [], channels: { C0123ABCDE: {} } })).toBe('C0123ABCDE')
+  })
+
+  it('prefers the DM allowlist entry over a group/channel fallback', () => {
+    expect(chatIdFromAccessConfig({ allowFrom: ['U0BKECRGKCY'], channels: { C0123: {} } })).toBe('U0BKECRGKCY')
+  })
+
   it('returns null for missing/empty/corrupt bindings (config gap, not a default)', () => {
     expect(chatIdFromAccessConfig(null)).toBeNull()
     expect(chatIdFromAccessConfig('nope')).toBeNull()
@@ -34,18 +45,36 @@ describe('chatIdFromAccessConfig (pure core)', () => {
   })
 })
 
-describe('schedule-runner source contract (sentinel removed)', () => {
+describe('channelDeliveryName (provider -> Hungarian channel noun)', () => {
+  it('names each provider for the "kuldd el <ide>" instruction', () => {
+    expect(channelDeliveryName('telegram')).toBe('Telegramon')
+    expect(channelDeliveryName('slack')).toBe('Slacken')
+    expect(channelDeliveryName('discord')).toBe('Discordon')
+    expect(channelDeliveryName('googlechat')).toBe('Google Chaten')
+    expect(channelDeliveryName('teams')).toBe('Teamsen')
+  })
+})
+
+describe('schedule-runner source contract (sentinel removed, provider-aware)', () => {
   const src = readFileSync(join(__dirname, '..', 'web', 'schedule-runner.ts'), 'utf-8')
 
   it('no prompt prefix carries the dead chat_id: 0 sentinel anymore', () => {
     expect(src).not.toMatch(/chat_id:\s*0[,)]/)
   })
 
-  it('the no-binding branch omits the Telegram instruction instead of guessing a chat', () => {
-    // The fallback prefix must be the bare task tag -- no Telegram mention, no
+  it('the no-binding branch omits the delivery instruction instead of guessing a chat', () => {
+    // The fallback prefix must be the bare task tag -- no channel mention, no
     // ALLOWED_CHAT_ID leak into a sub-agent prompt.
-    expect(src).toContain('prompt omits the Telegram delivery instruction')
+    expect(src).toContain('prompt omits the delivery instruction')
     expect(src).toMatch(/prefix = `\[Utemezett feladat: \$\{task\.name\}\] `/)
+  })
+
+  it('the delivery instruction names the resolved provider, not a hardcoded Telegram', () => {
+    // Regression guard: the instruction used to say "Telegramon" for every
+    // agent. It must now interpolate channelDeliveryName(bound.provider) so a
+    // Slack-bound agent is told to reply on Slack.
+    expect(src).toContain('channelDeliveryName(bound.provider)')
+    expect(src).not.toMatch(/kuldd el Telegramon \(chat_id/)
   })
 
   it('multi-entry allowlists produce an ambiguity warn (heuristic made visible)', () => {
@@ -55,8 +84,17 @@ describe('schedule-runner source contract (sentinel removed)', () => {
     expect(src).toMatch(/candidates > 1/)
   })
 
-  it('resolution reads the same access.json the plugin enforces', () => {
-    expect(src).toContain("channelStateDir('telegram'")
+  it('resolution reads the access.json for the agent\'s own provider, not always telegram', () => {
+    expect(src).toContain('resolveAgentProvider(agentName)')
+    expect(src).toContain('channelStateDir(provider')
     expect(src).toContain('chatIdFromAccessConfig')
+  })
+
+  it('the system-level scheduler alerts send over CHANNEL_PROVIDER, not Telegram directly', () => {
+    // The three alert paths (catch-up summary, pending-retry, task-timeout)
+    // must route through the provider abstraction, never sendTelegramMessage.
+    expect(src).not.toContain('sendTelegramMessage')
+    expect(src).toContain('sendSchedulerAlertMessage')
+    expect(src).toContain('getProvider(CHANNEL_PROVIDER)')
   })
 })

--- a/src/__tests__/schedule-runner-bound-chatid.test.ts
+++ b/src/__tests__/schedule-runner-bound-chatid.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
-import { chatIdFromAccessConfig, channelDeliveryName } from '../web/schedule-runner.js'
+import { chatIdFromAccessConfig, channelDeliveryName, resolveSchedulerAlertToken } from '../web/schedule-runner.js'
+import { PROJECT_ROOT } from '../config.js'
+import { channelStateDir, type ChannelProviderType } from '../channel-provider.js'
 
 // Regression guard for 2026-07-27 (Zara report, Marveen diagnosis): the
 // scheduled-task prompt prefix carried a "chat_id: 0" sentinel from a
@@ -52,6 +54,62 @@ describe('channelDeliveryName (provider -> Hungarian channel noun)', () => {
     expect(channelDeliveryName('discord')).toBe('Discordon')
     expect(channelDeliveryName('googlechat')).toBe('Google Chaten')
     expect(channelDeliveryName('teams')).toBe('Teamsen')
+  })
+})
+
+// Regression guard for the 2026-07-08 fix: the scheduler-alert bot token is
+// looked up in marveen/.env FIRST and the main agent's channel .env SECOND, for
+// every provider that has a bot token. The provider-aware rewrite once dropped
+// the second location for Telegram and every alert went silent on hosts whose
+// token lives in the plugin env. The reader is stubbed so the test pins the
+// lookup ORDER and the empty-value fall-through, not the filesystem.
+describe('resolveSchedulerAlertToken (lookup order via injected reader)', () => {
+  const PROJECT_ENV = join(PROJECT_ROOT, '.env')
+  const channelEnv = (p: ChannelProviderType) => join(channelStateDir(p), '.env')
+
+  /** Reader stub: answers per path, records the calls in order. */
+  function stub(answers: Record<string, string | null>) {
+    const calls: Array<[ChannelProviderType, string]> = []
+    const read = (p: ChannelProviderType, path: string) => {
+      calls.push([p, path])
+      return answers[path] ?? null
+    }
+    return { read, calls }
+  }
+
+  it('telegram: marveen/.env wins and the channel .env is not consulted', () => {
+    const { read, calls } = stub({ [PROJECT_ENV]: '111:project', [channelEnv('telegram')]: '222:plugin' })
+    expect(resolveSchedulerAlertToken('telegram', read)).toBe('111:project')
+    expect(calls).toEqual([['telegram', PROJECT_ENV]])
+  })
+
+  it('telegram: falls back to ~/.claude/channels/telegram/.env (the plugin env)', () => {
+    const { read, calls } = stub({ [PROJECT_ENV]: null, [channelEnv('telegram')]: '222:plugin' })
+    expect(resolveSchedulerAlertToken('telegram', read)).toBe('222:plugin')
+    expect(calls).toEqual([['telegram', PROJECT_ENV], ['telegram', channelEnv('telegram')]])
+  })
+
+  it('an EMPTY value in marveen/.env falls through, like the old `if (token)` did', () => {
+    const { read } = stub({ [PROJECT_ENV]: '', [channelEnv('telegram')]: '222:plugin' })
+    expect(resolveSchedulerAlertToken('telegram', read)).toBe('222:plugin')
+  })
+
+  it('slack: same two locations in the same order, provider passed through to the reader', () => {
+    const { read, calls } = stub({ [PROJECT_ENV]: null, [channelEnv('slack')]: 'xoxb-channel' })
+    expect(resolveSchedulerAlertToken('slack', read)).toBe('xoxb-channel')
+    expect(calls).toEqual([['slack', PROJECT_ENV], ['slack', channelEnv('slack')]])
+  })
+
+  it('no token anywhere -> undefined (callers take the log-only branch)', () => {
+    const { read } = stub({})
+    expect(resolveSchedulerAlertToken('telegram', read)).toBeUndefined()
+  })
+
+  it('creds-based providers never read a token: their reader value is a project/app id, not a bot token', () => {
+    const { read, calls } = stub({ [PROJECT_ENV]: 'project-id-would-be-here' })
+    expect(resolveSchedulerAlertToken('googlechat', read)).toBeUndefined()
+    expect(resolveSchedulerAlertToken('teams', read)).toBeUndefined()
+    expect(calls).toEqual([])
   })
 })
 

--- a/src/__tests__/schedule-runner-bound-chatid.test.ts
+++ b/src/__tests__/schedule-runner-bound-chatid.test.ts
@@ -31,11 +31,11 @@ describe('chatIdFromAccessConfig (pure core)', () => {
     // Slack access.json uses `channels`, not `groups` -- the same helper must
     // cover it so a Slack-bound agent with only a channel (no DM allowlist)
     // still resolves a deliverable id.
-    expect(chatIdFromAccessConfig({ allowFrom: [], channels: { C0123ABCDE: {} } })).toBe('C0123ABCDE')
+    expect(chatIdFromAccessConfig({ allowFrom: [], channels: { C0000000001: {} } })).toBe('C0000000001')
   })
 
   it('prefers the DM allowlist entry over a group/channel fallback', () => {
-    expect(chatIdFromAccessConfig({ allowFrom: ['U0BKECRGKCY'], channels: { C0123: {} } })).toBe('U0BKECRGKCY')
+    expect(chatIdFromAccessConfig({ allowFrom: ['U0000000001'], channels: { C0123: {} } })).toBe('U0000000001')
   })
 
   it('returns null for missing/empty/corrupt bindings (config gap, not a default)', () => {

--- a/src/__tests__/schedule-runner-parked-janitor.test.ts
+++ b/src/__tests__/schedule-runner-parked-janitor.test.ts
@@ -52,11 +52,20 @@ vi.mock('../db.js', () => ({
 
 // The alert paths resolve a REAL bot token from install-level config and send
 // to the real owner chat. Neutralize the sink: a green suite must never cost
-// the operator's attention.
-vi.mock('../web/telegram.js', () => ({
-  sendTelegramMessage: vi.fn(async () => {}),
-  sendTelegramPhoto: vi.fn(async () => {}),
-}))
+// the operator's attention. The runner sends over getProvider(CHANNEL_PROVIDER)
+// since the provider-aware alerts (not sendTelegramMessage any more), so THAT
+// is the export to neutralize; everything else stays real.
+vi.mock('../channel-provider.js', async (importOriginal) => {
+  const real = await importOriginal<typeof import('../channel-provider.js')>()
+  return {
+    ...real,
+    getProvider: (type: Parameters<typeof real.getProvider>[0]) => ({
+      ...real.getProvider(type),
+      sendMessage: vi.fn(async () => {}),
+      sendPhoto: vi.fn(async () => {}),
+    }),
+  }
+})
 
 vi.mock('../web/scheduled-tasks-io.js', () => ({
   listScheduledTasks: () => mockListScheduledTasks(),
@@ -75,6 +84,10 @@ vi.mock('../web/agent-process.js', () => ({
   capturePane: () => null,
   sendEnterToSession: vi.fn(),
   clearStaleParkedInput: (...a: unknown[]) => mockClearParked(...(a as [])),
+  // Only heartbeat tasks fire here, so the bound-channel path is not reached;
+  // the export is still mocked so a future non-heartbeat case does not die on
+  // "No resolveAgentProvider export is defined on the mock".
+  resolveAgentProvider: () => 'telegram',
 }))
 
 const TASK: ScheduledTask = {

--- a/src/__tests__/schedule-runner-retry-missing.test.ts
+++ b/src/__tests__/schedule-runner-retry-missing.test.ts
@@ -79,6 +79,7 @@ vi.mock('../web/agent-process.js', () => ({
   capturePane: () => null,
   sendEnterToSession: vi.fn(),
   clearStaleParkedInput: vi.fn(() => false),
+  resolveAgentProvider: () => 'telegram',
 }))
 
 function task(overrides: Partial<ScheduledTask> & { name: string; schedule: string }): ScheduledTask {

--- a/src/__tests__/schedule-runner-retry-missing.test.ts
+++ b/src/__tests__/schedule-runner-retry-missing.test.ts
@@ -58,10 +58,20 @@ vi.mock('../db.js', () => ({
 // (HOME-based, so a test worktree does not isolate them) and send to the real
 // owner chat. Neutralize the sink entirely: a green suite must never cost the
 // operator's attention.
-vi.mock('../web/telegram.js', () => ({
-  sendTelegramMessage: vi.fn(async () => {}),
-  sendTelegramPhoto: vi.fn(async () => {}),
-}))
+// The runner sends over getProvider(CHANNEL_PROVIDER) since the provider-aware
+// alerts (not sendTelegramMessage any more), so THAT is the export to
+// neutralize; everything else in channel-provider stays real.
+vi.mock('../channel-provider.js', async (importOriginal) => {
+  const real = await importOriginal<typeof import('../channel-provider.js')>()
+  return {
+    ...real,
+    getProvider: (type: Parameters<typeof real.getProvider>[0]) => ({
+      ...real.getProvider(type),
+      sendMessage: vi.fn(async () => {}),
+      sendPhoto: vi.fn(async () => {}),
+    }),
+  }
+})
 
 vi.mock('../web/scheduled-tasks-io.js', () => ({
   listScheduledTasks: () => mockListScheduledTasks(),

--- a/src/channel-provider.ts
+++ b/src/channel-provider.ts
@@ -5,6 +5,7 @@ import { homedir } from 'node:os'
 import { logger } from './logger.js'
 import { formatForTelegram, splitMessage } from './format.js'
 import { markIfTestRun } from './test-run-marker.js'
+import { TOOL_TIMEOUTS } from './tool-timeouts.js'
 
 export type ChannelProviderType = 'telegram' | 'slack' | 'discord' | 'googlechat' | 'teams'
 
@@ -24,6 +25,11 @@ export interface ChannelProvider {
 
 // -- Telegram implementation --
 
+// Every sendMessage below carries a deadline. The scheduler's pending-retry
+// alert stamps `alert_sent_at` BEFORE the send and clears it only on a thrown
+// error, so a socket that never answers would pin the stamp forever and
+// silence that alert for good. A timeout turns the hang into an error the
+// callers already classify as transient (no HTTP status) and retry next tick.
 function telegramHttpPost(token: string, method: string, body: string, contentType: string): Promise<void> {
   return new Promise((resolve, reject) => {
     const req = https.request(
@@ -34,6 +40,7 @@ function telegramHttpPost(token: string, method: string, body: string, contentTy
           'Content-Type': contentType,
           'Content-Length': Buffer.byteLength(body),
         },
+        timeout: TOOL_TIMEOUTS['telegram'],
       },
       (res) => {
         res.resume()
@@ -45,6 +52,8 @@ function telegramHttpPost(token: string, method: string, body: string, contentTy
       }
     )
     req.on('error', reject)
+    // The `timeout` option only emits the event; the request must be destroyed by hand, which surfaces through the 'error' handler above.
+    req.on('timeout', () => req.destroy(new Error(`Telegram ${method} timed out after ${TOOL_TIMEOUTS['telegram']}ms`)))
     req.write(body)
     req.end()
   })
@@ -196,6 +205,7 @@ const slackProvider: ChannelProvider = {
         unfurl_links: false,
         unfurl_media: false,
       }),
+      signal: AbortSignal.timeout(TOOL_TIMEOUTS['slack']),
     })
     if (!resp.ok) {
       throw new Error(`Slack API HTTP ${resp.status}`)
@@ -300,6 +310,7 @@ const discordProvider: ChannelProvider = {
         'Authorization': `Bot ${token}`,
       },
       body: JSON.stringify({ content: text }),
+      signal: AbortSignal.timeout(TOOL_TIMEOUTS['discord']),
     })
     if (!resp.ok) {
       const body = await resp.text().catch(() => '')

--- a/src/channel-provider.ts
+++ b/src/channel-provider.ts
@@ -601,6 +601,11 @@ export function readChannelToken(provider: ChannelProviderType, envFilePath: str
     : provider === 'googlechat' ? 'GOOGLECHAT_PROJECT_ID'
     : provider === 'teams' ? 'TEAMS_BOT_APP_ID'
     : 'TELEGRAM_BOT_TOKEN'
-  const match = content.match(new RegExp(`${key}=(.+)`))
+  // Anchored to a whole line: a commented-out `# SLACK_BOT_TOKEN=old` or a
+  // prefixed `OLD_TELEGRAM_BOT_TOKEN=` must NOT match. Unanchored, a dead
+  // token left commented in one .env shadowed the live one in the next lookup
+  // location, and a commented-out GOOGLECHAT_PROJECT_ID still counted as a
+  // configured channel for hasChannel/agentHasChannel.
+  const match = content.match(new RegExp(`^\\s*${key}=(.+)$`, 'm'))
   return match ? match[1].trim() : null
 }

--- a/src/owner-chat.ts
+++ b/src/owner-chat.ts
@@ -102,8 +102,15 @@ export function resolveOwnerChatId(
         if (id) return id
       }
     }
-    if (raw.groups && typeof raw.groups === 'object') {
-      for (const key of Object.keys(raw.groups as Record<string, unknown>)) {
+    // Telegram/Discord keep allowed groups under `groups`, Slack under
+    // `channels` -- the same allowFrom -> groups -> channels heuristic as
+    // schedule-runner's chatIdFromAccessConfig, so a Slack main agent bound
+    // only to a channel (empty DM allowlist) resolves an owner here too, not
+    // just in the task-prompt path.
+    for (const mapKey of ['groups', 'channels'] as const) {
+      const map = raw[mapKey]
+      if (!map || typeof map !== 'object') continue
+      for (const key of Object.keys(map as Record<string, unknown>)) {
         const id = normalizeChatId(key)
         if (id) return id
       }

--- a/src/owner-chat.ts
+++ b/src/owner-chat.ts
@@ -29,8 +29,23 @@
 //    migration, and must never ship in the same release as this.
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
-import { ALLOWED_CHAT_ID, MAIN_AGENT_ID } from './config.js'
+import { ALLOWED_CHAT_ID, CHANNEL_CHAT_ID, MAIN_AGENT_ID } from './config.js'
 import { channelStateDir, type ChannelProviderType } from './channel-provider.js'
+
+/**
+ * The .env value that names the owner chat for a given provider. ALLOWED_CHAT_ID
+ * is the Telegram key; every other provider has its own (SLACK_CHANNEL_ID,
+ * DISCORD_CHANNEL_ID, ... -- getChannelChatId), surfaced as CHANNEL_CHAT_ID.
+ * A Slack-bound install routinely keeps a stale numeric Telegram id in
+ * ALLOWED_CHAT_ID; feeding that to chat.postMessage earns a permanent
+ * `channel_not_found`, so the provider's own key must win there.
+ */
+export function configuredOwnerChatFor(
+  provider: ChannelProviderType,
+  env: { allowedChatId: string; channelChatId: string } = { allowedChatId: ALLOWED_CHAT_ID, channelChatId: CHANNEL_CHAT_ID },
+): string {
+  return provider === 'telegram' ? env.allowedChatId : env.channelChatId
+}
 
 /**
  * Normalise a configured chat id to "set" or "not set".

--- a/src/owner-chat.ts
+++ b/src/owner-chat.ts
@@ -30,7 +30,7 @@
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { ALLOWED_CHAT_ID, MAIN_AGENT_ID } from './config.js'
-import { channelStateDir } from './channel-provider.js'
+import { channelStateDir, type ChannelProviderType } from './channel-provider.js'
 
 /**
  * Normalise a configured chat id to "set" or "not set".
@@ -65,11 +65,17 @@ export function normalizeChatId(raw: string | null | undefined): string | null {
 export function resolveOwnerChatId(
   readAccessFile: (path: string) => string = (p) => readFileSync(p, 'utf-8'),
   configured: string | null = ALLOWED_CHAT_ID,
+  provider: ChannelProviderType = 'telegram',
 ): string | null {
   const fromEnv = normalizeChatId(configured)
   if (fromEnv) return fromEnv
   try {
-    const raw = JSON.parse(readAccessFile(join(channelStateDir('telegram'), 'access.json'))) as Record<string, unknown>
+    // `provider` defaults to 'telegram' so every existing caller (daily digest,
+    // welcome/avatar messages, command-task, inbound-probe) is byte-identical.
+    // The schedule-runner passes CHANNEL_PROVIDER so a Slack-bound main agent
+    // resolves the owner from its slack/access.json instead of a (missing)
+    // telegram one.
+    const raw = JSON.parse(readAccessFile(join(channelStateDir(provider), 'access.json'))) as Record<string, unknown>
     // Same shape and same "first allowlist entry" heuristic as
     // schedule-runner's resolveBoundChatId, which already resolves the main
     // agent from this exact file. access.json has no owner field; with more

--- a/src/pending-retries.ts
+++ b/src/pending-retries.ts
@@ -82,6 +82,7 @@ export function shouldSendAlert(
 export function classifySendError(errMessage: string): 'transient' | 'permanent' {
   if (errMessage.includes('Telegram API')) return classifyTelegramError(errMessage)
   if (errMessage.includes('Slack API')) return classifySlackError(errMessage)
+  if (errMessage.includes('Discord API')) return classifyDiscordError(errMessage)
   return 'transient' // no recognized provider prefix -> network-level failure
 }
 
@@ -95,6 +96,14 @@ function classifyHttpStatus(status: number): 'transient' | 'permanent' {
 /** Telegram: "Telegram API <status>: ...". */
 function classifyTelegramError(errMessage: string): 'transient' | 'permanent' {
   const match = /Telegram API (\d{3})\b/.exec(errMessage)
+  return match ? classifyHttpStatus(Number(match[1])) : 'transient'
+}
+
+/** Discord (discordProvider.sendMessage): "Discord API <status>: <body>".
+ *  Same HTTP-status policy -- without this branch a bad channel id / revoked
+ *  bot token (4xx) fell through as "transient" and respun every 60s. */
+function classifyDiscordError(errMessage: string): 'transient' | 'permanent' {
+  const match = /Discord API (\d{3})\b/.exec(errMessage)
   return match ? classifyHttpStatus(Number(match[1])) : 'transient'
 }
 

--- a/src/pending-retries.ts
+++ b/src/pending-retries.ts
@@ -54,31 +54,78 @@ export function shouldSendAlert(
 }
 
 /**
- * Classify a Telegram send failure as transient (worth retrying) or
+ * Classify a channel send failure as transient (worth retrying) or
  * permanent (a config / client error that will fail identically every
- * tick). sendTelegramMessage throws `Error("Telegram API <status>: ...")`
- * on a non-2xx response and a bare network error (TypeError "fetch
- * failed") when the request never reaches Telegram.
+ * tick). Provider-agnostic entry point: the scheduler alert path sends over
+ * whatever channel the main agent is bound to (Telegram or Slack), so this
+ * dispatches on the provider prefix to a per-provider classifier below.
+ *
+ * Telegram (channel-provider telegramProvider / sendTelegramMessage) throws
+ * `Error("Telegram API <status>: ...")` on a non-2xx response. Slack
+ * (slackProvider.sendMessage) throws `Error("Slack API HTTP <status>")` on a
+ * transport-level non-2xx and `Error("Slack API error: <code>")` when the
+ * API returns `ok:false`. A bare network error (TypeError "fetch failed")
+ * carries no status on either provider.
  *
  *   - transient: network failure (no status), HTTP 429 (rate limited),
- *     or any 5xx. The next 60s tick should retry, so the caller clears
- *     the per-attempt stamp.
+ *     any 5xx, or a Slack `ratelimited`/`internal_error`-class code. The
+ *     next tick should retry, so the caller clears the per-attempt stamp.
  *   - permanent: HTTP 4xx other than 429 (400 bad chat_id, 401/404 bad
- *     token, 403 blocked). Retrying every tick just spams the log with
- *     the identical failure, so the caller KEEPS the stamp to stop the
- *     alert from re-firing until the underlying config is fixed.
+ *     token, 403 blocked), or a Slack config code (channel_not_found,
+ *     invalid_auth, token_revoked, not_in_channel, ...). Retrying every
+ *     tick just spams the log with the identical failure, so the caller
+ *     KEEPS the stamp until the underlying config is fixed.
  *
  * Pure (takes the error message string) so it is unit-testable without a
- * live Telegram endpoint.
+ * live endpoint.
  */
-export function classifyTelegramSendError(errMessage: string): 'transient' | 'permanent' {
-  const m = /Telegram API (\d{3})\b/.exec(errMessage)
-  if (!m) return 'transient' // no HTTP status -> network-level failure
-  const status = Number(m[1])
+export function classifySendError(errMessage: string): 'transient' | 'permanent' {
+  if (errMessage.includes('Telegram API')) return classifyTelegramError(errMessage)
+  if (errMessage.includes('Slack API')) return classifySlackError(errMessage)
+  return 'transient' // no recognized provider prefix -> network-level failure
+}
+
+/** Shared HTTP-status policy: 429 and 5xx retry, other 4xx is config. */
+function classifyHttpStatus(status: number): 'transient' | 'permanent' {
   if (status === 429 || status >= 500) return 'transient'
   if (status >= 400) return 'permanent'
   return 'transient'
 }
+
+/** Telegram: "Telegram API <status>: ...". */
+function classifyTelegramError(errMessage: string): 'transient' | 'permanent' {
+  const match = /Telegram API (\d{3})\b/.exec(errMessage)
+  return match ? classifyHttpStatus(Number(match[1])) : 'transient'
+}
+
+/**
+ * Slack application-level error codes that are worth retrying; everything
+ * else (bad channel/token/scope) is a config error that will fail
+ * identically next tick.
+ */
+const SLACK_TRANSIENT_CODES = new Set([
+  'ratelimited', 'rate_limited', 'internal_error', 'service_unavailable',
+  'fatal_error', 'request_timeout', 'timeout',
+])
+
+/**
+ * Slack: "Slack API HTTP <status>" (transport-level non-2xx) or
+ * "Slack API error: <code>" (API returned ok:false).
+ */
+function classifySlackError(errMessage: string): 'transient' | 'permanent' {
+  const httpStatus = /Slack API HTTP (\d{3})\b/.exec(errMessage)
+  if (httpStatus) return classifyHttpStatus(Number(httpStatus[1]))
+  const code = /Slack API error:\s*([a-z_]+)/i.exec(errMessage)
+  if (code) return SLACK_TRANSIENT_CODES.has(code[1].toLowerCase()) ? 'transient' : 'permanent'
+  return 'transient'
+}
+
+/**
+ * Backward-compatible alias. The classifier is provider-agnostic now
+ * (see classifySendError); the old name is kept so existing call sites and
+ * tests continue to resolve.
+ */
+export const classifyTelegramSendError = classifySendError
 
 /**
  * Shape of a pending retry used by the UI + the alert layer. A small

--- a/src/tool-timeouts.ts
+++ b/src/tool-timeouts.ts
@@ -7,6 +7,7 @@ export const TOOL_TIMEOUTS = {
   'telegram':        10_000,
   'github':          10_000,
   'slack':           10_000,
+  'discord':         10_000,
   // CPU-only Ollama embeds a ~1500-char memory in 40-60s, which overran the
   // former 30s deadline and left large memories permanently un-vectorized
   // (search silently fell back to FTS). 90s covers the slow CPU path.

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -806,7 +806,7 @@ export function stampFableOverageConsentSharedRoots(): void {
   }
 }
 
-function resolveAgentProvider(name: string): ChannelProviderType {
+export function resolveAgentProvider(name: string): ChannelProviderType {
   const perAgent = readAgentChannelProvider(name)
   if (perAgent === 'slack' || perAgent === 'telegram' || perAgent === 'discord' || perAgent === 'googlechat' || perAgent === 'teams') return perAgent
   return CHANNEL_PROVIDER

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -1,5 +1,4 @@
 import { join, isAbsolute } from 'node:path'
-import { homedir } from 'node:os'
 import { checkTaskMcpRequirements } from './schedule-mcp-precheck.js'
 import { existsSync, readFileSync } from 'node:fs'
 import { spawnSync } from 'node:child_process'
@@ -10,6 +9,7 @@ import {
   MAIN_AGENT_ID,
   BOT_NAME,
   APP_TZ_INVALID,
+  CHANNEL_PROVIDER,
 } from '../config.js'
 import { resolveOwnerChatId } from '../owner-chat.js'
 import {
@@ -22,7 +22,7 @@ import {
   clearPendingTaskRetryAlert,
   markScheduledTaskKanbanWaiting,
 } from '../db.js'
-import { toPendingRetryView, classifyTelegramSendError, type PendingRetryView } from '../pending-retries.js'
+import { toPendingRetryView, classifySendError, type PendingRetryView } from '../pending-retries.js'
 import {
   SCHEDULED_TASK_PREAMBLE,
   wrapScheduledTask,
@@ -35,7 +35,7 @@ import {
 } from './scheduled-tasks-io.js'
 import { listAgentNames, readFileOr, readAgentRemoteHost, agentDir, readAgentClaudeConfigDir } from './agent-config.js'
 import { readTranscriptMtimeFromProjectDir } from './active-model.js'
-import { channelStateDir } from '../channel-provider.js'
+import { channelStateDir, getProvider, readChannelToken, type ChannelProviderType } from '../channel-provider.js'
 import {
   agentSessionName,
   isAgentRunning,
@@ -46,9 +46,9 @@ import {
   capturePane,
   sendEnterToSession,
   clearStaleParkedInput,
+  resolveAgentProvider,
 } from './agent-process.js'
 import { MAIN_CHANNELS_SESSION } from './main-agent.js'
-import { sendTelegramMessage } from './telegram.js'
 import { runCommandTask } from './command-task.js'
 import { decideQuotaAction, type QuotaWorkClass } from '../quota-gate.js'
 import { readQuotaSnapshot } from '../quota-snapshot.js'
@@ -441,18 +441,28 @@ function persistLastTickMs(nowMs: number): void {
 //   non-zero exit            → log warning, run LLM anyway (fail-open)
 // --- Bound-channel chat id resolution for scheduled-task prompts ---
 //
-// The prompt prefix used to carry a "chat_id: 0" sentinel meaning "the running
+// TELEGRAM: The prompt prefix used to carry a "chat_id: 0" sentinel meaning "the running
 // agent's own bound channel". The convention belonged to an earlier channel
-// implementation; the official Telegram plugin (0.0.6) knows nothing about it:
-// its reply tool calls assertAllowedChat(chat_id) first, "0" is never on the
-// allowlist, so every non-heartbeat scheduled task threw at delivery time
-// (Zara, 2026-07-27; all 32 task-configs affected -- none carries a chat_id).
-// The sentinel's INTENT stays correct (a sub-agent's result must go to its own
-// owner, never the boss's chat), so the fix resolves the concrete chat id at
-// prompt-build time from the same place the plugin enforces it: the agent's
-// own channel access.json allowlist.
+// implementation; the official Telegram plugin (0.0.6) knows nothing about it: the reply
+// tool calls assertAllowedChat(chat_id) first, "0" is never on the allowlist, so
+// every non-heartbeat scheduled task threw at delivery time (Zara, 2026-07-27;
+// all 32 task-configs affected -- none carries a chat_id). The sentinel's INTENT
+// stays correct (a sub-agent's result must go to its own owner, never the boss's
+// chat), so the fix resolves the concrete chat id at prompt-build time from the
+// same place the plugin enforces it: the agent's own channel access.json.
+//
+// SLACK: the resolution is now provider-aware. The main agent and each
+// sub-agent can be bound to Telegram OR Slack (CHANNEL_PROVIDER / per-agent
+// agent-config.json channelProvider), and the access.json lives under the
+// matching provider subdir. Reading telegram/access.json unconditionally meant a
+// Slack-bound agent (no telegram/access.json at all) resolved to null and its
+// scheduled tasks silently shipped with NO delivery instruction (measured on the
+// live CHANNEL_PROVIDER=slack install: telegram/access.json absent, so every
+// scheduled task result had nowhere to go).
 
-/** Pure core: first DM allowlist entry, else first allowed group, else null. */
+/** Pure core: first DM allowlist entry, else first allowed group/channel, else
+ *  null. Handles both the Telegram/Discord `groups` map and the Slack `channels`
+ *  map so one helper covers every provider's access.json shape. */
 export function chatIdFromAccessConfig(raw: unknown): string | null {
   if (!raw || typeof raw !== 'object') return null
   const o = raw as Record<string, unknown>
@@ -461,23 +471,55 @@ export function chatIdFromAccessConfig(raw: unknown): string | null {
     if (typeof first === 'string' && first.trim()) return first.trim()
     if (typeof first === 'number') return String(first)
   }
-  if (o.groups && typeof o.groups === 'object') {
-    const keys = Object.keys(o.groups as Record<string, unknown>)
-    if (keys.length > 0) return keys[0]
+  for (const key of ['groups', 'channels'] as const) {
+    const map = o[key]
+    if (map && typeof map === 'object') {
+      const keys = Object.keys(map as Record<string, unknown>)
+      if (keys.length > 0) return keys[0]
+    }
   }
   return null
 }
 
-/** The agent's own bound Telegram chat, or null when no binding exists.
- *  Reads <agent channels dir>/telegram/access.json -- the exact file the
- *  plugin's assertAllowedChat enforces, so a resolved id is deliverable by
- *  construction. Deliberately NOT falling back to ALLOWED_CHAT_ID: that is
- *  the boss's chat, and pointing a sub-agent's result there is the precise
- *  bug the old sentinel existed to avoid. */
-export function resolveBoundChatId(agentName: string): string | null {
+/** How a scheduled-task prompt names the delivery channel, in Hungarian, for
+ *  the "kuldd el <ide>" instruction. The reply tool itself is the same across
+ *  providers -- only the channel noun and the chat_id format differ. */
+export function channelDeliveryName(provider: ChannelProviderType): string {
+  switch (provider) {
+    case "slack":
+      return "Slacken";
+    case "discord":
+      return "Discordon";
+    case "googlechat":
+      return "Google Chaten";
+    case "teams":
+      return "Teamsen";
+    case "telegram":
+      return "Telegramon";
+    default:
+      return "Telegramon";
+  }
+}
+
+export interface BoundChannel {
+  /** The provider the agent is bound to (main: CHANNEL_PROVIDER; sub-agent:
+   *  its agent-config.json channelProvider, falling back to CHANNEL_PROVIDER). */
+  provider: ChannelProviderType
+  /** The agent's own bound chat id, or null when no binding exists. */
+  chatId: string | null
+}
+
+/** The agent's own bound channel + chat, or {provider, chatId:null} when no
+ *  binding exists. Reads <agent channels dir>/<provider>/access.json -- the
+ *  exact file the plugin's assertAllowedChat enforces, so a resolved id is
+ *  deliverable by construction. Deliberately NOT falling back to
+ *  ALLOWED_CHAT_ID: that is the boss's chat, and pointing a sub-agent's result
+ *  there is the precise bug the old sentinel existed to avoid. */
+export function resolveBoundChannel(agentName: string): BoundChannel {
+  const provider = resolveAgentProvider(agentName)
   const dir = agentName === MAIN_AGENT_ID
-    ? channelStateDir('telegram')
-    : channelStateDir('telegram', agentDir(agentName))
+    ? channelStateDir(provider)
+    : channelStateDir(provider, agentDir(agentName))
   try {
     const raw = JSON.parse(readFileSync(join(dir, 'access.json'), 'utf-8')) as Record<string, unknown>
     const chosen = chatIdFromAccessConfig(raw)
@@ -489,10 +531,10 @@ export function resolveBoundChatId(agentName: string): string | null {
     // log line; behaviour is unchanged (Marveen, msg 7002).
     const candidates = Array.isArray(raw?.allowFrom) ? raw.allowFrom.length : 0
     if (chosen && candidates > 1) {
-      logger.warn({ agent: agentName, candidates, chosen }, 'bound-chat resolution is ambiguous: multiple DM allowlist entries, using the first')
+      logger.warn({ agent: agentName, provider, candidates, chosen }, 'bound-chat resolution is ambiguous: multiple DM allowlist entries, using the first')
     }
-    return chosen
-  } catch { return null }
+    return { provider, chatId: chosen }
+  } catch { return { provider, chatId: null } }
 }
 
 // What a scheduled task costs the shared quota pool, for the gate in
@@ -721,18 +763,20 @@ async function attemptFireTask(
       // ALLOWED_CHAT_ID. The latter is the main/admin chat; injecting it here
       // pointed every sub-agent's task result at the boss's chat instead of its
       // own owner (e.g. attilamarveenja -> Papp Attila). The old "chat_id: 0"
-      // sentinel encoded the same intent, but the official Telegram plugin
-      // rejects it (assertAllowedChat: "0" is never allowlisted), so the
-      // binding is resolved to a CONCRETE id here at prompt-build time. No
-      // binding -> no Telegram instruction at all: better to skip delivery
-      // than to deliver to the wrong chat, and the warn below makes the
-      // config gap visible. The system-level pending-retry alert further
-      // down still uses ALLOWED_CHAT_ID by design.
-      const boundChatId = resolveBoundChatId(agentName)
-      if (boundChatId) {
-        prefix = `[Utemezett feladat: ${task.name}] Az eredmenyt kuldd el Telegramon (chat_id: ${boundChatId}, reply tool). `
+      // sentinel encoded the same intent, but the official Telegram plugin rejects it
+      // (assertAllowedChat: "0" is never allowlisted), so the binding is
+      // resolved to a CONCRETE id here at prompt-build time.
+      // SLACK: the resolution follows the agent's actual provider (Telegram or Slack) and
+      // the instruction names that channel + uses its chat_id format. No
+      // binding -> no delivery instruction at all: better to skip delivery than
+      // to deliver to the wrong chat, and the warn below makes the config gap
+      // visible. The system-level pending-retry alert further down uses the
+      // owner chat by design.
+      const bound = resolveBoundChannel(agentName)
+      if (bound.chatId) {
+        prefix = `[Utemezett feladat: ${task.name}] Az eredmenyt kuldd el ${channelDeliveryName(bound.provider)} (chat_id: ${bound.chatId}, reply tool). `
       } else {
-        logger.warn({ task: task.name, agent: agentName }, 'scheduled task: agent has no bound telegram chat (access.json missing/empty) -- prompt omits the Telegram delivery instruction')
+        logger.warn({ task: task.name, agent: agentName, provider: bound.provider }, 'scheduled task: agent has no bound channel (access.json missing/empty) -- prompt omits the delivery instruction')
         prefix = `[Utemezett feladat: ${task.name}] `
       }
     }
@@ -948,25 +992,52 @@ export async function runScheduledTaskNow(
   return { ok: true, result: summary.join(', ') }
 }
 
-// Fire a Telegram alert when a pending retry has been stuck past the
-// threshold. Stamps `alert_sent_at` BEFORE the network call so concurrent
-// ticks and crash-restarts cannot race into double-alerting on the same
-// attempt. If the send fails, the stamp is cleared so the next tick can
-// retry -- that way a transient Telegram outage or a bad token doesn't
-// silently suppress every future alert on this row. Net semantics:
-// exactly-one stamp per delivery attempt, at-least-once delivery with a
-// 60s retry cadence until success.
+// Fire an owner alert when a pending retry has been stuck past the threshold.
+// The alert goes over the main agent's bound channel (CHANNEL_PROVIDER:
+// Telegram or Slack). Stamps `alert_sent_at` BEFORE the network call so
+// concurrent ticks and crash-restarts cannot race into double-alerting on the
+// same attempt. If the send fails, the stamp is cleared so the next tick can
+// retry -- that way a transient channel outage or a bad token doesn't silently
+// suppress every future alert on this row. Net semantics: exactly-one stamp per
+// delivery attempt, at-least-once delivery with a 60s retry cadence until success.
 // Bot token for the system-level scheduler alerts (pending-retry, task-timeout,
-// catch-up summary). Since the channels migration the token lives in the
-// telegram plugin's env, not marveen/.env (2026-07-08: every scheduler alert
-// was silently suppressed on such hosts), so both locations are tried -- same
-// fallback order as scripts/notify.sh.
+// catch-up summary). SLACKAWARE: the alerts go over whatever channel the MAIN
+// agent is bound to (CHANNEL_PROVIDER), so the token is resolved for that
+// provider. Telegram keeps its historical dual-location lookup (marveen/.env
+// first, then the plugin env -- 2026-07-08: every scheduler alert was silently
+// suppressed on hosts where the token had moved to the plugin env after the
+// channels migration); other providers read the main agent's channel .env via
+// readChannelToken. A creds-based provider (Google Chat/Teams) has no bot token,
+// so the alert send falls back to the log-only path in each caller.
 function resolveSchedulerAlertToken(): string | undefined {
-  const envContent = readFileOr(join(PROJECT_ROOT, '.env'), '')
-  const token = envContent.match(/TELEGRAM_BOT_TOKEN=(.+)/)?.[1]?.trim()
-  if (token) return token
-  const channelEnv = readFileOr(join(homedir(), '.claude', 'channels', 'telegram', '.env'), '')
-  return channelEnv.match(/TELEGRAM_BOT_TOKEN=(.+)/)?.[1]?.trim()
+  if (CHANNEL_PROVIDER === 'telegram') {
+    const envContent = readFileOr(join(PROJECT_ROOT, '.env'), '')
+    const token = envContent.match(/TELEGRAM_BOT_TOKEN=(.+)/)?.[1]?.trim()
+    if (token) return token
+  } else if (CHANNEL_PROVIDER === 'slack') {
+    const token = readChannelToken(CHANNEL_PROVIDER, join(channelStateDir(CHANNEL_PROVIDER), '.env'))
+    if (token) return token
+  }
+  
+  return undefined
+}
+
+// Resolve the owner chat for the MAIN agent's bound provider. The default
+// resolveOwnerChatId() reads telegram/access.json; the scheduler alerts must
+// follow CHANNEL_PROVIDER so a Slack-bound main agent resolves its owner from
+// slack/access.json (the live CHANNEL_PROVIDER=slack install has no telegram
+// access.json at all, so the default path returned null and every scheduler
+// alert was suppressed).
+function resolveSchedulerOwnerChat(): string | null {
+  return resolveOwnerChatId(undefined, undefined, CHANNEL_PROVIDER)
+}
+
+// Send a system-level scheduler alert over the MAIN agent's bound channel. The
+// message is plain text (no markdown) as it always has been, so no formatMessage
+// pass is applied; getProvider throws on a non-2xx / ok:false response so the
+// callers' try/catch + classifySendError paths work for every provider.
+function sendSchedulerAlertMessage(token: string, chatId: string, text: string): Promise<void> {
+  return getProvider(CHANNEL_PROVIDER).sendMessage(token, chatId, text)
 }
 
 // One line about what the scheduler missed while it was down: which tasks it
@@ -981,12 +1052,12 @@ function sendCatchUpSummary(
 ): void {
   const token = resolveSchedulerAlertToken()
   if (!token) {
-    logger.warn('catch-up summary suppressed: no TELEGRAM_BOT_TOKEN (config error)')
+    logger.warn({ provider: CHANNEL_PROVIDER }, 'catch-up summary suppressed: no channel bot token (config error)')
     return
   }
-  const ownerChat = resolveOwnerChatId()
+  const ownerChat = resolveSchedulerOwnerChat()
   if (!ownerChat) {
-    logger.warn('catch-up summary suppressed: no owner chat (ALLOWED_CHAT_ID unset/placeholder and no paired channel)')
+    logger.warn({ provider: CHANNEL_PROVIDER }, 'catch-up summary suppressed: no owner chat (ALLOWED_CHAT_ID unset/placeholder and no paired channel)')
     return
   }
   const mins = (ms: number) => `${Math.round(ms / 60000)} perc`
@@ -1004,8 +1075,8 @@ function sendCatchUpSummary(
   const text = lines.join('\n')
   ;(async () => {
     try {
-      await sendTelegramMessage(token, ownerChat, text)
-      logger.info({ caughtUp: caughtUp.length, stale: stale.length }, 'catch-up summary Telegram alert sent')
+      await sendSchedulerAlertMessage(token, ownerChat, text)
+      logger.info({ caughtUp: caughtUp.length, stale: stale.length, provider: CHANNEL_PROVIDER }, 'catch-up summary alert sent')
     } catch (err) {
       logger.warn({ err }, 'catch-up summary delivery failed')
     }
@@ -1030,12 +1101,12 @@ function sendPendingRetryAlert(view: PendingRetryView, nowMs: number): void {
   // itself keeps retrying regardless -- only this alert is suppressed.
   const token = resolveSchedulerAlertToken()
   if (!token) {
-    logger.warn({ task: view.taskName, agent: view.agentName }, 'Pending-retry alert suppressed: no TELEGRAM_BOT_TOKEN (config error, stamp kept to avoid 60s spin)')
+    logger.warn({ task: view.taskName, agent: view.agentName, provider: CHANNEL_PROVIDER }, 'Pending-retry alert suppressed: no channel bot token (config error, stamp kept to avoid 60s spin)')
     return
   }
-  const ownerChat = resolveOwnerChatId()
+  const ownerChat = resolveSchedulerOwnerChat()
   if (!ownerChat) {
-    logger.warn({ task: view.taskName, agent: view.agentName }, 'Pending-retry alert suppressed: no owner chat (ALLOWED_CHAT_ID unset/placeholder and no paired channel; stamp kept to avoid 60s spin)')
+    logger.warn({ task: view.taskName, agent: view.agentName, provider: CHANNEL_PROVIDER }, 'Pending-retry alert suppressed: no owner chat (ALLOWED_CHAT_ID unset/placeholder and no paired channel; stamp kept to avoid 60s spin)')
     return
   }
 
@@ -1070,15 +1141,15 @@ function sendPendingRetryAlert(view: PendingRetryView, nowMs: number): void {
       ]).join('\n')
   ;(async () => {
     try {
-      await sendTelegramMessage(token, ownerChat, text)
-      logger.info({ task: view.taskName, agent: view.agentName, ageMinutes }, 'Pending-retry Telegram alert sent')
+      await sendSchedulerAlertMessage(token, ownerChat, text)
+      logger.info({ task: view.taskName, agent: view.agentName, ageMinutes, provider: CHANNEL_PROVIDER }, 'Pending-retry alert sent')
     } catch (err) {
       // Distinguish a transient failure (network blip, 429, 5xx) from a
       // permanent one (4xx: bad chat_id / revoked token). Transient ->
       // clear the per-attempt stamp so the next tick retries. Permanent
       // -> KEEP the stamp; retrying every 60s would just repeat the same
       // rejection and spam the log until the config is fixed.
-      const kind = classifyTelegramSendError(err instanceof Error ? err.message : String(err))
+      const kind = classifySendError(err instanceof Error ? err.message : String(err))
       if (kind === 'transient') {
         logger.warn({ err, task: view.taskName, agent: view.agentName }, 'Pending-retry alert delivery failed (transient), clearing stamp for retry')
         clearPendingTaskRetryAlert(view.taskName, view.agentName)
@@ -1089,20 +1160,20 @@ function sendPendingRetryAlert(view: PendingRetryView, nowMs: number): void {
   })()
 }
 
-// One-shot Telegram alert when a fired task/heartbeat has been continuously
-// busy past TASK_FIRE_TIMEOUT_MS. Follows the same token-resolution and
-// ALLOWED_CHAT_ID path as sendPendingRetryAlert: this is a system-level
-// scheduler alert, not a per-agent channel notification.
+// One-shot alert when a fired task/heartbeat has been continuously busy past
+// TASK_FIRE_TIMEOUT_MS. Follows the same token-resolution and owner-chat path as
+// sendPendingRetryAlert (provider-aware, over CHANNEL_PROVIDER): this is a
+// system-level scheduler alert, not a per-agent channel notification.
 function sendTaskTimeoutAlert(entry: TaskInflightEntry, elapsedMs: number): void {
   const ageMinutes = Math.floor(elapsedMs / 60000)
   const token = resolveSchedulerAlertToken()
   if (!token) {
-    logger.warn({ task: entry.taskName, agent: entry.agentName }, 'task-timeout alert suppressed: no TELEGRAM_BOT_TOKEN (config error)')
+    logger.warn({ task: entry.taskName, agent: entry.agentName, provider: CHANNEL_PROVIDER }, 'task-timeout alert suppressed: no channel bot token (config error)')
     return
   }
-  const ownerChat = resolveOwnerChatId()
+  const ownerChat = resolveSchedulerOwnerChat()
   if (!ownerChat) {
-    logger.warn({ task: entry.taskName, agent: entry.agentName }, 'task-timeout alert suppressed: no owner chat (ALLOWED_CHAT_ID unset/placeholder and no paired channel)')
+    logger.warn({ task: entry.taskName, agent: entry.agentName, provider: CHANNEL_PROVIDER }, 'task-timeout alert suppressed: no owner chat (ALLOWED_CHAT_ID unset/placeholder and no paired channel)')
     return
   }
   // If there is an active kanban card whose title matches the task name, move it
@@ -1124,8 +1195,8 @@ function sendTaskTimeoutAlert(entry: TaskInflightEntry, elapsedMs: number): void
   ].join('\n')
   ;(async () => {
     try {
-      await sendTelegramMessage(token, ownerChat, text)
-      logger.info({ task: entry.taskName, agent: entry.agentName, ageMinutes }, 'task-timeout Telegram alert sent')
+      await sendSchedulerAlertMessage(token, ownerChat, text)
+      logger.info({ task: entry.taskName, agent: entry.agentName, ageMinutes, provider: CHANNEL_PROVIDER }, 'task-timeout alert sent')
     } catch (err) {
       logger.warn({ err, task: entry.taskName, agent: entry.agentName }, 'task-timeout alert delivery failed')
     }

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -11,7 +11,7 @@ import {
   APP_TZ_INVALID,
   CHANNEL_PROVIDER,
 } from '../config.js'
-import { resolveOwnerChatId } from '../owner-chat.js'
+import { resolveOwnerChatId, configuredOwnerChatFor } from '../owner-chat.js'
 import {
   appendTaskRun,
   listPendingTaskRetries,
@@ -1027,13 +1027,15 @@ export function resolveSchedulerAlertToken(
 }
 
 // Resolve the owner chat for the MAIN agent's bound provider. The default
-// resolveOwnerChatId() reads telegram/access.json; the scheduler alerts must
-// follow CHANNEL_PROVIDER so a Slack-bound main agent resolves its owner from
-// slack/access.json (the live CHANNEL_PROVIDER=slack install has no telegram
-// access.json at all, so the default path returned null and every scheduler
-// alert was suppressed).
+// resolveOwnerChatId() reads ALLOWED_CHAT_ID + telegram/access.json; the
+// scheduler alerts must follow CHANNEL_PROVIDER on BOTH halves: the configured
+// id comes from the provider's own .env key (SLACK_CHANNEL_ID etc. via
+// configuredOwnerChatFor -- a stale Telegram ALLOWED_CHAT_ID must not win on a
+// Slack install) and the paired fallback from slack/access.json (the live
+// CHANNEL_PROVIDER=slack install has no telegram access.json at all, so the
+// default path returned null and every scheduler alert was suppressed).
 function resolveSchedulerOwnerChat(): string | null {
-  return resolveOwnerChatId(undefined, undefined, CHANNEL_PROVIDER)
+  return resolveOwnerChatId(undefined, configuredOwnerChatFor(CHANNEL_PROVIDER), CHANNEL_PROVIDER)
 }
 
 // Send a system-level scheduler alert over the MAIN agent's bound channel. The

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -1003,23 +1003,27 @@ export async function runScheduledTaskNow(
 // Bot token for the system-level scheduler alerts (pending-retry, task-timeout,
 // catch-up summary). SLACKAWARE: the alerts go over whatever channel the MAIN
 // agent is bound to (CHANNEL_PROVIDER), so the token is resolved for that
-// provider. Telegram keeps its historical dual-location lookup (marveen/.env
-// first, then the plugin env -- 2026-07-08: every scheduler alert was silently
-// suppressed on hosts where the token had moved to the plugin env after the
-// channels migration); other providers read the main agent's channel .env via
-// readChannelToken. A creds-based provider (Google Chat/Teams) has no bot token,
-// so the alert send falls back to the log-only path in each caller.
-function resolveSchedulerAlertToken(): string | undefined {
-  if (CHANNEL_PROVIDER === 'telegram') {
-    const envContent = readFileOr(join(PROJECT_ROOT, '.env'), '')
-    const token = envContent.match(/TELEGRAM_BOT_TOKEN=(.+)/)?.[1]?.trim()
-    if (token) return token
-  } else if (CHANNEL_PROVIDER === 'slack') {
-    const token = readChannelToken(CHANNEL_PROVIDER, join(channelStateDir(CHANNEL_PROVIDER), '.env'))
-    if (token) return token
-  }
-  
-  return undefined
+// provider. Every provider keeps the historical dual-location lookup:
+// marveen/.env first, then the main agent's channel .env (2026-07-08: every
+// scheduler alert was silently suppressed on hosts where the token had moved
+// to the plugin env after the channels migration -- that fallback must hold
+// for Telegram and Slack alike). readChannelToken maps the provider to its
+// env key (TELEGRAM_BOT_TOKEN / SLACK_BOT_TOKEN / ...). A creds-based
+// provider (Google Chat/Teams) has no bot token and no direct send path, so
+// the alert falls back to the log-only path in each caller.
+// `provider` and `readToken` are injectable for the unit test only (lookup
+// order + empty-value fall-through); production callers use the defaults.
+export function resolveSchedulerAlertToken(
+  provider: ChannelProviderType = CHANNEL_PROVIDER,
+  readToken: (provider: ChannelProviderType, envFilePath: string) => string | null = readChannelToken,
+): string | undefined {
+  if (provider === "googlechat" || provider === "teams") return undefined;
+
+  return (
+    readToken(provider, join(PROJECT_ROOT, ".env")) ||
+    readToken(provider, join(channelStateDir(provider), ".env")) ||
+    undefined
+  );
 }
 
 // Resolve the owner chat for the MAIN agent's bound provider. The default

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -496,8 +496,8 @@ export function channelDeliveryName(provider: ChannelProviderType): string {
       return "Teamsen";
     case "telegram":
       return "Telegramon";
-    default:
-      return "Telegramon";
+    // No default: the switch is exhaustive over ChannelProviderType, so a new
+    // provider is a compile error here instead of silently reading "Telegramon".
   }
 }
 


### PR DESCRIPTION


## A változtatás típusa / Type of change

- [ X] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

 **HU:**

Két útvonal Telegramra volt keményen bekódolva, és emiatt csendben hibára futott Slack telepítés esetén (CHANNEL_PROVIDER=slack, nincs telegram/access.json):

Az ütemezett feladatok eredményének kézbesítése.
A resolveBoundChatId -> resolveBoundChannel most az agent tényleges providerét olvassa, miközben a prompt a megfelelő csatornát nevezi meg („kuldd el Slacken (chat_id: U...)”). Korábban ez feltétel nélkül a telegram/access.json fájlt olvasta, amely itt nem létezik, ezért minden ütemezett feladat kézbesítési utasítás nélkül indult el. Ez volt a fő hiba.
Rendszerértesítések (pending-retry, task-timeout, catch-up summary).
A token kezelése, a tulajdonos chatjének feloldása és az üzenetküldés most már mind a CHANNEL_PROVIDER értékét követi a provider abstractionön keresztül. Ha nem volt TELEGRAM_BOT_TOKEN, az értesítések korábban csendben el lettek nyelve.

További változás: a classifyTelegramSendError → classifySendError lett átnevezve (az alias megmaradt), és most már a Slack hibáit is osztályozza: a ratelimited / rate_limited / internal_error / service_unavailable hibák, valamint bármely 5xx hiba átmeneti (transient) hibának számít. A channel_not_found / invalid_auth / token_revoked és a többi Slack konfigurációs hibakód pedig végleges (permanent) hibának minősül, így az értesítések nem próbálkoznak újra 60 másodpercenként.

A resolveAgentProvider most már exportálva van az agent-process.ts fájlból (resolveBoundChannel használja), ezért a schedule-runner-retry-missing teszt modul-mockjához hozzá kellett adni ezt az egy

 **EN:** 
 Two paths were Telegram-hardcoded and silently broke on a Slack install (CHANNEL_PROVIDER=slack, no telegram/access.json):

1. Scheduled-task result delivery. resolveBoundChatId -> resolveBoundChannel: reads the agent's actual provider and the prompt names the correct channel ("kuldd el Slacken (chat_id: U...)"). Previously it read telegram/access.json unconditionally, which does not exist here, so every scheduled task shipped with no delivery instruction. This was the core bug.

2. System alerts (pending-retry, task-timeout, catch-up summary). Token, owner-chat resolution and the send now follow CHANNEL_PROVIDER through the provider abstraction. With no TELEGRAM_BOT_TOKEN they were silently swallowed.

Also: classifyTelegramSendError -> classifySendError (alias kept) now classifies Slack errors too: ratelimited/rate_limited/internal_error/service_unavailable and any 5xx = transient; channel_not_found/invalid_auth/token_revoked and the other Slack config codes = permanent, so alerts don't spin every 60s.

resolveAgentProvider is now exported from agent-process.ts (resolveBoundChannel needs it), so the schedule-runner-retry-missing test's module mock gained that one export.

## Kapcsolódó issue / Related issue

Closes #

## Ellenőrzőlista / Checklist

- [x ] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [ ] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
- [ x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [ x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).

## Titok-kapu / Secret gate

A `secret-gate` CI-job a valodi kapu. A lokalis pre-commit hook csak gyors
elorejelzes, es `--no-verify`-jal megkerulheto -- ne tekintsd elegnek.
The `secret-gate` CI job is the real gate; the local pre-commit hook is a fast
preview and can be skipped with `--no-verify`, so it is not sufficient on its own.

- [ ] Nincs a valtoztatasban bizonyitek-/artefaktum-mappa, titok-alaku string vagy idezett csatorna-uzenet.
      / No evidence or artifact directory, secret-shaped string, or quoted channel message in this change.

## TESZTELES

Slack kommunikációs csatornával:
<img width="1067" height="749" alt="slack_test_01" src="https://github.com/user-attachments/assets/bed2a715-aa18-43e2-8615-a86bf5b205c1" />
<img width="804" height="743" alt="slack_test_02" src="https://github.com/user-attachments/assets/2b14fbed-e4fd-4e30-8d5b-55bf7f5e1236" />

Telegram kommunikációs csatornával:

<img width="950" height="724" alt="telegram_test_01" src="https://github.com/user-attachments/assets/6fe093b5-d036-4d35-8cbf-afb962942e2b" />
<img width="659" height="701" alt="telegram_test_02" src="https://github.com/user-attachments/assets/487866d9-dbca-4308-a215-61ce98aa54aa" />
