### PR TITLE
fix(scripts): LIVE limit-monitor dedupe hashed with a tool macOS does not have -- shared existence-checked hash helper (MD5SUMHIANY826)

### DIFF
--- a/scripts/lib/content-hash.sh
+++ b/scripts/lib/content-hash.sh
@@ -1,0 +1,71 @@
+# Shared, existence-checked content hashing for shell scripts (MD5SUMHIANY826).
+#
+# Why this exists: `md5sum` does not exist on macOS, and the flagship host's
+# service PATH does not even carry /sbin/md5. A bare `... | md5sum | awk ...`
+# pipeline therefore yields an EMPTY string with exit 0 -- and two empty
+# hashes are EQUAL. The same root cause produced two OPPOSITE lies on the
+# same day: the limit-monitor dedupe saw every alert as "already sent" and
+# swallowed all of them, while a session-stuck comparison saw two live pane
+# captures as "unchanged" and raised a false alarm. A hash helper must never
+# hand back an empty fingerprint: it either hashes or it FAILS.
+#
+# Usage:
+#   . "$INSTALL_DIR/scripts/lib/content-hash.sh"
+#   HASH="$(printf '%s' "$data" | content_hash)" || <handle loudly>
+#
+#   printf '%s' "$data" | dedupe_check "$state_file"
+#     exit 0 -> NEW signal (caller should alert; stamp the state file with
+#               the printed hash ONLY after a confirmed send)
+#     exit 1 -> unchanged (already alerted)
+#     exit 2 -> hashing unavailable (caller must fail OPEN for alert paths:
+#               better a duplicate alert than a swallowed one)
+#
+# The output is prefixed with the algorithm (md5:/sha1:/cksum:) so fingerprints
+# from different tiers can never compare equal by accident when a host's PATH
+# changes between runs.
+
+# Tool availability probe. CONTENT_HASH_DISABLE is a space-separated list of
+# tool names/paths to treat as absent -- a TEST seam only: the no-tool branch
+# is otherwise unreachable on any sane host (cksum is POSIX), and a branch
+# that cannot be exercised is a branch that rots.
+_ch_has() {
+  case " ${CONTENT_HASH_DISABLE:-} " in *" $1 "*) return 1 ;; esac
+  command -v "$1" >/dev/null 2>&1
+}
+
+content_hash() {
+  if _ch_has md5sum; then
+    printf 'md5:%s' "$(md5sum | awk '{print $1}')"
+    return 0
+  fi
+  # macOS/BSD md5 reads stdin and prints the bare digest. The service PATH may
+  # miss /sbin, so probe absolute locations too.
+  for _ch_md5 in md5 /sbin/md5 /usr/bin/md5; do
+    if _ch_has "$_ch_md5"; then
+      printf 'md5:%s' "$("$_ch_md5")"
+      return 0
+    fi
+  done
+  if _ch_has shasum; then
+    printf 'sha1:%s' "$(shasum | awk '{print $1}')"
+    return 0
+  fi
+  # cksum is POSIX-mandated; reaching past it means a broken userland.
+  if _ch_has cksum; then
+    printf 'cksum:%s' "$(cksum | awk '{print $1"-"$2}')"
+    return 0
+  fi
+  echo "content_hash: no hashing tool available (md5sum/md5/shasum/cksum) -- refusing to return an empty fingerprint" >&2
+  return 127
+}
+
+# Reads the candidate from stdin, prints its hash, and answers whether it is
+# NEW relative to the state file. Never writes the state file itself: the
+# stamp belongs to the caller, AFTER a confirmed delivery (NOTIFYVAKSWEEP826).
+dedupe_check() {
+  _dc_state="$1"
+  _dc_hash="$(content_hash)" || return 2
+  printf '%s' "$_dc_hash"
+  _dc_prev="$(cat "$_dc_state" 2>/dev/null)"
+  [ "$_dc_hash" != "$_dc_prev" ]
+}

--- a/scripts/limit-monitor.sh
+++ b/scripts/limit-monitor.sh
@@ -59,12 +59,26 @@ fi
 # its own dedupe -- the send failed, the hash said "already alerted", and the
 # warning was lost forever, precisely during quota/network degradation
 # (NOTIFYVAKSWEEP826, the worst row of the sweep).
-HASH="$(printf '%s' "$CANDIDATE" | md5sum | awk '{print $1}')"
-PREV="$(cat "$STATE" 2>/dev/null)"
-if [ "$HASH" = "$PREV" ]; then
-  log "signal unchanged, already alerted ($HASH)"
-  exit 0
-fi
+#
+# The hash comes from the shared existence-checked helper (MD5SUMHIANY826):
+# the old bare `md5sum` pipeline yielded an EMPTY hash on macOS (no md5sum),
+# empty == empty compared "unchanged", and every alert was silently swallowed
+# on the flagship host. If NO hashing tool exists at all, this path fails
+# OPEN: a duplicate alert on every tick is recoverable, a swallowed limit
+# warning is not.
+. "$INSTALL_DIR/scripts/lib/content-hash.sh"
+HASH="$(printf '%s' "$CANDIDATE" | dedupe_check "$STATE")"
+case $? in
+  0) : ;; # new signal -> alert below
+  1)
+    log "signal unchanged, already alerted ($HASH)"
+    exit 0
+    ;;
+  *)
+    HASH=""
+    log "content_hash UNAVAILABLE -- dedupe disabled for this tick, alerting anyway (fail-open)"
+    ;;
+esac
 
 # Alert the owner via Bot API (token-free path; no Claude invocation)
 TOKEN="$(grep -oE '[0-9]+:[A-Za-z0-9_-]+' "$HOME/.claude/channels/telegram/.env" 2>/dev/null | head -1)"
