### PR TITLE
feat(hooks): digest-provenance gate -- closed work and fabricated citations cannot ship (DIGESTSTALE825)

### DIFF
--- a/scripts/digest-provenance-gate.mjs
+++ b/scripts/digest-provenance-gate.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+// PreToolUse hard-gate: the heartbeat worker's outgoing digest must cite REAL,
+// CURRENT state -- provenance enforced in code, not prose.
+//
+// DIGESTSTALE825 (2026-08-26): the delegalt-feladat-figyelo digest reported
+// closed work as open (0/4 accuracy on the 10:13 round), fabricated an owner
+// decision that never existed, and misattributed an agent. The instruction
+// layer was PROVEN insufficient the same morning: a "re-measure before
+// emitting" gate was added to the task's SKILL.md at 09:34 and the very first
+// run after it (10:13) still shipped all four errors. Same lesson as
+// kanban-write-gate (HBFUTTATOIR824): a rule that lives only in prompt text is
+// the never-installed-guard pattern. This hook is the technical enforcement,
+// wired ONLY for the heartbeat worker (same scope as kanban-write-gate in
+// agent-scaffold.ts) -- every other agent's /api/messages traffic is not
+// digest traffic and must stay untouched.
+//
+// What is validated (ONLY on Bash commands that POST to /api/messages):
+//   1. ACTION ROWS (the jelolt-tetel format: `card_id | status | javasolt
+//      atmenet | evidencia`, i.e. lines with >=2 " | " separators): any kanban
+//      card id in the row must be an OPEN card (not done, not archived), and
+//      any #NNNN PR reference must not already be merged to origin/develop.
+//      Prose mentions outside action rows are free -- a real alert saying
+//      "a #1062 mergelve" must pass (the failure mode is proposing CLOSED work
+//      as actionable, not mentioning it). A line starting with "kozben
+//      lezarult" is the sanctioned way to mention just-closed items (exempt).
+//   2. MESSAGE CITATIONS anywhere in the draft (`msg 16014` / `msg_id:16014`):
+//      the cited id must exist in agent_messages, must NOT be a message the
+//      heartbeat itself authored (self-citation is how a digest cited its own
+//      previous digest as a source), and when the same line carries a
+//      >>verbatim quote<<, the quote must be a substring of that message's
+//      content (whitespace-normalized). A fabricated attribution cannot carry
+//      a verifiable citation.
+//
+// KNOWN LIMIT (accepted by Marveen, msg 16050): a wrong-AGENT-name in prose
+// (the Dani/geri error) is not mechanically catchable; mandatory verbatim
+// citations only constrain it, they do not eliminate it.
+//
+// Failure posture (Marveen stipulation, msg 16050): an INTERNAL error while
+// validating an in-scope POST (DB unreadable, payload file missing) DENIES
+// loudly with the error in the reason -- never fail-open, never a silent
+// swallow. Empty/malformed stdin (a non-matching hook event) allows, same as
+// the sibling gates: that path never had a digest to validate.
+
+import { readFileSync, realpathSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url))
+const PROJECT_ROOT = process.env.DIGEST_GATE_ROOT || join(SCRIPT_DIR, '..')
+const DB_PATH = process.env.DIGEST_GATE_DB || join(PROJECT_ROOT, 'store', 'claudeclaw.db')
+const HEARTBEAT_ID = process.env.HEARTBEAT_AGENT_ID || 'heartbeat'
+
+// ---- payload extraction ---------------------------------------------------
+
+const API_MESSAGES_RX = /\/api\/messages\b/
+const DATA_FLAG_RX = /(?:^|\s)(?:-d|--data(?:-(?:raw|binary|ascii))?|--json)\b/
+
+// Extract the JSON body a curl command sends: either inline (-d '...' /
+// -d "...") or from a file (-d @path / --data-binary @path -- the task's own
+// SKILL instructs `--data @/tmp/lelet.json`).
+export function extractPayload(command, readFile) {
+  const fileRef = command.match(/(?:-d|--data(?:-(?:raw|binary|ascii))?|--json)[\s=]+@([^\s'"]+)/)
+  if (fileRef) return readFile(fileRef[1])
+  const single = command.match(/(?:-d|--data(?:-(?:raw|binary|ascii))?|--json)[\s=]+'((?:[^'\\]|\\.)*)'/)
+  if (single) return single[1]
+  const dbl = command.match(/(?:-d|--data(?:-(?:raw|binary|ascii))?|--json)[\s=]+"((?:[^"\\]|\\.)*)"/)
+  if (dbl) return dbl[1].replace(/\\(["\\$`])/g, '$1')
+  return null
+}
+
+// ---- content validation ---------------------------------------------------
+
+const norm = (s) => s.replace(/\s+/g, ' ').trim()
+
+// A jelolt-tetel action row: at least two " | " column separators.
+const isActionRow = (line) => line.split(' | ').length >= 3
+const isClosedNoteLine = (line) => /^\s*kozben lezarult/i.test(line)
+
+const MSG_CITE_RX = /\bmsg(?:_id)?[:\s#]+(\d{2,8})\b/gi
+const PR_REF_RX = /#(\d{3,5})\b/g
+const QUOTE_RX = />>([^<]{4,}?)<</g
+
+export function validateContent(content, deps) {
+  const violations = []
+  const cards = deps.allCards() // [{id, status, archived}]
+  const closedIds = cards.filter((c) => c.status === 'done' || c.archived).map((c) => c.id)
+
+  for (const line of content.split('\n')) {
+    if (isActionRow(line) && !isClosedNoteLine(line)) {
+      for (const c of closedIds) {
+        if (new RegExp(`\\b${c}\\b`).test(line)) {
+          violations.push(`lezart kartya (${c}) akcio-sorban -- a 6a kapu szerint az ilyen tetel KIESIK`)
+        }
+      }
+      for (const m of line.matchAll(PR_REF_RX)) {
+        if (deps.prMerged(Number(m[1]))) {
+          violations.push(`mergelt PR (#${m[1]}) akcio-sorban -- mar nem nyitott munka`)
+        }
+      }
+    }
+    const cites = [...line.matchAll(MSG_CITE_RX)]
+    if (cites.length === 0) continue
+    const quotes = [...line.matchAll(QUOTE_RX)].map((q) => norm(q[1]))
+    for (const cite of cites) {
+      const msg = deps.getMessage(Number(cite[1]))
+      if (!msg) {
+        violations.push(`nem letezo uzenet-hivatkozas (msg ${cite[1]})`)
+        continue
+      }
+      if (msg.from_agent === HEARTBEAT_ID) {
+        violations.push(`onhivatkozas (msg ${cite[1]} a heartbeat sajat uzenete) -- digest nem forras`)
+        continue
+      }
+      for (const q of quotes) {
+        if (!norm(msg.content).includes(q)) {
+          violations.push(`az idezet nem talalhato a hivatkozott uzenetben (msg ${cite[1]}: ">>${q.slice(0, 60)}<<")`)
+        }
+      }
+    }
+  }
+  return violations
+}
+
+// ---- default deps (live DB / repo) ----------------------------------------
+
+function sqliteJson(sql) {
+  const out = execFileSync('sqlite3', [DB_PATH, '-json', sql], { encoding: 'utf-8', timeout: 8000 })
+  return out.trim() ? JSON.parse(out) : []
+}
+
+export const defaultDeps = {
+  allCards: () =>
+    sqliteJson('SELECT id, status, archived_at FROM kanban_cards').map((r) => ({
+      id: r.id,
+      status: r.status,
+      archived: r.archived_at != null,
+    })),
+  getMessage: (id) => {
+    const rows = sqliteJson(`SELECT id, from_agent, content FROM agent_messages WHERE id=${Number(id)}`)
+    return rows[0] || null
+  },
+  // Best-effort: a PR squash-merged to develop leaves "(#N)" in the subject.
+  // If the local origin/develop ref lags, a just-merged PR can slip through --
+  // documented, the card-status check is the authoritative half.
+  prMerged: (n) => {
+    try {
+      const out = execFileSync(
+        'git',
+        ['-C', PROJECT_ROOT, 'log', 'origin/develop', '--oneline', '-n', '1', '--fixed-strings', '--grep', `(#${n})`],
+        { encoding: 'utf-8', timeout: 8000 },
+      )
+      return out.trim() !== ''
+    } catch {
+      return false
+    }
+  },
+  readFile: (p) => readFileSync(p, 'utf-8'),
+}
+
+// ---- gate decision ---------------------------------------------------------
+
+export function gateDecision(toolName, toolInput, deps = defaultDeps) {
+  if (toolName !== 'Bash') return { deny: false }
+  const command = toolInput?.command
+  if (typeof command !== 'string' || command.trim() === '') return { deny: false }
+  if (!API_MESSAGES_RX.test(command) || !DATA_FLAG_RX.test(command)) return { deny: false }
+
+  // From here the command IS an in-scope digest send: internal failures deny.
+  let payloadRaw
+  try {
+    payloadRaw = extractPayload(command, deps.readFile)
+  } catch (err) {
+    return { deny: true, reason: `INTERNAL ERROR (payload beolvasas): ${err?.message || err} -- fail-closed` }
+  }
+  if (payloadRaw == null) {
+    return { deny: true, reason: 'a /api/messages POST torzse nem nyerheto ki a parancsbol -- fail-closed (hasznalj -d @file vagy -d \'json\' alakot)' }
+  }
+  let payload
+  try {
+    payload = JSON.parse(payloadRaw)
+  } catch (err) {
+    return { deny: true, reason: `INTERNAL ERROR (payload nem valid JSON): ${err?.message || err} -- fail-closed` }
+  }
+  const content = payload?.content
+  if (typeof content !== 'string' || content.trim() === '') return { deny: false }
+
+  let violations
+  try {
+    violations = validateContent(content, deps)
+  } catch (err) {
+    return { deny: true, reason: `INTERNAL ERROR (provenancia-ellenorzes): ${err?.message || err} -- fail-closed` }
+  }
+  if (violations.length > 0) return { deny: true, reason: violations.join('; ') }
+  return { deny: false }
+}
+
+// ---- hook entrypoint -------------------------------------------------------
+
+const GATE_PREFIX =
+  'Digest-provenancia kapu (DIGESTSTALE825): a lelet-uzenet ellenorzese elbukott. ' +
+  'Merd ujra az erintett tetelt (kartya-statusz / gh pr view / agent_messages), ' +
+  'javitsd a draftot, es kuldd ujra. Reszletek: '
+
+function allow() { process.exit(0) }
+
+function deny(reason) {
+  process.stdout.write(JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'deny',
+      permissionDecisionReason: GATE_PREFIX + reason,
+    },
+  }))
+  process.exit(0)
+}
+
+function isInvokedDirectly() {
+  try {
+    const self = realpathSync(fileURLToPath(import.meta.url))
+    const entry = process.argv[1] ? realpathSync(process.argv[1]) : ''
+    return self === entry
+  } catch {
+    return false
+  }
+}
+
+if (isInvokedDirectly()) {
+  let payload
+  try {
+    payload = JSON.parse(readFileSync(0, 'utf-8'))
+  } catch {
+    allow() // malformed/empty stdin = not a matching hook event, nothing to validate
+  }
+  const result = gateDecision(payload?.tool_name, payload?.tool_input)
+  if (result.deny) deny(result.reason)
+  allow()
+}

