### PR TITLE
fix(scripts): one honest Telegram send contract, state stamps only after delivery (NOTIFYVAKSWEEP826)

### DIFF
--- a/scripts/disk-space-guard.sh
+++ b/scripts/disk-space-guard.sh
@@ -131,9 +131,18 @@ alert_owner() {
   if [ -z "$token" ] || [ -z "$chat" ]; then
     log "ALERT (no bot token or owner chat id configured, could not Telegram): $msg"; return 1
   fi
-  curl -s -m 10 -o /dev/null "https://api.telegram.org/bot${token}/sendMessage" \
-    --data-urlencode "chat_id=${chat}" --data-urlencode "text=${msg}" \
-    && log "owner alerted via direct Bot API" || log "ALERT sendMessage FAILED: $msg"
+  # Honest send (NOTIFYVAKSWEEP826): curl exit 0 alone is not delivery -- an
+  # HTTP 200 with {"ok":false} logged "owner alerted" here while nothing
+  # arrived. Return reflects CONFIRMED delivery so the caller's cooldown stamp
+  # can depend on it.
+  . "$(cd "$(dirname "$0")" && pwd)/lib/send-telegram.sh"
+  local send_err
+  if send_err="$(send_telegram_message "$token" "$chat" "$msg" 2>&1)"; then
+    log "owner alerted via direct Bot API (delivery confirmed)"
+    return 0
+  fi
+  log "ALERT sendMessage FAILED: ${send_err}"
+  return 1
 }
 
 main() {
@@ -161,8 +170,14 @@ main() {
     last=0; [ -f "$ALERT_STAMP" ] && last="$(cat "$ALERT_STAMP" 2>/dev/null || echo 0)"
     case "$last" in (''|*[!0-9]*) last=0;; esac
     if [ $(( now - last )) -ge "$ALERT_COOLDOWN" ]; then
-      alert_owner "🔴 Disk space critical: ${DISK_PATH} is at ${usage}% after reaping ${removed} scratch item(s). Manual cleanup needed -- a full disk can wedge the channel session (deafness)."
-      echo "$now" > "$ALERT_STAMP" 2>/dev/null || true
+      # Cooldown stamp ONLY on confirmed delivery: a stamp written after a
+      # failed send suppressed the retry for an hour -- exactly when a full
+      # disk was already wedging the primary channel (NOTIFYVAKSWEEP826).
+      if alert_owner "🔴 Disk space critical: ${DISK_PATH} is at ${usage}% after reaping ${removed} scratch item(s). Manual cleanup needed -- a full disk can wedge the channel session (deafness)."; then
+        echo "$now" > "$ALERT_STAMP" 2>/dev/null || true
+      else
+        log "alert not delivered -- cooldown stamp NOT written, will retry next tick"
+      fi
     else
       log "disk ${usage}% critical but within alert cooldown ($(( now - last ))s) -- skip alert"
     fi

--- a/scripts/host-restart-watchdog.sh
+++ b/scripts/host-restart-watchdog.sh
@@ -41,9 +41,11 @@ else
 fi
 
 # Current kernel boot epoch (changes only on a real (re)boot of the VM/host).
-btime="$(awk '/^btime/{print $2}' /proc/stat 2>/dev/null)"
+# HOSTWD_PROC_STAT exists for tests only (there is no /proc to stub on macOS).
+PROC_STAT="${HOSTWD_PROC_STAT:-/proc/stat}"
+btime="$(awk '/^btime/{print $2}' "$PROC_STAT" 2>/dev/null)"
 if [[ -z "${btime:-}" ]]; then
-  log "no btime in /proc/stat; nothing to do"
+  log "no btime in $PROC_STAT; nothing to do"
   exit 0
 fi
 
@@ -51,10 +53,13 @@ mkdir -p "$STATE_DIR" 2>/dev/null || true
 prev=""
 [[ -f "$STATE_FILE" ]] && prev="$(tr -dc '0-9' <"$STATE_FILE" 2>/dev/null)"
 
-# Persist the current btime for the next run no matter what happens below.
-echo "$btime" >"$STATE_FILE" 2>/dev/null || true
+# The btime baseline is persisted on init below, but after a DETECTED restart
+# only once the notice actually delivered (see the send block): this is a
+# one-shot message, and stamping before a failed send lost it forever
+# (NOTIFYVAKSWEEP826). While the send keeps failing, every timer run retries.
 
 if [[ -z "$prev" ]]; then
+  echo "$btime" >"$STATE_FILE" 2>/dev/null || true
   log "baseline initialised (btime=$btime); no alert on first run"
   exit 0
 fi
@@ -96,11 +101,17 @@ if [[ -f "$ENV_FILE" ]]; then
   token="$(grep -E '^TELEGRAM_BOT_TOKEN=' "$ENV_FILE" 2>/dev/null | head -1 | cut -d= -f2- | tr -d '"'"'"' \r\n')"
 fi
 if [[ -n "$token" && -n "$CHAT_ID" ]]; then
-  curl -s --max-time 15 \
-    "https://api.telegram.org/bot${token}/sendMessage" \
-    --data-urlencode "chat_id=${CHAT_ID}" \
-    --data-urlencode "text=${msg}" >/dev/null 2>&1 \
-    && log "Telegram sent" || log "Telegram send failed (best-effort)"
+  # Honest send (curl exit 0 AND "ok":true -- an HTTP 200 with ok:false was
+  # invisible here before). Baseline stamped ONLY on confirmed delivery: this
+  # one-shot notice must survive a transient send failure by retrying on the
+  # next run, not by being marked done.
+  . "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/send-telegram.sh"
+  if send_err="$(send_telegram_message "$token" "$CHAT_ID" "$msg" 2>&1)"; then
+    echo "$btime" >"$STATE_FILE" 2>/dev/null || true
+    log "Telegram sent (btime baseline stamped)"
+  else
+    log "Telegram send FAILED -- baseline NOT stamped, will retry next run: ${send_err}"
+  fi
 else
   log "skipping Telegram (${HOST_KIND} restart still logged): missing${token:+}$( [[ -z "$token" ]] && echo ' TELEGRAM_BOT_TOKEN(via TELEGRAM_ENV)')$( [[ -z "$CHAT_ID" ]] && echo ' MARVEEN_ALERT_CHAT_ID')"
 fi

--- a/scripts/lib/send-telegram.sh
+++ b/scripts/lib/send-telegram.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# send-telegram.sh -- the fleet's ONE honest Telegram send primitive.
+#
+# NOTIFYVAKSWEEP826: 13 scripts sent to the Bot API; only notify.sh (after
+# NOTIFYVAK826/#1081) and telegram_fallback_send.py checked the outcome. Every
+# bash sender either swallowed the curl exit, ignored the response body, or
+# both -- an HTTP 200 with {"ok":false} (bad chat_id, blocked bot, mangled
+# .env) was invisible everywhere, and several loggers printed unconditional
+# "sent" on failure. This library IS the proven notify.sh contract, extracted
+# so there is exactly one truth:
+#
+#   send_telegram_message TOKEN CHAT_ID TEXT [extra curl args...]
+#
+#   returns 0  ONLY when curl exited 0 AND the Bot API answered "ok":true
+#   returns 1  on transport failure, API rejection, or misuse (empty args),
+#              with the reason on stderr and the bot token redacted (some curl
+#              errors quote the request URL).
+#
+# The caller decides what a failure means for its own exit code (an OnFailure
+# unit must still exit 0; notify.sh exits 1) -- but it can no longer NOT KNOW.
+# State stamps (dedupe hashes, cooldowns, baselines) must be written only
+# after this returns 0: a failed alert buried by its own suppression stamp is
+# lost forever (the limit-monitor failure mode).
+#
+# Bash 3.2 compatible (macOS system bash). Source it, do not execute it:
+#   . "$(dirname "$0")/lib/send-telegram.sh"
+
+send_telegram_message() {
+  if [ "$#" -lt 3 ]; then
+    echo "send_telegram_message: usage: send_telegram_message TOKEN CHAT_ID TEXT [curl args...]" >&2
+    return 1
+  fi
+  local token="$1" chat_id="$2" text="$3"
+  shift 3
+  if [ -z "$token" ] || [ -z "$chat_id" ] || [ -z "$text" ]; then
+    echo "send_telegram_message: empty token/chat_id/text -- refusing (nothing would be delivered)" >&2
+    return 1
+  fi
+
+  local response curl_exit
+  response=$(curl -sS -m 15 "https://api.telegram.org/bot${token}/sendMessage" \
+    --data-urlencode "chat_id=${chat_id}" \
+    --data-urlencode "text=${text}" \
+    "$@" 2>&1)
+  curl_exit=$?
+  # Never let the token reach a log/journal: redact before any echo.
+  response="${response//${token}/<token>}"
+
+  if [ "$curl_exit" -ne 0 ]; then
+    echo "send_telegram_message: transport failure (curl exit ${curl_exit}): ${response}" >&2
+    return 1
+  fi
+  case "$response" in
+    *'"ok":true'*)
+      return 0
+      ;;
+    *)
+      echo "send_telegram_message: Bot API rejected the send: ${response}" >&2
+      return 1
+      ;;
+  esac
+}

