### PR TITLE
fix(scripts): honest-send round 2 + the watchdog replay path leaves a record (NOTIFYVAKSWEEP826, MSGSZIVARGAS826)

### DIFF
--- a/scripts/fleet-memory-gate.sh
+++ b/scripts/fleet-memory-gate.sh
@@ -93,8 +93,10 @@ ALERT_COOLDOWN=600   # seconds; do not repeat the same band's alert within this
 log() { echo "[fleet-memory-gate] $*" >&2; }
 
 # --- read memory ---
-mem_total="$(awk '/^MemTotal:/{print $2}' /proc/meminfo 2>/dev/null)"
-mem_avail="$(awk '/^MemAvailable:/{print $2}' /proc/meminfo 2>/dev/null)"
+# MEMGATE_PROC_MEMINFO exists for tests only (no /proc to stub on macOS).
+PROC_MEMINFO="${MEMGATE_PROC_MEMINFO:-/proc/meminfo}"
+mem_total="$(awk '/^MemTotal:/{print $2}' "$PROC_MEMINFO" 2>/dev/null)"
+mem_avail="$(awk '/^MemAvailable:/{print $2}' "$PROC_MEMINFO" 2>/dev/null)"
 if [[ -z "${mem_total:-}" || -z "${mem_avail:-}" || "$mem_total" -le 0 ]]; then
   log "cannot read /proc/meminfo -- fail-open (allow)"
   echo "meminfo-unreadable: allow"
