### PR TITLE
fix(scripts): honest-send closing round -- dashboard-API senders + the marker's own failure trace (NOTIFYVAKSWEEP826)

### DIFF
--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -500,8 +500,17 @@ if [ -n "$_node_bin" ] && [ -f "$INSTALL_DIR/dist/web/agent-process.js" ]; then
         -H "Content-Type: application/json" \
         -H "Authorization: Bearer $(cat "$INSTALL_DIR/store/.dashboard-token")" \
         -d "{\"from\":\"channels-sh-guard\",\"to\":\"${MAIN_AGENT_ID:-marveen}\",\"content\":\"[GUARD] A fo agens a KOZOS ~/.claude alol indult, pedig van flotta setup-token (store/.claude-oauth-token). A MAIN_AGENT_ISOLATED_CONFIG nincs beallitva, ezert az auth a rotalodo megosztott credentialbol megy: ez lejarhat, 401-be all a TUI, es a csatorna NEMAN elerhetetlen lesz. Teendo: MAIN_AGENT_ISOLATED_CONFIG=1 beallitasa, majd channels session restart.\"}" \
-        >/dev/null 2>&1 || true
-      unset _guard_port
+        -o /dev/null -w '%{http_code}' 2>>"$INSTALL_DIR/store/channels-failures.log" > "$INSTALL_DIR/store/.channels-guard-http.$$" || true
+      # Honest delivery (NOTIFYVAKSWEEP826 zaro kor): a fenti WARN csak a helyi
+      # logban el -- ha a koordinatornak szolo POST elbukik, az is a logba
+      # kerul, kulonben a riasztas-vesztes lathatatlan.
+      _guard_http="$(cat "$INSTALL_DIR/store/.channels-guard-http.$$" 2>/dev/null || echo 000)"
+      rm -f "$INSTALL_DIR/store/.channels-guard-http.$$"
+      case "$_guard_http" in
+        2*) : ;;
+        *) echo "$(date '+%Y-%m-%d %H:%M:%S') channels.sh: WARN guard alert POST failed (HTTP ${_guard_http:-000}) -- a fenti WARN nem erte el a koordinatort" >> "$INSTALL_DIR/store/channels-failures.log" ;;
+      esac
+      unset _guard_port _guard_http
     fi
   fi
   # Trigger 2 (below): an install that HAS run isolated before. Its
@@ -517,8 +526,17 @@ if [ -n "$_node_bin" ] && [ -f "$INSTALL_DIR/dist/web/agent-process.js" ]; then
         -H "Content-Type: application/json" \
         -H "Authorization: Bearer $(cat "$INSTALL_DIR/store/.dashboard-token")" \
         -d "{\"from\":\"channels-sh-guard\",\"to\":\"${MAIN_AGENT_ID:-marveen}\",\"content\":\"[GUARD] A channels session most a KOZOS ~/.claude alol indult, pedig letezik izolalt config dir (.channels-config). A MAIN_AGENT_ISOLATED_CONFIG beallitas valoszinuleg elveszett (store/config-overrides.json torlodott es nincs .env kulcs). Az auth a rotalodo shared sessionbol megy, 401-veszely. Teendo: MAIN_AGENT_ISOLATED_CONFIG=1 visszaallitasa, majd channels session restart.\"}" \
-        >/dev/null 2>&1 || true
-      unset _guard_port
+        -o /dev/null -w '%{http_code}' 2>>"$INSTALL_DIR/store/channels-failures.log" > "$INSTALL_DIR/store/.channels-guard-http.$$" || true
+      # Honest delivery (NOTIFYVAKSWEEP826 zaro kor): a fenti WARN csak a helyi
+      # logban el -- ha a koordinatornak szolo POST elbukik, az is a logba
+      # kerul, kulonben a riasztas-vesztes lathatatlan.
+      _guard_http="$(cat "$INSTALL_DIR/store/.channels-guard-http.$$" 2>/dev/null || echo 000)"
+      rm -f "$INSTALL_DIR/store/.channels-guard-http.$$"
+      case "$_guard_http" in
+        2*) : ;;
+        *) echo "$(date '+%Y-%m-%d %H:%M:%S') channels.sh: WARN guard alert POST failed (HTTP ${_guard_http:-000}) -- a fenti WARN nem erte el a koordinatort" >> "$INSTALL_DIR/store/channels-failures.log" ;;
+      esac
+      unset _guard_port _guard_http
     fi
   fi
   unset _cfg_line _cfg_mode _cfg_dir