--- a/scripts/limit-monitor.sh
+++ b/scripts/limit-monitor.sh
@@ -54,14 +54,17 @@ if [ -z "$CANDIDATE" ]; then
   exit 0
 fi
 
-# Dedupe: hash the signal; only alert if new
+# Dedupe: hash the signal; only alert if new. The stamp is written ONLY after
+# a confirmed send (below): stamping up front buried every failed alert under
+# its own dedupe -- the send failed, the hash said "already alerted", and the
+# warning was lost forever, precisely during quota/network degradation
+# (NOTIFYVAKSWEEP826, the worst row of the sweep).
 HASH="$(printf '%s' "$CANDIDATE" | md5sum | awk '{print $1}')"
 PREV="$(cat "$STATE" 2>/dev/null)"
 if [ "$HASH" = "$PREV" ]; then
   log "signal unchanged, already alerted ($HASH)"
   exit 0
 fi
-echo "$HASH" > "$STATE"
 
 # Alert the owner via Bot API (token-free path; no Claude invocation)
 TOKEN="$(grep -oE '[0-9]+:[A-Za-z0-9_-]+' "$HOME/.claude/channels/telegram/.env" 2>/dev/null | head -1)"
@@ -73,11 +76,16 @@ $SNIP
 
 Lehet hogy közeledünk vagy elértük a Claude előfizetés keretét. Ha kell, ritkítom a heartbeatet vagy szünetet tartok. Nézd meg a sessiont ha tudod."
 if [ -n "$TOKEN" ]; then
