### PR TITLE
fix(telegram): TS senders honor the honest-send contract -- HTTP 200 + ok:false is a failure (TSOKFALSE827)

### DIFF
--- a/src/__tests__/channel-provider-send-timeout.test.ts
+++ b/src/__tests__/channel-provider-send-timeout.test.ts
@@ -35,10 +35,14 @@ describe('telegram sendMessage deadline', () => {
   it('passes the TOOL_TIMEOUTS.telegram deadline to https.request', async () => {
     const pending = getProvider('telegram').sendMessage('tok', '1', 'hi')
     expect(opts?.timeout).toBe(TOOL_TIMEOUTS['telegram'])
-    // Let the request "complete" so the promise settles.
+    // Let the request "complete" so the promise settles. The sender reads the
+    // body since TSOKFALSE827, so the fake response must stream end (a real
+    // IncomingMessage always does).
     const cb = httpsRequest.mock.calls[0][2] as (res: EventEmitter & { statusCode: number; resume: () => void }) => void
     const res = Object.assign(new EventEmitter(), { statusCode: 200, resume: () => {} })
     cb(res)
+    res.emit('data', Buffer.from('{"ok":true}'))
+    res.emit('end')
     await expect(pending).resolves.toBeUndefined()
   })
 

--- a/src/__tests__/telegram-send-okfalse.test.ts
+++ b/src/__tests__/telegram-send-okfalse.test.ts
@@ -1,0 +1,133 @@
+// TSOKFALSE827: the honest-send contract on the TS Telegram senders.
+//
+// NOTIFYVAKSWEEP826 closed this on the bash side (success = transport OK AND
+// "ok":true, 13/13 senders); the TS side still treated HTTP 200 + {"ok":false}
+// as success -- telegramProvider.sendMessage discarded the body entirely and
+// sendTelegramMessage only read it for the message_id. The historical logs
+// cannot show whether that ever bit us, precisely BECAUSE the senders were
+// blind (every observed ok:false rode inside a 4xx error, but a 200-path
+// occurrence would have left no trace). These tests pin the closed contract:
+// HTTP 200 + ok:false REJECTS, and the error message carries the body's
+// error_code in the "Telegram API <code>" shape so classifySendError keeps
+// sorting transient/permanent.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { EventEmitter } from 'node:events'
+
+// `import https from 'node:https'` -> the mock must provide `default`.
+const httpsRequest = vi.fn()
+vi.mock('node:https', () => ({ default: { request: (...a: unknown[]) => httpsRequest(...a) } }))
+
+const { getProvider } = await import('../channel-provider.js')
+const { classifySendError } = await import('../pending-retries.js')
+const { sendTelegramMessage, sendTelegramPhoto } = await import('../web/telegram.js')
+
+class FakeRequest extends EventEmitter {
+  write = vi.fn()
+  end = vi.fn()
+  destroy = vi.fn((err?: Error) => { if (err) this.emit('error', err) })
+}
+
+/** Fake http.IncomingMessage: statusCode + a body streamed as data/end. */
+function fakeResponse(statusCode: number, body: string): EventEmitter & { statusCode: number; resume: () => void } {
+  const res = Object.assign(new EventEmitter(), { statusCode, resume: () => {} })
+  queueMicrotask(() => {
+    if (body.length > 0) res.emit('data', Buffer.from(body))
+    res.emit('end')
+  })
+  return res
+}
+
+describe('telegramProvider.sendMessage reads the body it used to discard', () => {
+  let req: FakeRequest
+
+  beforeEach(() => {
+    req = new FakeRequest()
+    httpsRequest.mockImplementation(() => req)
+  })
+  afterEach(() => { httpsRequest.mockReset() })
+
+  function respond(statusCode: number, body: string): void {
+    const cb = httpsRequest.mock.calls[0][2] as (res: unknown) => void
+    cb(fakeResponse(statusCode, body))
+  }
+
+  it('HTTP 200 + ok:true resolves', async () => {
+    const pending = getProvider('telegram').sendMessage('tok', '1', 'hi')
+    respond(200, '{"ok":true,"result":{"message_id":7}}')
+    await expect(pending).resolves.toBeUndefined()
+  })
+
+  it('HTTP 200 + ok:false REJECTS with the error_code in classifiable shape', async () => {
+    const pending = getProvider('telegram').sendMessage('tok', '1', 'hi')
+    respond(200, '{"ok":false,"error_code":400,"description":"Bad Request: chat not found"}')
+    await expect(pending).rejects.toThrow(/Telegram API 400: ok:false Bad Request: chat not found/)
+  })
+
+  it('the ok:false rejection classifies permanent on a 4xx code, transient without one', () => {
+    expect(classifySendError('Telegram API 400: ok:false Bad Request: chat not found')).toBe('permanent')
+    expect(classifySendError('Telegram API 429: ok:false Too Many Requests')).toBe('transient')
+    expect(classifySendError('Telegram API: ok:false something without a code')).toBe('transient')
+  })
+
+  it('a malformed body on HTTP 200 stays a success (the message may be delivered)', async () => {
+    const pending = getProvider('telegram').sendMessage('tok', '1', 'hi')
+    respond(200, 'not json at all')
+    await expect(pending).resolves.toBeUndefined()
+  })
+
+  it('a non-200 now carries the body in the error, not just the status', async () => {
+    const pending = getProvider('telegram').sendMessage('tok', '1', 'hi')
+    respond(403, '{"ok":false,"error_code":403,"description":"Forbidden: bot was blocked"}')
+    await expect(pending).rejects.toThrow(/Telegram API 403: .*bot was blocked/)
+  })
+})
+
+describe('sendTelegramMessage (web/telegram) closes the same gap', () => {
+  const realFetch = globalThis.fetch
+
+  afterEach(() => { globalThis.fetch = realFetch })
+
+  function mockFetch(status: number, body: string): void {
+    globalThis.fetch = vi.fn(async () => new Response(body, { status })) as unknown as typeof fetch
+  }
+
+  it('HTTP 200 + ok:true returns the message_id', async () => {
+    mockFetch(200, '{"ok":true,"result":{"message_id":41}}')
+    await expect(sendTelegramMessage('tok', '1', 'hi')).resolves.toBe(41)
+  })
+
+  it('HTTP 200 + ok:false THROWS in the classifiable shape', async () => {
+    mockFetch(200, '{"ok":false,"error_code":400,"description":"Bad Request: chat not found"}')
+    await expect(sendTelegramMessage('tok', '1', 'hi')).rejects.toThrow(/Telegram API 400: ok:false/)
+  })
+
+  it('a malformed success body still returns null, never throws', async () => {
+    mockFetch(200, 'garbage')
+    await expect(sendTelegramMessage('tok', '1', 'hi')).resolves.toBeNull()
+  })
+})
+
+describe('sendTelegramPhoto checked nothing; now it checks everything', () => {
+  const realFetch = globalThis.fetch
+
+  afterEach(() => { globalThis.fetch = realFetch })
+
+  function mockFetch(status: number, body: string): void {
+    globalThis.fetch = vi.fn(async () => new Response(body, { status })) as unknown as typeof fetch
+  }
+
+  it('a 4xx now throws instead of vanishing', async () => {
+    mockFetch(404, '{"ok":false,"error_code":404,"description":"Not Found"}')
+    await expect(sendTelegramPhoto('tok', '1', import.meta.filename, 'cap')).rejects.toThrow(/Telegram API 404/)
+  })
+
+  it('HTTP 200 + ok:false throws too', async () => {
+    mockFetch(200, '{"ok":false,"error_code":400,"description":"PHOTO_INVALID_DIMENSIONS"}')
+    await expect(sendTelegramPhoto('tok', '1', import.meta.filename, 'cap')).rejects.toThrow(/Telegram API 400: ok:false PHOTO_INVALID_DIMENSIONS/)
+  })
+
+  it('HTTP 200 + ok:true resolves', async () => {
+    mockFetch(200, '{"ok":true,"result":{}}')
+    await expect(sendTelegramPhoto('tok', '1', import.meta.filename, 'cap')).resolves.toBeUndefined()
+  })
+})

--- a/src/channel-provider.ts
+++ b/src/channel-provider.ts
@@ -43,12 +43,35 @@ function telegramHttpPost(token: string, method: string, body: string, contentTy
         timeout: TOOL_TIMEOUTS['telegram'],
       },
       (res) => {
-        res.resume()
-        if (res.statusCode === 200) {
+        // Read the body even on HTTP 200: the Bot API can answer 200 with
+        // {"ok":false,...}, and discarding the body turned that into a silent
+        // success -- the same blind spot the bash senders closed in
+        // NOTIFYVAKSWEEP826 (success = transport OK AND "ok":true). TSOKFALSE827.
+        const chunks: Buffer[] = []
+        res.on('data', (chunk: Buffer) => { chunks.push(chunk) })
+        res.on('end', () => {
+          const responseBody = Buffer.concat(chunks).toString('utf-8')
+          if (res.statusCode !== 200) {
+            reject(new Error(`Telegram API ${res.statusCode}: ${responseBody.slice(0, 200)}`))
+            return
+          }
+          try {
+            const parsed = JSON.parse(responseBody) as { ok?: boolean; error_code?: number; description?: string }
+            if (parsed.ok === false) {
+              // Carry the body's error_code in the "Telegram API <code>" shape so
+              // classifySendError sorts it transient/permanent like an HTTP status;
+              // without a code the message stays status-free -> transient (retry).
+              const code = typeof parsed.error_code === 'number' ? ` ${parsed.error_code}` : ''
+              reject(new Error(`Telegram API${code}: ok:false ${String(parsed.description ?? '').slice(0, 200)}`))
+              return
+            }
+          } catch {
+            // A malformed body on HTTP 200 is not a send failure; the message
+            // may well be delivered. Same tolerance as sendTelegramMessage.
+          }
           resolve()
-        } else {
-          reject(new Error(`Telegram API ${res.statusCode}`))
-        }
+        })
+        res.on('error', reject)
       }
     )
     req.on('error', reject)

--- a/src/web/telegram.ts
+++ b/src/web/telegram.ts
@@ -140,12 +140,24 @@ export async function sendTelegramMessage(token: string, chatId: string, text: s
   // Some callers need the message id back (the approval gate stamps it onto
   // the request row so the decision UI can reference the exact message). A
   // malformed success body is not a send failure -- return null, never throw.
+  type SendResponse = { ok?: boolean; error_code?: number; description?: string; result?: { message_id?: number } }
+  let data: SendResponse | null = null
   try {
-    const data = await resp.json() as { result?: { message_id?: number } }
-    return typeof data.result?.message_id === 'number' ? data.result.message_id : null
+    data = await resp.json() as SendResponse
   } catch {
     return null
   }
+  // HTTP 200 + {"ok":false} is a REJECTED send, not a malformed success: treat
+  // it exactly like a non-2xx so the callers' try/catch + classifySendError
+  // paths see it -- success means transport OK AND ok:true, the same contract
+  // the bash senders adopted in NOTIFYVAKSWEEP826. TSOKFALSE827. The
+  // "Telegram API <code>" shape keeps classifySendError's transient/permanent
+  // sorting; a code-less body stays status-free -> transient (retry).
+  if (data?.ok === false) {
+    const code = typeof data.error_code === 'number' ? ` ${data.error_code}` : ''
+    throw new Error(`Telegram API${code}: ok:false ${String(data.description ?? '').slice(0, 200)}`)
+  }
+  return typeof data?.result?.message_id === 'number' ? data.result.message_id : null
 }
 
 export async function sendTelegramPhoto(token: string, chatId: string, photoPath: string, caption: string): Promise<void> {
@@ -157,12 +169,30 @@ export async function sendTelegramPhoto(token: string, chatId: string, photoPath
   parts.push(Buffer.from(`--${boundary}\r\nContent-Disposition: form-data; name="photo"; filename="avatar.png"\r\nContent-Type: image/png\r\n\r\n`))
   parts.push(fileData)
   parts.push(Buffer.from(`\r\n--${boundary}--\r\n`))
-  await fetch(`https://api.telegram.org/bot${token}/sendPhoto`, {
+  const resp = await fetch(`https://api.telegram.org/bot${token}/sendPhoto`, {
     method: 'POST',
     headers: { 'Content-Type': `multipart/form-data; boundary=${boundary}` },
     body: Buffer.concat(parts),
     signal: AbortSignal.timeout(TOOL_TIMEOUTS['telegram']),
   })
+  // This sender checked NOTHING -- a 4xx or an ok:false vanished without a
+  // trace. Same honest-send contract as sendTelegramMessage (TSOKFALSE827):
+  // success means transport OK AND ok:true; every caller already wraps this
+  // in try/catch, so the throw lands in an existing warn path.
+  if (!resp.ok) {
+    const body = await resp.text().catch(() => '')
+    throw new Error(`Telegram API ${resp.status}: ${body.slice(0, 200)}`)
+  }
+  try {
+    const data = await resp.json() as { ok?: boolean; error_code?: number; description?: string }
+    if (data.ok === false) {
+      const code = typeof data.error_code === 'number' ? ` ${data.error_code}` : ''
+      throw new Error(`Telegram API${code}: ok:false ${String(data.description ?? '').slice(0, 200)}`)
+    }
+  } catch (err) {
+    if (err instanceof Error && err.message.startsWith('Telegram API')) throw err
+    // Malformed body on HTTP 200: not a send failure.
+  }
 }
 
 export async function sendWelcomeMessage(agentName: string, token: string): Promise<void> {


### PR DESCRIPTION
## Élő küldő-utat érint: telegramProvider.sendMessage, sendTelegramMessage, sendTelegramPhoto

A NOTIFYVAKSWEEP826 a bash-oldalon lezárta a kontraktust (siker = transport OK ÉS ok:true, 13/13 sender); a TS-oldal volt a befejezetlen fél.

## Mérés (a kártya első lépése, elvégezve)
- A dashboard.log TELJES történetében minden megfigyelt ok:false (2 független esemény) HTTP 400-zal EGYÜTT jött (látható osztály, sendTelegramMessage dobta).
- DE a TS-küldők a 200-as ágon szerkezetileg vakok voltak (a provider eldobta a body-t, a sendTelegramMessage csak message_id-ért olvasta, a sendTelegramPhoto SEMMIT nem nézett, még a státuszt sem) -- egy 200+ok:false előfordulás nyomtalan maradt volna. A "nulla előfordulás" tehát a műszer vaksága mellett áll, nem cáfolat.
- Bash-oldali becsületes küldők (08-25 óta): 0 elnyelt hiba a failure-nyomokban.
- Konklúzió: a fix a legjobb elérhető mérés szerint PREVENTÍV.

## Változások
- **telegramHttpPost** (channel-provider): body-t olvas; 200+ok:false reject, nem-200 hibája viszi a body-szeletet.
- **sendTelegramMessage**: 200+ok:false dob; malformed success body továbbra is null (a kézbesítés megtörténhetett).
- **sendTelegramPhoto**: eddig SEMMIT nem ellenőrzött -- most státuszt ÉS ok-ot is.
- Hiba-alak: `Telegram API <error_code>: ok:false <description>` -- a classifySendError transient/permanent osztályozása változatlanul működik rá; kód nélküli body -> státusz-mentes üzenet -> transient (fail-toward-retry).

## Verify
- **Red-before**: az 5 új kontrakt-teszt bukik a régi küldőkön (stash-próbával mérve), 6 megőrzött-viselkedés teszt mindkét irányban zöld.
- Teljes suite: **314 fájl / 4198 passed / 1 skipped**; tsc clean; build OK.
- A meglévő timeout-teszt fake response-a end-eseményt kapott (valós IncomingMessage mindig emittálja).

Kártya: TSOKFALSE827. Pre-existing hibaosztály, nem a #1074 regressziója (az épp a másik irányban javított).

🤖 Generated with [Claude Code](https://claude.com/claude-code)