--- a/scripts/install-prod-tree-guard-hook.sh
+++ b/scripts/install-prod-tree-guard-hook.sh
@@ -163,10 +163,19 @@ TOKEN_FILE="$PROD_ROOT/store/.dashboard-token"
 # reader starts an investigation (cost one wasted round on 2026-08-22).
 ORIGIN="${MARVEEN_DASHBOARD_ORIGIN:-http://localhost:3420}"
 ALERT_TO="${MARVEEN_GUARD_ALERT_TO:-marveen}"
-curl -s -m 5 -X POST "$ORIGIN/api/messages" \
+# Honest delivery (NOTIFYVAKSWEEP826): the alert POST used to be fire-and-
+# forget -- a failed send left the branch-switch alert lost with no trace.
+# The hook stays exit-0 (a guard must not break git), but a delivery failure
+# is now loud on the git command's own output.
+GUARD_HTTP="$(curl -s -m 5 -X POST "$ORIGIN/api/messages" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $(cat "$TOKEN_FILE")" \
-  -d "{\"from\":\"marveen\",\"to\":\"$ALERT_TO\",\"content\":\"[PROD-FA ORSEG, post-checkout hook] Fa: $TOPLEVEL -- agat valtott a(z) $BRANCH agra. (Ha ez az utvonal nem a telepites fo faja, ez PROBA, nem eles riasztas.) AUTO-VISSZAALLITAS: $REVERTED. Commitot a pre-commit hook blokkol; szandekos valtashoz MARVEEN_PROD_CHECKOUT_OK=1.\"}" >/dev/null 2>&1 || true
+  -o /dev/null -w '%{http_code}' \
+  -d "{\"from\":\"marveen\",\"to\":\"$ALERT_TO\",\"content\":\"[PROD-FA ORSEG, post-checkout hook] Fa: $TOPLEVEL -- agat valtott a(z) $BRANCH agra. (Ha ez az utvonal nem a telepites fo faja, ez PROBA, nem eles riasztas.) AUTO-VISSZAALLITAS: $REVERTED. Commitot a pre-commit hook blokkol; szandekos valtashoz MARVEEN_PROD_CHECKOUT_OK=1.\"}" 2>/dev/null)" || GUARD_HTTP="000"
+case "$GUARD_HTTP" in
+  2*) : ;;
+  *) echo "[prod-tree-guard] FIGYELEM: a branch-valtas riasztas NEM ert celba (HTTP ${GUARD_HTTP:-000}) -- a koordinator nem tud a valtasrol" >&2 ;;
+esac
 exit 0
 EOF
 chmod +x "$HOOK_DIR/post-checkout"

--- a/scripts/watchdog.sh
+++ b/scripts/watchdog.sh
@@ -80,9 +80,13 @@ replay_unfinished_messages() {
   # Replay logic extracted to its own file (testable) + MSGSZIVARGAS826: every
   # injected message writes a dated marker into the dashboard log -- this used
   # to be a fully record-less injection path, invisible to every detector.
+  # stderr goes to the watchdog log, NOT /dev/null (NOTIFYVAKSWEEP826 zaro
+  # kor, Marveen msg 16091): the replay python is honest about a failed
+  # marker write, but the old 2>/dev/null buried exactly that line -- the
+  # instrument built against silence would have gone blind silently.
   python3 "$INSTALL_DIR/scripts/watchdog-replay.py" \
     "$SESSION_NAME" "$AGENT_ID" "$CUTOFF" "$TMPDATA" \
-    "$INSTALL_DIR/store/dashboard.log" 2>/dev/null
+    "$INSTALL_DIR/store/dashboard.log" 2>>"$LOG"
 
   rm -f "$TMPDATA"
 }