--- a/src/__tests__/digest-provenance-gate.test.ts
+++ b/src/__tests__/digest-provenance-gate.test.ts
@@ -1,0 +1,208 @@
+// DIGESTSTALE825: the heartbeat digest reported closed work as open (0/4 on
+// the 10:13 round) and fabricated an owner decision. The prompt-layer fix was
+// falsified live the same morning (the first run AFTER the SKILL.md freshness
+// gate shipped all four errors), so the rule is enforced here in code, as a
+// PreToolUse hook scoped to the heartbeat worker. These tests pin the gate's
+// contract, including Marveen's three stipulations (msg 16050): legitimate
+// traffic passes, internal failure is loud fail-closed, and the RED-BEFORE
+// baseline is measured (the bad drafts pass the pre-existing gate stack, so
+// only THIS gate blocks them).
+
+import { describe, it, expect } from 'vitest'
+import { spawnSync } from 'node:child_process'
+import { join } from 'node:path'
+// @ts-expect-error -- plain .mjs hook script, no types
+import { gateDecision, validateContent, extractPayload } from '../../scripts/digest-provenance-gate.mjs'
+// @ts-expect-error -- plain .mjs hook script, no types
+import { gateDecision as kanbanGateDecision } from '../../scripts/kanban-write-gate.mjs'
+import { agentGetsKanbanWriteGate, injectDigestProvenanceGate } from '../web/agent-scaffold.js'
+import { MAIN_AGENT_ID, HEARTBEAT_AGENT_ID } from '../config.js'
+
+const ROOT = join(__dirname, '..', '..')
+
+const deps = {
+  allCards: () => [
+    { id: 'OPENCARD1', status: 'in_progress', archived: false },
+    { id: 'DONECARD1', status: 'done', archived: false },
+    { id: 'ARCHCARD1', status: 'waiting', archived: true },
+  ],
+  getMessage: (id: number) =>
+    ({
+      100: { id: 100, from_agent: 'samu', content: 'PR kesz: build zold, mergelheto -- reszletek a kartyan' },
+      200: { id: 200, from_agent: 'heartbeat', content: 'NYERSANYAG -- korabbi digest' },
+    })[id] ?? null,
+  prMerged: (n: number) => n === 1062,
+  readFile: (p: string) => {
+    if (p === '/stub/lelet.json') return JSON.stringify({ from: 'heartbeat', to: 'marveen', content: 'DONECARD1 | done | zard le | evidencia' })
+    throw new Error(`ENOENT: ${p}`)
+  },
+}
+
+const post = (content: string) =>
+  `curl -s -X POST http://localhost:3420/api/messages -H "Content-Type: application/json" -d '${JSON.stringify({ from: 'heartbeat', to: 'marveen', content })}'`
+
+const decide = (cmd: string) => gateDecision('Bash', { command: cmd }, deps)
+
+describe('digest-provenance-gate: scope (legitimate traffic passes untouched)', () => {
+  it('ignores non-Bash tools', () => {
+    expect(gateDecision('Read', { file_path: '/x' }, deps).deny).toBe(false)
+  })
+  it('ignores Bash that does not touch /api/messages', () => {
+    expect(decide('sqlite3 store/claudeclaw.db "SELECT 1"').deny).toBe(false)
+  })
+  it('ignores a GET on /api/messages (status polling has no data flag)', () => {
+    expect(decide('curl -s -H "Authorization: Bearer x" "http://localhost:3420/api/messages?agent=heartbeat"').deny).toBe(false)
+  })
+  it('passes a REAL alert draft: no action rows, no citations', () => {
+    expect(decide(post('RIASZTAS: a dashboard nem valaszol, HTTP 000 harom probalkozasra. Azonnali figyelem kell.')).deny).toBe(false)
+  })
+  it('passes a valid jelolt-tetel row: open card + existing citation + matching quote', () => {
+    const draft = 'NYERSANYAG -- ellenorizetlen javaslatok\nOPENCARD1 | in_progress | done-ra | msg 100 >>build zold, mergelheto<<'
+    expect(decide(post(draft)).deny).toBe(false)
+  })
+  it('passes prose that MENTIONS a merged PR outside an action row', () => {
+    expect(decide(post('Kontextus: a #1062 mergelve, ez mar lezart munka.')).deny).toBe(false)
+  })
+  it('passes the sanctioned "kozben lezarult" summary line with closed ids', () => {
+    expect(decide(post('kozben lezarult: DONECARD1 | ARCHCARD1 | #1062')).deny).toBe(false)
+  })
+})
+
+describe('digest-provenance-gate: stale-state violations (the 10:13 failure modes)', () => {
+  it('denies a done card proposed as actionable', () => {
+    const r = decide(post('DONECARD1 | in_progress | zard done-ra | evidencia nelkul'))
+    expect(r.deny).toBe(true)
+    expect(r.reason).toContain('DONECARD1')
+  })
+  it('denies an archived card in an action row', () => {
+    expect(decide(post('ARCHCARD1 | waiting | eszkalald | regi allapot')).deny).toBe(true)
+  })
+  it('denies a merged PR proposed as open work', () => {
+    const r = decide(post('OPENCARD1 | in_progress | merge #1062 | varakozik'))
+    expect(r.deny).toBe(true)
+    expect(r.reason).toContain('#1062')
+  })
+})
+
+describe('digest-provenance-gate: fabricated provenance', () => {
+  it('denies a citation of a nonexistent message', () => {
+    const r = decide(post('A gazda dontese szukseges, lasd msg 99999.'))
+    expect(r.deny).toBe(true)
+    expect(r.reason).toContain('99999')
+  })
+  it('denies self-citation (the digest citing its own previous digest)', () => {
+    const r = decide(post('Forras: msg 200, a korabbi osszefoglalo.'))
+    expect(r.deny).toBe(true)
+    expect(r.reason).toContain('onhivatkozas')
+  })
+  it('denies a verbatim quote that is not in the cited message', () => {
+    const r = decide(post('msg 100 szerint >>Szabolcs dontese szukseges a HBTELIT-hez<<'))
+    expect(r.deny).toBe(true)
+    expect(r.reason).toContain('idezet')
+  })
+  it('accepts the same citation when the quote IS verbatim', () => {
+    expect(decide(post('msg 100 szerint >>build zold, mergelheto<<')).deny).toBe(false)
+  })
+})
+
+describe('digest-provenance-gate: loud fail-closed on internal error (stipulation #2)', () => {
+  it('denies with INTERNAL ERROR when the payload file is unreadable', () => {
+    const r = decide('curl -s -X POST http://localhost:3420/api/messages -d @/stub/missing.json')
+    expect(r.deny).toBe(true)
+    expect(r.reason).toContain('INTERNAL ERROR')
+  })
+  it('denies with INTERNAL ERROR when the DB layer throws mid-validation', () => {
+    const broken = { ...deps, allCards: () => { throw new Error('SQLITE_CANTOPEN') } }
+    const r = gateDecision('Bash', { command: post('DONECARD1 | x | y | z') }, broken)
+    expect(r.deny).toBe(true)
+    expect(r.reason).toContain('INTERNAL ERROR')
+    expect(r.reason).toContain('SQLITE_CANTOPEN')
+  })
+  it('denies when the POST body cannot be extracted at all', () => {
+    const r = decide('curl -s -X POST http://localhost:3420/api/messages --data-urlencode content=x')
+    expect(r.deny).toBe(true)
+  })
+  it('reads the body from -d @file (the SKILL-mandated form) and validates it', () => {
+    const r = decide('curl -s -X POST http://localhost:3420/api/messages -d @/stub/lelet.json')
+    expect(r.deny).toBe(true)
+    expect(r.reason).toContain('DONECARD1')
+  })
+})
+
+describe('RED-BEFORE baseline (stipulation #3): only THIS gate blocks the bad drafts', () => {
+  const badDrafts = [
+    post('DONECARD1 | in_progress | zard done-ra | evidencia nelkul'),
+    post('A gazda dontese szukseges, lasd msg 99999.'),
+    post('msg 100 szerint >>Szabolcs dontese szukseges<<'),
+  ]
+  it('every bad draft PASSES the pre-existing gate stack (kanban-write-gate)', () => {
+    for (const cmd of badDrafts) {
+      expect(kanbanGateDecision('Bash', { command: cmd }).deny).toBe(false)
+    }
+  })
+  it('and every bad draft is DENIED by the provenance gate', () => {
+    for (const cmd of badDrafts) {
+      expect(decide(cmd).deny).toBe(true)
+    }
+  })
+})
+
+describe('digest-provenance-gate: wiring', () => {
+  it('shares the heartbeat-only scope with the kanban-write gate', () => {
+    expect(agentGetsKanbanWriteGate(HEARTBEAT_AGENT_ID)).toBe(true)
+    expect(agentGetsKanbanWriteGate(MAIN_AGENT_ID)).toBe(false)
+    expect(agentGetsKanbanWriteGate('samu')).toBe(false)
+  })
+  it('injects a Bash-matcher PreToolUse entry, idempotently', () => {
+    const settings: Record<string, unknown> = {}
+    injectDigestProvenanceGate(settings)
+    injectDigestProvenanceGate(settings)
+    const entries = (settings.hooks as { PreToolUse: unknown[] }).PreToolUse
+      .filter((e) => JSON.stringify(e).includes('digest-provenance-gate.mjs'))
+    expect(entries).toHaveLength(1)
+    expect(JSON.stringify(entries[0])).toContain('"matcher":"Bash"')
+  })
+  it('does not clobber pre-existing PreToolUse entries', () => {
+    const settings: Record<string, unknown> = { hooks: { PreToolUse: [{ matcher: 'Bash', hooks: [{ type: 'command', command: 'other.sh' }] }] } }
+    injectDigestProvenanceGate(settings)
+    const all = (settings.hooks as { PreToolUse: unknown[] }).PreToolUse
+    expect(all).toHaveLength(2)
+    expect(JSON.stringify(all[0])).toContain('other.sh')
+  })
+})
+
+describe('digest-provenance-gate: spawned entrypoint contract', () => {
+  const SCRIPT = join(ROOT, 'scripts', 'digest-provenance-gate.mjs')
+  const run = (stdin: string) => spawnSync('node', [SCRIPT], { input: stdin, encoding: 'utf-8', timeout: 15000 })
+
+  it('malformed stdin (non-matching event) allows with exit 0 and no deny JSON', () => {
+    const r = run('not json at all')
+    expect(r.status).toBe(0)
+    expect(r.stdout).not.toContain('deny')
+  })
+  it('out-of-scope Bash allows with exit 0', () => {
+    const r = run(JSON.stringify({ tool_name: 'Bash', tool_input: { command: 'ls -la' } }))
+    expect(r.status).toBe(0)
+    expect(r.stdout).not.toContain('deny')
+  })
+  it('in-scope POST with unreadable @file emits a loud deny decision', () => {
+    const r = run(JSON.stringify({ tool_name: 'Bash', tool_input: { command: 'curl -X POST http://localhost:3420/api/messages -d @/nonexistent/lelet.json' } }))
+    expect(r.status).toBe(0)
+    const out = JSON.parse(r.stdout)
+    expect(out.hookSpecificOutput.permissionDecision).toBe('deny')
+    expect(out.hookSpecificOutput.permissionDecisionReason).toContain('INTERNAL ERROR')
+  })
+})
+
+describe('extractPayload / validateContent units', () => {
+  it('extracts a single-quoted inline body', () => {
+    expect(extractPayload(`curl -d '{"a":1}' u`, () => '')).toBe('{"a":1}')
+  })
+  it('extracts an @file body via the injected reader', () => {
+    expect(extractPayload('curl --data @/tmp/x.json u', (p: string) => `read:${p}`)).toBe('read:/tmp/x.json')
+  })
+  it('POSITIVE CONTROL: validateContent flags a known-bad draft and stays quiet on a known-good one', () => {
+    expect(validateContent('DONECARD1 | a | b | c', deps).length).toBeGreaterThan(0)
+    expect(validateContent('OPENCARD1 | a | b | msg 100 >>build zold, mergelheto<<', deps)).toHaveLength(0)
+  })
+})