@@ -135,13 +137,20 @@ send_alert() {
   local token=""
   [[ -f "$ENV_FILE" ]] && token="$(grep -E '^TELEGRAM_BOT_TOKEN=' "$ENV_FILE" 2>/dev/null | head -1 | cut -d= -f2- | tr -d '"'"'"' \r\n')"
   if [[ -n "$token" ]]; then
-    curl -s --max-time 15 "https://api.telegram.org/bot${token}/sendMessage" \
-      --data-urlencode "chat_id=${CHAT_ID}" --data-urlencode "text=${msg}" >/dev/null 2>&1 \
-      && log "Telegram sent [$band]" || log "Telegram send failed (best-effort)"
+    # Honest send + cooldown stamp ONLY on confirmed delivery
+    # (NOTIFYVAKSWEEP826): stamping a failed send suppressed the retry for
+    # ALERT_COOLDOWN while the fleet was heading into OOM.
+    . "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/send-telegram.sh"
+    local send_err
+    if send_err="$(send_telegram_message "$token" "$CHAT_ID" "$msg" 2>&1)"; then
+      log "Telegram sent [$band]"
+      echo "${band}:${now}" >"$ALERT_STAMP" 2>/dev/null || true
+    else
+      log "Telegram send FAILED -- cooldown stamp NOT written, will retry next run: ${send_err}"
+    fi
   else
     log "no TELEGRAM_BOT_TOKEN; alert only logged"
   fi
-  echo "${band}:${now}" >"$ALERT_STAMP" 2>/dev/null || true
 }
 
 set_safe_mode() {

--- a/scripts/github-pr-monitor.sh
+++ b/scripts/github-pr-monitor.sh
@@ -55,12 +55,15 @@ CHAT_ID="$(grep -E '^ALLOWED_CHAT_ID=' .env | cut -d= -f2- | tr -d '"'"'"' ')"
 
 send_telegram() {
   local text="$1"
-  [ -n "${BOT_TOKEN:-}" ] && [ -n "${CHAT_ID:-}" ] || return 0
-  curl -s -m 20 -o /dev/null \
-    -X POST "https://api.telegram.org/bot${BOT_TOKEN}/sendMessage" \
-    --data-urlencode "chat_id=${CHAT_ID}" \
-    --data-urlencode "text=${text}" \
-    --data-urlencode "disable_web_page_preview=true" || true
+  if [ -z "${BOT_TOKEN:-}" ] || [ -z "${CHAT_ID:-}" ]; then
+    echo "send_telegram: no BOT_TOKEN/CHAT_ID configured, alert skipped" >&2
+    return 0
+  fi
+  # Honest send (NOTIFYVAKSWEEP826): the old fire-and-forget curl let a failed
+  # alert vanish while the state snapshot below marked the change as reported.
+  . "$(cd "$(dirname "$0")" && pwd)/lib/send-telegram.sh"
+  send_telegram_message "$BOT_TOKEN" "$CHAT_ID" "$text" \
+    --data-urlencode "disable_web_page_preview=true"
 }
 
 # --- fetch current signatures -------------------------------------------
@@ -119,12 +122,22 @@ while IFS=$'\t' read -r pr sig; do
   fi
 done <<< "$CUR"
 
+PERSIST=1
 if [ -n "$CHANGES" ]; then
-  send_telegram "GitHub PR valtozas (reagalt valaki?):
+  if send_telegram "GitHub PR valtozas (reagalt valaki?):
 ${CHANGES}
-https://github.com/${REPO}/pulls"
-  echo "change detected, alerted"
+https://github.com/${REPO}/pulls"; then
+    echo "change detected, alerted"
+  else
+    # Snapshot NOT persisted on a failed alert (NOTIFYVAKSWEEP826): persisting
+    # consumed the diff, so the change was marked reported while nobody saw
+    # it. Keeping the old snapshot makes the next tick re-diff and retry.
+    echo "change detected but the alert did NOT deliver -- snapshot kept, will retry" >&2
+    PERSIST=0
+  fi
 fi
 
-# always persist the freshest non-error snapshot
-printf '%s' "$CUR" > "$STATE_FILE"
+# persist the freshest non-error snapshot (unless a failed alert must retry)
+if [ "$PERSIST" = 1 ]; then
+  printf '%s' "$CUR" > "$STATE_FILE"
+fi

--- a/scripts/lib/send-telegram.sh
+++ b/scripts/lib/send-telegram.sh
@@ -25,6 +25,42 @@
 # Bash 3.2 compatible (macOS system bash). Source it, do not execute it:
 #   . "$(dirname "$0")/lib/send-telegram.sh"
 
+# telegram_api_call TOKEN METHOD [curl args...] -- the same contract for ANY
+# Bot API method (setMyCommands, sendPhoto, ...): success only on curl exit 0
+# AND "ok":true, loud stderr otherwise, token redacted.
+telegram_api_call() {
+  if [ "$#" -lt 2 ]; then
+    echo "telegram_api_call: usage: telegram_api_call TOKEN METHOD [curl args...]" >&2
+    return 1
+  fi
+  local token="$1" method="$2"
+  shift 2
+  if [ -z "$token" ] || [ -z "$method" ]; then
+    echo "telegram_api_call: empty token/method -- refusing (nothing would be delivered)" >&2
+    return 1
+  fi
+
+  local response curl_exit
+  response=$(curl -sS -m 15 "https://api.telegram.org/bot${token}/${method}" "$@" 2>&1)
+  curl_exit=$?
+  # Never let the token reach a log/journal: redact before any echo.
+  response="${response//${token}/<token>}"
+
+  if [ "$curl_exit" -ne 0 ]; then
+    echo "telegram_api_call(${method}): transport failure (curl exit ${curl_exit}): ${response}" >&2
+    return 1
+  fi
+  case "$response" in
+    *'"ok":true'*)
+      return 0
+      ;;
+    *)
+      echo "telegram_api_call(${method}): Bot API rejected the call: ${response}" >&2
+      return 1
+      ;;
+  esac
+}
+
 send_telegram_message() {
   if [ "$#" -lt 3 ]; then
     echo "send_telegram_message: usage: send_telegram_message TOKEN CHAT_ID TEXT [curl args...]" >&2
@@ -36,27 +72,8 @@ send_telegram_message() {
     echo "send_telegram_message: empty token/chat_id/text -- refusing (nothing would be delivered)" >&2
     return 1
   fi
-
-  local response curl_exit
-  response=$(curl -sS -m 15 "https://api.telegram.org/bot${token}/sendMessage" \
+  telegram_api_call "$token" "sendMessage" \
     --data-urlencode "chat_id=${chat_id}" \
     --data-urlencode "text=${text}" \
-    "$@" 2>&1)
-  curl_exit=$?
-  # Never let the token reach a log/journal: redact before any echo.
-  response="${response//${token}/<token>}"
-
-  if [ "$curl_exit" -ne 0 ]; then
-    echo "send_telegram_message: transport failure (curl exit ${curl_exit}): ${response}" >&2
-    return 1
-  fi
-  case "$response" in
-    *'"ok":true'*)
-      return 0
-      ;;
-    *)
-      echo "send_telegram_message: Bot API rejected the send: ${response}" >&2
-      return 1
-      ;;
-  esac
+    "$@"
 }

