### PR TITLE
feat(heartbeat): metrics from a fixed on-disk instrument (HBMEMBLIND819)

### DIFF
--- a/scripts/heartbeat-metrics.sh
+++ b/scripts/heartbeat-metrics.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# heartbeat-metrics.sh -- the heartbeat round's single callable instrument
+# (HBMEMBLIND819, third contract).
+#
+# Why a script and not a prescribed command, measured three times: the
+# hot-memory metric drifted through three prescription layers -- 2026-08-07
+# (HBMEMBLIND807) a prose bullet let the round compose its own SQL; the fix
+# shipped a ready-made query, and 2026-08-19 (HBMEMBLIND819) post-compact
+# rounds reconstructed it with the wrong agent_id; the next fix shipped a
+# ready-made one-liner, and 2026-08-24 22:00 a round re-composed it with a
+# truncated format string, so a missing field printed as a silent 0.
+# A prescription the agent must re-copy every hour is not a mechanism; a
+# script on disk has nothing to recompose.
+#
+# Output contract (consumed VERBATIM by the heartbeat agent's CLAUDE.md,
+# rendered from src/web/heartbeat-agent-scaffold.ts):
+#
+#   HB_METRICS_V1 ts=<local time in CLAW_TZ>
+#   COUNTS urgent=N in_progress=N waiting=N planned=N new_hot_memories_1h=N db_size_mb=N waiting_shown=N
+#   URGENT <id> <title>            (0..n lines)
+#   WAITING <id> <title>           (0..n lines)
+#   SCHEDULES enabled=N
+#   TASK_RUNS_1H total=N [<status>=N ...]
+#   ERROR <section>: <reason>      (any failed measurement)
+#
+# Fail-closed (the load-bearing property): a missing or null field NEVER
+# prints as 0 -- it prints an ERROR line and the exit code is non-zero.
+# A 0 in this output is always a measured zero. The sentinel line always
+# prints first, so partial output stays usable; the version in the
+# sentinel is the reader's compatibility check ("known sentinel or
+# instrument failure", never "looks like output").
+#
+# Env (all optional):
+#   CLAW_STORE_DIR         store/ holding .dashboard-token + claudeclaw.db
+#                          (default: <repo root>/store, derived from this
+#                          script's own location)
+#   CLAW_DASHBOARD_ORIGIN  dashboard origin (default http://localhost:3420)
+#   CLAW_TZ                timezone for the ts= stamp (default Europe/Budapest)
+
+set -u
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+STORE_DIR="${CLAW_STORE_DIR:-$ROOT/store}"
+ORIGIN="${CLAW_DASHBOARD_ORIGIN:-http://localhost:3420}"
+TZNAME="${CLAW_TZ:-Europe/Budapest}"
+
+echo "HB_METRICS_V1 ts=$(TZ="$TZNAME" date +'%Y-%m-%d %H:%M')"
+
+# All measurements run in ONE python3 process: no pipes, no shell variables
+# carrying JSON, and no data piped into a heredoc (the HBHEREDOC819 shape
+# was `echo "$JSON" | python3 <<PY` -- the heredoc replaces stdin and the
+# piped data is silently lost; here the heredoc IS the program and nothing
+# is piped). python3's sqlite3 module replaces the sqlite3 CLI, which does
+# not exist on a stock Linux install (exit 127).
+STORE_DIR="$STORE_DIR" ORIGIN="$ORIGIN" python3 - <<'PY'
+import json, os, sqlite3, sys, urllib.request
+
+store = os.environ['STORE_DIR']
+origin = os.environ['ORIGIN']
+fail = 0
+
+def err(section, reason):
+    global fail
+    print('ERROR %s: %s' % (section, reason))
+    fail = 1
+
+tok = None
+try:
+    with open(os.path.join(store, '.dashboard-token')) as f:
+        tok = f.read().strip()
+except OSError as e:
+    err('token', 'cannot read .dashboard-token: %s' % e)
+
+def get(path):
+    req = urllib.request.Request(
+        origin + path, headers={'Authorization': 'Bearer ' + tok})
+    with urllib.request.urlopen(req, timeout=10) as r:
+        return json.load(r)
+
+if tok is not None:
+    # Kanban + memory + DB size: every number is computed server-side on
+    # /api/kanban/heartbeat-summary and copied here -- there is nothing to
+    # recompose (HBMEMBLIND807/819, HBKANBANDRIFT819, HBDBMERET822).
+    try:
+        d = get('/api/kanban/heartbeat-summary')
+        c = d.get('counts')
+        if not isinstance(c, dict):
+            err('summary', 'counts missing from response')
+        else:
+            required = ['urgent', 'in_progress', 'waiting', 'planned',
+                        'new_hot_memories_1h', 'db_size_mb']
+            missing = [k for k in required if c.get(k) is None]
+            if missing:
+                # Fail-closed: the absent field must not become a 0.
+                err('summary', 'missing/null fields: %s' % ','.join(missing))
+            else:
+                print('COUNTS urgent=%s in_progress=%s waiting=%s planned=%s '
+                      'new_hot_memories_1h=%s db_size_mb=%s waiting_shown=%s'
+                      % (c['urgent'], c['in_progress'], c['waiting'],
+                         c['planned'], c['new_hot_memories_1h'],
+                         c['db_size_mb'], d.get('waiting_shown')))
+            for x in d.get('urgent') or []:
+                print('URGENT', x.get('id'), x.get('title'))
+            for x in d.get('waiting') or []:
+                print('WAITING', x.get('id'), x.get('title'))
+    except Exception as e:
+        err('summary', repr(e))
+
+    # The live schedule registry -- NOT the scheduled_tasks table, which is
+    # empty on this deployment and would report 0 forever.
+    try:
+        r = get('/api/schedules')
+        print('SCHEDULES enabled=%d' % sum(1 for x in r if x.get('enabled')))
+    except Exception as e:
+        err('schedules', repr(e))
+
+# task_runs.ts is epoch MILLISECONDS: the cutoff must be *1000. With a
+# seconds cutoff every row matches and "last hour" silently becomes "since
+# the beginning". strftime('%s','now') instead of unixepoch() so the query
+# also runs on sqlite < 3.38.
+try:
+    db = os.path.join(store, 'claudeclaw.db')
+    if not os.path.exists(db):
+        err('task_runs', 'db not found: %s' % db)
+    else:
+        con = sqlite3.connect('file:%s?mode=ro' % db, uri=True)
+        rows = con.execute(
+            "SELECT status, COUNT(*) FROM task_runs "
+            "WHERE ts > (strftime('%s','now') - 3600) * 1000 "
+            "GROUP BY status").fetchall()
+        total = sum(n for _, n in rows)
+        parts = ' '.join('%s=%d' % (s, n) for s, n in rows)
+        print('TASK_RUNS_1H total=%d%s' % (total, (' ' + parts) if parts else ''))
+except Exception as e:
+    err('task_runs', repr(e))
+
+sys.exit(1 if fail else 0)
+PY