--- a/src/web/agent-scaffold.ts
+++ b/src/web/agent-scaffold.ts
@@ -380,7 +380,10 @@ export function writeAgentSettingsFromProfile(name: string, profile: ProfileTemp
   // covered by the self-pace block + the #0 CLAUDE.md doctrine.
   if (agentGetsEmailGate(name)) injectEmailSendGate(existing)
   if (agentGetsGovernanceGates(name)) injectSelfPaceGate(existing)
-  if (agentGetsKanbanWriteGate(name)) injectKanbanWriteGate(existing)
+  if (agentGetsKanbanWriteGate(name)) {
+    injectKanbanWriteGate(existing)
+    injectDigestProvenanceGate(existing)
+  }
   injectEgressGate(existing)
   atomicWriteFileSync(settingsPath, JSON.stringify(existing, null, 2))
 }
@@ -506,6 +509,30 @@ export function injectKanbanWriteGate(existing: Record<string, unknown>): void {
   const prev = Array.isArray(hooks.PreToolUse) ? (hooks.PreToolUse as unknown[]) : []
   hooks.PreToolUse = [
     ...prev.filter((e) => !JSON.stringify(e).includes('kanban-write-gate.mjs')),
+    entry,
+  ]
+}
+
+// Idempotently wire the digest-provenance-gate PreToolUse hook (validates the
+// heartbeat worker's /api/messages POSTs: closed cards / merged PRs in action
+// rows and unverifiable msg-id citations are denied -- DIGESTSTALE825). Scoped
+// by the SAME predicate as the kanban-write gate: heartbeat worker only. The
+// prompt-layer version of this rule was proven insufficient live (the first
+// run after the SKILL.md gate still shipped 0/4 accuracy + a fabricated owner
+// decision), so the rule lives here, in code.
+export function injectDigestProvenanceGate(existing: Record<string, unknown>): void {
+  const hooks = (existing.hooks && typeof existing.hooks === 'object'
+    ? existing.hooks
+    : (existing.hooks = {})) as Record<string, unknown>
+  const command = hookCommand(join(PROJECT_ROOT, 'scripts', 'digest-provenance-gate.mjs'))
+  if (isUnsafeHookCommand(command)) return
+  const entry = {
+    matcher: 'Bash',
+    hooks: [{ type: 'command', command, timeout: 10 }],
+  }
+  const prev = Array.isArray(hooks.PreToolUse) ? (hooks.PreToolUse as unknown[]) : []
+  hooks.PreToolUse = [
+    ...prev.filter((e) => !JSON.stringify(e).includes('digest-provenance-gate.mjs')),
     entry,
   ]
 }


