### PR TITLE
fix(watchdog): the session watchdog's respawn keeps per-agent config isolation

### DIFF
--- a/scripts/__tests__/watchdog-config-isolation.test.sh
+++ b/scripts/__tests__/watchdog-config-isolation.test.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# Contract tests for scripts/watchdog.sh launch-env isolation parity.
+#
+# Regression origin: the dashboard launches every sub-agent with a per-agent
+# CLAUDE_CONFIG_DIR (agent-process.ts provisions <agent>/.claude-config, gated
+# on store/.claude-oauth-token), and channel-watchdog.sh rebuilds the same
+# CFG_ENV on its respawn path -- but this watchdog's tmux launch dropped both.
+# The FIRST auto-recovery therefore silently moved an agent back onto the
+# shared ~/.claude, reintroducing the plugin-slot collisions isolation exists
+# to prevent (a live fleet measured 9 agents de-isolated this way).
+#
+# Driven through `watchdog.sh --launch-env <dir>`, which prints the prefix and
+# exits before touching tmux, the dashboard API or the log -- so these run
+# from fixtures with no live agent and no real token.
+# Run: bash scripts/__tests__/watchdog-config-isolation.test.sh
+
+set -u
+
+PASS=0; FAIL=0
+pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1 -- got: $2"; }
+
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+# Overridable so the suite can be pointed at a deliberately-broken copy to
+# confirm it actually fails on the bug.
+WATCHDOG="${WATCHDOG_BIN:-$REPO_DIR/scripts/watchdog.sh}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# The watchdog resolves store/.claude-oauth-token relative to its own
+# INSTALL_DIR; run it from a fixture install so the token file is ours.
+FIXTURE_INSTALL="$TMP/install"
+mkdir -p "$FIXTURE_INSTALL/scripts" "$FIXTURE_INSTALL/store" "$FIXTURE_INSTALL/agents"
+cp "$WATCHDOG" "$FIXTURE_INSTALL/scripts/watchdog.sh"
+WD="$FIXTURE_INSTALL/scripts/watchdog.sh"
+
+AGENT_ISO="$FIXTURE_INSTALL/agents/iso-agent"
+AGENT_PLAIN="$FIXTURE_INSTALL/agents/plain-agent"
+mkdir -p "$AGENT_ISO/.claude-config" "$AGENT_PLAIN"
+
+echo "watchdog launch-env isolation contract:"
+
+# 1) No fleet token at all -> no isolation, even with a provisioned dir
+#    (matches agent-process.ts gating: no token -> intended shared mode).
+OUT="$(bash "$WD" --launch-env "$AGENT_ISO")"
+case "$OUT" in
+  isolation=no) pass "no token file -> no isolation" ;;
+  *) fail "no token file -> no isolation" "$OUT" ;;
+esac
+
+# 2) Empty token file -> still no isolation (gate is -s, not -f).
+: > "$FIXTURE_INSTALL/store/.claude-oauth-token"
+OUT="$(bash "$WD" --launch-env "$AGENT_ISO")"
+case "$OUT" in
+  isolation=no) pass "empty token file -> no isolation" ;;
+  *) fail "empty token file -> no isolation" "$OUT" ;;
+esac
+
+# 3) Token present + provisioned dir -> isolation prefix with both exports.
+echo "sk-test-fixture-token" > "$FIXTURE_INSTALL/store/.claude-oauth-token"
+OUT="$(bash "$WD" --launch-env "$AGENT_ISO")"
+case "$OUT" in
+  "isolation=yes prefix="*CLAUDE_CONFIG_DIR*CLAUDE_CODE_OAUTH_TOKEN*)
+    pass "token + .claude-config -> isolation prefix" ;;
+  *) fail "token + .claude-config -> isolation prefix" "$OUT" ;;
+esac
+
+# 4) The literal token must NOT appear in the prefix: it is read inside the
+#    pane via \$(cat ...), so it never lands in the command string or ps.
+case "$OUT" in
+  *sk-test-fixture-token*) fail "literal token kept out of the prefix" "$OUT" ;;
+  *'$(cat '*) pass "literal token kept out of the prefix (read via \$(cat))" ;;
+  *) fail "literal token kept out of the prefix" "$OUT" ;;
+esac
+
+# 5) Token present but the agent has no .claude-config -> no isolation
+#    (unprovisioned agents keep their current behaviour).
+OUT="$(bash "$WD" --launch-env "$AGENT_PLAIN")"
+case "$OUT" in
+  isolation=no) pass "no .claude-config dir -> no isolation" ;;
+  *) fail "no .claude-config dir -> no isolation" "$OUT" ;;
+esac
+
+echo "watchdog-config-isolation: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/scripts/watchdog.sh
+++ b/scripts/watchdog.sh
@@ -48,6 +48,33 @@ if [ "${1:-}" = "--resolve-provider" ]; then
   exit 0
 fi
 