--- a/src/__tests__/agent-scaffold-dashboard-origin.test.ts
+++ b/src/__tests__/agent-scaffold-dashboard-origin.test.ts
@@ -122,6 +122,7 @@ describe('renderHeartbeatClaudeMd: respects dashboardOrigin', () => {
     storeDir: '/srv/app/store',
     dashboardOrigin: 'http://localhost:3420',
     calendarAccount: '',
+    metricsScript: '/srv/app/scripts/heartbeat-metrics.sh',
   }
 
   it('uses a public URL when dashboardOrigin is set to one', () => {

--- a/src/__tests__/heartbeat-agent-scaffold.test.ts
+++ b/src/__tests__/heartbeat-agent-scaffold.test.ts
@@ -15,6 +15,7 @@ const ID: HeartbeatIdentity = {
   storeDir: '/srv/app/store',
   dashboardOrigin: 'http://localhost:3420',
   calendarAccount: 'nina@example.com',
+  metricsScript: '/srv/app/scripts/heartbeat-metrics.sh',
 }
 
 describe('renderHeartbeatClaudeMd', () => {
@@ -36,10 +37,15 @@ describe('renderHeartbeatClaudeMd', () => {
     expect(out).toContain('"from":"heartbeat"')
   })
 
-  it('uses the supplied store dir (absolute) for the DB and token paths', () => {
+  it('uses the supplied store dir (absolute) for the instrument env and the token path', () => {
     const out = renderHeartbeatClaudeMd(ID)
-    expect(out).toContain('/srv/app/store/claudeclaw.db')
+    // The DB path itself no longer appears in the prose: the metrics
+    // instrument derives it from CLAW_STORE_DIR, so the only store-dir
+    // surfaces left are the instrument's env prefix and the step-3
+    // message POST's token read.
+    expect(out).toContain('CLAW_STORE_DIR=/srv/app/store')
     expect(out).toContain('cat /srv/app/store/.dashboard-token')
+    expect(out).not.toContain('claudeclaw.db')
   })
 
   it('uses the supplied dashboard origin for the messages API', () => {
@@ -121,11 +127,13 @@ describe('renderHeartbeatClaudeMd', () => {
       storeDir: '/data/store',
       dashboardOrigin: 'http://localhost:9000',
       calendarAccount: '',
+      metricsScript: '/data/scripts/heartbeat-metrics.sh',
     })
     expect(a).not.toBe(b)
     expect(b).toContain("across Omar's systems")
     expect(b).toContain('"to":"atlas"')
-    expect(b).toContain('/data/store/claudeclaw.db')
+    expect(b).toContain('CLAW_STORE_DIR=/data/store')
+    expect(b).toContain('bash /data/scripts/heartbeat-metrics.sh')
     expect(b).toContain('http://localhost:9000/api/messages')
   })
 
@@ -182,11 +190,17 @@ describe('renderHeartbeatClaudeMd', () => {
     expect(out).not.toContain('next_run_at')
   })
 
-  it('compares task_runs.ts in milliseconds', () => {
+  it('names the task_runs milliseconds trap but ships no runnable SQL for it', () => {
     // ts is epoch MILLISECONDS; a seconds comparison matches every row and
-    // silently turns "last hour" into "since the beginning".
+    // silently turns "last hour" into "since the beginning". This assertion
+    // REPLACES the older one that required the literal
+    // `(unixepoch()-3600)*1000` query in the prose: the cutoff now lives in
+    // scripts/heartbeat-metrics.sh (asserted by its own conformance test),
+    // and the prose only names the trap so nobody re-derives it by hand.
     const out = renderHeartbeatClaudeMd(ID)
-    expect(out).toContain('(unixepoch()-3600)*1000')
+    expect(out).toContain('MILLISECONDS')
+    expect(out).toMatch(/\*1000[^\n]*cutoff/)
+    expect(out).not.toMatch(/sqlite3 [^\n]*task_runs/)
   })
 })
 
@@ -234,8 +248,14 @@ describe('hot-memory metric is an endpoint number, never an agent-run query (HBM
   })
 
   it('degrades a missing field to "no data", never to a self-run query or a zero', () => {
+    // Phrase updated with the instrument contract: the missing-field case
+    // now surfaces as an ERROR line from the script, and the report writes
+    // "nincs adat (muszer-hiba)" -- the load-bearing part is that the
+    // degradation path exists and is named, and that fabricating a 0 is
+    // called out as the defect.
     const out = renderHeartbeatClaudeMd(ID)
-    expect(out).toContain('nincs adat (a summary nem adja)')
+    expect(out).toContain('nincs adat (muszer-hiba)')
+    expect(out).toMatch(/fabricated 0 is the defect/)
   })
 })
 
@@ -298,44 +318,63 @@ describe('deferred MCP tools (HBCALMCP808)', () => {
 // json.load reads EOF. A command the agent re-improvises every hour is not a
 // mechanism (the HBMEMBLIND819 lesson, extraction-side): the scaffold now
 // ships the COMPLETE one-line extractor and bans the pipe+heredoc shape.
-describe('kanban extraction is a shipped one-liner, never an improvised pipe+heredoc (HBHEREDOC819)', () => {
-  it('ships the complete python3 -c extractor with every counts field', () => {
+// HBHEREDOC819 -> HBMEMBLIND819 third contract: the shipped one-liner era
+// ended 2026-08-24 22:00, when a post-compact round re-composed the shipped
+// extractor with a truncated format string and a missing field printed as a
+// silent 0 -- the third failure of the same metric on a third layer. The
+// extraction now lives in scripts/heartbeat-metrics.sh (its own conformance
+// test exercises it); the prose ships NO extractor at all, only the
+// instrument call and the sentinel rule.
+describe('metrics come from the on-disk instrument, never from prose the agent can recompose', () => {
+  it('ships the instrument call with identity-derived env and path', () => {
     const out = renderHeartbeatClaudeMd(ID)
-    expect(out).toContain(`python3 -c "import json,urllib.request;`)
-    expect(out).toContain(`${ID.dashboardOrigin}/api/kanban/heartbeat-summary`)
-    expect(out).toMatch(/COUNTS urgent=%s in_progress=%s waiting=%s planned=%s new_hot_memories_1h=%s db_size_mb=%s waiting_shown=%s/)
+    expect(out).toContain(
+      'CLAW_STORE_DIR=/srv/app/store CLAW_DASHBOARD_ORIGIN=http://localhost:3420'
+    )
+    expect(out).toContain('bash /srv/app/scripts/heartbeat-metrics.sh')
   })
 
-  it('the ONLY python3-heredoc mention is the quoted example inside the ban paragraph', () => {
+  it('ships NO runnable extractor -- the copy-surface that drifted three times', () => {
     const out = renderHeartbeatClaudeMd(ID)
-    // The ban paragraph must quote the forbidden shape (so the agent can
-    // recognise it), and NOTHING else in the prompt may contain one -- a
-    // runnable heredoc anywhere would be exactly the copy-surface that broke
-    // the 18:00 round. Window: the ban paragraph's own bounds.
-    // Class-level, not variant-enumerated: two review rounds each found a
-    // form the previous narrow regex missed (bare, then -u, then `python3 -`
-    // dash-stdin -- the commonest shape here). The pinned property is that on
-    // one line, `python3` is never followed by `<<` at all; enumerating
-    // switches guarantees a fourth variant.
+    expect(out).not.toContain('python3 -c "import json,urllib.request')
+    expect(out).not.toMatch(/COUNTS urgent=%s/)
+    // The endpoint may be NAMED (as the server-side source of the numbers)
+    // but never fetched from the prose.
+    expect(out).toContain('/api/kanban/heartbeat-summary')
+    expect(out).not.toMatch(/curl[^\n]*heartbeat-summary/)
+  })
+
+  it('states the sentinel rule: known sentinel or instrument failure, never "looks like output"', () => {
+    const out = renderHeartbeatClaudeMd(ID)
+    expect(out).toContain('HB_METRICS_V1')
+    // The unknown-version branch is named explicitly (a future V2 under
+    // these instructions must read as instrument failure, not be accepted
+    // silently) -- Marveen's stipulation on HBMEMBLIND819, 2026-08-25.
+    expect(out).toContain('HB_METRICS_V2')
+    expect(out).toContain('muszer-hiba')
+    expect(out).toMatch(/NEVER write 0/)
+  })
+
+  it('the ONLY python3-heredoc mention is the quoted example inside the ban text', () => {
+    const out = renderHeartbeatClaudeMd(ID)
+    // The ban must quote the forbidden shape (so the agent can recognise
+    // it), and NOTHING else in the prompt may contain one. Class-level, not
+    // variant-enumerated: on one line, `python3` is never followed by `<<`
+    // outside the ban sentence.
     const matches = [...out.matchAll(/python3[^\n]*<</g)]
     expect(matches.length).toBe(1)
-    const banStart = out.indexOf('FORBIDDEN SHAPE (HBHEREDOC819)')
+    const banStart = out.indexOf('THE SENTINEL RULE (HBMEMBLIND819)')
     expect(banStart).toBeGreaterThanOrEqual(0)
-    const banEnd = out.indexOf('It returns exactly', banStart)
+    const banEnd = out.indexOf('If the output contains', banStart)
     expect(banEnd).toBeGreaterThan(banStart)
     const idx = matches[0].index ?? -1
     expect(idx).toBeGreaterThan(banStart)
     expect(idx).toBeLessThan(banEnd)
   })
 
-  it('the kanban endpoint is never fetched with curl (the curl+shell-var path is what got improvised)', () => {
+  it('names the heredoc incident so the ban survives paraphrase', () => {
     const out = renderHeartbeatClaudeMd(ID)
-    expect(out).not.toMatch(/curl[^\n]*heartbeat-summary/)
-  })
-
-  it('names the forbidden shape and the incident so the ban survives paraphrase', () => {
-    const out = renderHeartbeatClaudeMd(ID)
-    expect(out).toContain('FORBIDDEN SHAPE (HBHEREDOC819)')
+    expect(out).toContain('HBHEREDOC819')
     expect(out).toMatch(/heredoc becomes python3's stdin/)
   })
 })

--- a/src/__tests__/heartbeat-db-size.test.ts
+++ b/src/__tests__/heartbeat-db-size.test.ts
@@ -68,13 +68,17 @@ describe('wiring contract: endpoint -> agent, never agent -> du/stat', () => {
 
   it('the scaffold names counts.db_size_mb as the ONLY source and forbids self-measurement', () => {
     expect(SCAFFOLD).toMatch(/counts\.db_size_mb/)
-    // The one-line kanban command must surface the number in its measured
-    // output, tolerant of older builds (dict.get, no KeyError).
-    expect(SCAFFOLD).toMatch(/db_size_mb=%s/)
-    expect(SCAFFOLD).toMatch(/c\.get\('db_size_mb'\)/)
+    // The extractor moved from the prose into scripts/heartbeat-metrics.sh
+    // (HBMEMBLIND819 third contract): the measured-output surface and the
+    // missing-field handling are asserted on the SCRIPT now. Older-build
+    // tolerance flipped on purpose: a missing field is an ERROR line + a
+    // non-zero exit, never a silently absent (or zeroed) value.
+    const METRICS = readFileSync(join(ROOT, 'scripts', 'heartbeat-metrics.sh'), 'utf-8')
+    expect(METRICS).toMatch(/db_size_mb=%s/)
+    expect(METRICS).toMatch(/required = \[[^\]]*'db_size_mb'/)
     // The drifted surface itself: the template placeholder with no source.
     expect(SCAFFOLD).not.toMatch(/DB size: <X> MB/)
     // Missing/null degrades to "no data", never to a self-run measurement.
-    expect(SCAFFOLD).toMatch(/DB size: nincs adat \(a summary nem adja\)/)
+    expect(SCAFFOLD).toMatch(/nincs adat \(muszer-hiba\)/)
   })
 })

--- a/src/__tests__/heartbeat-hot-memory-count.test.ts
+++ b/src/__tests__/heartbeat-hot-memory-count.test.ts
@@ -106,6 +106,8 @@ describe('wiring contract: the number flows endpoint -> agent, never agent -> qu
     // hot-memory SQL anymore -- that is the exact surface that drifted twice.
     expect(SCAFFOLD).not.toMatch(/FROM memories[\s\S]{0,120}category='hot'/)
     // Missing field degrades to "no data", never to a self-run query or a 0.
-    expect(SCAFFOLD).toMatch(/nincs adat \(a summary nem adja\)/)
+    // (Phrase updated with the HBMEMBLIND819 third contract: the missing
+    // field now surfaces as the instrument's ERROR line.)
+    expect(SCAFFOLD).toMatch(/nincs adat \(muszer-hiba\)/)
   })
 })

--- a/src/__tests__/heartbeat-metrics-script.test.ts
+++ b/src/__tests__/heartbeat-metrics-script.test.ts
@@ -1,0 +1,236 @@
+// Conformance tests for scripts/heartbeat-metrics.sh -- the heartbeat
+// round's single callable instrument (HBMEMBLIND819, third contract).
+//
+// Two properties are load-bearing and each gets both a positive and a
+// negative control:
+//   1. Fail-closed: a missing/null field NEVER prints as 0 -- it prints an
+//      ERROR line and the exit code is non-zero. (The 2026-08-24 22:00
+//      failure was exactly a missing field surfacing as a silent 0.)
+//   2. Path binding: the scaffold prose references this script by path, so
+//      a rename/move must fail HERE, in CI, not at 22:00 on the host.
+//      (The prose side is fail-safe too -- sentinel rule -- but that only
+//      makes the breakage visible, not impossible.)
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { execFile, spawnSync } from 'node:child_process'
+import { createServer, type Server } from 'node:http'
+import { accessSync, constants, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { AddressInfo } from 'node:net'
+
+const REPO_ROOT = join(__dirname, '..', '..')
+const SCRIPT = join(REPO_ROOT, 'scripts', 'heartbeat-metrics.sh')
+const TOKEN = 'test-token-abc'
+
+// Mutable fixtures the server serves; individual tests reshape them.
+let summaryBody: unknown
+let schedulesBody: unknown
+let server: Server
+let origin: string
+let storeDir: string
+
+const FULL_SUMMARY = () => ({
+  counts: {
+    urgent: 2,
+    in_progress: 3,
+    waiting: 280,
+    planned: 5,
+    new_hot_memories_1h: 0,
+    db_size_mb: 166.6,
+  },
+  waiting_shown: 8,
+  urgent: [{ id: 'CARD1', title: 'first urgent' }],
+  waiting: [{ id: 'CARD2', title: 'a waiting card' }],
+})
+
+// ASYNC on purpose: the fixture server lives in THIS process, and a
+// spawnSync would block the event loop for the child's whole lifetime --
+// the server could never answer and every HTTP-dependent case would
+// "fail" with a timeout (measured on the first run of this file).
+function runScript(env: Record<string, string> = {}): Promise<{ status: number; stdout: string }> {
+  return new Promise(resolve => {
+    execFile(
+      'bash',
+      [SCRIPT],
+      {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          CLAW_STORE_DIR: storeDir,
+          CLAW_DASHBOARD_ORIGIN: origin,
+          ...env,
+        },
+      },
+      (err, stdout) => {
+        const code = (err as { code?: unknown } | null)?.code
+        resolve({ status: err ? (typeof code === 'number' ? code : 1) : 0, stdout })
+      }
+    )
+  })
+}
+
+beforeAll(async () => {
+  storeDir = mkdtempSync(join(tmpdir(), 'hb-metrics-store-'))
+  writeFileSync(join(storeDir, '.dashboard-token'), TOKEN + '\n')
+
+  // Fixture task_runs DB, created with the same python3 the script uses.
+  // Three rows probe the milliseconds cutoff behaviourally:
+  //   - two recent rows with ts in MILLISECONDS -> must be counted
+  //   - one old ms row (2h ago)                 -> must not be counted
+  //   - one row with ts in SECONDS (now-60)     -> must not be counted;
+  //     a seconds-cutoff regression would count it (and the old row too).
+  const mk = spawnSync('python3', ['-c', `
+import sqlite3, sys, time
+con = sqlite3.connect(sys.argv[1])
+con.execute('CREATE TABLE task_runs (ts INTEGER, status TEXT)')
+now_ms = int(time.time() * 1000)
+rows = [(now_ms - 60_000, 'fired'), (now_ms - 120_000, 'fired'),
+        (now_ms - 7_200_000, 'fired'), (int(time.time()) - 60, 'fired')]
+con.executemany('INSERT INTO task_runs VALUES (?, ?)', rows)
+con.commit()
+`, join(storeDir, 'claudeclaw.db')])
+  if (mk.status !== 0) throw new Error('fixture db failed: ' + mk.stderr)
+
+  server = createServer((req, res) => {
+    if (req.headers.authorization !== 'Bearer ' + TOKEN) {
+      res.writeHead(401).end('{"error":"unauthorized"}')
+      return
+    }
+    const body =
+      req.url === '/api/kanban/heartbeat-summary' ? summaryBody
+      : req.url === '/api/schedules' ? schedulesBody
+      : undefined
+    if (body === undefined) {
+      res.writeHead(404).end('{}')
+      return
+    }
+    res.writeHead(200, { 'content-type': 'application/json' })
+    res.end(JSON.stringify(body))
+  })
+  await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve))
+  origin = 'http://127.0.0.1:' + (server.address() as AddressInfo).port
+})
+
+afterAll(async () => {
+  await new Promise<void>(resolve => server.close(() => resolve()))
+  rmSync(storeDir, { recursive: true, force: true })
+})
+
+describe('path binding (a rename must fail in CI, not at 22:00 on the host)', () => {
+  it('the script exists at the path the scaffold derives and is executable', () => {
+    expect(existsSync(SCRIPT)).toBe(true)
+    accessSync(SCRIPT, constants.X_OK)
+  })
+
+  it('the scaffold source builds exactly this relative path', () => {
+    const src = readFileSync(join(REPO_ROOT, 'src', 'web', 'heartbeat-agent-scaffold.ts'), 'utf8')
+    expect(src).toMatch(/'scripts',\s*'heartbeat-metrics\.sh'/)
+  })
+
+  it('script and scaffold agree on the sentinel version', () => {
+    // The reporter accepts ONLY the known sentinel; if the script ever
+    // bumps to V2, the prose must move in the same commit or every round
+    // reads as instrument failure.
+    const script = readFileSync(SCRIPT, 'utf8')
+    const scaffold = readFileSync(join(REPO_ROOT, 'src', 'web', 'heartbeat-agent-scaffold.ts'), 'utf8')
+    expect(script).toContain('echo "HB_METRICS_V1 ')
+    expect(scaffold).toContain('HB_METRICS_V1')
+  })
+})
+
+describe('positive control: full fixture', () => {
+  it('prints the sentinel first, every field, and exits 0', async () => {
+    summaryBody = FULL_SUMMARY()
+    schedulesBody = [{ enabled: true }, { enabled: false }, { enabled: true }]
+    const r = await runScript()
+    expect(r.status).toBe(0)
+    const lines = r.stdout.trim().split('\n')
+    expect(lines[0]).toMatch(/^HB_METRICS_V1 ts=\d{4}-\d{2}-\d{2} \d{2}:\d{2}$/)
+    expect(r.stdout).toContain(
+      'COUNTS urgent=2 in_progress=3 waiting=280 planned=5 new_hot_memories_1h=0 db_size_mb=166.6 waiting_shown=8'
+    )
+    expect(r.stdout).toContain('URGENT CARD1 first urgent')
+    expect(r.stdout).toContain('WAITING CARD2 a waiting card')
+    expect(r.stdout).toContain('SCHEDULES enabled=2')
+    expect(r.stdout).not.toContain('ERROR')
+  })
+
+  it('counts only the millisecond rows inside the hour (the *1000 cutoff, behaviourally)', async () => {
+    summaryBody = FULL_SUMMARY()
+    schedulesBody = []
+    const r = await runScript()
+    // 2 recent ms rows in; the 2h-old ms row and the seconds-unit row out.
+    // A seconds-cutoff regression reports total=4 here.
+    expect(r.stdout).toContain('TASK_RUNS_1H total=2 fired=2')
+  })
+})
+
+describe('fail-closed: a missing value is an ERROR line + non-zero exit, never a 0', () => {
+  it('missing new_hot_memories_1h (the 2026-08-24 22:00 shape)', async () => {
+    const s = FULL_SUMMARY()
+    delete (s.counts as Record<string, unknown>).new_hot_memories_1h
+    summaryBody = s
+    schedulesBody = [{ enabled: true }]
+    const r = await runScript()
+    expect(r.status).not.toBe(0)
+    expect(r.stdout).toContain('ERROR summary: missing/null fields: new_hot_memories_1h')
+    expect(r.stdout).not.toContain('new_hot_memories_1h=0')
+    // Partial output stays usable: the unaffected sections still print.
+    expect(r.stdout).toContain('SCHEDULES enabled=1')
+    expect(r.stdout).toContain('TASK_RUNS_1H total=2 fired=2')
+  })
+
+  it('null db_size_mb (the HBDBMERET822 shape) never becomes 0.0', async () => {
+    const s = FULL_SUMMARY()
+    ;(s.counts as Record<string, unknown>).db_size_mb = null
+    summaryBody = s
+    schedulesBody = []
+    const r = await runScript()
+    expect(r.status).not.toBe(0)
+    expect(r.stdout).toContain('ERROR summary: missing/null fields: db_size_mb')
+    expect(r.stdout).not.toMatch(/db_size_mb=/)
+  })
+
+  it('unreachable dashboard: sentinel still first, ERROR lines, non-zero exit', async () => {
+    const r = await runScript({ CLAW_DASHBOARD_ORIGIN: 'http://127.0.0.1:1' })
+    expect(r.status).not.toBe(0)
+    expect(r.stdout.split('\n')[0]).toMatch(/^HB_METRICS_V1 /)
+    expect(r.stdout).toContain('ERROR summary:')
+    expect(r.stdout).toContain('ERROR schedules:')
+    expect(r.stdout).not.toContain('COUNTS')
+    // task_runs reads the local DB and still works.
+    expect(r.stdout).toContain('TASK_RUNS_1H total=2 fired=2')
+  })
+
+  it('missing token file: ERROR token, non-zero exit, no fabricated numbers', async () => {
+    const bare = mkdtempSync(join(tmpdir(), 'hb-metrics-bare-'))
+    try {
+      summaryBody = FULL_SUMMARY()
+      schedulesBody = []
+      const r = await runScript({ CLAW_STORE_DIR: bare })
+      expect(r.status).not.toBe(0)
+      expect(r.stdout).toContain('ERROR token:')
+      expect(r.stdout).toContain('ERROR task_runs: db not found:')
+      expect(r.stdout).not.toContain('COUNTS')
+      expect(r.stdout).not.toContain('SCHEDULES')
+    } finally {
+      rmSync(bare, { recursive: true, force: true })
+    }
+  })
+
+  it('rejected token (401): ERROR from the summary and schedules sections', async () => {
+    summaryBody = FULL_SUMMARY()
+    schedulesBody = []
+    writeFileSync(join(storeDir, '.dashboard-token'), 'wrong-token\n')
+    try {
+      const r = await runScript()
+      expect(r.status).not.toBe(0)
+      expect(r.stdout).toContain('ERROR summary:')
+      expect(r.stdout).toContain('ERROR schedules:')
+      expect(r.stdout).not.toContain('COUNTS')
+    } finally {
+      writeFileSync(join(storeDir, '.dashboard-token'), TOKEN + '\n')
+    }
+  })
+})

--- a/src/__tests__/heartbeat-summary-truncation-safe.test.ts
+++ b/src/__tests__/heartbeat-summary-truncation-safe.test.ts
@@ -90,9 +90,12 @@ describe('wiring: the endpoint serves the pure builder, the scaffold forbids cou
     expect(handler).toMatch(/countPlannedKanbanCards\(\)/)
   })
 
-  it('the scaffold says numbers come from counts.* only and names the drift incident', () => {
-    expect(SCAFFOLD).toMatch(/EVERY NUMBER COMES FROM \\`counts\.\*\\`/)
+  it('the scaffold says numbers come from the COUNTS line only and names the drift incident', () => {
+    // Wording moved with the HBMEMBLIND819 third contract: the copy-surface
+    // is now the instrument's COUNTS line (fed by counts.*), and the ban on
+    // counting the capped lists is stated next to it.
+    expect(SCAFFOLD).toMatch(/EVERY number comes from this line and nowhere else/)
     expect(SCAFFOLD).toMatch(/HBKANBANDRIFT819/)
-    expect(SCAFFOLD).toMatch(/never count the lists as/)
+    expect(SCAFFOLD).toMatch(/counting list items once\s+reported waiting: 12 against a real 280/)
   })
 })

--- a/src/__tests__/heartbeat-urgent-open-only.test.ts
+++ b/src/__tests__/heartbeat-urgent-open-only.test.ts
@@ -137,9 +137,11 @@ describe('there is ONE definition, and both consumers read it', () => {
 
 describe('the heartbeat AGENT is handed the list, not a filter to re-apply', () => {
   const SCAFFOLD_SRC = readFileSync(join(ROOT, 'src', 'web', 'heartbeat-agent-scaffold.ts'), 'utf-8')
+  // The kanban step lives inside the single Metrics instrument bullet since
+  // the HBMEMBLIND819 third contract; the window is that bullet's own bounds.
   const kanbanBlock = SCAFFOLD_SRC.slice(
-    SCAFFOLD_SRC.indexOf('- **Kanban**'),
-    SCAFFOLD_SRC.indexOf('- **Scheduled tasks**'),
+    SCAFFOLD_SRC.indexOf('- **Metrics ('),
+    SCAFFOLD_SRC.indexOf('2. **Format**'),
   )
 
   it('the kanban step is one endpoint call', () => {
@@ -153,7 +155,7 @@ describe('the heartbeat AGENT is handed the list, not a filter to re-apply', () 
   })
 
   it('it says out loud that an empty list stays empty', () => {
-    expect(kanbanBlock).toMatch(/EMPTY/)
+    expect(kanbanBlock).toMatch(/report it as empty/i)
     expect(kanbanBlock).toMatch(/Do not widen the query|do not fall back|do not fill/i)
   })
 })

--- a/src/web/heartbeat-agent-scaffold.ts
+++ b/src/web/heartbeat-agent-scaffold.ts
@@ -98,6 +98,12 @@ export interface HeartbeatIdentity {
   // Google Calendar account to summarise, or '' to let the calendar MCP
   // server use whatever account it is authenticated as.
   calendarAccount: string
+  // Absolute path to scripts/heartbeat-metrics.sh -- the round's single
+  // callable instrument (HBMEMBLIND819 third contract). The rendered
+  // CLAUDE.md references this path and nothing else about how the
+  // numbers are produced, so there is no command prose left to
+  // recompose.
+  metricsScript: string
 }
 
 // Build the identity from the live config. Kept separate from the pure
@@ -110,6 +116,7 @@ export function currentHeartbeatIdentity(): HeartbeatIdentity {
     storeDir: STORE_DIR,
     dashboardOrigin: resolveDashboardOrigin(DASHBOARD_PUBLIC_URL, WEB_PORT),
     calendarAccount: HEARTBEAT_CALENDAR_ACCOUNT,
+    metricsScript: join(PROJECT_ROOT, 'scripts', 'heartbeat-metrics.sh'),
   }
 }
 
@@ -204,117 +211,77 @@ When you receive the heartbeat prompt:
      If the call fails (token revoked / 401), record the failure
      reason rather than the events; the main agent can act on the
      failure.
-   - **Kanban** -- ONE command, fetch AND extract together; run it EXACTLY
-     as written, do not recompose it:
+   - **Metrics (kanban + tasks + memory + DB size)** -- ONE fixed,
+     on-disk instrument. Run it EXACTLY as written and copy its output
+     lines VERBATIM into the report sections below; never recompose any
+     of its measurements yourself:
 
      \`\`\`bash
-     python3 -c "import json,urllib.request; tok=open('${id.storeDir}/.dashboard-token').read().strip(); d=json.load(urllib.request.urlopen(urllib.request.Request('${id.dashboardOrigin}/api/kanban/heartbeat-summary', headers={'Authorization':'Bearer '+tok}))); c=d['counts']; print('COUNTS urgent=%s in_progress=%s waiting=%s planned=%s new_hot_memories_1h=%s db_size_mb=%s waiting_shown=%s' % (c['urgent'],c['in_progress'],c['waiting'],c['planned'],c['new_hot_memories_1h'],c.get('db_size_mb'),d.get('waiting_shown'))); [print('URGENT',x['id'],x['title']) for x in d['urgent']]; [print('WAITING',x['id'],x['title']) for x in d['waiting']]"
+     CLAW_STORE_DIR=${id.storeDir} CLAW_DASHBOARD_ORIGIN=${id.dashboardOrigin} CLAW_TZ=${APP_TZ} bash ${id.metricsScript}
      \`\`\`
 
-     The command is ONE line on purpose: it survives copy-paste from any
-     indentation, needs no shell variable, no pipe, and no second
-     process -- the failure modes that produced HBHEREDOC819 and
-     HBKANBANDRIFT819 structurally cannot occur in it.
+     THE SENTINEL RULE (HBMEMBLIND819): a number may enter your report
+     ONLY from an output whose FIRST line starts with the known
+     sentinel \`HB_METRICS_V1\`. Anything else -- an unknown or newer
+     sentinel (a future \`HB_METRICS_V2\` under these instructions
+     included), "No such file or directory", a shell error, empty
+     output -- is an INSTRUMENT FAILURE: put the literal first line of
+     what you got into EVERY affected section as
+     \`muszer-hiba: <line>\`. NEVER write 0 for a value the instrument
+     did not print, and NEVER rebuild these numbers with your own
+     curl / python3 / sqlite3 / du / ls / stat -- not even a
+     correct-looking one-liner. That includes the pipe+heredoc shape
+     that produced HBHEREDOC819 (\`echo "$X" | python3 << 'PY'\` loses
+     the piped data silently: the heredoc becomes python3's stdin).
 
-     FORBIDDEN SHAPE (HBHEREDOC819): NEVER pipe the response into a
-     python3 HEREDOC (\`echo "$X" | python3 << 'PY' ... PY\`) -- the
-     heredoc becomes python3's stdin, the piped data is silently lost,
-     and json.load reads EOF. Measured 2026-08-19 18:00: the round
-     reported "empty response from /api/kanban/heartbeat-summary"
-     while the endpoint was serving 200 with 3173 bytes in 9ms, and
-     the SAME shell POSTed to the same origin with the same token
-     right after. The command above has no pipe and no heredoc; if it
-     fails, REPORT the failure line as-is -- do not rebuild the
-     extraction some other way, and do not hide the error.
+     If the output contains \`ERROR <section>: <reason>\` lines, copy
+     each into its section verbatim as \`muszer-hiba: ERROR ...\` and
+     use the lines that ARE present -- partial output is fine, silence
+     and substitution are not. The instrument is fail-closed: a
+     missing or null field never prints as 0, so
+     \`new hot memories (1h): nincs adat (muszer-hiba)\` is the honest
+     report and a fabricated 0 is the defect.
 
-     It returns exactly what this section may report:
-     \`{"counts":{...}, "urgent":[...], "waiting":[...]}\`, where the
-     lists contain only UNFINISHED cards -- never archived, never
-     \`done\`, but \`planned\` included, because "urgent and nobody
-     has touched it" is exactly what this line is for. Report the ids
-     and titles it gives you and nothing else.
+     Why a fixed script and not a prescribed command, measured three
+     times on the SAME metric: 2026-08-07 (HBMEMBLIND807) a prose
+     bullet let the round compose its own SQL (reported 0 beside 3 hot
+     memories); the fix prescribed a ready-made query, and 2026-08-19
+     (HBMEMBLIND819) post-compact rounds reconstructed it with the
+     wrong agent_id (14/14 rounds a false 0); the next fix shipped a
+     ready-made one-liner, and 2026-08-24 22:00 a round re-composed
+     THAT with a truncated format string, so the missing field printed
+     as 0 again. A prescription you must re-copy every hour is not a
+     mechanism; a script on disk has nothing to recompose.
 
-     EVERY NUMBER COMES FROM \`counts.*\` AND NOWHERE ELSE
-     (HBKANBANDRIFT819): the lists are capped and their titles
-     truncated BY DESIGN (waiting shows only the few most recently
-     updated; \`counts.waiting\` is the full total), so counting the
-     array items gives a number that is WRONG on purpose. Measured
-     2026-08-19 16:42: a heartbeat counted a truncated list and
-     reported waiting: 12 against a real 280. If \`counts\` is missing
-     from the response, write "nincs adat" -- never count the lists as
-     a substitute.
-
-     Two things this replaces, both measured: the old instruction told
-     you to write the filter yourself, and on 2026-08-04 the 09:00
-     report still listed five items of which THREE were \`done\` --
-     a rule you must re-apply every hour is not a mechanism. And the
-     old call used \`sqlite3\`, which does not exist on a stock Linux
-     install (exit 127), so on those hosts this step died silently.
-
-     If a list comes back EMPTY, write that it is empty. Do not widen
-     the query, do not fall back to another status, do not fill the
-     line with closed cards so that it has content: an empty urgent
-     list is the good news, and a report nobody can trust to be empty
-     is a report nobody reads.
-   - **Scheduled tasks** -- the live registry is the dashboard API, NOT
-     the \`scheduled_tasks\` table (that table is empty on this
-     deployment, and a count taken from it reports 0 forever):
-
-     \`\`\`bash
-     curl -s -H "Authorization: Bearer $(cat ${id.storeDir}/.dashboard-token)" \\
-       ${id.dashboardOrigin}/api/schedules \\
-       | python3 -c "import json,sys; r=json.load(sys.stdin); print(sum(1 for x in r if x.get('enabled')))"
-     \`\`\`
-
-     For what actually ran, query \`task_runs\`. Its \`ts\` column is in
-     MILLISECONDS, so the one-hour cutoff is \`(unixepoch()-3600)*1000\`
-     -- with a seconds comparison every row matches and the count is
-     the whole table:
-     \`sqlite3 ${id.storeDir}/claudeclaw.db "SELECT status, COUNT(*) FROM
-     task_runs WHERE ts > (unixepoch()-3600)*1000 GROUP BY status"\`.
-   - **Memory + system** -- DB file size and new hot memories.
-     HBWARN807: there is NO warnings metric here on purpose. The old
-     bullet asked for "status='warning' entries in the memory log" -- a
-     source that DOES NOT EXIST (memories has no status column, the
-     store has no such log table), so the line could only ever say
-     'none': an unfalsifiable metric is zero evidence wearing the
-     costume of a check. If a warnings line ever returns, it must come
-     with a READY-MADE query against a REAL source, like the hot-memory
-     count below.
-     HBMEMBLIND807+819: the hot-memory count comes from the SAME
-     \`/api/kanban/heartbeat-summary\` call you already made for the
-     Kanban section: report \`counts.new_hot_memories_1h\` from that
-     response. Do NOT run any query for this number -- not even a
-     correct-looking one.
-
-     Why an endpoint number and not a query, measured twice:
-     2026-08-07 (HBMEMBLIND807) this bullet was prose, the agent
-     composed its own SQL and reported 0 while three hot memories sat
-     in the window. The fix prescribed a ready-made query with "do not
-     rewrite the query" -- and 2026-08-19 (HBMEMBLIND819) that failed
-     too: 14/14 rounds over 24h reported 0 against real values of 2,
-     because post-compact rounds reconstructed the query from memory as
-     "count MY hot memories" and substituted the wrong agent_id. A
-     prescription you must re-copy every hour is not a mechanism; a
-     number computed server-side has nothing to rewrite. The kanban
-     counts above never drifted for exactly this reason.
-
-     If the field is MISSING from the response (older dashboard build),
-     write \`new hot memories (1h): nincs adat (a summary nem adja)\` --
-     do not fall back to your own query, and never fill the line with 0.
-
-     HBDBMERET822: the DB size comes from the SAME response: report
-     \`counts.db_size_mb\`. Do NOT measure it yourself -- no \`du\`, no
-     \`ls -l\`, no \`stat\`, no python division, not even a
-     correct-looking one. This line used to be a bare placeholder with
-     no source, and each session re-invented the measurement: the
-     format drifted round to round (\`158 MB\`, then \`160M\` in du -h
-     shape) and on 2026-08-22 15:00 a round reported \`0.0 MB\`
-     against a real 159 MB, right after a restart. A growth signal
-     that reads 0.0 does not die loudly -- nobody misses a zero.
-     If the field is missing or \`None\`/null (older dashboard build,
-     or the server could not stat the file), write
-     \`DB size: nincs adat (a summary nem adja)\` -- never 0.
+     What the lines mean, and where each number is allowed to come from:
+     - \`COUNTS ...\` -- kanban totals plus \`counts.new_hot_memories_1h\`
+       and \`counts.db_size_mb\`, all computed server-side on
+       \`${id.dashboardOrigin}/api/kanban/heartbeat-summary\` and copied
+       through. EVERY number comes from this line and nowhere else
+       (HBKANBANDRIFT819: the URGENT/WAITING lists are capped and
+       their titles truncated BY DESIGN -- counting list items once
+       reported waiting: 12 against a real 280).
+     - \`URGENT <id> <title>\` / \`WAITING <id> <title>\` -- only
+       UNFINISHED cards, never \`done\`, \`planned\` included. If a
+       list is empty, report it as empty: do not widen the query, do
+       not fill the line with closed cards. An empty urgent list is
+       the good news, and a report nobody can trust to be empty is a
+       report nobody reads.
+     - \`SCHEDULES enabled=N\` -- the live registry
+       (\`${id.dashboardOrigin}/api/schedules\`), NOT the
+       \`scheduled_tasks\` table (empty on this deployment; a count
+       from it reports 0 forever).
+     - \`TASK_RUNS_1H ...\` -- what actually ran in the last hour.
+       \`task_runs.ts\` is in MILLISECONDS and the script bakes the
+       \`*1000\` cutoff in -- exactly the kind of trap that must never
+       be re-derived by hand.
+     HBWARN807 still holds: there is NO warnings metric here on
+     purpose. The old bullet pointed at a source that does not exist
+     (memories has no status column, the store has no such log table),
+     so the line could only ever say 'none' -- an unfalsifiable metric
+     is zero evidence wearing the costume of a check. If a warnings
+     line ever returns, it must come as a field of this instrument's
+     output, backed by a real source.
 
 2. **Format** the result as a single inter-agent message:
 
@@ -327,22 +294,22 @@ When you receive the heartbeat prompt:
    - <or: "calendar fetch failed: <reason>">
 
    ### Kanban
-   - urgent: <N> (<short titles, comma-separated>)
-   - in_progress: <N>
-   - waiting: <N> (<short titles>)
-   - planned: <N>
+   - urgent: <N from COUNTS> (<short titles from the URGENT lines>)
+   - in_progress: <N from COUNTS>
+   - waiting: <N from COUNTS> (<short titles from the WAITING lines>)
+   - planned: <N from COUNTS>
 
    ### Tasks
-   - enabled schedules: <N>
-   - last hour: <N fired, N skipped>
+   - enabled schedules: <N from SCHEDULES>
+   - last hour: <the TASK_RUNS_1H line, verbatim>
 
    ### Memory / system
-   - DB size: <counts.db_size_mb> MB
-   - new hot memories (1h): <N>
+   - DB size: <db_size_mb from COUNTS> MB
+   - new hot memories (1h): <new_hot_memories_1h from COUNTS>
    \`\`\`
 
    Every line above is a MEASUREMENT of this round, never a memory of
-   an earlier one. Run the queries again and report what they return
+   an earlier one. Run the instrument again and report what it returns
    now, even when you are sure nothing changed -- especially then.
    A value carried over from an earlier round makes its line constant,
    and a line that always says the same thing stops being read -- at


### PR DESCRIPTION
## What

The heartbeat round's four recomposable measurements (summary COUNTS/URGENT/WAITING, schedules, task_runs) move from prescribed prose into a single callable instrument, `scripts/heartbeat-metrics.sh`. The scaffolded CLAUDE.md now ships the instrument call plus the sentinel rule instead of commands the round can re-improvise.

## Why

The same metric failed three times on three different layers, each time as a silent 0 (HBMEMBLIND807: self-composed SQL; HBMEMBLIND819: reconstructed query with wrong agent_id, 14/14 rounds; 2026-08-24 22:00: re-composed one-liner with a truncated format string). A prescription that must be re-copied every hour is not a mechanism; a script on disk has nothing to recompose. Inventory + placement proposal on card HBMEMBLIND819; Marveen GO 2026-08-25 (msg 15352) with two stipulations, both addressed below.

## Design (three layers against the silent-zero family)

1. **Reporter side**: numbers may enter the report only from output whose first line carries the KNOWN sentinel `HB_METRICS_V1`; anything else (including a future `HB_METRICS_V2` under old instructions -- Marveen stipulation 2) is an instrument failure, reported as a literal `muszer-hiba` line, never a 0.
2. **Script side**: fail-closed -- a missing/null field prints `ERROR <section>: <reason>` and exits non-zero; a 0 in the output is always a measured zero. Sentinel always prints first, so partial output stays usable.
3. **CI side**: conformance test binds the path (scaffold source builds `scripts/heartbeat-metrics.sh`; the file must exist and be executable) and the sentinel version, with positive AND negative controls: full fixture passes; missing `new_hot_memories_1h` (the 22:00 shape) and null `db_size_mb` (HBDBMERET822 shape) produce ERROR + non-zero and never a fabricated 0; a seconds-unit `task_runs` row proves the ms cutoff behaviourally.

Not covered, stated in the prose: the calendar MCP step is not scriptable (MCP tools only exist in the session tool list) and keeps its ToolSearch deferred-load protocol.

## Evidence

- Full suite: 294 files / 3946 tests PASS (this branch).
- Live smoke on the host (read-only GETs): sentinel + full COUNTS (`db_size_mb=166.6`, `new_hot_memories_1h=0`), `SCHEDULES enabled=28`, `TASK_RUNS_1H total=9 fired=9`, exit 0.
- Test-infra note: the conformance test runs the script via async `execFile` on purpose -- a `spawnSync` blocks the event loop and the in-process fixture server can never answer (measured on the first run: 3 false timeouts).

## After merge (Marveen stipulation 1, on the card)

CI-green is not evidence on the prod host (HOSTLAG-class lag): at the first live round after the host update, measure that the script exists and runs ON THE HOST and write the measurement to card HBMEMBLIND819.

🤖 Generated with [Claude Code](https://claude.com/claude-code)