-  curl -s -m 15 "https://api.telegram.org/bot$TOKEN/sendMessage" \
-    --data-urlencode "chat_id=$CHAT_ID" \
-    --data-urlencode "text=$MSG" \
-    --data-urlencode "disable_web_page_preview=true" -o /dev/null
-  log "ALERT sent to $CHAT_ID: $HASH"
+  # Honest send via the shared contract (curl exit 0 AND "ok":true); the
+  # dedupe stamp is written ONLY on success so a failed alert retries on the
+  # next timer tick instead of vanishing.
+  . "$INSTALL_DIR/scripts/lib/send-telegram.sh"
+  if send_telegram_message "$TOKEN" "$CHAT_ID" "$MSG" --data-urlencode "disable_web_page_preview=true" 2>>"$LOG"; then
+    echo "$HASH" > "$STATE"
+    log "ALERT sent to $CHAT_ID: $HASH"
+  else
+    log "ALERT send FAILED (will retry next tick, stamp NOT written): $HASH"
+  fi
 else
   log "ALERT wanted but no bot token found: $HASH"
 fi

--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -79,30 +79,15 @@ if [ -n "${VITEST:-}" ] || [ "${NODE_ENV:-}" = "test" ]; then
 fi
 
 # Delivery must be HONEST (NOTIFYVAK826): this script is the fleet's FALLBACK
-# channel, used exactly when the primary Telegram plugin is already down. A
-# swallowed curl failure here reported success while nothing was delivered --
-# indistinguishable, from the owner's side, from "nothing happened". Success
-# therefore requires BOTH a clean curl exit AND the Bot API's own "ok":true
-# (an HTTP 200 with ok:false -- bad chat_id, parse error -- exits 0 in curl).
-RESPONSE=$(curl -sS -X POST "https://api.telegram.org/bot${TOKEN}/sendMessage" \
-  -d "chat_id=${CHAT_ID}" \
-  -d "text=${MESSAGE}" \
-  -d "parse_mode=HTML" 2>&1)
-CURL_EXIT=$?
-# Never echo the bot token: some curl errors quote the request URL.
-RESPONSE="${RESPONSE//${TOKEN}/<token>}"
+# channel, used exactly when the primary Telegram plugin is already down. The
+# success contract (curl exit 0 AND Bot API "ok":true, loud stderr otherwise,
+# token redacted) lives in the shared library so every sender speaks the same
+# truth (NOTIFYVAKSWEEP826) -- this script consumes it, it no longer inlines it.
+. "$SCRIPT_DIR/lib/send-telegram.sh"
 
