### PR TITLE
fix(ledger): capture every channel provider, not only Telegram (LEDGE…

### DIFF
--- a/docs/conversation-continuity.md
+++ b/docs/conversation-continuity.md
@@ -17,13 +17,18 @@ agent behaviour (which can fail or restart).
    `initDatabase()` migration; `scripts/hooks/ledger_lib.py` re-creates it defensively
    too (a hook may run before the dashboard migration on a fresh boot).
 2. **Inbound capture** — `UserPromptSubmit` hook `scripts/hooks/ledger-capture.py`
-   parses every inbound `<channel source="plugin:telegram:telegram" …>` block from
+   parses every inbound `<channel source="plugin:<provider>:<server>" …>` block from
    the prompt and `INSERT OR IGNORE`s it as `direction='in'`, **before** the agent
-   acts. The `UNIQUE` constraint makes re-capture idempotent.
-3. **Outbound capture** — `PostToolUse` hook `scripts/hooks/ledger-outbound.py` on the
-   telegram reply tool records the reply text as `direction='out'` (resolves the
-   `chat_id=0` shorthand to the owner chat). Outbound rows carry `message_id=NULL`, so
-   they are never deduped against each other.
+   acts. The `UNIQUE` constraint makes re-capture idempotent. The match is on the
+   source *shape*, so **every** channel plugin (telegram, discord, slack, …) is
+   captured into the same transcript.
+3. **Outbound capture** — `PostToolUse` hook `scripts/hooks/ledger-outbound.py` on a
+   channel plugin's reply tool records the reply text as `direction='out'` (resolves
+   the `chat_id=0` shorthand to the owner chat). The hook accepts any
+   `mcp__plugin_<provider>_<server>__reply` tool, but **`PostToolUse` matchers are not
+   automatic — register one per installed channel plugin** (see the settings block
+   below). A missing matcher is the silent-failure case described under
+   *Provider coverage*.
 4. **Startup replay** — `SessionStart` hook `scripts/hooks/ledger-replay.py` injects
    hidden `additionalContext` at the top of the fresh session's context:
    - the **last N turns** of the transcript in chronological order, each prefixed
@@ -78,7 +83,8 @@ self-scope by cwd, so they are safe even if inherited. Merge this `hooks` object
       { "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/ledger-capture.py\"", "timeout": 15 } ] }
     ],
     "PostToolUse": [
-      { "matcher": "mcp__plugin.telegram.telegram__reply", "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/ledger-outbound.py\"", "timeout": 15 } ] }
+      { "matcher": "mcp__plugin_telegram_telegram__reply", "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/ledger-outbound.py\"", "timeout": 15 } ] },
+      { "matcher": "mcp__plugin_discord_discord__reply", "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/ledger-outbound.py\"", "timeout": 15 } ] }
     ],
     "SessionStart": [
       { "matcher": "startup|resume|clear", "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/ledger-replay.py\"", "timeout": 15 } ] }