@@ -81,8 +95,10 @@ if [ -n "$TOKEN" ]; then
   # next timer tick instead of vanishing.
   . "$INSTALL_DIR/scripts/lib/send-telegram.sh"
   if send_telegram_message "$TOKEN" "$CHAT_ID" "$MSG" --data-urlencode "disable_web_page_preview=true" 2>>"$LOG"; then
-    echo "$HASH" > "$STATE"
-    log "ALERT sent to $CHAT_ID: $HASH"
+    # No stamp on an empty hash (fail-open tick): an empty state file is the
+    # exact shape the MD5SUMHIANY826 bug hid behind.
+    [ -n "$HASH" ] && echo "$HASH" > "$STATE"
+    log "ALERT sent to $CHAT_ID: ${HASH:-nohash}"
   else
     log "ALERT send FAILED (will retry next tick, stamp NOT written): $HASH"
   fi

--- a/src/__tests__/content-hash.test.ts
+++ b/src/__tests__/content-hash.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+// MD5SUMHIANY826: the shared content-hash helper must never hand back an
+// empty fingerprint. The old bare `md5sum` pipeline did exactly that on
+// macOS, and the SAME root cause produced two opposite lies: the
+// limit-monitor dedupe swallowed every alert (empty == empty -> "already
+// sent"), while a session-stuck pane comparison called two live captures
+// "unchanged" and raised a false alarm. These tests run the REAL helper in a
+// real bash.
+
+const HELPER = resolve(__dirname, '../../scripts/lib/content-hash.sh')
+const NO_TOOLS = 'md5sum md5 /sbin/md5 /usr/bin/md5 shasum cksum'
+
+function bash(script: string, env: Record<string, string> = {}): { out: string; code: number } {
+  try {
+    // Absolute bash: with a stripped PATH in env, a PATH-resolved spawn would
+    // ENOENT before the helper under test even runs.
+    const out = execFileSync('/bin/bash', ['-c', script], {
+      encoding: 'utf8',
+      env: { ...process.env, ...env },
+    })
+    return { out, code: 0 }
+  } catch (err) {
+    const e = err as { stdout?: string; status?: number }
+    return { out: e.stdout ?? '', code: e.status ?? -1 }
+  }
+}
+
+describe('content_hash', () => {
+  it('hashes stdin with an algorithm prefix and is stable', () => {
+    const a1 = bash(`. ${HELPER}; printf 'alma' | content_hash`)
+    const a2 = bash(`. ${HELPER}; printf 'alma' | content_hash`)
+    expect(a1.code).toBe(0)
+    expect(a1.out).toMatch(/^(md5|sha1|cksum):\S+$/)
+    expect(a1.out).toBe(a2.out)
+  })
+
+  it('different content yields different fingerprints (the session-stuck false-alarm case)', () => {
+    const a = bash(`. ${HELPER}; printf 'pane snapshot A' | content_hash`)
+    const b = bash(`. ${HELPER}; printf 'pane snapshot B' | content_hash`)
+    expect(a.out).not.toBe(b.out)
+  })
+
+  it('FAILS with no output when no hashing tool exists -- never an empty string', () => {
+    // The absolute-path md5 probe works regardless of PATH (that is a
+    // feature), so absence is simulated via the helper's test seam.
+    const r = bash(`. ${HELPER}; printf 'alma' | content_hash`, { CONTENT_HASH_DISABLE: NO_TOOLS })
+    expect(r.code).toBe(127)
+    expect(r.out).toBe('')
+  })
+})
+
+describe('dedupe_check (limit-monitor contract)', () => {
+  it('known positive: a SECOND, DIFFERENT alert in the same window must get out', () => {
+    // This is the exact control the card demands: the broken empty-hash
+    // dedupe passed the first alert concept and swallowed every later one.
+    const dir = mkdtempSync(join(tmpdir(), 'md5fix-'))
+    const state = join(dir, 'state')
+
+    // Alert 1: new -> exit 0, caller stamps after confirmed send.
+    const first = bash(`. ${HELPER}; printf 'limit signal A' | dedupe_check ${state}`)
+    expect(first.code).toBe(0)
+    expect(first.out).toMatch(/^(md5|sha1|cksum):/)
+    writeFileSync(state, first.out)
+
+    // Same alert again: unchanged -> exit 1 (deduped).
+    const repeat = bash(`. ${HELPER}; printf 'limit signal A' | dedupe_check ${state}`)
+    expect(repeat.code).toBe(1)
+
+    // Alert 2, DIFFERENT content, same window: MUST come back as new.
+    const second = bash(`. ${HELPER}; printf 'limit signal B' | dedupe_check ${state}`)
+    expect(second.code).toBe(0)
+    expect(second.out).not.toBe(first.out)
+  })
+
+  it('empty state file never swallows a real signal (the original bug shape)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'md5fix-'))
+    const state = join(dir, 'state')
+    writeFileSync(state, '') // what the broken pipeline left behind
+    const r = bash(`. ${HELPER}; printf 'limit signal' | dedupe_check ${state}`)
+    expect(r.code).toBe(0)
+    expect(r.out).not.toBe('')
+  })
+
+  it('hashing unavailable -> exit 2 so the caller can fail OPEN', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'md5fix-'))
+    const state = join(dir, 'state')
+    const r = bash(`. ${HELPER}; printf 'x' | dedupe_check ${state}`, { CONTENT_HASH_DISABLE: NO_TOOLS })
+    expect(r.code).toBe(2)
+  })
+})
+
+describe('limit-monitor wiring', () => {
+  it('sources the shared helper and no bare md5sum pipeline remains', () => {
+    const monitor = readFileSync(resolve(__dirname, '../../scripts/limit-monitor.sh'), 'utf8')
+    expect(monitor).toContain('scripts/lib/content-hash.sh')
+    expect(monitor).toContain('dedupe_check')
+    expect(monitor).not.toMatch(/\|\s*md5sum/)
+  })
+})