-if [ $CURL_EXIT -ne 0 ]; then
-  echo "Hiba: ertesites kuldese sikertelen (curl exit ${CURL_EXIT}): ${RESPONSE}" >&2
+if send_telegram_message "$TOKEN" "$CHAT_ID" "$MESSAGE" --data-urlencode "parse_mode=HTML"; then
+  echo "Ertesites elkuldve."
+else
+  echo "Hiba: ertesites kuldese sikertelen (reszletek fent)." >&2
   exit 1
 fi
-
-case "$RESPONSE" in
-  *'"ok":true'*)
-    echo "Ertesites elkuldve."
-    ;;
-  *)
-    echo "Hiba: a Telegram API elutasitotta az ertesitest: ${RESPONSE}" >&2
-    exit 1
-    ;;
-esac

--- a/scripts/unit-fail-notify.sh
+++ b/scripts/unit-fail-notify.sh
@@ -27,10 +27,16 @@ if [[ -f "$ENV_FILE" ]]; then
   token="$(grep -E '^TELEGRAM_BOT_TOKEN=' "$ENV_FILE" 2>/dev/null | head -1 | cut -d= -f2- | tr -d '"'"'"' \r\n')"
 fi
 if [[ -n "$token" && -n "$CHAT_ID" ]]; then
-  curl -s --max-time 15 \
-    "https://api.telegram.org/bot${token}/sendMessage" \
-    --data-urlencode "chat_id=${CHAT_ID}" \
-    --data-urlencode "text=${msg}" >/dev/null 2>&1 || true
+  # Honest send (NOTIFYVAKSWEEP826): the unit stays best-effort (exit 0 either
+  # way, an OnFailure handler must never itself enter `failed`), but a delivery
+  # failure now lands in the journal instead of vanishing -- this is the script
+  # that reports app crashes, so its own silence was the worst kind.
+  . "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/send-telegram.sh"
+  if send_telegram_message "$token" "$CHAT_ID" "$msg"; then
+    echo "[unit-fail-notify] ${UNIT} FAILED notice delivered" >&2
+  else
+    echo "[unit-fail-notify] ${UNIT} FAILED but the Telegram notice did NOT deliver (see error above)" >&2
+  fi
 else
   # Not silent: name the missing piece so a misconfigured install is diagnosable.
   miss=""; [[ -z "$token" ]] && miss+=" TELEGRAM_BOT_TOKEN(via TELEGRAM_ENV=$ENV_FILE)"; [[ -z "$CHAT_ID" ]] && miss+=" MARVEEN_ALERT_CHAT_ID"

--- a/src/__tests__/notify-delivery-honesty.test.ts
+++ b/src/__tests__/notify-delivery-honesty.test.ts
@@ -21,9 +21,11 @@ let stage: string
 // of the script one level below a temp root that carries the fake .env.
 function stageScript(): { scriptCopy: string } {
   const scriptsDir = join(stage, 'scripts')
-  mkdirSync(scriptsDir, { recursive: true })
+  mkdirSync(join(scriptsDir, 'lib'), { recursive: true })
   const scriptCopy = join(scriptsDir, 'notify.sh')
   execFileSync('/bin/cp', [SCRIPT, scriptCopy])
+  // notify.sh sources the shared send contract from its own lib/ sibling.
+  execFileSync('/bin/cp', [join(ROOT, 'scripts', 'lib', 'send-telegram.sh'), join(scriptsDir, 'lib', 'send-telegram.sh')])
   writeFileSync(join(stage, '.env'), `TELEGRAM_BOT_TOKEN=${FAKE_TOKEN}\nALLOWED_CHAT_ID=42\nMAIN_AGENT_ID=mainbot\n`)
   return { scriptCopy }
 }

