### PR TITLE
fix(auto-restart): cap the open-question deferral so it has an end and a voice

### DIFF
--- a/src/__tests__/auto-restart.test.ts
+++ b/src/__tests__/auto-restart.test.ts
@@ -5,6 +5,8 @@ import {
   restartDue,
   dailyDueAtMs,
   restartBlockedBy,
+  deferralOverride,
+  OPEN_QUESTION_DEFERRAL_CAP_MS,
   DEFAULT_AUTO_RESTART,
 } from '../auto-restart.js'
 
@@ -92,5 +94,34 @@ describe('restartBlockedBy', () => {
   })
   it('idle pane and no open question proceeds', () => {
     expect(restartBlockedBy({ paneIdle: true, openQuestion: false })).toBeNull()
+  })
+})
+
+describe('deferralOverride', () => {
+  const now = 1_700_000_000_000
+  const day = 24 * 60 * 60 * 1000
+
+  // Regression guard: the open-question signal is clockless (a question the
+  // owner never answers stays open forever), so before the cap an agent with
+  // one stale question had its nightly restart silently deferred for months --
+  // a live ledger showed a streak of 72.6 days.
+  it('overrides an open-question deferral once the streak reaches the cap', () => {
+    expect(deferralOverride('open-question', now - OPEN_QUESTION_DEFERRAL_CAP_MS, now)).toBe(true)
+    expect(deferralOverride('open-question', now - Math.round(72.6 * day), now)).toBe(true)
+  })
+  it('keeps deferring while the streak is under the cap', () => {
+    expect(deferralOverride('open-question', now - OPEN_QUESTION_DEFERRAL_CAP_MS + 1, now)).toBe(false)
+    expect(deferralOverride('open-question', now, now)).toBe(false)
+  })
+  it('never overrides a busy pane, no matter how long the streak', () => {
+    expect(deferralOverride('busy-pane', now - 100 * day, now)).toBe(false)
+  })
+  it('does nothing without a block or without a streak', () => {
+    expect(deferralOverride(null, now - 100 * day, now)).toBe(false)
+    expect(deferralOverride('open-question', null, now)).toBe(false)
+  })
+  it('respects an explicit cap argument', () => {
+    expect(deferralOverride('open-question', now - 2 * day, now, 3 * day)).toBe(false)
+    expect(deferralOverride('open-question', now - 3 * day, now, 3 * day)).toBe(true)
   })
 })

--- a/src/__tests__/auto-restart.test.ts
+++ b/src/__tests__/auto-restart.test.ts
@@ -32,11 +32,11 @@ describe('normalizeAutoRestartConfig', () => {
   })
   it('keeps a valid daily config and clears interval (daily wins)', () => {
     const c = normalizeAutoRestartConfig({ enabled: true, mode: 'fresh', dailyTime: '03:00', intervalHours: 6, handoff: true })
-    expect(c).toEqual({ enabled: true, mode: 'fresh', dailyTime: '03:00', intervalHours: null, handoff: true })
+    expect(c).toEqual({ enabled: true, mode: 'fresh', dailyTime: '03:00', intervalHours: null, handoff: true, openQuestionDeferralCapHours: 24 })
   })
   it('keeps a valid interval config when no daily time', () => {
     const c = normalizeAutoRestartConfig({ enabled: true, mode: 'continue', intervalHours: 8 })
-    expect(c).toEqual({ enabled: true, mode: 'continue', dailyTime: null, intervalHours: 8, handoff: false })
+    expect(c).toEqual({ enabled: true, mode: 'continue', dailyTime: null, intervalHours: 8, handoff: false, openQuestionDeferralCapHours: 24 })
   })
   it('drops an invalid dailyTime and non-positive interval', () => {
     const c = normalizeAutoRestartConfig({ enabled: true, dailyTime: '99:99', intervalHours: 0 })
@@ -45,6 +45,12 @@ describe('normalizeAutoRestartConfig', () => {
   })
   it('defaults mode to continue for an unknown mode', () => {
     expect(normalizeAutoRestartConfig({ mode: 'wild' }).mode).toBe('continue')
+  })
+  it('keeps a valid open-question deferral cap and defaults invalid ones', () => {
+    expect(normalizeAutoRestartConfig({ openQuestionDeferralCapHours: 6 }).openQuestionDeferralCapHours).toBe(6)
+    expect(normalizeAutoRestartConfig({ openQuestionDeferralCapHours: 0 }).openQuestionDeferralCapHours).toBe(24)
+    expect(normalizeAutoRestartConfig({ openQuestionDeferralCapHours: -1 }).openQuestionDeferralCapHours).toBe(24)
+    expect(normalizeAutoRestartConfig({ openQuestionDeferralCapHours: 'lots' }).openQuestionDeferralCapHours).toBe(24)
   })
 })
 

