### PR TITLE
fix(notify): report delivery failure instead of unconditional success (NOTIFYVAK826)

### DIFF
--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -78,9 +78,31 @@ if [ -n "${VITEST:-}" ] || [ "${NODE_ENV:-}" = "test" ]; then
   MESSAGE="[TESZT] ${MESSAGE}"
 fi
 
-curl -s -X POST "https://api.telegram.org/bot${TOKEN}/sendMessage" \
+# Delivery must be HONEST (NOTIFYVAK826): this script is the fleet's FALLBACK
+# channel, used exactly when the primary Telegram plugin is already down. A
+# swallowed curl failure here reported success while nothing was delivered --
+# indistinguishable, from the owner's side, from "nothing happened". Success
+# therefore requires BOTH a clean curl exit AND the Bot API's own "ok":true
+# (an HTTP 200 with ok:false -- bad chat_id, parse error -- exits 0 in curl).
+RESPONSE=$(curl -sS -X POST "https://api.telegram.org/bot${TOKEN}/sendMessage" \
   -d "chat_id=${CHAT_ID}" \
   -d "text=${MESSAGE}" \
-  -d "parse_mode=HTML" > /dev/null
+  -d "parse_mode=HTML" 2>&1)
+CURL_EXIT=$?
+# Never echo the bot token: some curl errors quote the request URL.
+RESPONSE="${RESPONSE//${TOKEN}/<token>}"
 
-echo "Ertesites elkuldve."
+if [ $CURL_EXIT -ne 0 ]; then
+  echo "Hiba: ertesites kuldese sikertelen (curl exit ${CURL_EXIT}): ${RESPONSE}" >&2
+  exit 1
+fi
+
+case "$RESPONSE" in
+  *'"ok":true'*)
+    echo "Ertesites elkuldve."
+    ;;
+  *)
+    echo "Hiba: a Telegram API elutasitotta az ertesitest: ${RESPONSE}" >&2
+    exit 1
+    ;;
+esac