--- a/src/__tests__/send-honesty-sweep.test.ts
+++ b/src/__tests__/send-honesty-sweep.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, chmodSync, existsSync, readFileSync, cpSync } from 'node:fs'
+import { tmpdir, platform } from 'node:os'
+import { join } from 'node:path'
+
+// NOTIFYVAKSWEEP826 round 1: the sweep measured 13 Telegram/dashboard senders
+// and found only two honest ones. This round extracts the proven notify.sh
+// contract into scripts/lib/send-telegram.sh and converts the top of the
+// ranking (limit-monitor, unit-fail-notify, host-restart-watchdog,
+// disk-space-guard), moving every dedupe/cooldown/baseline stamp to AFTER a
+// confirmed delivery. These tests are EMPIRICAL (staged trees, PATH-stubbed
+// curl, nothing leaves the machine) so that running them against the pre-fix
+// scripts fails: the old senders were silent and stamped state up front --
+// that is the red-before baseline Marveen required (msg 16061).
+const ROOT = join(__dirname, '..', '..')
+const FAKE_TOKEN = '1234567890:TESTTOKENTESTTOKEN'
+
+let stage: string
+
+beforeEach(() => {
+  stage = mkdtempSync(join(tmpdir(), 'send-sweep-'))
+})
+afterEach(() => {
+  rmSync(stage, { recursive: true, force: true })
+})
+
+// Staged install tree: scripts/ + scripts/lib/ + store/ + .env, plus a bin/
+// with a controllable curl stub (CURL_STUB_EXIT / CURL_STUB_BODY) and no-op
+// tmux. The stub records its argv so a "send attempted" claim is provable.
+function stageTree(scriptNames: string[]): { root: string; bin: string } {
+  const scripts = join(stage, 'scripts')
+  mkdirSync(join(scripts, 'lib'), { recursive: true })
+  mkdirSync(join(stage, 'store'), { recursive: true })
+  for (const s of scriptNames) cpSync(join(ROOT, 'scripts', s), join(scripts, s))
+  cpSync(join(ROOT, 'scripts', 'lib', 'send-telegram.sh'), join(scripts, 'lib', 'send-telegram.sh'))
+  const bin = join(stage, 'bin')
+  mkdirSync(bin, { recursive: true })
+  writeFileSync(join(bin, 'curl'),
+    '#!/bin/bash\necho "$@" >> "${CURL_ARGV_LOG:-/dev/null}"\nif [ "${CURL_STUB_EXIT:-0}" -ne 0 ]; then\n  echo "curl: (6) Could not resolve host for https://api.telegram.org/bot${CURL_STUB_TOKEN:-}/sendMessage" >&2\n  exit "${CURL_STUB_EXIT}"\nfi\nprintf \'%s\' "${CURL_STUB_BODY:-{\\"ok\\":true}}"\n')
+  writeFileSync(join(bin, 'tmux'), '#!/bin/bash\nexit 1\n')
+  // limit-monitor hashes with md5sum, which macOS lacks (md5 only); the hash
+  // value is irrelevant to these tests, only the stamp lifecycle is.
+  writeFileSync(join(bin, 'md5sum'), '#!/bin/bash\ninput=$(cat)\nprintf \'%s  -\\n\' "stubhash$(printf \'%s\' "$input" | wc -c | tr -d \' \')"\n')
+  for (const b of ['curl', 'tmux', 'md5sum']) chmodSync(join(bin, b), 0o755)
+  return { root: stage, bin }
+}
+
+function runScript(rel: string, args: string[], env: Record<string, string>, bin: string) {
+  return spawnSync('/bin/bash', [join(stage, 'scripts', rel), ...args], {
+    env: {
+      PATH: `${bin}:/usr/bin:/bin`,
+      HOME: stage,
+      CURL_STUB_TOKEN: FAKE_TOKEN,
+      CURL_ARGV_LOG: join(stage, 'curl-argv.log'),
+      ...env,
+    },
+    encoding: 'utf-8',
+    timeout: 20000,
+  })
+}
+
+const curlWasInvoked = () => existsSync(join(stage, 'curl-argv.log'))
+
+// ---- the shared contract itself -------------------------------------------
+
+describe('send-telegram.sh library contract', () => {
+  const driver = (call: string) => {
+    const { bin } = stageTree([])
+    writeFileSync(join(stage, 'scripts', 'driver.sh'), `#!/bin/bash\n. "$(dirname "$0")/lib/send-telegram.sh"\n${call}\n`)
+    return runScript('driver.sh', [], {}, bin)
+  }
+
+  it('returns 0 only on curl exit 0 + Bot API ok:true', () => {
+    const r = driver(`send_telegram_message "${FAKE_TOKEN}" 42 "hello"`)
+    expect(r.status).toBe(0)
+  })
+  it('POSITIVE CONTROL: transport failure returns 1, loud, token redacted', () => {
+    const { bin } = stageTree([])
+    writeFileSync(join(stage, 'scripts', 'driver.sh'), `#!/bin/bash\n. "$(dirname "$0")/lib/send-telegram.sh"\nsend_telegram_message "${FAKE_TOKEN}" 42 "hello"\n`)
+    const r = runScript('driver.sh', [], { CURL_STUB_EXIT: '6' }, bin)
+    expect(r.status).toBe(1)
+    expect(r.stderr).toContain('curl exit 6')
+    expect(r.stderr).toContain('<token>')
+    expect(r.stderr).not.toContain(FAKE_TOKEN)
+  })
+  it('an HTTP-200 ok:false rejection returns 1 with the API reason', () => {
+    const { bin } = stageTree([])
+    writeFileSync(join(stage, 'scripts', 'driver.sh'), `#!/bin/bash\n. "$(dirname "$0")/lib/send-telegram.sh"\nsend_telegram_message "${FAKE_TOKEN}" 42 "hello"\n`)
+    const r = runScript('driver.sh', [], { CURL_STUB_BODY: '{"ok":false,"error_code":400,"description":"Bad Request: chat not found"}' }, bin)
+    expect(r.status).toBe(1)
+    expect(r.stderr).toContain('chat not found')
+  })
+  it('misuse (empty token) is loud and never reaches curl', () => {
+    const r = driver('send_telegram_message "" 42 "hello"')
+    expect(r.status).toBe(1)
+    expect(r.stderr).toContain('empty token')
+    expect(curlWasInvoked()).toBe(false)
+  })
+})
+
+// ---- unit-fail-notify.sh ---------------------------------------------------
+
+describe('unit-fail-notify.sh: honest journal, exit 0 by design', () => {
+  const setup = () => {
+    const { bin } = stageTree(['unit-fail-notify.sh'])
+    const tgEnv = join(stage, 'tg.env')
+    writeFileSync(tgEnv, `TELEGRAM_BOT_TOKEN=${FAKE_TOKEN}\n`)
+    return { bin, env: { TELEGRAM_ENV: tgEnv, MARVEEN_ALERT_CHAT_ID: '42' } }
+  }
+  it('confirmed delivery is stated in the journal', () => {
+    const { bin, env } = setup()
+    const r = runScript('unit-fail-notify.sh', ['dash.service'], env, bin)
+    expect(r.status).toBe(0)
+    expect(r.stderr).toContain('delivered')
+  })
+  it('RED-BEFORE: a failed send is no longer silent (old script emitted nothing)', () => {
+    const { bin, env } = setup()
+    const r = runScript('unit-fail-notify.sh', ['dash.service'], { ...env, CURL_STUB_EXIT: '6' }, bin)
+    expect(r.status).toBe(0) // OnFailure handler must never itself fail
+    expect(r.stderr).toContain('did NOT deliver')
+    expect(curlWasInvoked()).toBe(true) // the attempt provably happened
+  })
+})
+
+// ---- limit-monitor.sh ------------------------------------------------------
+
+describe('limit-monitor.sh: dedupe stamp only after confirmed delivery', () => {
+  const setup = () => {
+    const { bin } = stageTree(['limit-monitor.sh'])
+    writeFileSync(join(stage, '.env'), 'MAIN_AGENT_ID=testbot\nBOT_NAME=Testbot\nALLOWED_CHAT_ID=42\n')
+    mkdirSync(join(stage, '.claude', 'channels', 'telegram'), { recursive: true })
+    writeFileSync(join(stage, '.claude', 'channels', 'telegram', '.env'), `TELEGRAM_BOT_TOKEN=${FAKE_TOKEN}\n`)
+    writeFileSync(join(stage, 'store', 'channels.log'), 'usage limit reached -- upgrade or wait\n')
+    return { bin, state: join(stage, 'store', '.limit-monitor-state'), log: join(stage, 'store', 'limit-monitor.log') }
+  }
+  it('successful send writes the dedupe stamp and logs ALERT sent', () => {
+    const { bin, state, log } = setup()
+    const r = runScript('limit-monitor.sh', [], {}, bin)
+    expect(r.status).toBe(0)
+    expect(existsSync(state)).toBe(true)
+    expect(readFileSync(log, 'utf-8')).toContain('ALERT sent')
+  })
+  it('RED-BEFORE: failed send does NOT stamp (old script stamped up front) and the retry then delivers', () => {
+    const { bin, state, log } = setup()
+    const r1 = runScript('limit-monitor.sh', [], { CURL_STUB_EXIT: '6' }, bin)
+    expect(r1.status).toBe(0)
+    expect(existsSync(state)).toBe(false) // the alert is NOT buried
+    expect(readFileSync(log, 'utf-8')).toContain('FAILED')
+    expect(readFileSync(log, 'utf-8')).not.toContain('ALERT sent to')
+    const r2 = runScript('limit-monitor.sh', [], {}, bin) // next tick, transport back
+    expect(r2.status).toBe(0)
+    expect(existsSync(state)).toBe(true)
+    expect(readFileSync(log, 'utf-8')).toContain('ALERT sent to')
+  })
+})
+
+// ---- host-restart-watchdog.sh ---------------------------------------------
+
+describe('host-restart-watchdog.sh: one-shot notice retries until delivered', () => {
+  const setup = () => {
+    const { bin } = stageTree(['host-restart-watchdog.sh'])
+    const procStat = join(stage, 'proc-stat')
+    writeFileSync(procStat, 'cpu 1 2 3\nbtime 1000\n')
+    const tgEnv = join(stage, 'tg.env')
+    writeFileSync(tgEnv, `TELEGRAM_BOT_TOKEN=${FAKE_TOKEN}\n`)
+    const env = {
+      HOSTWD_PROC_STAT: procStat,
+      MARVEEN_STORE: join(stage, 'store'),
+      TELEGRAM_ENV: tgEnv,
+      MARVEEN_ALERT_CHAT_ID: '42',
+    }
+    return { bin, env, procStat, state: join(stage, 'store', '.last-btime') }
+  }
+  it('baseline init stamps without sending; a detected restart stamps ONLY on delivery', () => {
+    const { bin, env, procStat, state } = setup()
+    const r1 = runScript('host-restart-watchdog.sh', [], env, bin)
+    expect(r1.status).toBe(0)
+    expect(readFileSync(state, 'utf-8').trim()).toBe('1000')
+    expect(curlWasInvoked()).toBe(false)
+
+    writeFileSync(procStat, 'cpu 1 2 3\nbtime 2000\n') // the host rebooted
+    const r2 = runScript('host-restart-watchdog.sh', [], { ...env, CURL_STUB_EXIT: '6' }, bin)
+    expect(r2.status).toBe(0)
+    // RED-BEFORE: the old script stamped btime up front, losing the notice.
+    expect(readFileSync(state, 'utf-8').trim()).toBe('1000')
+
+    const r3 = runScript('host-restart-watchdog.sh', [], env, bin) // retry succeeds
+    expect(r3.status).toBe(0)
+    expect(readFileSync(state, 'utf-8').trim()).toBe('2000')
+  })
+})
+
+// ---- disk-space-guard.sh ---------------------------------------------------
+
+describe('disk-space-guard.sh: cooldown stamp only after confirmed delivery', () => {
+  const setup = () => {
+    const { bin } = stageTree(['disk-space-guard.sh'])
+    writeFileSync(join(stage, '.env'), 'ALLOWED_CHAT_ID=42\n')
+    mkdirSync(join(stage, '.claude', 'channels', 'telegram'), { recursive: true })
+    writeFileSync(join(stage, '.claude', 'channels', 'telegram', '.env'), `TELEGRAM_BOT_TOKEN=${FAKE_TOKEN}\n`)
+    const scratch = join(stage, 'scratch')
+    mkdirSync(scratch, { recursive: true })
+    const env = {
+      DISK_GUARD_USAGE_OVERRIDE: '96',
+      DISK_GUARD_SCRATCH_DIR: scratch,
+      DISK_GUARD_STATE_DIR: join(stage, 'store'),
+    }
+    return { bin, env, stamp: join(stage, 'store', '.disk-guard-alerted') }
+  }
+  it('an ok:false rejection no longer logs "owner alerted" and does NOT start the 1h cooldown', () => {
+    const { bin, env, stamp } = setup()
+    const r = runScript('disk-space-guard.sh', [], { ...env, CURL_STUB_BODY: '{"ok":false,"error_code":400,"description":"chat not found"}' }, bin)
+    expect(r.status).toBe(0)
+    // RED-BEFORE: the old script logged "owner alerted via direct Bot API"
+    // on exactly this input and stamped the cooldown.
+    expect(existsSync(stamp)).toBe(false)
+    expect(r.stdout + r.stderr).not.toContain('owner alerted')
+  })
+  it('confirmed delivery stamps the cooldown', () => {
+    const { bin, env, stamp } = setup()
+    const r = runScript('disk-space-guard.sh', [], env, bin)
+    expect(r.status).toBe(0)
+    expect(existsSync(stamp)).toBe(true)
+    expect(r.stdout + r.stderr).toContain('delivery confirmed')
+  })
+})


