### PR TITLE
fix(hooks): LIVE outgoing-copy gate fires on the resend METHOD, not the hostname (RESENDGATE826)

### DIFF
--- a/scripts/hooks/outgoing-copy-gate.py
+++ b/scripts/hooks/outgoing-copy-gate.py
@@ -108,6 +108,88 @@ def _code_string_sends(code: str) -> bool:
 # Token-ELEJERE horgonyzott cel-minta: egy URL-argumentum vagy csupasz
 # domain/utvonal illik ra; egy JSON-payload ('{...api.resend.com...}') nem.
 _RESEND_TARGET = re.compile(r"^(https?://)?([^/@\s]*\.)?api\.resend\.com(/|$|\s|$)", re.I)
+
+# RESENDGATE826: a resend-celu curl/wget csak akkor KULDES, ha a METODUS az.
+# A korabbi minta metodus-vak volt, es egy read-only GET /domains (nincs torzs,
+# nincs cimzett) ugyanugy fail-closed elutasitast kapott -- pont egy domain-
+# verifikacios MERES akadt el rajta. A szukites iranya szigoru: a metodust
+# FELISMERNI kell (explicit -X/--request/--method, vagy implicit POST a
+# torzs-flagekbol); ha nem allapithato meg (valtozo, config-fajl, csonka flag),
+# marad a fail-closed. Egy "nincs felismerheto torzs -> atmegy" szabaly a
+# kaput utne ki, ezert ILYEN AG NINCS.
+_CURL_BODY_OPTS = {
+    "-d", "--data", "--data-raw", "--data-binary", "--data-urlencode",
+    "--data-ascii", "-F", "--form", "--form-string", "--json",
+    "-T", "--upload-file",
+    # wget torzs-flagek
+    "--post-data", "--post-file", "--body-data", "--body-file",
+}
+_SAFE_METHODS = {"GET", "HEAD"}
+
+
+def _curl_resend_verdict(rest):
+    """'read' | 'send' | 'unknown' -- unknown a hivo oldalon fail-closed."""
+    method = None
+    has_body = False
+    get_forced = False
+    i, n = 0, len(rest)
+    while i < n:
+        t = rest[i]
+        if t in ("-X", "--request", "--method"):
+            if i + 1 >= n or not rest[i + 1].isalpha():
+                return "unknown"  # csonka vagy valtozo ($METHOD) -- nem dontheto
+            method = rest[i + 1].upper()
+            i += 2
+            continue
+        if t.startswith("--request=") or t.startswith("--method="):
+            m = t.split("=", 1)[1]
+            if not m.isalpha():
+                return "unknown"
+            method = m.upper()
+            i += 1
+            continue
+        if t in ("-G", "--get"):
+            get_forced = True
+            i += 1
+            continue
+        if t in ("-K", "--config"):
+            return "unknown"  # a config-fajl rejtett metodust/torzset hordozhat
+        if t in _CURL_BODY_OPTS or any(
+            t.startswith(o + "=") for o in _CURL_BODY_OPTS if o.startswith("--")
+        ):
+            has_body = True
+            i += 1
+            continue
+        if t.startswith("-") and not t.startswith("--") and len(t) > 1:
+            # egy-kotojeles cluster (-sS, -sX POST, -sd '{}'): a betuk kotegelve
+            letters = t[1:]
+            if "X" in letters:
+                after = letters.split("X", 1)[1]
+                if after:
+                    if not after.isalpha():
+                        return "unknown"
+                    method = after.upper()
+                else:
+                    if i + 1 >= n or not rest[i + 1].isalpha():
+                        return "unknown"
+                    method = rest[i + 1].upper()
+                    i += 1
+            elif "d" in letters or "F" in letters or "T" in letters:
+                has_body = True
+            elif "G" in letters:
+                get_forced = True
+            elif "K" in letters:
+                return "unknown"
+            i += 1
+            continue
+        i += 1
+    if method is not None and method not in _SAFE_METHODS:
+        return "send"
+    if has_body and not get_forced:
+        # implicit POST (curl -d/-F/--json/-T alapertelmezese), vagy egy
+        # gyanus "GET torzzsel" alak -- mindketto kuldeskent kezelve
+        return "send"
+    return "read"
 # A tovabbi kuldes-jellegu literalok, amikre a parse-hiba eseten (es CSAK
 # akkor) konzervativan visszaesunk -- lasd is_send_invocation vegen.
 _FALLBACK_LITERALS = re.compile(
@@ -197,9 +279,12 @@ def _segment_is_send(toks, depth: int) -> bool:
     if any(_GRAPHMAIL.match(_basename(t)) for t in toks) and "send" in rest:
         return True
     # curl/wget: a cel-token akkor is muvelet, ha idezojelben allt -- a
-    # horgonyzott minta valasztja el a payload-belseji emlitestol
+    # horgonyzott minta valasztja el a payload-belseji emlitestol.
+    # RESENDGATE826: csak a TENYLEGES kuldes (POST/PUT/... vagy torzs) akad
+    # fenn; a read-only GET/HEAD lekerdezes atmegy; a nem-donthato metodus
+    # tovabbra is fail-closed.
     if _CURLISH.match(prog) and any(_RESEND_TARGET.match(t) for t in rest):
-        return True
+        return _curl_resend_verdict(rest) != "read"
     return False
 
 

--- a/src/__tests__/outgoing-copy-gate-scope.test.ts
+++ b/src/__tests__/outgoing-copy-gate-scope.test.ts
@@ -148,3 +148,40 @@ describe('outgoing-copy gate: quoted tokens in OPERATION position still fire (ms
     expect(isSend(`echo "lezaratlan idezojel, artalmatlan szoveg`)).toBe(false)
   })
 })
