### PR TITLE
fix(update): refresh the top-level scheduled-tasks seeds too + render the PROJECT_ROOT alias (SEEDREFRESH826)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,3 +43,7 @@ jobs:
           EOF
       - run: npm run typecheck
       - run: npm test
+      # Shell-test wiring (SEEDREFRESH826 fold-in, from the #1066 verify): a
+      # regression guard that only runs manually rots exactly like a one-shot
+      # seed. Runs natively here (ubuntu = the Linux branch it asserts).
+      - run: bash scripts/__tests__/stop-start-system-unit.test.sh

--- a/src/__tests__/seed-refresh-untouched-only.test.ts
+++ b/src/__tests__/seed-refresh-untouched-only.test.ts
@@ -230,3 +230,89 @@ describe('the refresh runs where it can reach an already-current machine', () =>
     expect(UPDATE).toMatch(/REGEN_CLAUDEMD/)   // the flag still exists, unchanged
   })
 })
+
+// SEEDREFRESH826: the TOP-LEVEL scheduled-tasks/ dir was a one-shot seed --
+// ensureDefaultScheduledTasks copies missing dirs at boot, update.sh never
+// refreshed them, so every shipped fix reached new installs only (measured:
+// 5/5 live seeded copies drifted on the reference host). Same untouched-only
+// rule, plus the {{PROJECT_ROOT}} alias the node seeder resolves.
+describe('top-level scheduled-tasks/ refresh (SEEDREFRESH826)', () => {
+  function makeTopLevelFixture() {
+    const base = mkdtempSync(join(tmpdir(), 'seedrefresh-top-'))
+    const install = join(base, 'install')
+    const home = join(base, 'home')
+    mkdirSync(join(install, 'scheduled-tasks', 'demo-top'), { recursive: true })
+    mkdirSync(join(home, '.claude', 'scheduled-tasks'), { recursive: true })
+    git(install, ['init', '-q'])
+    git(install, ['config', 'user.email', 'test@example.invalid'])
+    git(install, ['config', 'user.name', 'test'])
+    const task = join(install, 'scheduled-tasks', 'demo-top', 'SKILL.md')
+    const versions = [
+      'top v1: cat {{PROJECT_ROOT}}/DREAM.md ({{MAIN_AGENT_ID}})\n',
+      'top v2: cat {{PROJECT_ROOT}}/DREAM.md ({{MAIN_AGENT_ID}})\n',
+    ]
+    for (let i = 0; i < versions.length; i++) {
+      writeFileSync(task, versions[i])
+      git(install, ['add', 'scheduled-tasks/demo-top/SKILL.md'])
+      git(install, ['commit', '-q', '-m', `top v${i + 1}`])
+    }
+    // What the NODE seeder wrote at install time: v1 with PROJECT_ROOT and
+    // MAIN_AGENT_ID resolved -- exactly the on-disk shape update.sh meets.
+    const rendered = (s: string) => s.replaceAll('{{PROJECT_ROOT}}', install).replaceAll('{{MAIN_AGENT_ID}}', 'marveen')
+    const liveDir = join(home, '.claude', 'scheduled-tasks', 'demo-top')
+    mkdirSync(liveDir, { recursive: true })
+    return { base, install, home, versions, rendered, livePath: join(liveDir, 'SKILL.md') }
+  }
+
+  function runRefreshAsMain(install: string, home: string): { out: string; code: number } {
+    const script = join(install, 'probe-top.sh')
+    writeFileSync(script, [
+      'set -u',
+      'GREEN=""; NC=""',
+      `INSTALL_DIR="${install}"`,
+      `HOME="${home}"`,
+      'MAIN_AGENT_ID="marveen"; BOT_NAME="Bot"; OWNER_NAME="Owner"; WEB_PORT="3420"',
+      FUNCS,
+      'run_seed_refresh',
+    ].join('\n') + '\n')
+    try {
+      return { out: execFileSync('bash', [script], { encoding: 'utf-8' }).trim(), code: 0 }
+    } catch (e) {
+      const err = e as { stdout?: string; stderr?: string; status?: number }
+      return { out: `${String(err.stdout ?? '')}${String(err.stderr ?? '')}`.trim(), code: err.status ?? -1 }
+    }
+  }
+
+  it('an untouched node-seeded copy (old version, PROJECT_ROOT resolved) is refreshed to current', () => {
+    const f = makeTopLevelFixture()
+    try {
+      writeFileSync(f.livePath, f.rendered(f.versions[0]))
+      const r = runRefreshAsMain(f.install, f.home)
+      expect(r.code).toBe(0)
+      const after = readFileSync(f.livePath, 'utf-8')
+      expect(after).toBe(f.rendered(f.versions[1]))
+      expect(after).not.toContain('{{PROJECT_ROOT}}') // the alias renders, not leaks
+    } finally {
+      rmSync(f.base, { recursive: true, force: true })
+    }
+  })
+
+  it('a locally modified top-level task copy survives byte-for-byte', () => {
+    const f = makeTopLevelFixture()
+    try {
+      const edited = f.rendered(f.versions[0]) + '# helyi tanulsag, nem veszhet el\n'
+      writeFileSync(f.livePath, edited)
+      const r = runRefreshAsMain(f.install, f.home)
+      expect(r.code).toBe(0)
+      expect(readFileSync(f.livePath, 'utf-8')).toBe(edited)
+    } finally {
+      rmSync(f.base, { recursive: true, force: true })
+    }
+  })
+
+  it('RED-BEFORE property: without the new source line, the top-level dir is out of scope', () => {
+    // The pre-fix run_seed_refresh listed only seed-skills + seed-scheduled-tasks;
+    // this pins that the fix is the source line, not an accident of the fixture.
+    expect(FUNCS).toContain('refresh_untouched_seeds "scheduled-tasks"')
+  })
+})

