### PR TITLE
fix(install-macos): load brew shellenv before the dependency checks (INSTPWURES825)

### DIFF
--- a/install-macos.sh
+++ b/install-macos.sh
@@ -180,6 +180,21 @@ check_cmd() {
   fi
 }
 
+# INSTPWURES825: egy tavoli, NEM interaktiv SSH-session nem tolti be a
+# shell-profilt, ezert az Apple Siliconos Homebrew (es minden, amit o
+# telepitett: node, tmux, git) NINCS a PATH-on. A lenti ellenorzesek brew
+# nelkul hamisan hianyt jeleznenek, a telepito ag pedig ujra telepitene a
+# mar meglevo Homebrew-t. Ezert a meres ELOTT betoltjuk a brew kornyezetet,
+# ha a binaris letezik -- ugyanaz a ket sor, amit a telepito ag a sajat
+# telepitese utan mar hasznal.
+if ! command -v brew &>/dev/null; then
+  if [ -x /opt/homebrew/bin/brew ]; then
+    eval "$(/opt/homebrew/bin/brew shellenv)"
+  elif [ -x /usr/local/bin/brew ]; then
+    eval "$(/usr/local/bin/brew shellenv)"
+  fi
+fi
+
 MISSING=0
 check_cmd "node" "Node.js (v20+)" || MISSING=1
 check_cmd "npm" "npm" || MISSING=1


### PR DESCRIPTION
Upstream half of Szotasz/marveen-bridge-installer#66 (live customer incident on the remote macOS path). A non-interactive SSH session loads no shell profile, so Apple Silicon brew is off PATH: the dependency checks falsely fail and the install branch re-installs an existing Homebrew. The fix loads `brew shellenv` before measuring, when the binary exists off-PATH -- the same two lines the script already uses after its own install. The installer's vendored copy already carries this, so the next re-vendor converges instead of diverging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)