+
+describe('RESENDGATE826: the resend trigger fires on the METHOD, not the hostname', () => {
+  // The method-blind pattern blocked a read-only GET /domains (no body, no
+  // recipient, nothing leaves) exactly when a domain-verification MEASUREMENT
+  // needed it. The narrowing is strict: recognize the method, or stay closed.
+
+  it('read-only queries pass: bare GET, explicit GET, forced -G', () => {
+    expect(isSend(`curl -s -H "Authorization: Bearer re_x" https://api.resend.com/domains`)).toBe(false)
+    expect(isSend(`curl -sS -X GET https://api.resend.com/emails/abc123 -H "Authorization: Bearer re_x"`)).toBe(false)
+    expect(isSend(`curl -G https://api.resend.com/domains -H "Authorization: Bearer re_x"`)).toBe(false)
+    expect(isSend(`wget -qO- https://api.resend.com/domains`)).toBe(false)
+  })
+
+  it('KNOWN POSITIVE: a real POST /emails still fires, in every spelling', () => {
+    // The condition of the narrowing: an actual send may never slip through.
+    expect(isSend(`curl -X POST https://api.resend.com/emails -H "Authorization: Bearer X" -d '{"to":"a@b.hu"}'`)).toBe(true)
+    expect(isSend(`curl 'https://api.resend.com/emails' -d @/tmp/mail.json`)).toBe(true) // implicit POST via body
+    expect(isSend(`curl -sX POST https://api.resend.com/emails -d '{}'`)).toBe(true) // bundled cluster
+    expect(isSend(`curl --request=POST https://api.resend.com/emails`)).toBe(true)
+    expect(isSend(`curl --json '{"to":"a@b.hu"}' https://api.resend.com/emails`)).toBe(true)
+  })
+
+  it('state-changing non-POST methods fire too', () => {
+    expect(isSend(`curl -X DELETE https://api.resend.com/emails/abc123`)).toBe(true)
+    expect(isSend(`curl --request PATCH https://api.resend.com/emails/abc123 -d '{"scheduled_at":null}'`)).toBe(true)
+  })
+
+  it('an undeterminable method stays FAIL-CLOSED: variable, truncated flag, config file', () => {
+    expect(isSend(`curl -X "$METHOD" https://api.resend.com/domains`)).toBe(true)
+    expect(isSend(`curl https://api.resend.com/domains -X`)).toBe(true)
+    expect(isSend(`curl -K /tmp/curlrc https://api.resend.com/domains`)).toBe(true)
+  })
+
+  it('a GET carrying a body is suspicious and stays closed', () => {
+    expect(isSend(`curl -X GET https://api.resend.com/emails -d '{"to":"a@b.hu"}'`)).toBe(true)
+  })
+})


### PR DESCRIPTION
## Touches a LIVE hook (top billing)

`scripts/hooks/outgoing-copy-gate.py` -- every fleet session runs it on Bash commands. The behavior change is deliberate and is the fix.

## The bug

The `_RESEND_TARGET` trigger was method-blind: ANY curl whose URL pointed at api.resend.com counted as a send. A read-only `GET /domains` (no body, no recipient, nothing leaves the machine) got the same fail-closed refusal -- and blocked the domain-verification measurement that is a precondition of the licence-email work (msg 16174).

## The narrowing (strict, per the review condition)

The METHOD must be recognized -- there is deliberately **no 'no visible body → pass' branch**, because that would gut the gate:

- **read (passes)**: bare/explicit GET or HEAD, forced `-G/--get`, wget default
- **send (fires)**: explicit non-safe method (`-X`/`--request`/`--method`, `=` forms, bundled clusters like `-sX POST`), OR a body flag (`-d`/`--data*`/`-F`/`--form*`/`--json`/`-T`, wget `--post-*`/`--body-*`) implying POST, OR the suspicious 'GET carrying a body' shape
- **unknown (fail-closed, fires)**: variable method (`-X "$METHOD"`), truncated flag, `-K/--config` (a config file can hide both method and body)

## Verify

- **Known positive kept and widened** (the explicit condition): a real `POST /emails` still fires in every spelling -- explicit `-X POST`, implicit body-only, bundled `-sX POST`, `--request=POST`, `--json`. DELETE and PATCH fire. All three undeterminable shapes fire.
- The four read-only shapes pass (bare GET, `-X GET`, `-G`, wget).
- Gate suites 32/32; **full suite 4122 passed / 1 skipped** (run from the worktree).
- The pre-existing content-side protections are untouched: payload-internal api.resend.com mentions still do not fire (existing tests kept green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)