--- a/src/__tests__/send-honesty-final.test.ts
+++ b/src/__tests__/send-honesty-final.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { spawnSync, execFileSync } from 'node:child_process'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, chmodSync, existsSync, readFileSync, cpSync, realpathSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+// NOTIFYVAKSWEEP826 closing round: the two dashboard-API senders get the
+// honest-delivery treatment (channels.sh guard POSTs, the generated prod-tree
+// post-checkout hook), and the watchdog replay's stderr is routed to the
+// watchdog log instead of /dev/null. Marveen's stipulation (msg 16091): the
+// marker fix needs its own POSITIVE CONTROL -- a deliberately unwritable log
+// target must leave a visible trace, otherwise the fix is as unmeasurable as
+// the failure was. channels.sh itself is unsafe to execute even stubbed
+// (absolute-path kill reaper, measured in the sweep), so its coverage is
+// source-pinned with a known-positive; the hook and the replay run for real.
+const ROOT = join(__dirname, '..', '..')
+
+let stage: string
+// realpath, mert a macOS /var/folders symlink miatt a hook TOPLEVEL==PROD_ROOT
+// osszevetese kulonben hamisan elterne (a show-toplevel felold, a cd+pwd nem).
+beforeEach(() => { stage = realpathSync(mkdtempSync(join(tmpdir(), 'send-final-'))) })
+afterEach(() => { rmSync(stage, { recursive: true, force: true }) })
+
+function stubBin(): string {
+  const bin = join(stage, 'bin')
+  mkdirSync(bin, { recursive: true })
+  writeFileSync(join(bin, 'curl'),
+    '#!/bin/bash\necho "$@" >> "${CURL_ARGV_LOG:-/dev/null}"\nif [ "${CURL_STUB_EXIT:-0}" -ne 0 ]; then exit "${CURL_STUB_EXIT}"; fi\nprintf \'%s\' "${CURL_STUB_HTTP:-200}"\n')
+  writeFileSync(join(bin, 'tmux'), '#!/bin/bash\necho "$@" >> "${TMUX_ARGV_LOG:-/dev/null}"\nexit 0\n')
+  for (const b of ['curl', 'tmux']) chmodSync(join(bin, b), 0o755)
+  return bin
+}
+
+describe('watchdog-replay marker: POSITIVE CONTROL for the failure trace (Marveen msg 16091)', () => {
+  const run = (logTarget: string) => {
+    const bin = stubBin()
+    const data = join(stage, 'msgs.json')
+    writeFileSync(data, JSON.stringify([
+      { id: 424242, to_agent: 'probetest', status: 'delivered', completed_at: null, created_at: 5, content: 'probe' },
+    ]))
+    return spawnSync('python3', [join(ROOT, 'scripts', 'watchdog-replay.py'),
+      'agent-probetest', 'probetest', '0', data, logTarget], {
+      env: { PATH: `${bin}:/usr/bin:/bin`, TMUX_ARGV_LOG: join(stage, 'tmux.log') },
+      encoding: 'utf-8',
+      timeout: 60000,
+    })
+  }
+  it('an unwritable log target leaves a LOUD stderr trace and does not stop the replay', () => {
+    const r = run(join(stage, 'no-such-dir', 'nested', 'dashboard.log'))
+    expect(r.status).toBe(0) // replay priority holds
+    expect(existsSync(join(stage, 'tmux.log'))).toBe(true) // injection still happened
+    expect(r.stderr).toContain('marker write failed')
+    expect(r.stderr).toContain('424242')
+  })
+  it('control pair: a writable target produces the marker and NO failure trace', () => {
+    const target = join(stage, 'dashboard.log')
+    const r = run(target)
+    expect(r.status).toBe(0)
+    expect(readFileSync(target, 'utf-8')).toContain('"id": 424242')
+    expect(r.stderr).not.toContain('marker write failed')
+  })
+  it('watchdog.sh routes the replay stderr to its log, not /dev/null', () => {
+    const src = readFileSync(join(ROOT, 'scripts', 'watchdog.sh'), 'utf-8')
+    expect(src).toMatch(/watchdog-replay\.py[\s\S]{0,200}2>>"\$LOG"/)
+    expect(src).not.toMatch(/watchdog-replay\.py[\s\S]{0,200}2>\/dev\/null/)
+  })
+  it('KNOWN-POSITIVE for the pin: the pre-fix invocation shape fails it', () => {
+    const preFix = 'python3 "$INSTALL_DIR/scripts/watchdog-replay.py" \\\n "$SESSION_NAME" "$AGENT_ID" "$CUTOFF" "$TMPDATA" \\\n "$INSTALL_DIR/store/dashboard.log" 2>/dev/null'
+    expect(preFix).toMatch(/watchdog-replay\.py[\s\S]{0,200}2>\/dev\/null/)
+  })
+})
+
+describe('generated prod-tree post-checkout hook: honest alert delivery', () => {
+  const setupRepoWithHook = (): { hook: string; repo: string } => {
+    const repo = join(stage, 'repo')
+    mkdirSync(join(repo, 'scripts'), { recursive: true })
+    mkdirSync(join(repo, 'store'), { recursive: true })
+    execFileSync('git', ['-C', repo, 'init', '-q', '-b', 'develop'])
+    writeFileSync(join(repo, 'x.txt'), 'x')
+    execFileSync('git', ['-C', repo, 'add', '.'], { env: { ...process.env } })
+    execFileSync('git', ['-C', repo, '-c', 'user.email=t@t', '-c', 'user.name=t', 'commit', '-qm', 'init'])
+    cpSync(join(ROOT, 'scripts', 'install-prod-tree-guard-hook.sh'), join(repo, 'scripts', 'install-prod-tree-guard-hook.sh'))
+    writeFileSync(join(repo, 'store', '.dashboard-token'), 'test-token\n')
+    // git-common-dir returns a RELATIVE .git from inside the repo, so the
+    // installer must run with the repo root as cwd (it does in production).
+    const r = spawnSync('/bin/bash', [join(repo, 'scripts', 'install-prod-tree-guard-hook.sh')], { cwd: repo, encoding: 'utf-8', timeout: 20000 })
+    expect(r.status).toBe(0)
+    const hook = join(repo, '.git', 'hooks', 'post-checkout')
+    expect(existsSync(hook)).toBe(true)
+    return { hook, repo }
+  }
+  const runHook = (hook: string, repo: string, env: Record<string, string>) => {
+    const bin = stubBin()
+    // The hook only alerts on a NON-home branch -- park the scratch repo on a
+    // feature branch first. CRITICAL: this setup checkout itself FIRES the
+    // installed post-checkout hook, which would alert (live curl!) and
+    // auto-revert back to develop, making the measured run a silent no-op --
+    // exactly what the first draft of this test did. Waive the hook for the
+    // setup step (MARVEEN_PROD_CHECKOUT_OK=1) and keep the stub curl on PATH
+    // so no invocation can ever reach a live endpoint.
+    execFileSync('git', ['-C', repo, 'checkout', '-q', '-B', 'feature-probe'], {
+      env: { ...process.env, PATH: `${bin}:/usr/bin:/bin`, MARVEEN_PROD_CHECKOUT_OK: '1' },
+    })
+    return spawnSync('/bin/bash', [hook, 'a'.repeat(40), 'b'.repeat(40), '1'], {
+      cwd: repo,
+      env: {
+        PATH: `${bin}:/usr/bin:/bin`,
+        HOME: stage,
+        CURL_ARGV_LOG: join(stage, 'curl.log'),
+        ...env,
+      },
+      encoding: 'utf-8',
+      timeout: 20000,
+    })
+  }
+  it('a delivered alert (HTTP 2xx) stays quiet; a failed one is loud on stderr but exit 0', () => {
+    const { hook, repo } = setupRepoWithHook()
+    const ok = runHook(hook, repo, { CURL_STUB_HTTP: '200' })
+    expect(ok.status).toBe(0)
+    expect(ok.stderr).not.toContain('NEM ert celba')
+    const bad = runHook(hook, repo, { CURL_STUB_HTTP: '500' })
+    expect(bad.status).toBe(0) // a guard must not break git
+    expect(bad.stderr).toContain('NEM ert celba')
+    const dead = runHook(hook, repo, { CURL_STUB_EXIT: '6' })
+    expect(dead.status).toBe(0)
+    expect(dead.stderr).toContain('NEM ert celba')
+  })
+})
+
+describe('channels.sh guard POSTs: source-pinned honest delivery (unsafe to execute)', () => {
+  const src = readFileSync(join(ROOT, 'scripts', 'channels.sh'), 'utf-8')
+  it('both guard POSTs capture the HTTP code and log a delivery failure', () => {
+    const matches = src.match(/guard alert POST failed/g) ?? []
+    expect(matches.length).toBe(2)
+    expect(src).not.toMatch(/api\/messages[\s\S]{0,400}>\/dev\/null 2>&1 \|\| true/)
+  })
+  it('KNOWN-POSITIVE for the pin: the pre-fix shape fails it', () => {
+    const preFix = 'curl ... "http://localhost:3420/api/messages" -d "{}" >/dev/null 2>&1 || true'
+    expect(preFix).toMatch(/api\/messages[\s\S]{0,400}>\/dev\/null 2>&1 \|\| true/)
+  })
+})