@@ -88,6 +94,29 @@ self-scope by cwd, so they are safe even if inherited. Merge this `hooks` object
 ```
 
 - `UserPromptSubmit` takes no matcher (fires on every prompt).
+- **One `PostToolUse` entry per installed channel plugin.** Drop the discord line if
+  that plugin is not installed; add a line for any other channel plugin you run.
+
+## Provider coverage — the silent failure to avoid
+
+The transcript is only as complete as the set of channels it captures, and a
+missing channel does **not** look like a failure. The replay still emits a
+non-empty block from the channels that *are* captured, so a respawned session
+reads what looks like a full history while the conversation that actually
+matters is absent. An empty block invites suspicion; a full block from the wrong
+channel reads as normal operation.
+
+Check coverage by channel, not by row count:
+
+```sql
+SELECT chat_id, direction, COUNT(*), MAX(created_at)
+FROM conversation_log GROUP BY chat_id, direction;
+```
+
+Every channel you actually converse on should appear, in **both** directions. If
+your primary channel is missing, the inbound hook is not matching its envelope or
+its reply tool has no `PostToolUse` matcher — continuity is not working for it,
+however healthy the totals look.
 - `PostToolUse` matcher `mcp__plugin.telegram.telegram__reply`: the `.` are regex
   wildcards that match the sanitized tool name `mcp__plugin_telegram_telegram__reply`
   (the hook also double-checks `tool_name` contains `telegram`+`reply`).

--- a/scripts/__tests__/conversation-ledger.test.sh
+++ b/scripts/__tests__/conversation-ledger.test.sh
@@ -53,9 +53,17 @@ run_drain() { # db
 age_rows() { # db seconds
     python3 - "$1" "$2" <<'PYEOF'
 import sqlite3, sys
+# Tolerant of a missing table: when a hook under test recorded nothing, the
+# caller must still reach its assertion and FAIL cleanly. Aborting here would
+# hide every later check in the run.
 con = sqlite3.connect(sys.argv[1])
-con.execute("UPDATE conversation_log SET created_at = created_at - ?", (int(sys.argv[2]),))
-con.commit(); con.close()
+try:
+    con.execute("UPDATE conversation_log SET created_at = created_at - ?", (int(sys.argv[2]),))
+    con.commit()
+except Exception:
+    pass
+finally:
+    con.close()
 PYEOF
 }
 
@@ -97,6 +105,34 @@ payload = {"tool_name": "mcp__plugin_telegram_telegram__reply",
            "tool_input": {"chat_id": sys.argv[1], "text": sys.argv[2]}}
 if len(sys.argv) > 3:
     payload["cwd"] = sys.argv[3]
+print(json.dumps(payload))
+PYEOF
+}
+
+# Emit an inbound payload from ANY channel provider (the envelope shape is the
+# same for every plugin; only the source attribute differs).
+emit_inbound_provider() { # provider chat_id message_id text [cwd]
+    python3 - "$@" <<'PYEOF'
+import json, sys
+provider, chat_id, message_id, text = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
+block = (f'<channel source="plugin:{provider}:{provider}" chat_id="{chat_id}" '
+         f'message_id="{message_id}" user="x" ts="2026-06-02T14:20:25.000Z">\n{text}\n</channel>')
+payload = {"hook_event_name": "UserPromptSubmit", "prompt": block}
+if len(sys.argv) > 5:
+    payload["cwd"] = sys.argv[5]
+print(json.dumps(payload))
+PYEOF
+}
+
+# Emit a reply PostToolUse payload for ANY channel provider. `response` is the
+# tool's plain-text answer, from which the message_id is parsed.
+emit_reply_provider() { # provider chat_id text response
+    python3 - "$@" <<'PYEOF'
+import json, sys
+provider, chat_id, text, response = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
+payload = {"tool_name": f"mcp__plugin_{provider}_{provider}__reply",
+           "tool_input": {"chat_id": chat_id, "text": text},
+           "tool_response": [{"type": "text", "text": response}]}
 print(json.dumps(payload))
 PYEOF
 }
@@ -453,6 +489,96 @@ mkdir -p "$TMPDIR_BASE/ld4"; DB_LD4="$TMPDIR_BASE/ld4/x.db"
 emit_inbound 10000000001 1131 "Epp most erkezett" | run_hook ledger-capture.py "$DB_LD4"
 OUT_G4="$(run_drain "$DB_LD4")"
 assert_eq "live drain: in-flight question (within grace) is not surfaced" "" "$OUT_G4"
+
+# ---------------------------------------------------------------------------
+# (h) SECOND CHANNEL PROVIDER -- the ledger must not be blind to a non-Telegram
+#     channel. Regression guard: both hooks were hardcoded to
+#     `plugin:telegram:telegram` / a "telegram" substring, so an install whose
+#     primary channel was Discord recorded ZERO turns -- and the failure was
+#     invisible, because the replay still produced a non-empty block from the
+#     one provider that WAS captured.
+# ---------------------------------------------------------------------------
+echo ""
+echo "(h) Second channel provider (discord)"
+
+# (h1) inbound from a non-telegram provider is captured
+DB_H="$TMPDIR_BASE/h.db"
+emit_inbound_provider discord 20000000002 7001 "kerdes egy masik csatornarol" \
+    | run_hook ledger-capture.py "$DB_H"
+H_IN="$(db_scalar "$DB_H" "SELECT text FROM conversation_log WHERE direction='in'")"
+assert_eq "discord inbound is captured" "kerdes egy masik csatornarol" "$H_IN"
+H_CHAT="$(db_scalar "$DB_H" "SELECT chat_id FROM conversation_log WHERE direction='in'")"
+assert_eq "discord inbound keeps its chat_id" "20000000002" "$H_CHAT"
+
+# (h2) outbound reply from a non-telegram provider is captured
+emit_reply_provider discord 20000000002 "valasz egy masik csatornara" "sent (id: 7002)" \
+    | run_hook ledger-outbound.py "$DB_H"
+H_OUT="$(db_scalar "$DB_H" "SELECT text FROM conversation_log WHERE direction='out'")"
+assert_eq "discord outbound is captured" "valasz egy masik csatornara" "$H_OUT"
+H_MID="$(db_scalar "$DB_H" "SELECT message_id FROM conversation_log WHERE direction='out'")"
+assert_eq "discord outbound records its message_id" "7002" "$H_MID"
+
+# (h3) a split reply answers "sent 2 parts (ids: A, B)" -> the first id is used
+DB_H2="$TMPDIR_BASE/h2.db"
+emit_reply_provider discord 10000000001 "hosszu valasz" "sent 2 parts (ids: 991, 992)" \
+    | run_hook ledger-outbound.py "$DB_H2"
+H2_MID="$(db_scalar "$DB_H2" "SELECT message_id FROM conversation_log WHERE direction='out'")"
+assert_eq "multi-part reply extracts the first message_id" "991" "$H2_MID"
+
+# (h4) the open question closes across providers: an unanswered discord inbound
+#      IS surfaced by the drain, and stops being surfaced once answered.
+mkdir -p "$TMPDIR_BASE/h3"; DB_H3="$TMPDIR_BASE/h3/x.db"
+emit_inbound_provider discord 10000000001 4201 "kerdes discordon" | run_hook ledger-capture.py "$DB_H3"
+age_rows "$DB_H3" 600
+OUT_H3A="$(run_drain "$DB_H3")"
+case "$OUT_H3A" in
+    *"kerdes discordon"*) pass "discord open question is surfaced by the drain" ;;
+    *) fail "discord open question was NOT surfaced by the drain" ;;
+esac
+emit_reply_provider discord 10000000001 "valasz" "sent (id: 4202)" | run_hook ledger-outbound.py "$DB_H3"
+mkdir -p "$TMPDIR_BASE/h3b"; cp "$DB_H3" "$TMPDIR_BASE/h3b/x.db"
+OUT_H3B="$(run_drain "$TMPDIR_BASE/h3b/x.db")"
+assert_eq "an answered discord question is not surfaced" "" "$OUT_H3B"
+
+# (h5) both providers land in ONE transcript
+DB_H4="$TMPDIR_BASE/h4.db"
+emit_inbound 10000000001 5001 "TELEGRAM_UZENET" | run_hook ledger-capture.py "$DB_H4"
+emit_inbound_provider discord 20000000002 5002 "DISCORD_UZENET" \
+    | run_hook ledger-capture.py "$DB_H4"
+emit_session | run_hook ledger-replay.py "$DB_H4" > "$TMPDIR_BASE/h4.json"
+H4_CTX="$(ctx_of "$TMPDIR_BASE/h4.json")"
+case "$H4_CTX" in
+    *TELEGRAM_UZENET*) pass "replay keeps the telegram turn" ;;
+    *) fail "replay lost the telegram turn" ;;
+esac
+case "$H4_CTX" in
+    *DISCORD_UZENET*) pass "replay includes the discord turn" ;;
+    *) fail "replay lost the discord turn -- the ledger is provider-blind" ;;
+esac
+
+# (h6) NEGATIVE: a non-channel tool that merely contains "reply" is still
+#      rejected. The gate is anchored on the mcp__plugin_<x>__reply shape, so
+#      widening it to a second provider must not widen it to everything.
+DB_H5="$TMPDIR_BASE/h5.db"
+echo '{"tool_name":"mcp__github__reply_to_review_comment","tool_input":{"chat_id":"10000000001","text":"nope"}}' \
+    | run_hook ledger-outbound.py "$DB_H5"
+H5_OUT="$(db_scalar "$DB_H5" "SELECT COUNT(*) FROM conversation_log WHERE direction='out'")"
+if [ "$H5_OUT" = "0" ] || [ "$H5_OUT" = "NULL" ]; then
+    pass "a non-channel tool containing 'reply' records no outbound row"
+else
+    fail "a non-channel 'reply' tool recorded an outbound row: $H5_OUT"
+fi
+
+# (h7) NEGATIVE: a channel plugin's NON-reply tool (react/edit) records nothing.
+DB_H6="$TMPDIR_BASE/h6.db"
+echo '{"tool_name":"mcp__plugin_discord_discord__react","tool_input":{"chat_id":"10000000001","text":"x"}}' \
+    | run_hook ledger-outbound.py "$DB_H6"
+H6_OUT="$(db_scalar "$DB_H6" "SELECT COUNT(*) FROM conversation_log WHERE direction='out'")"
+if [ "$H6_OUT" = "0" ] || [ "$H6_OUT" = "NULL" ]; then
+    pass "a channel plugin's non-reply tool records no outbound row"
+else
+    fail "a non-reply channel tool recorded an outbound row: $H6_OUT"
+fi
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/scripts/hooks/ledger-capture.py
+++ b/scripts/hooks/ledger-capture.py
@@ -1,9 +1,16 @@
 #!/usr/bin/env python3
-"""UserPromptSubmit hook: capture inbound Telegram messages into the rolling
+"""UserPromptSubmit hook: capture inbound channel messages into the rolling
 transcript (direction='in') BEFORE the agent processes the prompt. Deterministic
 and agent-independent. agent_id is derived from the session's cwd so the hook is
 generic across all three channel agents and never cross-contaminates. Never
 blocks the prompt (always exit 0).
+
+PROVIDER-AGNOSTIC: every channel plugin emits the same <channel source="..">
+envelope, so the capture matches any `plugin:<provider>:<name>` source rather
+than one hardcoded provider. Hardcoding a single provider silently drops the
+whole conversation on every other channel -- and the failure is invisible,
+because the replay still produces a non-empty block from the one provider that
+IS captured.
 """
 import sys
 import os
@@ -16,8 +23,11 @@ import ledger_lib  # noqa: E402
 # <channel source="plugin:telegram:telegram" chat_id="X" message_id="Y" ... ts="Z">
 #   TEXT
 # </channel>
+# The source is `plugin:<provider>:<server>` for every channel plugin
+# (telegram, discord, slack, ...). Matching the shape instead of one literal
+# keeps a new provider working without a code change.
 CHANNEL_RX = re.compile(
-    r'<channel\s+source="plugin:telegram:telegram"([^>]*)>(.*?)</channel>',
+    r'<channel\s+source="plugin:[A-Za-z0-9_.-]+:[A-Za-z0-9_.-]+"([^>]*)>(.*?)</channel>',
     re.DOTALL,
 )
 

--- a/scripts/hooks/ledger-outbound.py
+++ b/scripts/hooks/ledger-outbound.py
@@ -1,12 +1,17 @@
 #!/usr/bin/env python3
-"""PostToolUse hook (matcher: the Telegram reply tool): record the OUTBOUND reply
-text into the rolling transcript (direction='out'). This both (a) gives the
+"""PostToolUse hook (matcher: a channel plugin's reply tool): record the OUTBOUND
+reply text into the rolling transcript (direction='out'). This both (a) gives the
 SessionStart replay full conversation context and (b) closes the open question
 (an inbound with a later outbound is considered answered). Deterministic.
 
 agent_id is derived from the session's cwd (generic across the three agents). The
 reply tool sometimes uses chat_id=0/empty as a shorthand for the main chat
 (CLAUDE.md), resolved to the agent's owner chat. Never blocks (exit 0).
+
+PROVIDER-AGNOSTIC: matches `mcp__plugin_<provider>_<server>__reply` for any
+channel plugin rather than one hardcoded provider, so a second channel does not
+silently vanish from the transcript. Register one PostToolUse matcher per
+installed channel plugin -- see docs/conversation-continuity.md.
 """
 import sys
 import os
@@ -17,6 +22,10 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import ledger_lib  # noqa: E402
 
 
+# mcp__plugin_telegram_telegram__reply, mcp__plugin_discord_discord__reply, ...
+REPLY_TOOL_RX = re.compile(r"^mcp__plugin_[A-Za-z0-9_]+__reply$")
+
+
 def _owner_chat():
     v = os.environ.get("LEDGER_OWNER_CHAT") or os.environ.get("ALLOWED_CHAT_ID")
     return v.strip() if v else ""
@@ -25,15 +34,24 @@ def _owner_chat():
 def _id_from_text(text):
     """Extract a numeric id from a plain-text string, or return None.
 
-    Two patterns in priority order:
+    Three patterns in priority order:
     1. Parenthesized exact form: "sent (id: 3461)" -> "3461"
        Matches the current Telegram plugin response format.
-    2. Word-boundary fallback: matches "id: 42" or "id 42" but not
+    2. Multi-part form: "sent 2 parts (ids: 3461, 3462)" -> "3461"
+       Matches a channel plugin that splits an over-long reply (Discord).
+    3. Word-boundary fallback: matches "id: 42" or "id 42" but not
        "invalid 42" (the word boundary \b prevents partial-word hits
        that would produce false positives from error messages).
     """
     # Exact parenthesized form first.
     m = re.search(r"\(id:\s*(\d+)\)", text, re.IGNORECASE)
+    if m:
+        return str(m.group(1))
+    # Multi-part form: a long reply is split and the tool answers
+    # "sent 2 parts (ids: 123, 456)". The FIRST id identifies the turn; it is
+    # only used to deduplicate a double-fire of the hook, so any stable choice
+    # works as long as it is deterministic.
+    m = re.search(r"\(ids:\s*(\d+)", text, re.IGNORECASE)
     if m:
         return str(m.group(1))
     # Word-boundary fallback for looser formats.
@@ -99,8 +117,10 @@ def main():
     except Exception:
         sys.exit(0)
     tool = payload.get("tool_name") or ""
-    # Double-check (the matcher should already filter): only the telegram reply.
-    if "telegram" not in tool or "reply" not in tool:
+    # Double-check (the matcher should already filter): only a channel plugin's
+    # reply tool. Anchored on the full MCP tool-name shape so an unrelated tool
+    # that merely contains "reply" cannot write a bogus turn into the ledger.
+    if not REPLY_TOOL_RX.match(tool):
         sys.exit(0)
     agent_id = ledger_lib.agent_id_from_cwd(payload.get("cwd"))
     tool_input = payload.get("tool_input") or {}


### PR DESCRIPTION
…RPROV826)

The conversation-continuity ledger was hardcoded to one provider at two points, so an install whose primary channel is not Telegram recorded ZERO turns and lost its entire conversation on every respawn.

  - ledger-capture.py matched only source="plugin:telegram:telegram"
  - ledger-outbound.py required "telegram" in the tool name, and only the Telegram reply tool had a PostToolUse matcher

Measured on a live install whose owner chat is Discord: conversation_log held 0 Discord rows over the table's entire lifetime, and 9 rows in the preceding 7 days -- all outbound Telegram. A respawn mid-conversation therefore replayed five unrelated turns and dropped the 40 minutes that mattered, including a commitment the fresh session then failed to honour.

What makes this hard to notice is that the replay does NOT go empty. It still renders a full, chronological block from the provider that IS captured, so the failure reads as normal operation. An empty block invites suspicion; a full block from the wrong channel does not.

Changes:
  - capture matches the source *shape* `plugin:<provider>:<server>`, so any channel plugin lands in the same transcript
  - the outbound gate is anchored on `^mcp__plugin_[A-Za-z0-9_]+__reply$`. Anchoring rather than loosening to a "reply" substring keeps unrelated tools (e.g. a GitHub reply-to-comment tool) out of the transcript
  - handle the multi-part reply response `sent 2 parts (ids: A, B)` that a plugin returns when it splits an over-long message; the first id is used for dedup
  - docs: register one PostToolUse matcher per installed channel plugin, and a "Provider coverage" section with the per-channel query that actually detects this (a row count cannot)

Tests: 11 new cases in section (h), 50/50 green. Verified by mutation -- with the two hooks reverted, the 7 positive assertions fail and the 4 negative ones still pass, so the suite pins the fix rather than merely accompanying it. age_rows() in the harness is now tolerant of a missing table so a regression FAILS cleanly instead of aborting the run and hiding the remaining checks.

No schema change; existing rows and behaviour for Telegram are unaffected.

<!--
  HU + EN. Töltsd ki minden szakaszt. / Fill in every section.
  A jelölőnégyzeteket így pipáld: [x]  /  Tick a box like this: [x]
-->

## A változtatás típusa / Type of change

- [ ] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

<!-- HU: Foglald össze, milyen problémát old meg a PR és milyen technikai megközelítést alkalmaztál.
     EN: Summarize what problem this PR solves and the technical approach you took. -->

## Kapcsolódó issue / Related issue

Closes #

## Ellenőrzőlista / Checklist

- [ ] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [ ] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
- [ ] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [ ] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).

## Titok-kapu / Secret gate

A `secret-gate` CI-job a valodi kapu. A lokalis pre-commit hook csak gyors
elorejelzes, es `--no-verify`-jal megkerulheto -- ne tekintsd elegnek.
The `secret-gate` CI job is the real gate; the local pre-commit hook is a fast
preview and can be skipped with `--no-verify`, so it is not sufficient on its own.

- [ ] Nincs a valtoztatasban bizonyitek-/artefaktum-mappa, titok-alaku string vagy idezett csatorna-uzenet.
      / No evidence or artifact directory, secret-shaped string, or quoted channel message in this change.