+# ISOLATION PARITY: the dashboard launches every sub-agent with a per-agent
+# CLAUDE_CONFIG_DIR (agent-process.ts provisions <agent>/.claude-config, gated
+# on the fleet OAuth token) so plugin registries never clobber each other in
+# the shared ~/.claude. channel-watchdog.sh already rebuilds the same CFG_ENV
+# on its respawn path (channel-watchdog.sh:183-201); this watchdog's tmux
+# launch dropped it, so the FIRST auto-recovery silently moved an agent back
+# onto the shared ~/.claude. Same gating as agent-process.ts: no token file ->
+# no isolation (degraded shared mode is then the intended behaviour). The
+# token is read inside the pane via $(cat), so the literal secret never lands
+# in the command string, `ps` output or tmux pane history.
+agent_launch_env() {
+  local AGENT_DIR="$1"
+  if [ -d "$AGENT_DIR/.claude-config" ] && [ -s "$INSTALL_DIR/store/.claude-oauth-token" ]; then
+    printf '%s' "export CLAUDE_CONFIG_DIR=\"$AGENT_DIR/.claude-config\" && export CLAUDE_CODE_OAUTH_TOKEN=\"\$(cat '$INSTALL_DIR/store/.claude-oauth-token')\" && "
+  fi
+}
+
+# Self-test hook, mirroring --resolve-provider: print the launch-env prefix
+# for one agent dir and exit, so the isolation contract is testable from
+# fixtures (scripts/__tests__/watchdog-config-isolation.test.sh).
+if [ "${1:-}" = "--launch-env" ]; then
+  [ -n "${2:-}" ] || { echo "usage: watchdog.sh --launch-env <agent-dir>" >&2; exit 2; }
+  ENV_PREFIX="$(agent_launch_env "$2")"
+  if [ -n "$ENV_PREFIX" ]; then echo "isolation=yes prefix=$ENV_PREFIX"; else echo "isolation=no"; fi
+  exit 0
+fi
+
 
 export PATH="/opt/homebrew/bin:$HOME/.bun/bin:/home/linuxbrew/.linuxbrew/bin:$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
 
@@ -145,7 +172,9 @@ for AGENT_DIR in "$INSTALL_DIR/agents"/*/; do
     continue
   fi
 
-  CMD="export PATH=\"/opt/homebrew/bin:\$HOME/.bun/bin:/home/linuxbrew/.linuxbrew/bin:\$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin:\$PATH\" && unset TELEGRAM_BOT_TOKEN SLACK_BOT_TOKEN SLACK_APP_TOKEN DISCORD_BOT_TOKEN && export ${STATE_ENV_VAR}=\"$CHAN_DIR\" && cd \"$AGENT_DIR\" && ${CLAUDE_BIN} --dangerously-skip-permissions --model '$MODEL' --channels plugin:${AGENT_PROVIDER}@claude-plugins-official"
+  ISO_ENV="$(agent_launch_env "$AGENT_DIR")"
+
+  CMD="${ISO_ENV}export PATH=\"/opt/homebrew/bin:\$HOME/.bun/bin:/home/linuxbrew/.linuxbrew/bin:\$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin:\$PATH\" && unset TELEGRAM_BOT_TOKEN SLACK_BOT_TOKEN SLACK_APP_TOKEN DISCORD_BOT_TOKEN && export ${STATE_ENV_VAR}=\"$CHAN_DIR\" && cd \"$AGENT_DIR\" && ${CLAUDE_BIN} --dangerously-skip-permissions --model '$MODEL' --channels plugin:${AGENT_PROVIDER}@claude-plugins-official"
 
   tmux new-session -d -s "$SESSION_NAME" "$CMD" 2>/dev/null
   sleep 2


### PR DESCRIPTION
## Symptom

The 5-minute session watchdog (`scripts/watchdog.sh`) relaunches a missing agent WITHOUT the per-agent `CLAUDE_CONFIG_DIR` and fleet OAuth token the dashboard provisions. The first auto-recovery therefore silently moves the agent back onto the shared `~/.claude`, reintroducing exactly the plugin-slot collisions isolation exists to prevent. From the log the restart looks routine ("restarted OK").

## When it broke

Never worked: the isolation mechanism (agent-process.ts provisioning `<agent>/.claude-config`, gated on `store/.claude-oauth-token`) shipped with the dashboard launcher and was mirrored onto `channel-watchdog.sh`'s respawn path (its CFG_ENV block names this exact gap), but `watchdog.sh`'s tmux launch was never updated. A live fleet measured nine agents de-isolated after watchdog sweeps.

## Reproduction

1. Provision an agent via the dashboard (it gets `<agent>/.claude-config` and runs with `CLAUDE_CONFIG_DIR` set).
2. Kill its tmux session and let the watchdog restart it.
3. `ps eww` on the new pane: no `CLAUDE_CONFIG_DIR` -- the agent is back on the shared `~/.claude`.

Fixture-level: `bash scripts/__tests__/watchdog-config-isolation.test.sh` -- 5/5 fail against the previous script, 5/5 pass with the fix.

## Fix

`agent_launch_env()` builds the same prefix as `channel-watchdog.sh` with the same gating as `agent-process.ts`: no token file (or empty) -> no isolation, because degraded shared mode is then the intended behaviour; provisioned dir + token -> `CLAUDE_CONFIG_DIR` + `CLAUDE_CODE_OAUTH_TOKEN` exports. The token is read inside the pane via `$(cat ...)`, so the literal secret never lands in the command string, `ps` output or pane history. A `--launch-env` self-test hook mirrors the existing `--resolve-provider` pattern so the contract runs from fixtures.

## Tests

New `scripts/__tests__/watchdog-config-isolation.test.sh` (token gating both directions, unprovisioned agent untouched, literal-token-never-in-prefix). Existing `watchdog-provider.test.sh`: 11/11 still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)