--- a/src/__tests__/notify-delivery-honesty.test.ts
+++ b/src/__tests__/notify-delivery-honesty.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { execFileSync, spawnSync } from 'node:child_process'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, chmodSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+// NOTIFYVAK826: notify.sh is the fleet's FALLBACK channel -- it fires exactly
+// when the primary Telegram plugin is down. Until this fix it discarded curl's
+// output and exit code and always printed success, so a dead fallback was
+// indistinguishable from a delivered alert. These tests run the real script
+// with a PATH-stubbed curl (nothing leaves the machine) and pin the contract:
+// success ONLY on curl exit 0 + Bot API "ok":true; every failure mode exits
+// non-zero, keeps the success line off stdout, and never leaks the bot token.
+const ROOT = join(__dirname, '..', '..')
+const SCRIPT = join(ROOT, 'scripts', 'notify.sh')
+const FAKE_TOKEN = '1234567890:TESTTOKENTESTTOKEN'
+
+let stage: string
+
+// The script resolves .env relative to its own location, so stage a full copy
+// of the script one level below a temp root that carries the fake .env.
+function stageScript(): { scriptCopy: string } {
+  const scriptsDir = join(stage, 'scripts')
+  mkdirSync(scriptsDir, { recursive: true })
+  const scriptCopy = join(scriptsDir, 'notify.sh')
+  execFileSync('/bin/cp', [SCRIPT, scriptCopy])
+  writeFileSync(join(stage, '.env'), `TELEGRAM_BOT_TOKEN=${FAKE_TOKEN}\nALLOWED_CHAT_ID=42\nMAIN_AGENT_ID=mainbot\n`)
+  return { scriptCopy }
+}
+
+// A curl stub controlled per-case via env: CURL_STUB_EXIT + CURL_STUB_BODY.
+// Failure bodies quote the request URL (token included) on purpose, to prove
+// the script redacts it before echoing.
+function writeCurlStub(dir: string): void {
+  const stub = join(dir, 'curl')
+  writeFileSync(stub, '#!/bin/bash\nif [ "${CURL_STUB_EXIT:-0}" -ne 0 ]; then\n  echo "curl: (6) Could not resolve host for https://api.telegram.org/bot${CURL_STUB_TOKEN}/sendMessage" >&2\n  exit "${CURL_STUB_EXIT}"\nfi\nprintf \'%s\' "${CURL_STUB_BODY}"\n')
+  chmodSync(stub, 0o755)
+}
+
+function runNotify(env: Record<string, string>): { status: number | null; stdout: string; stderr: string } {
+  const { scriptCopy } = stageScript()
+  const binDir = join(stage, 'bin')
+  mkdirSync(binDir, { recursive: true })
+  writeCurlStub(binDir)
+  const r = spawnSync('/bin/bash', [scriptCopy, 'probe message'], {
+    env: {
+      PATH: `${binDir}:/usr/bin:/bin`,
+      CURL_STUB_TOKEN: FAKE_TOKEN,
+      // Keep the [TESZT] marker deterministic: vitest exports VITEST anyway.
+      VITEST: '1',
+      ...env,
+    },
+    encoding: 'utf-8',
+  })
+  return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' }
+}
+
+beforeAll(() => {
+  stage = mkdtempSync(join(tmpdir(), 'notify-honesty-'))
+})
+
+afterAll(() => {
+  rmSync(stage, { recursive: true, force: true })
+})
+
+describe('notify.sh delivery honesty (NOTIFYVAK826)', () => {
+  it('reports success only when the Bot API says ok:true', () => {
+    const r = runNotify({ CURL_STUB_BODY: '{"ok":true,"result":{"message_id":7}}' })
+    expect(r.status).toBe(0)
+    expect(r.stdout).toContain('Ertesites elkuldve.')
+  })
+
+  it('POSITIVE CONTROL: a transport failure must NOT report success', () => {
+    const r = runNotify({ CURL_STUB_EXIT: '6' })
+    expect(r.status).toBe(1)
+    expect(r.stdout).not.toContain('Ertesites elkuldve.')
+    expect(r.stderr).toContain('curl exit 6')
+  })
+
+  it('an HTTP-200 API rejection (ok:false) must NOT report success', () => {
+    const r = runNotify({ CURL_STUB_BODY: '{"ok":false,"error_code":400,"description":"Bad Request: chat not found"}' })
+    expect(r.status).toBe(1)
+    expect(r.stdout).not.toContain('Ertesites elkuldve.')
+    expect(r.stderr).toContain('chat not found')
+  })
+
+  it('never leaks the bot token into its error output', () => {
+    const r = runNotify({ CURL_STUB_EXIT: '6' })
+    expect(r.stderr).not.toContain(FAKE_TOKEN)
+    expect(r.stderr).toContain('<token>')
+  })
+})


### PR DESCRIPTION
## Problem
`notify.sh` is the fleet's FALLBACK alert channel -- it fires exactly when the primary Telegram plugin is down. Until now it discarded curl's output and exit code and unconditionally printed `Ertesites elkuldve.` (scripts/notify.sh:71-76 pre-fix). A dead fallback was therefore indistinguishable from a delivered alert: the primary path silent AND the fallback lying about its own success.

Found during the #1053 verify (pre-existing, not introduced by that PR); card NOTIFYVAK826.

## Fix
Success now requires **both** a clean curl exit **and** the Bot API's own `"ok":true` -- an HTTP 200 with `ok:false` (bad chat_id, HTML parse error) leaves curl at exit 0, so checking the transport alone is not enough. Every failure mode exits 1 with the reason on stderr. The bot token is redacted from echoed responses (some curl errors quote the request URL).

## Blast radius
Callers (`channel-coordinator.ts` sendAlert, `reauth-healer.ts`) run the script via execFile and already treat a non-zero exit as a logged warning -- the change only makes real failures visible to them. `scripts/unit-fail-notify.sh` has the same swallow pattern and is intentionally out of scope here (sibling follow-up).

## Verification
- New vitest file `src/__tests__/notify-delivery-honesty.test.ts` (runs in CI, not a manual shell test): PATH-stubbed curl, nothing leaves the machine. Cases: ok:true -> exit 0 + success line; curl transport failure -> exit 1, no success line (POSITIVE CONTROL); ok:false rejection -> exit 1; token never leaks into error output.
- Red-before proven: the test fails 3/4 against the pre-fix script, passes 4/4 with the fix.
- `bash -n` + shellcheck clean; `tsc --noEmit` clean; full vitest 304 files / 4041 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)