### PR TITLE
fix(heartbeat): registry default matched the code, and the sandbox stays hidden when the feature is off

### DIFF
--- a/src/config-registry.ts
+++ b/src/config-registry.ts
@@ -311,9 +311,15 @@ export const SETTINGS_REGISTRY: SettingDefinition[] = [
   {
     key: 'HEARTBEAT_AGENT_ENABLED',
     type: 'string',
-    default: '1',
+    // OFF by default, matching config.ts: an unset key resolves to false there
+    // (deliberate opt-in -- a fresh/upgrading install must not silently spawn a
+    // sub-agent that reads the operator's calendar and database). The registry
+    // previously advertised '1', so the settings UI showed the feature as
+    // enabled while it never booted -- a silent mismatch that can hide for
+    // months.
+    default: '0',
     valueSet: ['0', '1'],
-    description: 'Heartbeat sub-ágens engedélyezése. 1 = bekapcsolva (újraindítás után lép életbe).',
+    description: 'Heartbeat sub-ágens engedélyezése. 1 = bekapcsolva (újraindítás után lép életbe). Alapértelmezés: kikapcsolva.',
     module: 'heartbeat',
     secret: false,
     requiresRestart: true,

--- a/src/heartbeat.ts
+++ b/src/heartbeat.ts
@@ -74,11 +74,35 @@ interface ClaudeSettings {
 // our enabledPlugins:{} override. .DS_Store / lock files are just noise.
 const HEARTBEAT_CONFIG_SKIP = new Set(['settings.json', '.DS_Store', '.lock'])
 
+/**
+ * Mark the isolation-sandbox dir as hidden from the dashboard's agent list.
+ *
+ * MUST be callable independently of whether the heartbeat feature is enabled:
+ * agents/heartbeat-worker is a plain cwd, not an agent, but listAgentNames()
+ * cannot tell the difference without this sentinel. Before 2026-08-25 the
+ * write lived only at the END of ensureHeartbeatWorkerCwd(), which runs solely
+ * from executeHeartbeat() -- so on any install with HEARTBEAT_AGENT_ENABLED
+ * unset (the default) the sentinel was never created, the sandbox showed up as
+ * a real agent, and could be started as one. Observed in the wild.
+ */
+export function ensureHeartbeatWorkerHidden(): void {
+  try {
+    if (!existsSync(HEARTBEAT_AGENT_CWD)) return
+    const sentinelPath = join(HEARTBEAT_AGENT_CWD, '.hidden-from-dashboard')
+    if (!existsSync(sentinelPath)) writeFileSync(sentinelPath, '')
+  } catch (err) {
+    logger.warn({ err }, 'Heartbeat: failed to write the dashboard-hide sentinel')
+  }
+}
+
 function ensureHeartbeatWorkerCwd(): void {
   try {
     if (!existsSync(HEARTBEAT_AGENT_CWD)) {
       mkdirSync(HEARTBEAT_AGENT_CWD, { recursive: true })
     }
+    // Write the hide-sentinel FIRST, right after the dir exists: if any later
+    // step throws, the dir must still not masquerade as an agent.
+    ensureHeartbeatWorkerHidden()
     // Project-scope empty MCP list (defense in depth -- the load-bearing
     // gates are the enabledPlugins override + CLAUDE_CONFIG_DIR).
     const mcpPath = join(HEARTBEAT_AGENT_CWD, '.mcp.json')
@@ -208,13 +232,8 @@ function ensureHeartbeatWorkerCwd(): void {
       logger.warn({ err }, 'Heartbeat: failed to materialise .claude.json into isolated config dir (sub-agent will lack project MCPs)')
     }
 
-    // Dashboard-hide sentinel: Szabi 2026-06-02 asked that this technical
-    // worker NOT show up as a real agent on the dashboard. listAgentNames()
-    // filters out any subdir of agents/ that contains this sentinel file.
-    const sentinelPath = join(HEARTBEAT_AGENT_CWD, '.hidden-from-dashboard')
-    if (!existsSync(sentinelPath)) {
-      writeFileSync(sentinelPath, '')
-    }
+    // (The dashboard-hide sentinel is written at the top of this function --
+    // see ensureHeartbeatWorkerHidden.)
   } catch (err) {
     logger.warn({ err, cwd: HEARTBEAT_AGENT_CWD }, 'Heartbeat: failed to ensure isolated worker cwd, falling back to PROJECT_ROOT')
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import { PROJECT_ROOT, STORE_DIR, PID_FILENAME, WEB_PORT, MAIN_AGENT_ID, RESPAWN
 import { resolveOwnerChatId } from './owner-chat.js'
 import { initDatabase, backfillEmbeddings } from './db.js'
 import { runDecaySweep, runDailyDigest } from './memory.js'
-import { initHeartbeat, stopHeartbeat } from './heartbeat.js'
+import { initHeartbeat, stopHeartbeat, ensureHeartbeatWorkerHidden } from './heartbeat.js'
 import { ensureHeartbeatAgent, shouldBootHeartbeatAgent, HEARTBEAT_AGENT_NAME } from './web/heartbeat-agent-scaffold.js'
 import { startAgentProcess } from './web/agent-process.js'
 import { renameSharedCredentialsIfSafe, fleetTokenBootPass } from './web/claude-credentials-guard.js'
@@ -557,6 +557,10 @@ async function main(): Promise<void> {
       logger.warn({ error: heartbeatStart.error }, 'Heartbeat agent failed to start (legacy native heartbeat is NOT a fallback any more)')
     }
   } else {
+    // Even with the feature off, keep the isolation sandbox out of the agent
+    // list: agents/heartbeat-worker is a cwd, not an agent, and without the
+    // sentinel the dashboard offers it as a startable agent (2026-08-25).
+    ensureHeartbeatWorkerHidden()
     logger.info('Heartbeat agent boot-start skipped (set HEARTBEAT_AGENT_ENABLED=1 on the respawn host to enable)')
   }
 


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

HU: Két csendes hiba, amit egy éles telepítésen találtam, ahol a heartbeat sub-ágens még soha nem futott.
A kettő össze is függ: az első miatt a második sosem derül ki.

**1. A registry bekapcsoltnak hirdette a funkciót, a kód viszont kikapcsoltnak veszi.**
A `config-registry.ts` a `HEARTBEAT_AGENT_ENABLED` kulcsot `default: '1'` értékkel deklarálta
("1 = bekapcsolva"), a `config.ts` viszont a hiányzó kulcsot `false`-ra oldja fel. A beállítás-felületen
tehát bekapcsoltként látszott a heartbeat egy olyan telepítésen, ahol el sem indult. A KIKAPCSOLT
alapértelmezés a szándékolt viselkedés (az `index.ts` kommentje is ezt mondja ki: egy friss vagy frissülő
telepítés nem indíthat magától olyan sub-ágenst, ami az üzemeltető naptárát és adatbázisát olvassa),
tehát nem a kódot javítottam, hanem a registryt igazítottam hozzá.

**2. A dashboard-elrejtő sentinelt csak egy tényleges heartbeat-FUTÁS írta ki.**
Az `agents/heartbeat-worker` egy izolációs cwd, nem ágens, és a `listAgentNames()` csak a
`.hidden-from-dashboard` sentinel alapján tudja megkülönböztetni. A sentinel írása az
`ensureHeartbeatWorkerCwd()` VÉGÉN volt, az pedig kizárólag az `executeHeartbeat()`-ből fut. Kikapcsolt
funkcióval (ez az alapértelmezés) tehát soha nem jött létre: a homokozó valódi ágensként jelent meg a
dashboardon, elindíthatóvá vált, és az én telepítésemen el is indult, sőt bekerült az
`agents-desired.json`-ba.

A javítás: kiszerveztem `ensureHeartbeatWorkerHidden()`-be, meghívom közvetlenül a könyvtár létrejötte
UTÁN (így egy későbbi hiba sem hagyhatja jelöletlenül a mappát), és a boot kikapcsolt ágán is.

Megjegyzés a hatókörhöz: ez NEM ugyanaz a könyvtár, mint amit a `heartbeat-agent-scaffold.ts` kezel.
A scaffold az `agents/<HEARTBEAT_AGENT_ID>` mappát hozza létre és látja el sentinellel, ez a javítás
pedig az `agents/heartbeat-worker` izolációs cwd-ről szól, amit a `heartbeat.ts` kezel. A kettő külön
mappa, és csak az utóbbi maradt jelöletlenül.

Mindkét hiba láthatatlan normál üzemben, ezért élhetett túl ilyen sokáig: az első csak felület-viselkedés
eltérésként jelentkezik, a második pedig kizárólag olyan telepítésen, ami soha nem kapcsolja be a funkciót.

EN: Two silent defects found on a live install where the heartbeat sub-agent had never run, and they
compound: because of the first, the second never surfaces.

1. `config-registry.ts` declared `HEARTBEAT_AGENT_ENABLED` with `default: '1'` while `config.ts` resolves
   an unset key to `false`. The settings UI showed the feature as enabled on an install where it had never
   booted. The OFF default is the intended behaviour, so the registry was the side that was wrong.
2. The `.hidden-from-dashboard` sentinel was written only at the end of `ensureHeartbeatWorkerCwd()`,
   which runs solely from `executeHeartbeat()`. With the feature disabled (the default) the sentinel was
   never created, so the isolation sandbox `agents/heartbeat-worker` appeared as a real, startable agent.
   Extracted `ensureHeartbeatWorkerHidden()`, called right after the dir exists and also from the disabled
   boot branch. Note this is a different directory from the one `heartbeat-agent-scaffold.ts` handles.

Tested: `npm run typecheck` clean; 86 tests green across `heartbeat-claude-json-bridge`,
`heartbeat-worker-isolation`, `heartbeat-agent-scaffold`, `config-registry`, `settings-store` and
`settings-heartbeat-calendar`, run from a separate worktree (the suite refuses to run on a live install).

## Kapcsolódó issue / Related issue

Nincs kapcsolódó issue. / No related issue.

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [x] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).

## Titok-kapu / Secret gate

- [x] Nincs a valtoztatasban bizonyitek-/artefaktum-mappa, titok-alaku string vagy idezett csatorna-uzenet.
      / No evidence or artifact directory, secret-shaped string, or quoted channel message in this change.