### PR DESCRIPTION
## Problem
The heartbeat digest (delegalt-feladat-figyelo) reported closed work as open (0/4 accuracy on the 2026-08-26 10:13 round), fabricated an owner decision that never existed, and cited its own previous digest as a source (Marveen msg 16042). The prompt-layer fix was **falsified live the same morning**: the re-measure-before-emitting rule entered the task's SKILL.md at 09:34:04, and the single run after it (task_runs fired 10:13:21) still shipped every error. The task is currently disabled; this gate is the re-enable condition (Marveen GO, msg 16050).

## Fix
`scripts/digest-provenance-gate.mjs` -- PreToolUse hook wired ONLY for the heartbeat worker (same `agentGetsKanbanWriteGate` predicate and injection pattern as the kanban-write gate). On Bash commands POSTing to `/api/messages`:
- **Action rows** (the `card_id | status | javasolt atmenet | evidencia` pipe format): a done/archived card or an already-merged PR (#NNNN, checked against origin/develop squash subjects, best-effort) is denied. Prose mentions outside action rows pass -- a real alert saying "a #1062 mergelve" is fine; the failure mode is proposing closed work as actionable. A line starting with `kozben lezarult` is the sanctioned mention form (note: a "KOZBEN LEZARULT" **column value** inside an action row still blocks -- the summary line is the contract).
- **Citations**: `msg NNNNN` must exist in `agent_messages`, must not be heartbeat-authored (self-citation ban), and a `>>verbatim quote<<` on the same line must be a substring of the cited message (whitespace-normalized).
- **Failure posture** (stipulation #2): internal error on an in-scope POST (unreadable `-d @file`, DB error) denies LOUDLY with the error in the reason -- never fail-open, never silent. Malformed stdin / out-of-scope commands allow, same as sibling gates.

## Known limit (stipulation: stated here, not left for the reader)
A wrong AGENT name in prose (the Dani/geri error) is **not** mechanically catchable. Mandatory verbatim citations only constrain it; they do not eliminate it.

## Verification
- 29 new tests (`src/__tests__/digest-provenance-gate.test.ts`): scope/pass cases (real alert, valid row, merged-PR-in-prose, kozben-lezarult line), the three 10:13 failure modes denied, loud fail-closed (INTERNAL ERROR on file/DB failure), wiring (heartbeat-only, idempotent, non-clobbering), spawned entrypoint contract, `@file` payload path.
- **Red-before** (stipulation #3): the bad drafts PASS the pre-existing gate stack (kanban-write-gate) and are denied only by this gate -- asserted in tests.
- **Live traffic check** (stipulation #1): the actual bad 10:14 digest (msg 16038) run through the gate against the live DB is DENIED on exactly the violations Marveen measured (closed card ALKQACEGADMIN825 in an action row, merged #1054/#1063 as open); the real 10:00 heartbeat status message and the real 08:47 instrument alert both PASS unchanged.
- tsc clean; full vitest **305 files / 4070 tests green**.

## Re-enable path (not in this PR)
After merge + dashboard restart (hook wiring lands via ensureAgentHooks), the task's SKILL.md gets the citation-format contract line and `enabled:true` -- per the disabledReason condition, with Marveen's sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)