--- a/src/__tests__/send-honesty-sweep.test.ts
+++ b/src/__tests__/send-honesty-sweep.test.ts
@@ -34,6 +34,8 @@ function stageTree(scriptNames: string[]): { root: string; bin: string } {
   mkdirSync(join(stage, 'store'), { recursive: true })
   for (const s of scriptNames) cpSync(join(ROOT, 'scripts', s), join(scripts, s))
   cpSync(join(ROOT, 'scripts', 'lib', 'send-telegram.sh'), join(scripts, 'lib', 'send-telegram.sh'))
+  // limit-monitor's dedupe hash comes from the shared helper (MD5SUMHIANY826).
+  cpSync(join(ROOT, 'scripts', 'lib', 'content-hash.sh'), join(scripts, 'lib', 'content-hash.sh'))
   const bin = join(stage, 'bin')
   mkdirSync(bin, { recursive: true })
   writeFileSync(join(bin, 'curl'),


### PR DESCRIPTION
## Touches a LIVE surface (top billing, per the new rule)

`scripts/limit-monitor.sh` -- the running limit-alert timer on every install -- and its dedupe path. Behavior change is deliberate and is the fix.

## The bug (two opposite lies, one root cause)

The dedupe piped through `md5sum`, which does not exist on macOS: the hash was an **empty string with exit 0**, and empty == empty, so on the flagship host **every text-path limit alert compared 'unchanged' and was silently swallowed** (dedupe sits BEFORE the sender, so the honest-send sweep could not catch it). The same day the same root cause produced the opposite lie in Marveen's session-stuck pane comparison: two live captures hashed empty, compared equal, false 'stuck' verdict.

## The fix

- **`scripts/lib/content-hash.sh` (new, shared)**: `content_hash()` tiers md5sum → md5 (absolute `/sbin`/`/usr/bin` probes too -- the service PATH misses /sbin on the flagship host, measured) → shasum → POSIX cksum; output is algorithm-prefixed so cross-tier fingerprints never compare equal by accident; if nothing exists it **fails (127, no output) -- never an empty string**. `dedupe_check()` wraps the compare and never writes the stamp: that stays with the caller, after a confirmed send (NOTIFYVAKSWEEP826 contract kept).
- **limit-monitor.sh**: sources the helper; if hashing is unavailable the alert path **fails OPEN** (a duplicate alert is recoverable, a swallowed limit warning is not), and an empty hash is never stamped.
- Marveen's own check scripts can source the same helper -- that was the ask: one shared, existence-checked implementation.

## Verify

- **Known positive (the card's explicit gate)**: two DIFFERENT alerts in the same dedupe window -- the second MUST get out; covered by a real-bash test against the real helper, plus: same-alert dedupes, empty state file never swallows, no-tool → loud 127/exit-2 (via a documented test seam -- the branch is otherwise unreachable since cksum is POSIX).
- Live on the flagship host: the helper picks the `/sbin/md5` tier and returns a real fingerprint (measured in this session's shell, where `command -v md5sum` and `command -v md5` both fail).
- send-honesty-sweep staging updated to ship the new lib; its stamp-lifecycle tests pass unchanged.
- **Full suite: 4117 passed / 1 skipped** (run from the worktree, not /tmp).

## Rollout note

Existing Linux installs: the state format gains an algo prefix, so the first tick after upgrade re-alerts once if a signal is live -- one duplicate, then normal. The fix reaches the flagship host with the next host-update (HOSTLAG flow), not by merge alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)