### PR TITLE
fix(watchdog): never start a half-scaffolded agent

### DIFF
--- a/scripts/__tests__/watchdog-scaffold-guard.test.sh
+++ b/scripts/__tests__/watchdog-scaffold-guard.test.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Contract tests for scripts/watchdog.sh half-scaffolded-agent guard.
+#
+# Regression origin: the dashboard wizard creates the agent directory first
+# and only then generates CLAUDE.md / SOUL.md through an LLM call. On a live
+# install that call took over five minutes. The watchdog ticks every few
+# minutes, saw the fresh directory as "an agent that should be running", and
+# started the session roughly three minutes before CLAUDE.md was written. The
+# agent came up with no identity, no rules and no persona, and stayed that
+# way: Claude Code reads CLAUDE.md at startup, so nothing short of a restart
+# could fix it. From the outside it looks like the creation failed.
+#
+# Driven through `watchdog.sh --check-scaffolded <dir>`, which evaluates the
+# predicate and exits before touching tmux, the dashboard API or the log -- so
+# these run from fixtures with no live agent.
+# Run: bash scripts/__tests__/watchdog-scaffold-guard.test.sh
+
+set -u
+
+PASS=0; FAIL=0
+pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1 -- got: $2"; }
+
+INSTALL_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+# Overridable so the suite can be pointed at a deliberately-broken copy to
+# confirm it actually fails on the bug.
+WATCHDOG="${WATCHDOG_BIN:-$INSTALL_DIR/scripts/watchdog.sh}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# $1 = fixture name, $2.. = files to create inside it
+make_agent() {
+  local dir="$TMP/$1"; shift
+  mkdir -p "$dir"
+  local f
+  for f in "$@"; do printf 'x' > "$dir/$f"; done
+  echo "$dir"
+}
+
+# $1 = label, $2 = agent dir, $3 = expected output line
+expect_check() {
+  local got
+  got=$(bash "$WATCHDOG" --check-scaffolded "$2" 2>&1)
+  if [ "$got" = "$3" ]; then pass "$1"; else fail "$1" "$got"; fi
+}
+
+echo "watchdog half-scaffolded-agent guard tests"
+
+# The finished agent: both personality files present, safe to start.
+expect_check "complete agent is startable" \
+  "$(make_agent complete CLAUDE.md SOUL.md)" "scaffolded=yes"
+
+# The incident itself: the wizard has made the directory, the LLM call is still
+# running. Starting here is what produced the identity-less live session.
+expect_check "bare directory mid-generation is NOT startable" \
+  "$(make_agent bare)" "scaffolded=no"
+
+# CLAUDE.md lands first in the handler (Promise.all resolves both, but a partial
+# write or a failed SOUL.md fallback can leave exactly this state). Personality
+# is incomplete, so it still must not start.
+expect_check "CLAUDE.md alone is NOT startable" \
+  "$(make_agent claude-only CLAUDE.md)" "scaffolded=no"
+
+expect_check "SOUL.md alone is NOT startable" \
+  "$(make_agent soul-only SOUL.md)" "scaffolded=no"
+
+# A directory that does not exist at all must not report ready either -- the
+# loop iterates a glob, but a deleted agent mid-tick must not resurrect.
+expect_check "missing directory is NOT startable" \
+  "$TMP/does-not-exist" "scaffolded=no"
+
+echo
+echo "  $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/scripts/watchdog.sh
+++ b/scripts/watchdog.sh
@@ -48,6 +48,27 @@ if [ "${1:-}" = "--resolve-provider" ]; then
   exit 0
 fi
 
+# An agent is READY to be started only once both personality files exist. The
+# dashboard wizard creates the directory first and generates CLAUDE.md /
+# SOUL.md afterwards through an LLM call that can take minutes
+# (routes/agents.ts: "Generating agent CLAUDE.md and SOUL.md..."), so a
+# directory alone proves nothing about whether the agent is finished. Claude
+# Code reads CLAUDE.md at startup: a session started before the files land
+# comes up with no identity, no rules and no persona, and stays that way
+# until restarted by hand -- from the outside the creation looks failed.
+agent_is_scaffolded() {
+  [ -f "$1/CLAUDE.md" ] && [ -f "$1/SOUL.md" ]
+}
+
+# Self-test hook, mirroring --resolve-provider: evaluate the predicate and
+# exit before touching tmux, so the contract is testable from fixtures
+# (scripts/__tests__/watchdog-scaffold-guard.test.sh).
+if [ "${1:-}" = "--check-scaffolded" ]; then
+  [ -n "${2:-}" ] || { echo "usage: watchdog.sh --check-scaffolded <agent-dir>" >&2; exit 2; }
+  if agent_is_scaffolded "$2"; then echo "scaffolded=yes"; else echo "scaffolded=no"; fi
+  exit 0
+fi
+
 
 export PATH="/opt/homebrew/bin:$HOME/.bun/bin:/home/linuxbrew/.linuxbrew/bin:$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
 
@@ -129,6 +150,13 @@ for AGENT_DIR in "$INSTALL_DIR/agents"/*/; do
   SESSION_NAME="agent-${AGENT_ID}"
 
   if tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
+    continue
+  fi
+
+  # Do not start a half-scaffolded agent: the wizard's LLM call may still be
+  # writing CLAUDE.md / SOUL.md. The next tick starts it once both exist.
+  if ! agent_is_scaffolded "$AGENT_DIR"; then
+    echo "$(timestamp) [watchdog] $AGENT_ID: personality files not ready yet (wizard still generating?), skipping this tick" >> "$LOG"
     continue
   fi
 


### PR DESCRIPTION
## Symptom

A freshly created agent can come up with no identity, no rules and no persona, and stay that way until restarted by hand -- from the outside the creation looks failed.

## When it broke

Latent since the watchdog's sub-agent loop: it treats any directory under `agents/` as an agent that should be running. The dashboard wizard creates the directory FIRST and generates CLAUDE.md / SOUL.md afterwards through an LLM call (`routes/agents.ts`: "Generating agent CLAUDE.md and SOUL.md...") that can take minutes -- on a live install one generation ran over five minutes, and the watchdog started the session roughly three minutes before CLAUDE.md existed. Claude Code reads CLAUDE.md at startup, so nothing short of a restart fixes the identity-less session.

## Reproduction

1. Create an agent directory under `agents/` without CLAUDE.md / SOUL.md (what the wizard's first step does).
2. Let the watchdog tick: it starts the session immediately.
3. The session runs with no personality; when the wizard's files land minutes later, the running session never reads them.

Fixture-level: `bash scripts/__tests__/watchdog-scaffold-guard.test.sh` -- 5/5 fail against the previous script, 5/5 pass with the guard.

## What the user sees

The wizard appears to have produced a broken agent: it responds without its persona or rules until someone notices and restarts it manually.

## Fix

`agent_is_scaffolded()` requires both personality files before the loop starts a session; a mid-generation directory is skipped with a log line, and the next tick starts it once the wizard has finished (no state, no timers -- the guard is a pure predicate). A `--check-scaffolded` self-test hook mirrors the existing `--resolve-provider` pattern so the contract runs from fixtures.

## Tests

New `scripts/__tests__/watchdog-scaffold-guard.test.sh` (complete agent startable; bare dir, CLAUDE.md-only, SOUL.md-only, missing dir all skipped). Existing `watchdog-provider.test.sh`: 11/11 still green.

Note: this branch and #1093 both touch `scripts/watchdog.sh` but in disjoint hunks (top-of-file predicate + loop guard vs. the launch-CMD construction); both are branched independently from `develop` and merge in either order with at most a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)