### PR DESCRIPTION
## Scope (the last tail of the sweep card + Marveen's stipulation from msg 16091)
- **channels.sh guard POSTs** (both isolation-warning triggers): HTTP code captured; a non-2xx lands in `channels-failures.log` next to the WARN it failed to deliver. Before, a lost guard alert was invisible while the local log looked complete (the sweep's PARTIAL verdict).
- **Generated prod-tree post-checkout hook**: the branch-switch alert POST captures the HTTP code; failed delivery is loud on the git command's own stderr, hook stays exit-0 (a guard must not break git).
- **watchdog.sh**: the replay python's stderr goes to the watchdog log instead of `/dev/null` -- the replay script is honest about a failed marker write, but the old redirect buried exactly that line. The instrument built against silence would have gone blind silently (Marveen's catch).

## Verification
- `send-honesty-final.test.ts` (7 tests):
  - **Marker positive control** (the stipulation): unwritable log target -> loud stderr naming the msg id, replay continues, injection still provably happens; writable target -> marker written, no failure trace. Plus a source pin that watchdog.sh routes stderr to `$LOG` (known-positive: the pre-fix `2>/dev/null` shape fails it).
  - **The GENERATED hook runs for real**: installed by the actual installer into a scratch git repo, exercised with stubbed curl for 2xx / HTTP 500 / transport failure.
  - **channels.sh is source-pinned** with a known-positive -- executing it is unsafe even stubbed (absolute-path kill reaper, measured in the sweep). Stated, not hidden.
- **Two traps the test itself uncovered** (documented in-code): the setup `git checkout -B` fires the very hook under test -- it alerted against the LIVE dashboard (rejected 401) and auto-reverted, turning the measured run into a silent no-op; setup now waives the hook (`MARVEEN_PROD_CHECKOUT_OK=1`, setup step only) and keeps the stub curl on PATH so no invocation can reach a live endpoint. And macOS `/var/folders` symlinks break the hook's `TOPLEVEL==PROD_ROOT` comparison (stage is realpath'd).
- **Red-before measured post-commit** (no stash): with the three scripts reverted to origin/develop, 3/7 tests fail; restored clean.
- Full suite **308 files / 4098 green + 1 linux-only skip**; tsc clean; `bash -n` clean; added lines free of em/en dashes; staged list verified unfiltered before commit; remote file list checked after push.

## Card state after merge
NOTIFYVAKSWEEP826 is fully covered: 13/13 senders honest (2 originally + 11 across #1084/#1086/this), all state-stamps delivery-gated, and the record-less replay path both marked and journal-visible on failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)