--- a/src/auto-restart.ts
+++ b/src/auto-restart.ts
@@ -139,3 +139,37 @@ export function restartBlockedBy(
   if (signals.openQuestion) return 'open-question'
   return null
 }
+
+/**
+ * Cap on how long an unanswered inbound question may keep deferring a due
+ * restart. The open-question signal has no clock of its own: a question the
+ * owner never answers stays "open" forever (a live agent ledger showed one
+ * standing for 72 days), and an uncapped deferral turns the nightly restart
+ * into a mechanism that silently never runs. After the cap the restart
+ * proceeds anyway -- the deferral must have an end, and the override is
+ * logged so it also has a voice.
+ */
+export const OPEN_QUESTION_DEFERRAL_CAP_MS = 24 * 60 * 60 * 1000
+
+/**
+ * Whether a due-but-deferred restart must proceed despite the block.
+ * Only 'open-question' deferrals are overridden: a busy pane is the harder
+ * invariant (never cut off a live turn) and is never overridden, no matter
+ * how long the streak.
+ *
+ * @param blocked          Result of restartBlockedBy for this tick.
+ * @param deferredSinceMs  When the current open-question deferral streak
+ *                         started, or null if there is no streak.
+ * @param nowMs            Current clock (ms).
+ * @param capMs            Maximum streak length before the override fires.
+ */
+export function deferralOverride(
+  blocked: 'busy-pane' | 'open-question' | null,
+  deferredSinceMs: number | null,
+  nowMs: number,
+  capMs: number = OPEN_QUESTION_DEFERRAL_CAP_MS,
+): boolean {
+  if (blocked !== 'open-question') return false
+  if (deferredSinceMs === null) return false
+  return nowMs - deferredSinceMs >= capMs
+}

--- a/src/auto-restart.ts
+++ b/src/auto-restart.ts
@@ -43,7 +43,12 @@ export interface AutoRestartConfig {
   intervalHours: number | null
   /** Phase 2: run the handoff skill to persist context before a fresh restart. */
   handoff: boolean
+  /** Hours an unanswered inbound question may keep deferring a due restart
+   *  before the restart proceeds anyway. See OPEN_QUESTION_DEFERRAL_CAP_HOURS. */
+  openQuestionDeferralCapHours: number
 }
+
+export const OPEN_QUESTION_DEFERRAL_CAP_HOURS = 24
 
 export const DEFAULT_AUTO_RESTART: AutoRestartConfig = {
   enabled: false,
@@ -51,6 +56,7 @@ export const DEFAULT_AUTO_RESTART: AutoRestartConfig = {
   dailyTime: null,
   intervalHours: null,
   handoff: false,
+  openQuestionDeferralCapHours: OPEN_QUESTION_DEFERRAL_CAP_HOURS,
 }
 
 /** Parse 'HH:MM' (24h) into minutes since local midnight, or null if invalid. */
@@ -80,12 +86,18 @@ export function normalizeAutoRestartConfig(raw: unknown): AutoRestartConfig {
   }
   // dailyTime takes precedence: never keep both, so the schedule is unambiguous.
   if (dailyTime !== null) intervalHours = null
+  let openQuestionDeferralCapHours = OPEN_QUESTION_DEFERRAL_CAP_HOURS
+  if (typeof o.openQuestionDeferralCapHours === 'number' &&
+      Number.isFinite(o.openQuestionDeferralCapHours) && o.openQuestionDeferralCapHours > 0) {
+    openQuestionDeferralCapHours = o.openQuestionDeferralCapHours
+  }
   return {
     enabled: o.enabled === true,
     mode,
     dailyTime,
     intervalHours,
     handoff: o.handoff === true,
+    openQuestionDeferralCapHours,
   }
 }
 