--- a/scripts/set-bot-menu.sh
+++ b/scripts/set-bot-menu.sh
@@ -33,7 +33,11 @@ fi
 # Wait for plugin to set its commands first
 sleep 15
 
-curl -s -X POST "https://api.telegram.org/bot${BOT_TOKEN}/setMyCommands" \
+# Honest call (NOTIFYVAKSWEEP826): the old fire-and-forget curl printed
+# "Bot menu updated" on transport failure and ok:false alike.
+. "$INSTALL_DIR/scripts/lib/send-telegram.sh"
+if telegram_api_call "$BOT_TOKEN" "setMyCommands" \
+  -X POST \
   -H "Content-Type: application/json" \
   -d '{
     "commands": [
@@ -48,6 +52,9 @@ curl -s -X POST "https://api.telegram.org/bot${BOT_TOKEN}/setMyCommands" \
       {"command": "status", "description": "Futó feladatok állapota"},
       {"command": "cancel", "description": "Futó feladat megszakítása"}
     ]
-  }' > /dev/null 2>&1
-
-echo "Bot menu updated"
+  }'; then
+  echo "Bot menu updated"
+else
+  echo "Bot menu update FAILED (see error above)" >&2
+  exit 1
+fi

--- a/scripts/stuck-modal-guard.sh
+++ b/scripts/stuck-modal-guard.sh
@@ -128,9 +128,18 @@ alert_owner() {
   if [ -z "$token" ] || [ -z "$chat" ]; then
     log "ALERT (no bot token or owner chat id configured): $msg"; return 1
   fi
-  curl -s -m 10 -o /dev/null "https://api.telegram.org/bot${token}/sendMessage" \
-    --data-urlencode "chat_id=${chat}" --data-urlencode "text=${msg}" \
-    && log "owner alerted via direct Bot API" || log "ALERT sendMessage FAILED: $msg"
+  # Honest send (NOTIFYVAKSWEEP826): curl exit 0 alone is not delivery -- an
+  # HTTP 200 with {"ok":false} logged "owner alerted" while nothing arrived.
+  # Return reflects CONFIRMED delivery so the caller's backoff stamp can
+  # depend on it.
+  . "$(cd "$(dirname "$0")" && pwd)/lib/send-telegram.sh"
+  local send_err
+  if send_err="$(send_telegram_message "$token" "$chat" "$msg" 2>&1)"; then
+    log "owner alerted via direct Bot API (delivery confirmed)"
+    return 0
+  fi
+  log "ALERT sendMessage FAILED: ${send_err}"
+  return 1
 }
 
 # --- live guard ----------------------------------------------------------------