--- a/update.sh
+++ b/update.sh
@@ -469,10 +469,15 @@ SEED_REFRESH_KEPT=0
 # Render a template stream the same way the seeder does. Keep in sync with the
 # sed blocks in the seeding loops below and in install-linux.sh.
 render_seed_template() {
+  # {{PROJECT_ROOT}} is the node seeder's alias for {{INSTALL_DIR}}
+  # (substituteTemplatePlaceholders) -- without it here, any shipped task using
+  # that form (ledger-live-drain does) hash-mismatches every rendered historical
+  # version and is permanently classified "touched", so it never refreshes.
   sed -e "s/{{MAIN_AGENT_ID}}/${MAIN_AGENT_ID:-}/g" \
       -e "s/{{BOT_NAME}}/${BOT_NAME:-}/g" \
       -e "s/{{OWNER_NAME}}/${OWNER_NAME:-}/g" \
       -e "s|{{INSTALL_DIR}}|${INSTALL_DIR}|g" \
+      -e "s|{{PROJECT_ROOT}}|${INSTALL_DIR}|g" \
       -e "s/{{WEB_PORT}}/${WEB_PORT:-3420}/g"
 }
 
@@ -555,6 +560,12 @@ run_seed_refresh() {
   refresh_untouched_seeds "seed-skills" "$HOME/.claude/skills" "verbatim"
   if [ -n "${MAIN_AGENT_ID:-}" ]; then
     refresh_untouched_seeds "seed-scheduled-tasks" "$HOME/.claude/scheduled-tasks" "template"
+    # SEEDREFRESH826: the TOP-LEVEL scheduled-tasks/ dir (dream-engine,
+    # memoria-heartbeat, reggeli-napindito, ledger-live-drain) was seeded by
+    # ensureDefaultScheduledTasks but never refreshed -- a one-shot seed, so
+    # every shipped fix reached new installs only. Measured on the reference
+    # host: 5/5 live seeded copies had drifted. Same untouched-only rule.
+    refresh_untouched_seeds "scheduled-tasks" "$HOME/.claude/scheduled-tasks" "template"
   fi
   if [ "$SEED_REFRESH_UPDATED" -gt 0 ]; then
     echo -e "  ${GREEN}✓${NC} Szallitott skill/feladat frissitve: ${SEED_REFRESH_UPDATED} (erintetlen masolat); megtartva: ${SEED_REFRESH_KEPT} (helyben modositott)"


### PR DESCRIPTION
## Problem (measured, card SEEDREFRESH826)
The top-level `scheduled-tasks/` dir was a **one-shot seed**: `ensureDefaultScheduledTasks` copies missing dirs at boot, and `update.sh`'s untouched-only refresh covered only `seed-skills/` and `seed-scheduled-tasks/`. Every shipped fix to these prompts reached new installs only -- measured on the reference host: 5/5 live seeded copies drifted (and the drift is bidirectional: our own host also missed repo-side lessons, per the card).

## Fix (two lines, both on the proven machinery)
- `run_seed_refresh` gains `scheduled-tasks/` as a third source (template mode). Same untouched-only contract: refresh only a copy byte-identical to SOME shipped rendered version (last 25 revisions); a locally modified copy survives byte-for-byte -- our hand-edited live tasks are explicitly safe.
- `render_seed_template` resolves `{{PROJECT_ROOT}}` as the node seeder's alias for `{{INSTALL_DIR}}`. Without it, a task shipped in that form (`ledger-live-drain`) hash-mismatches every rendered historical version and is **permanently classified touched** -- it would never refresh, silently.
- **CI wiring folded in from the #1066 verify** (Marveen's grouping): `stop-start-system-unit.test.sh` now runs in the test workflow (ubuntu = the Linux branch it asserts). A regression guard that only runs manually rots exactly like a one-shot seed.

## Verification
- The existing `seed-refresh-untouched-only` harness gains a top-level fixture with PROJECT_ROOT-resolved, node-seeded copies: untouched old copy refreshes to current with the alias rendered (no literal placeholder leaks); a locally edited copy survives byte-for-byte; a source pin holds the new refresh line. 14/14.
- **Red-before measured post-commit**: with `update.sh` reverted to the pre-fix version, 2/14 fail (the top-level refresh + the pin); restored clean.
- Full suite **309 files / 4110 green + 1 linux-only skip** on the fresh develop base (includes #1087/#1088); `bash -n` + tsc clean; staged list verified unfiltered before commit (incl. after a stash/pop base-update -- today's lesson applied).

## What this PR does NOT do (stated)
Our OWN host's 5 hand-edited live copies are TOUCHED by design, so this mechanism correctly never rewrites them. Reconciling those (repo is now the superset for 3 of 5 after #1085; 2 carry host-only items) is a separate, announced live-file round on the card -- not silent surgery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)