### PR DESCRIPTION
## Problem (measured, card NOTIFYVAKSWEEP826)
13 scripts send to the Telegram Bot API; the sweep (instrument-checked against a known-good and a known-bad control) found only `notify.sh` (post-#1081) and `telegram_fallback_send.py` honest. Two structural patterns:
1. **No bash sender inspected `"ok":true`** -- an HTTP 200 with `ok:false` (bad chat_id, blocked bot, mangled .env) was invisible everywhere, and the `&&/||`-logging family printed literal false success ("owner alerted", "ALERT sent").
2. **Six senders wrote their cooldown/dedupe/state stamp regardless of the send outcome** -- a failed alert was buried by its own suppression. Worst: `limit-monitor.sh`, which fires precisely during quota/network degradation and lost the alert forever.

## Fix (round 1: the top of the risk ranking)
- **`scripts/lib/send-telegram.sh`** -- the proven notify.sh contract as the single shared primitive: success ONLY on curl exit 0 AND Bot API `"ok":true`; failure returns 1 with the reason on stderr and the token redacted; misuse (empty args) is loud and never reaches curl.
- **`notify.sh` sources the library** instead of inlining the contract (stipulation a: one truth). Side effect: text is now urlencoded, so a literal `&` no longer truncates.
- **Converted with stamp-after-confirmed-delivery** (stipulation c, in the same round, not later): `limit-monitor.sh` (dedupe hash only on success -> failed alert retries next tick), `host-restart-watchdog.sh` (btime baseline only after the one-shot notice delivers; `HOSTWD_PROC_STAT` seam added for tests), `disk-space-guard.sh` (1h cooldown only on confirmed delivery; `ok:false` no longer logs "owner alerted"), `unit-fail-notify.sh` (stays exit-0 by design -- an OnFailure handler must not fail -- but a lost crash notice now lands loudly in the journal).

## Verification (stipulation b)
- Empirical staged-tree tests, PATH-stubbed curl, nothing leaves the machine (`src/__tests__/send-honesty-sweep.test.ts`, 11 tests; runs in CI).
- **Red-before measured**: with the five scripts reverted to origin/develop, 6/11 tests FAIL (each converted sender's silent behavior trips its test); the 4 library-contract tests are green both ways, as a new component should be.
- Existing `notify-delivery-honesty.test.ts` stays green after the refactor (staging now copies the lib).
- Full suite **305 files / 4052 tests green**; `tsc --noEmit` clean; `bash -n` all clean; shellcheck delta is SC1091 info only (dynamic source path).

## Known trade-offs (stated, not discovered later)
- `host-restart-watchdog` with a MISSING token now re-logs "skipping Telegram" every run instead of once (no baseline stamp without delivery) -- honest and self-healing once the token is configured.
- `limit-monitor` with a missing token also does not stamp: the wanted-but-unsendable alert stays visible in its log each tick.
- Remaining senders (stuck-modal-guard, fleet-memory-gate, channels.sh, watchdog.sh replay, set-bot-menu, github-pr-monitor, prod-tree hook) are the documented later round on the card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)