@@ -231,8 +240,14 @@ run_guard() {
     log "ALERT: stuck modal after $count respawns -- backing off, manual check needed"
     local bstamp=0; [ -f "$BACKOFF_STAMP" ] && bstamp="$(stat -c %Y "$BACKOFF_STAMP" 2>/dev/null || echo 0)"
     if [ $(( now - bstamp )) -ge 3600 ]; then
-      alert_owner "🔴 The ${SESSION} session is stuck in a /mcp modal and ${count} auto-respawns did not clear it. Manual check needed: tmux attach -t ${SESSION}. Messages sent during the outage may be lost -- please resend."
-      date +%s > "$BACKOFF_STAMP" 2>/dev/null || true
+      # Backoff stamp ONLY on confirmed delivery (NOTIFYVAKSWEEP826): this is
+      # the "your messages may be lost, resend" alert -- burying its own
+      # failure under an hour of backoff was the worst possible combination.
+      if alert_owner "🔴 The ${SESSION} session is stuck in a /mcp modal and ${count} auto-respawns did not clear it. Manual check needed: tmux attach -t ${SESSION}. Messages sent during the outage may be lost -- please resend."; then
+        date +%s > "$BACKOFF_STAMP" 2>/dev/null || true
+      else
+        log "alert not delivered -- backoff stamp NOT written, will retry next tick"
+      fi
     fi
     return 0
   fi

--- a/scripts/watchdog-replay.py
+++ b/scripts/watchdog-replay.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Replay delivered-but-unfinished inter-agent messages into a freshly
+restarted agent session (extracted from watchdog.sh so it is testable).
+
+MSGSZIVARGAS826: this is a RECORD-LESS injection path -- raw tmux send-keys
+with no delivery row anywhere, which made a leaked message impossible to
+attribute. Every replayed message now writes a dated marker line into the
+dashboard log (argv[5]) so transcript-side detectors have an anchor. The
+marker carries a FULL DATE deliberately: dashboard.log lines are time-only,
+and hour-based filtering across days has already produced a false backlog
+reading once.
+
+argv: session_name agent_id cutoff_epoch data_file log_target
+"""
+import json
+import subprocess
+import sys
+import time
+
+session_name, agent_id, cutoff_str, data_file, log_target = sys.argv[1:6]
+cutoff = int(cutoff_str)
+
+with open(data_file) as f:
+    msgs = json.load(f)
+
+pending = [
+    m for m in msgs
+    if m.get('to_agent') == agent_id
+       and m.get('status') == 'delivered'
+       and m.get('completed_at') is None
+       and m.get('created_at', 0) >= cutoff
+]
+
+if not pending:
+    sys.exit(0)
+
+print(f"[watchdog] {agent_id}: replaying {len(pending)} unfinished message(s)", flush=True)
+time.sleep(15)  # let claude boot up and reach the prompt
+
+
+def mark(msg_id: object, note: str) -> None:
+    # Marker for transcript-side delivery detectors (MSGSZIVARGAS826): the
+    # ONLY durable record this injection path produces, so it must never be
+    # skipped on the injected branch. Best-effort: a marker failure must not
+    # stop the replay itself.
+    line = json.dumps({
+        'time': time.strftime('%Y-%m-%dT%H:%M:%S%z'),
+        'msg': 'watchdog-replay injected',
+        'id': msg_id,
+        'agent': agent_id,
+        'session': session_name,
+        'note': note,
+    }, ensure_ascii=False)
+    try:
+        with open(log_target, 'a') as lf:
+            lf.write(line + '\n')
+    except Exception as exc:  # noqa: BLE001
+        print(f"[watchdog] marker write failed for msg {msg_id}: {exc}", file=sys.stderr, flush=True)
+
+
+for m in pending:
+    content = m.get('content', '')
+    full_msg = f"[Újraküldés - feladat elveszett restart előtt]: {content}"
+    chunk_size = 990
+    for i in range(0, len(full_msg), chunk_size):
+        chunk = full_msg[i:i + chunk_size]
+        subprocess.run(['tmux', 'send-keys', '-t', session_name, '-l', chunk],
+                       timeout=5, capture_output=True)
+    subprocess.run(['tmux', 'send-keys', '-t', session_name, 'Enter'],
+                   timeout=5, capture_output=True)
+    mark(m.get('id'), 'replayed-after-restart')
+    time.sleep(2)

--- a/scripts/watchdog.sh
+++ b/scripts/watchdog.sh
@@ -77,42 +77,12 @@ replay_unfinished_messages() {
   TMPDATA=$(mktemp)
   echo "$RESPONSE" > "$TMPDATA"
 
-  python3 - "$SESSION_NAME" "$AGENT_ID" "$CUTOFF" "$TMPDATA" <<'PYEOF' 2>/dev/null
-import json, sys, subprocess, time
-
-session_name, agent_id, cutoff_str, data_file = sys.argv[1:5]
-cutoff = int(cutoff_str)
-
-with open(data_file) as f:
-    msgs = json.load(f)
-
-pending = [
-    m for m in msgs
-    if m.get('to_agent') == agent_id
-       and m.get('status') == 'delivered'
-       and m.get('completed_at') is None
-       and m.get('created_at', 0) >= cutoff
-]
-
-if not pending:
-    sys.exit(0)
-
-print(f"[watchdog] {agent_id}: replaying {len(pending)} unfinished message(s)", flush=True)
-time.sleep(15)  # let claude boot up and reach the prompt
-
-for m in pending:
-    content = m.get('content', '')
-    full_msg = f"[Újraküldés - feladat elveszett restart előtt]: {content}"
-    chunk_size = 990
-    for i in range(0, len(full_msg), chunk_size):
-        chunk = full_msg[i:i + chunk_size]
-        subprocess.run(['tmux', 'send-keys', '-t', session_name, '-l', chunk],
-                       timeout=5, capture_output=True)
-    subprocess.run(['tmux', 'send-keys', '-t', session_name, 'Enter'],
-                   timeout=5, capture_output=True)
-    time.sleep(2)
-
-PYEOF
+  # Replay logic extracted to its own file (testable) + MSGSZIVARGAS826: every
+  # injected message writes a dated marker into the dashboard log -- this used
+  # to be a fully record-less injection path, invisible to every detector.
+  python3 "$INSTALL_DIR/scripts/watchdog-replay.py" \
+    "$SESSION_NAME" "$AGENT_ID" "$CUTOFF" "$TMPDATA" \
+    "$INSTALL_DIR/store/dashboard.log" 2>/dev/null
 
   rm -f "$TMPDATA"
 }

--- a/src/__tests__/send-honesty-round2.test.ts
+++ b/src/__tests__/send-honesty-round2.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, chmodSync, existsSync, readFileSync, cpSync } from 'node:fs'
+import { tmpdir, platform } from 'node:os'
+import { join } from 'node:path'
+
+// NOTIFYVAKSWEEP826 round 2: the remaining Telegram senders move to the shared
+// contract (telegram_api_call generalizes it beyond sendMessage), their
+// cooldown/backoff/state stamps move to after-confirmed-delivery, and the
+// watchdog replay path -- until now a fully RECORD-LESS injection route
+// (MSGSZIVARGAS826) -- writes a dated marker per injected message. Empirical
+// staged-tree tests, PATH-stubbed curl/tmux, nothing leaves the machine.
+// stuck-modal-guard is the one static-only conversion (running it needs a live
+// stuck tmux session); its alert_owner is byte-identical to the disk-guard
+// family measured in round 1, and bash -n covers syntax.
+const ROOT = join(__dirname, '..', '..')
+const FAKE_TOKEN = '1234567890:TESTTOKENTESTTOKEN'
+
+let stage: string
+beforeEach(() => { stage = mkdtempSync(join(tmpdir(), 'send-r2-')) })
+afterEach(() => { rmSync(stage, { recursive: true, force: true }) })
+
+function stageTree(scriptNames: string[]): { bin: string } {
+  const scripts = join(stage, 'scripts')
+  mkdirSync(join(scripts, 'lib'), { recursive: true })
+  mkdirSync(join(stage, 'store'), { recursive: true })
+  for (const s of scriptNames) cpSync(join(ROOT, 'scripts', s), join(scripts, s))
+  cpSync(join(ROOT, 'scripts', 'lib', 'send-telegram.sh'), join(scripts, 'lib', 'send-telegram.sh'))
+  const bin = join(stage, 'bin')
+  mkdirSync(bin, { recursive: true })
+  writeFileSync(join(bin, 'curl'),
+    '#!/bin/bash\necho "$@" >> "${CURL_ARGV_LOG:-/dev/null}"\nif [ "${CURL_STUB_EXIT:-0}" -ne 0 ]; then\n  echo "curl: (6) Could not resolve host for https://api.telegram.org/bot${CURL_STUB_TOKEN:-}/x" >&2\n  exit "${CURL_STUB_EXIT}"\nfi\nprintf \'%s\' "${CURL_STUB_BODY:-{\\"ok\\":true}}"\n')
+  writeFileSync(join(bin, 'sleep'), '#!/bin/bash\nexit 0\n') // set-bot-menu sleeps 15s; irrelevant here
+  writeFileSync(join(bin, 'tmux'), '#!/bin/bash\necho "$@" >> "${TMUX_ARGV_LOG:-/dev/null}"\nexit 0\n')
+  for (const b of ['curl', 'sleep', 'tmux']) chmodSync(join(bin, b), 0o755)
+  return { bin }
+}
+
+function run(rel: string, env: Record<string, string>, bin: string, args: string[] = []) {
+  return spawnSync('/bin/bash', [join(stage, 'scripts', rel), ...args], {
+    env: {
+      PATH: `${bin}:/usr/bin:/bin`,
+      HOME: stage,
+      CURL_STUB_TOKEN: FAKE_TOKEN,
+      CURL_ARGV_LOG: join(stage, 'curl-argv.log'),
+      ...env,
+    },
+    encoding: 'utf-8',
+    timeout: 20000,
+  })
+}
+
+describe('telegram_api_call: the generalized contract', () => {
+  const driver = (call: string, env: Record<string, string> = {}) => {
+    const { bin } = stageTree([])
+    writeFileSync(join(stage, 'scripts', 'driver.sh'), `#!/bin/bash\n. "$(dirname "$0")/lib/send-telegram.sh"\n${call}\n`)
+    return run('driver.sh', env, bin)
+  }
+  it('succeeds only on ok:true, for any method', () => {
+    expect(driver(`telegram_api_call "${FAKE_TOKEN}" setMyCommands -d '{}'`).status).toBe(0)
+  })
+  it('POSITIVE CONTROL: rejection is loud, method named, token redacted', () => {
+    const r = driver(`telegram_api_call "${FAKE_TOKEN}" setMyCommands -d '{}'`,
+      { CURL_STUB_BODY: '{"ok":false,"description":"Bad Request"}' })
+    expect(r.status).toBe(1)
+    expect(r.stderr).toContain('setMyCommands')
+    expect(r.stderr).not.toContain(FAKE_TOKEN)
+  })
+  it('send_telegram_message still honors the round-1 contract through the wrapper', () => {
+    const r = driver(`send_telegram_message "${FAKE_TOKEN}" 42 "hello"`, { CURL_STUB_EXIT: '6' })
+    expect(r.status).toBe(1)
+    expect(r.stderr).toContain('curl exit 6')
+    expect(r.stderr).toContain('<token>')
+  })
+})
+
+describe('set-bot-menu.sh: honest outcome', () => {
+  const setup = () => {
+    const { bin } = stageTree(['set-bot-menu.sh'])
+    writeFileSync(join(stage, '.env'), `CHANNEL_PROVIDER=telegram\nTELEGRAM_BOT_TOKEN=${FAKE_TOKEN}\n`)
+    return { bin }
+  }
+  it('reports success only on ok:true', () => {
+    const { bin } = setup()
+    const r = run('set-bot-menu.sh', {}, bin)
+    expect(r.status).toBe(0)
+    expect(r.stdout).toContain('Bot menu updated')
+  })
+  it('RED-BEFORE: a failed call no longer claims "Bot menu updated"', () => {
+    const { bin } = setup()
+    const r = run('set-bot-menu.sh', { CURL_STUB_EXIT: '6' }, bin)
+    expect(r.status).toBe(1)
+    expect(r.stdout).not.toContain('Bot menu updated')
+    expect(r.stderr).toContain('FAILED')
+  })
+})
+
+describe('fleet-memory-gate.sh: cooldown stamp only after confirmed delivery', () => {
+  const setup = () => {
+    const { bin } = stageTree(['fleet-memory-gate.sh'])
+    const meminfo = join(stage, 'meminfo')
+    // MemAvailable ~3% of MemTotal -> critical band, alert path taken
+    writeFileSync(meminfo, 'MemTotal:       16000000 kB\nMemAvailable:     480000 kB\n')
+    const tgEnv = join(stage, 'tg.env')
+    writeFileSync(tgEnv, `TELEGRAM_BOT_TOKEN=${FAKE_TOKEN}\n`)
+    const env = {
+      MEMGATE_PROC_MEMINFO: meminfo,
+      TELEGRAM_ENV: tgEnv,
+      MARVEEN_ALERT_CHAT_ID: '42',
+      MEMGATE_STATE_DIR: join(stage, 'store'),
+      MARVEEN_STORE: join(stage, 'store'),
+    }
+    return { bin, env, stamp: join(stage, 'store', '.fleet-memgate-alert') }
+  }
+  it('confirmed delivery writes the band stamp; failed delivery does not', () => {
+    const { bin, env, stamp } = setup()
+    const r1 = run('fleet-memory-gate.sh', { ...env, CURL_STUB_EXIT: '6' }, bin)
+    // The gate's exit code is its VERDICT (10 = block in the hard band, by
+    // design) -- a failed alert must not change the verdict, only the stamp.
+    expect(r1.status).toBe(10)
+    if (existsSync(stamp)) {
+      // If the stamp path resolved elsewhere the assertion below would be
+      // vacuous -- so assert the RESOLVED stamp is absent, not just this path.
+      expect(readFileSync(stamp, 'utf-8')).toBe('')
+    }
+    const r2 = run('fleet-memory-gate.sh', env, bin)
+    expect(r2.status).toBe(10) // same verdict, delivery now confirmed
+    expect(existsSync(stamp)).toBe(true)
+    expect(readFileSync(stamp, 'utf-8')).toMatch(/^\w+:\d+/)
+  })
+})
+
+describe('github-pr-monitor.sh: failed alert keeps the snapshot for retry', () => {
+  // The full script needs GNU grep -P (BSD grep exits 2 under set -e) -- known
+  // portability note from the sweep; run on Linux CI, skip on darwin dev boxes.
+  const linuxOnly = platform() === 'linux' ? it : it.skip
+  const setup = () => {
+    const { bin } = stageTree(['github-pr-monitor.sh'])
+    // The script cd-s to its INSTALL_DIR (= the stage root) and reads .env +
+    // store/ relative to it. gh stub: a single PR object with one comment.
+    writeFileSync(join(stage, '.env'), `TELEGRAM_BOT_TOKEN=${FAKE_TOKEN}\nALLOWED_CHAT_ID=42\n`)
+    writeFileSync(join(stage, 'bin', 'gh'),
+      '#!/bin/bash\nprintf \'{"state":"OPEN","reviewDecision":null,"reviews":[],"comments":[{"author":{"login":"x"},"createdAt":"2026-08-26T10:00:00Z"}],"title":"t"}\'\n')
+    chmodSync(join(stage, 'bin', 'gh'), 0o755)
+    const state = join(stage, 'store', '.github-pr-monitor-state')
+    writeFileSync(state, '7\tOPEN|none|0|0|\n') // old signature differs (0 comments) -> change detected
+    const envBase = { GITHUB_PR_MONITOR_PRS: '7', GITHUB_PR_MONITOR_REPO: 'o/r' }
+    return { bin, state, envBase }
+  }
+  linuxOnly('keeps the old snapshot when the alert fails, persists on success', () => {
+    const { bin, state, envBase } = setup()
+    const r1 = run('github-pr-monitor.sh', { ...envBase, CURL_STUB_EXIT: '6' }, bin)
+    expect(r1.stderr + r1.stdout).toContain('did NOT deliver')
+    expect(readFileSync(state, 'utf-8')).toContain('OPEN|none|0|0|') // old snapshot kept
+    const r2 = run('github-pr-monitor.sh', envBase, bin)
+    expect(r2.stdout).toContain('change detected, alerted')
+    expect(readFileSync(state, 'utf-8')).toContain('OPEN|none|0|1|') // fresh snapshot persisted
+  })
+})
+
+describe('watchdog-replay.py: the injection path now leaves a record (MSGSZIVARGAS826)', () => {
+  const runReplay = (msgs: unknown[], env: Record<string, string> = {}) => {
+    const { bin } = stageTree([])
+    cpSync(join(ROOT, 'scripts', 'watchdog-replay.py'), join(stage, 'scripts', 'watchdog-replay.py'))
+    const data = join(stage, 'msgs.json')
+    writeFileSync(data, JSON.stringify(msgs))
+    const logTarget = join(stage, 'store', 'dashboard.log')
+    const r = spawnSync('python3', [join(stage, 'scripts', 'watchdog-replay.py'),
+      'agent-testbot', 'testbot', '0', data, logTarget], {
+      env: {
+        PATH: `${bin}:/usr/bin:/bin`,
+        TMUX_ARGV_LOG: join(stage, 'tmux-argv.log'),
+        ...env,
+      },
+      encoding: 'utf-8',
+      timeout: 60000,
+    })
+    return { r, logTarget, tmuxLog: join(stage, 'tmux-argv.log') }
+  }
+  it('writes one dated marker per injected message, with the msg id', () => {
+    const { r, logTarget, tmuxLog } = runReplay([
+      { id: 16029, to_agent: 'testbot', status: 'delivered', completed_at: null, created_at: 5, content: 'hello' },
+      { id: 16030, to_agent: 'other', status: 'delivered', completed_at: null, created_at: 5, content: 'not mine' },
+    ])
+    expect(r.status).toBe(0)
+    expect(existsSync(tmuxLog)).toBe(true) // injection provably attempted
+    const lines = readFileSync(logTarget, 'utf-8').trim().split('\n')
+    expect(lines).toHaveLength(1) // only the addressed message, not the other agent's
+    const marker = JSON.parse(lines[0])
+    expect(marker.msg).toBe('watchdog-replay injected')
+    expect(marker.id).toBe(16029)
+    expect(marker.agent).toBe('testbot')
+    // Full date in the stamp -- time-only lines are the measured instrument trap.
+    expect(marker.time).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/)
+  })
+  it('RED-BEFORE property: with no pending messages, no marker and no injection', () => {
+    const { r, logTarget, tmuxLog } = runReplay([])
+    expect(r.status).toBe(0)
+    expect(existsSync(logTarget)).toBe(false)
+    expect(existsSync(tmuxLog)).toBe(false)
+  })
+})
+
+describe('stuck-modal-guard.sh: static conversion checks (live run needs a stuck session)', () => {
+  const src = readFileSync(join(ROOT, 'scripts', 'stuck-modal-guard.sh'), 'utf-8')
+  it('sources the shared library and gates the backoff stamp on alert_owner success', () => {
+    expect(src).toContain('lib/send-telegram.sh')
+    expect(src).toMatch(/if alert_owner[\s\S]{0,400}BACKOFF_STAMP/)
+  })
+  it('KNOWN-POSITIVE control for the pattern check: the pre-conversion shape would fail it', () => {
+    const old = 'alert_owner "..."\n      date +%s > "$BACKOFF_STAMP"'
+    expect(old).not.toMatch(/if alert_owner[\s\S]{0,400}BACKOFF_STAMP.*\n.*else/)
+  })
+})


### PR DESCRIPTION
## Scope (round 2 of the sweep card + the GO'd marker from MSGSZIVARGAS826)
- **lib**: `telegram_api_call TOKEN METHOD [curl args...]` generalizes the proven contract (curl exit 0 AND `"ok":true`, loud stderr, token redacted) to any Bot API method; `send_telegram_message` is now a thin wrapper -- one truth, no drift.
- **stuck-modal-guard**: confirmed-delivery return + 1h backoff stamp only on success. This is the *"your messages may be lost, resend"* alert -- burying its own failure under an hour of backoff was the worst combination. **Static-only conversion** (a live run needs a stuck tmux session); the pattern is byte-identical to the round-1-measured disk-guard family, and the test pins the structure with a known-positive control.
- **fleet-memory-gate**: honest send + band cooldown stamp only on success; `MEMGATE_PROC_MEMINFO` test seam (HOSTWD_PROC_STAT precedent). Measured: the gate's exit-code VERDICT (10 = block) is unchanged by a failed alert -- only the stamp behavior changes.
- **set-bot-menu**: `setMyCommands` through `telegram_api_call`; "Bot menu updated" only on ok:true, failure exits 1 loudly.
- **github-pr-monitor**: honest send; on a failed alert the state snapshot is NOT persisted -- the diff survives and the next tick retries. Before, the change was marked reported while nobody saw it.
- **watchdog replay (MSGSZIVARGAS826, Marveen GO msg 16066)**: the replay python extracted to `scripts/watchdog-replay.py` (directly testable) and every injected message writes a dated JSON marker into the dashboard log. This was a fully RECORD-LESS injection path -- the reason the 16029 leak could not be attributed. Full date in the stamp deliberately: dashboard.log lines are time-only, a measured instrument trap.

## Verification
- 11 staged-tree tests, stubbed curl/tmux/gh/sleep, nothing leaves the machine (`send-honesty-round2.test.ts`). The github-pr-monitor case is **linux-only** (BSD `grep -P` trap measured in the sweep) -- it runs in CI, skips on darwin dev boxes.
- **Red-before measured post-commit** (no stash: today's #1084 lesson): with the four scripts reverted to origin/develop, 3 tests FAIL (set-bot-menu false success; memgate pre-send stamp; stuck-modal structure); the lib/watchdog-replay tests are new components, green both ways; restored clean.
- Round-1 suites (`send-honesty-sweep`, `notify-delivery-honesty`) stay green through the lib refactor.
- Full vitest **307 files / 4091 green + 1 linux-only skip**; tsc clean; `bash -n` + `py_compile` clean; added lines free of em/en dashes.
- Staged file list verified unfiltered BEFORE commit, and the remote file list after push (below).

## Out of scope, stated
`channels.sh` guard curls and the prod-tree hook's `POST /api/messages` are dashboard-API senders (different contract), and channels.sh is unsafe to exercise even stubbed (absolute-path kill reaper, measured in the sweep). They remain the documented tail on the card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)