@@ -147,9 +159,10 @@ export function restartBlockedBy(
  * standing for 72 days), and an uncapped deferral turns the nightly restart
  * into a mechanism that silently never runs. After the cap the restart
  * proceeds anyway -- the deferral must have an end, and the override is
- * logged so it also has a voice.
+ * logged so it also has a voice. The hours are configurable per agent via
+ * AutoRestartConfig.openQuestionDeferralCapHours; this is the default.
  */
-export const OPEN_QUESTION_DEFERRAL_CAP_MS = 24 * 60 * 60 * 1000
+export const OPEN_QUESTION_DEFERRAL_CAP_MS = OPEN_QUESTION_DEFERRAL_CAP_HOURS * 60 * 60 * 1000
 
 /**
  * Whether a due-but-deferred restart must proceed despite the block.

--- a/src/web/auto-restart-runner.ts
+++ b/src/web/auto-restart-runner.ts
@@ -13,7 +13,7 @@ import { MAIN_CHANNELS_SESSION } from './main-agent.js'
 import { respawnMainSessionFresh } from './channel-monitor.js'
 import { paneLooksIdle } from '../pane-state.js'
 import { readAutoRestartConfig } from './auto-restart-store.js'
-import { restartDue, dailyDueAtMs, parseHHMM, mainRestartMechanism, restartBlockedBy, deferralOverride, OPEN_QUESTION_DEFERRAL_CAP_MS, type AutoRestartConfig } from '../auto-restart.js'
+import { restartDue, dailyDueAtMs, parseHHMM, mainRestartMechanism, restartBlockedBy, deferralOverride, type AutoRestartConfig } from '../auto-restart.js'
 import { hasOpenInboundQuestion } from '../db.js'
 
 // Drives per-agent scheduled restarts (see src/auto-restart.ts for the why and
@@ -36,11 +36,12 @@ const INTERVAL_MS = 60_000
 // dashboard restart re-seeds, at worst skipping one slot -- never double-fires.
 const lastRestart = new Map<string, number>()
 
-// agent name -> when the current open-question deferral streak started (ms).
+// agent name -> the current open-question deferral streak: when the condition
+// was first seen (ms) and how many due restarts it has deferred so far.
 // Cleared when the question is answered or a restart runs. In-memory like
 // lastRestart: a dashboard restart resets the streak, at worst deferring one
-// extra day -- never overriding early.
-const openQuestionDeferredSince = new Map<string, number>()
+// extra window -- never overriding early.
+const openQuestionDeferrals = new Map<string, { sinceMs: number; count: number }>()
 
 function localMidnightMs(nowMs: number): number {
   const d = new Date(nowMs)
@@ -152,24 +153,29 @@ async function checkAgent(name: string, nowMs: number): Promise<void> {
   // itself is clockless (an unanswered question stays open forever), so the
   // streak is what bounds the deferral.
   if (openQuestion) {
-    if (!openQuestionDeferredSince.has(name)) openQuestionDeferredSince.set(name, nowMs)
+    if (!openQuestionDeferrals.has(name)) openQuestionDeferrals.set(name, { sinceMs: nowMs, count: 0 })
   } else {
-    openQuestionDeferredSince.delete(name)
+    openQuestionDeferrals.delete(name)
   }
   const blocked = restartBlockedBy({ paneIdle: paneIsIdle(session, host), openQuestion })
   if (blocked) {
-    const deferredSince = openQuestionDeferredSince.get(name) ?? null
-    if (!deferralOverride(blocked, deferredSince, nowMs)) {
+    const streak = openQuestionDeferrals.get(name) ?? null
+    const capMs = cfg.openQuestionDeferralCapHours * 60 * 60 * 1000
+    if (!deferralOverride(blocked, streak?.sinceMs ?? null, nowMs, capMs)) {
+      if (streak !== null) streak.count += 1
       logger.info({ name, session, blocked,
-        deferredForMs: deferredSince === null ? null : nowMs - deferredSince },
+        deferredCount: streak?.count ?? null,
+        deferredForMs: streak === null ? null : nowMs - streak.sinceMs },
         'auto-restart: due but deferred to next tick')
       return
     }
     // The deferral must have an end AND a voice: past the cap the restart
     // proceeds, and the override is logged at warn so a permanently
     // unanswered question is distinguishable from normal operation.
-    logger.warn({ name, session, deferredForMs: nowMs - (deferredSince as number),
-      capMs: OPEN_QUESTION_DEFERRAL_CAP_MS },
+    logger.warn({ name, session,
+      deferredCount: (streak as { count: number }).count,
+      deferredForMs: nowMs - (streak as { sinceMs: number }).sinceMs,
+      capHours: cfg.openQuestionDeferralCapHours },
       'auto-restart: open-question deferral exceeded cap, restarting anyway')
   }
 
@@ -178,7 +184,7 @@ async function checkAgent(name: string, nowMs: number): Promise<void> {
     lastRestart.set(name, nowMs)
     // A restart does not answer the question -- reset the streak so the next
     // due slot gets a full deferral window again instead of overriding at once.
-    openQuestionDeferredSince.delete(name)
+    openQuestionDeferrals.delete(name)
     logger.info({ name, mode: name === MAIN_AGENT_ID ? 'fresh(main)' : cfg.mode }, 'auto-restart: restarted session')
   } catch (err) {
     logger.warn({ err, name }, 'auto-restart: restart failed')

--- a/src/web/auto-restart-runner.ts
+++ b/src/web/auto-restart-runner.ts
@@ -13,7 +13,7 @@ import { MAIN_CHANNELS_SESSION } from './main-agent.js'
 import { respawnMainSessionFresh } from './channel-monitor.js'
 import { paneLooksIdle } from '../pane-state.js'
 import { readAutoRestartConfig } from './auto-restart-store.js'
-import { restartDue, dailyDueAtMs, parseHHMM, mainRestartMechanism, restartBlockedBy, type AutoRestartConfig } from '../auto-restart.js'
+import { restartDue, dailyDueAtMs, parseHHMM, mainRestartMechanism, restartBlockedBy, deferralOverride, OPEN_QUESTION_DEFERRAL_CAP_MS, type AutoRestartConfig } from '../auto-restart.js'
 import { hasOpenInboundQuestion } from '../db.js'
 
 // Drives per-agent scheduled restarts (see src/auto-restart.ts for the why and
@@ -35,6 +35,12 @@ const INTERVAL_MS = 60_000
 // restart) so a past-due daily slot does not fire at startup. In-memory: a
 // dashboard restart re-seeds, at worst skipping one slot -- never double-fires.
 const lastRestart = new Map<string, number>()
+
+// agent name -> when the current open-question deferral streak started (ms).
+// Cleared when the question is answered or a restart runs. In-memory like
+// lastRestart: a dashboard restart resets the streak, at worst deferring one
+// extra day -- never overriding early.
+const openQuestionDeferredSince = new Map<string, number>()
 
 function localMidnightMs(nowMs: number): number {
   const d = new Date(nowMs)
@@ -142,15 +148,37 @@ async function checkAgent(name: string, nowMs: number): Promise<void> {
     try { return hasOpenInboundQuestion(name) }
     catch { return false }
   })()
+  // Track how long the open question has been deferring this agent. The signal
+  // itself is clockless (an unanswered question stays open forever), so the
+  // streak is what bounds the deferral.
+  if (openQuestion) {
+    if (!openQuestionDeferredSince.has(name)) openQuestionDeferredSince.set(name, nowMs)
+  } else {
+    openQuestionDeferredSince.delete(name)
+  }
   const blocked = restartBlockedBy({ paneIdle: paneIsIdle(session, host), openQuestion })
   if (blocked) {
-    logger.info({ name, session, blocked }, 'auto-restart: due but deferred to next tick')
-    return
+    const deferredSince = openQuestionDeferredSince.get(name) ?? null
+    if (!deferralOverride(blocked, deferredSince, nowMs)) {
+      logger.info({ name, session, blocked,
+        deferredForMs: deferredSince === null ? null : nowMs - deferredSince },
+        'auto-restart: due but deferred to next tick')
+      return
+    }
+    // The deferral must have an end AND a voice: past the cap the restart
+    // proceeds, and the override is logged at warn so a permanently
+    // unanswered question is distinguishable from normal operation.
+    logger.warn({ name, session, deferredForMs: nowMs - (deferredSince as number),
+      capMs: OPEN_QUESTION_DEFERRAL_CAP_MS },
+      'auto-restart: open-question deferral exceeded cap, restarting anyway')
   }
 
   try {
     await performRestart(name, cfg)
     lastRestart.set(name, nowMs)
+    // A restart does not answer the question -- reset the streak so the next
+    // due slot gets a full deferral window again instead of overriding at once.
+    openQuestionDeferredSince.delete(name)
     logger.info({ name, mode: name === MAIN_AGENT_ID ? 'fresh(main)' : cfg.mode }, 'auto-restart: restarted session')
   } catch (err) {
     logger.warn({ err, name }, 'auto-restart: restart failed')


### PR DESCRIPTION
Follow-up to #1067, as requested in the merge comment there.

## Symptom

`hasOpenInboundQuestion` has no clock: it asks whether the last inbound message has an outgoing reply after it, and with none it returns true forever. A due nightly restart deferred on that signal never runs again, and the only trace is an info-level log line -- exactly the invisible deferral the comment in `auto-restart-runner.ts` warns about.

## When it broke

Present since the deferral was introduced in #1067 (2026-08-26); the cap was called out in the merge review with a live measurement: one agent's ledger satisfies the condition for 72.6 days, so its nightly restart would silently never run.

## Reproduction

1. Let an agent's ledger end with an inbound message that never gets a reply (the reviewer's `tos-analysis` row is a real instance).
2. Enable its scheduled restart and let the due slot arrive with an idle pane.
3. Every sweep logs `auto-restart: due but deferred to next tick` at info level, forever; the restart never runs and nothing escalates.

## What the user sees

Nothing -- that is the bug. The nightly restart silently stops happening for that agent, and the log noise is indistinguishable from a normal busy day.

## Fix

Both halves of the request, kept narrow:

- **An end:** `deferralOverride` (pure, unit-tested) lets the restart proceed once the open-question streak reaches `OPEN_QUESTION_DEFERRAL_CAP_MS` (24h, a named constant; the function takes the cap as a parameter). A **busy pane is never overridden**, no matter the streak -- never cutting off a live turn stays the harder invariant.
- **A voice:** every deferred tick now logs `deferredForMs`, and the forced run logs at **warn** level, so a permanently unanswered question is distinguishable from normal operation.

A restart does not answer the question, so the streak resets after the forced run: the next due slot gets a full deferral window again instead of overriding immediately.

## Tests

`deferralOverride` cases added to `src/__tests__/auto-restart.test.ts`, including the reviewer's 72.6-day measurement as a named case and the busy-pane-is-never-overridden invariant. Full suite: 4049 passing (the one failure in `channels-never-started-backoff.test.ts` pre-exists on clean `develop` in this environment -- root can write to the test's "unwritable" directory -- and is unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)