### PR TITLE
fix(kanban): a subcard write must move its ancestors' updated_at

### DIFF
--- a/src/__tests__/kanban-parent-activity.test.ts
+++ b/src/__tests__/kanban-parent-activity.test.ts
@@ -14,7 +14,7 @@
 // relative to that backdated value -- otherwise "greater than before" would be measuring the
 // clock, not the code.
 
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import {
   initDatabase, getDb,
   createKanbanCard, updateKanbanCard, moveKanbanCard, addKanbanComment,
@@ -126,31 +126,57 @@ describe('parent updated_at follows subcard activity', () => {
   })
 
   // --- the walk must survive broken parent_id data ---
+  //
+  // Two guards stand here, and "the call returned" cannot tell them apart: with the visited set
+  // removed, the depth cap stops the cycle anyway. Measured the first time round, that mutation
+  // survived a green run. What separates them is the DIAGNOSIS -- a cycle reported as a
+  // sixteen-deep chain sends the next reader looking for a hierarchy that does not exist -- so
+  // these tests assert which guard fired, not merely that something did.
 
-  it('terminates on a parent_id cycle instead of spinning forever', () => {
-    createKanbanCard({ id: 'a', title: 'A' })
-    createKanbanCard({ id: 'b', title: 'B', parent_id: 'a' })
-    // Nothing validates parent_id, so the public API can close the loop: a -> b -> a.
-    updateKanbanCard('a', { parent_id: 'b' })
-    backdate('a'); backdate('b')
+  it('terminates on a parent_id cycle, and says it was a cycle', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      createKanbanCard({ id: 'a', title: 'A' })
+      createKanbanCard({ id: 'b', title: 'B', parent_id: 'a' })
+      // Nothing validates parent_id, so the public API can close the loop: a -> b -> a.
+      updateKanbanCard('a', { parent_id: 'b' })
+      backdate('a'); backdate('b')
+      warn.mockClear()
 
-    addKanbanComment('b', 'sanyiba', 'work note')
+      addKanbanComment('b', 'sanyiba', 'work note')
 
-    // Both cards in the cycle get stamped exactly once, and the call returns.
-    expect(updatedAt('a')).toBeGreaterThan(BACKDATED)
-    expect(updatedAt('b')).toBeGreaterThan(BACKDATED)
+      // Both cards in the cycle get stamped, and the call returns.
+      expect(updatedAt('a')).toBeGreaterThan(BACKDATED)
+      expect(updatedAt('b')).toBeGreaterThan(BACKDATED)
+
+      const messages = warn.mock.calls.map((c) => String(c[0]))
+      expect(messages.some((m) => m.includes('cycle'))).toBe(true)
+      expect(messages.some((m) => m.includes('deeper than'))).toBe(false)
+    } finally {
+      warn.mockRestore()
+    }
   })
 
-  it('stops at the depth limit on a chain longer than any real hierarchy', () => {
-    // 20 links, cap is 16: the walk has to stop on its own rather than run the chain out.
-    const ids = Array.from({ length: 20 }, (_, i) => `c${i}`)
-    ids.forEach((id, i) => createKanbanCard({ id, title: id, parent_id: i === 0 ? undefined : ids[i - 1] }))
-    ids.forEach((id) => backdate(id))
+  it('stops at the depth limit on a chain longer than any real hierarchy, and says so', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      // 20 links, cap is 16: the walk has to stop on its own rather than run the chain out.
+      const ids = Array.from({ length: 20 }, (_, i) => `c${i}`)
+      ids.forEach((id, i) => createKanbanCard({ id, title: id, parent_id: i === 0 ? undefined : ids[i - 1] }))
+      ids.forEach((id) => backdate(id))
+      warn.mockClear()
 
-    addKanbanComment(ids[ids.length - 1], 'sanyiba', 'work note')
+      addKanbanComment(ids[ids.length - 1], 'sanyiba', 'work note')
 
-    // The 16 nearest ancestors are stamped; the far end of the chain is not reached.
-    expect(updatedAt(ids[ids.length - 2])).toBeGreaterThan(BACKDATED)
-    expect(updatedAt(ids[0])).toBe(BACKDATED)
+      // The 16 nearest ancestors are stamped; the far end of the chain is not reached.
+      expect(updatedAt(ids[ids.length - 2])).toBeGreaterThan(BACKDATED)
+      expect(updatedAt(ids[0])).toBe(BACKDATED)
+
+      const messages = warn.mock.calls.map((c) => String(c[0]))
+      expect(messages.some((m) => m.includes('deeper than'))).toBe(true)
+      expect(messages.some((m) => m.includes('cycle'))).toBe(false)
+    } finally {
+      warn.mockRestore()
+    }
   })
 })

--- a/src/__tests__/kanban-parent-activity.test.ts
+++ b/src/__tests__/kanban-parent-activity.test.ts
@@ -1,0 +1,156 @@
+// Contract tests for parent-card activity bubbling (card 68763e8f).
+//
+// A subcard write stamps its ancestors' updated_at, so a thread whose work happens on its
+// subcards no longer reads as a stalled parent to the stuck-card detector
+// (`status='in_progress' AND updated_at < last_audit_at`).
+//
+// THE SECOND DIRECTION IS THE POINT. "Parent moved" alone would also pass if we simply stamped
+// every card on every write -- that is silencing, not fixing. So each positive test has a
+// standalone in_progress card next to it that must NOT move: it is the control that says the
+// detector can still see a real stall.
+//
+// Timestamps are whole seconds, so a card written twice inside one second shows no difference at
+// all. Every test therefore backdates the cards it is about to observe, and asserts a move
+// relative to that backdated value -- otherwise "greater than before" would be measuring the
+// clock, not the code.
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  initDatabase, getDb,
+  createKanbanCard, updateKanbanCard, moveKanbanCard, addKanbanComment,
+  archiveKanbanCard, getKanbanCard,
+} from '../db.js'
+
+const BACKDATED = 1_000_000
+
+/** Pushes a card's updated_at into the past so a later stamp is visible in whole seconds. */
+function backdate(id: string, ts = BACKDATED): void {
+  getDb().prepare('UPDATE kanban_cards SET updated_at = ? WHERE id = ?').run(ts, id)
+}
+
+function updatedAt(id: string): number {
+  return getKanbanCard(id)!.updated_at
+}
+
+/** Parent + child, both parked in the past. The lone card is the negative control. */
+function seedThread(): void {
+  createKanbanCard({ id: 'parent', title: 'Thread', status: 'in_progress' })
+  createKanbanCard({ id: 'child', title: 'Subtask', parent_id: 'parent' })
+  createKanbanCard({ id: 'lonely', title: 'Genuinely stalled', status: 'in_progress' })
+  backdate('parent')
+  backdate('child')
+  backdate('lonely')
+}
+
+describe('parent updated_at follows subcard activity', () => {
+  beforeEach(() => {
+    initDatabase(':memory:')
+  })
+
+  // --- the four write paths that stamp updated_at ---
+
+  it('bubbles up from addKanbanComment', () => {
+    seedThread()
+    addKanbanComment('child', 'sanyiba', 'work note')
+    expect(updatedAt('parent')).toBeGreaterThan(BACKDATED)
+    expect(updatedAt('lonely')).toBe(BACKDATED)
+  })
+
+  it('bubbles up from updateKanbanCard', () => {
+    seedThread()
+    updateKanbanCard('child', { title: 'Subtask, renamed' })
+    expect(updatedAt('parent')).toBeGreaterThan(BACKDATED)
+    expect(updatedAt('lonely')).toBe(BACKDATED)
+  })
+
+  it('bubbles up from moveKanbanCard -- the most common subcard event, a subcard moved to done', () => {
+    seedThread()
+    moveKanbanCard('child', 'done', 0, 'sanyiba')
+    expect(updatedAt('parent')).toBeGreaterThan(BACKDATED)
+    expect(updatedAt('lonely')).toBe(BACKDATED)
+  })
+
+  it('bubbles up from createKanbanCard -- filing a new subcard is work on the thread', () => {
+    seedThread()
+    createKanbanCard({ id: 'child-2', title: 'Another subtask', parent_id: 'parent' })
+    expect(updatedAt('parent')).toBeGreaterThan(BACKDATED)
+    expect(updatedAt('lonely')).toBe(BACKDATED)
+  })
+
+  // --- the control, on its own, because it carries the whole claim ---
+
+  it('leaves a childless in_progress card alone while another thread is written', () => {
+    seedThread()
+    addKanbanComment('child', 'sanyiba', 'work note')
+    moveKanbanCard('child', 'done', 0, 'sanyiba')
+    updateKanbanCard('parent', { assignee: 'sanyiba' })
+
+    // The stalled card is still exactly as stale as it was: the detector can see it.
+    expect(updatedAt('lonely')).toBe(BACKDATED)
+  })
+
+  // --- depth ---
+
+  it('walks the whole chain, not just one level', () => {
+    createKanbanCard({ id: 'grandparent', title: 'Epic', status: 'in_progress' })
+    createKanbanCard({ id: 'parent', title: 'Thread', parent_id: 'grandparent' })
+    createKanbanCard({ id: 'leaf', title: 'Subtask', parent_id: 'parent' })
+    backdate('grandparent'); backdate('parent'); backdate('leaf')
+
+    addKanbanComment('leaf', 'sanyiba', 'work note')
+
+    expect(updatedAt('parent')).toBeGreaterThan(BACKDATED)
+    expect(updatedAt('grandparent')).toBeGreaterThan(BACKDATED)
+  })
+
+  // --- re-parenting touches both threads ---
+
+  it('stamps the old parent too when a card is moved to another thread', () => {
+    createKanbanCard({ id: 'old-parent', title: 'Old thread', status: 'in_progress' })
+    createKanbanCard({ id: 'new-parent', title: 'New thread', status: 'in_progress' })
+    createKanbanCard({ id: 'child', title: 'Subtask', parent_id: 'old-parent' })
+    backdate('old-parent'); backdate('new-parent'); backdate('child')
+
+    updateKanbanCard('child', { parent_id: 'new-parent' })
+
+    expect(updatedAt('new-parent')).toBeGreaterThan(BACKDATED)
+    expect(updatedAt('old-parent')).toBeGreaterThan(BACKDATED)
+  })
+
+  // --- the deliberate exclusion, asserted so a future change to it is a measured decision ---
+
+  it('does NOT bubble up from archiving -- tidying a thread is not advancing it', () => {
+    seedThread()
+    archiveKanbanCard('child')
+    expect(updatedAt('parent')).toBe(BACKDATED)
+  })
+
+  // --- the walk must survive broken parent_id data ---
+
+  it('terminates on a parent_id cycle instead of spinning forever', () => {
+    createKanbanCard({ id: 'a', title: 'A' })
+    createKanbanCard({ id: 'b', title: 'B', parent_id: 'a' })
+    // Nothing validates parent_id, so the public API can close the loop: a -> b -> a.
+    updateKanbanCard('a', { parent_id: 'b' })
+    backdate('a'); backdate('b')
+
+    addKanbanComment('b', 'sanyiba', 'work note')
+
+    // Both cards in the cycle get stamped exactly once, and the call returns.
+    expect(updatedAt('a')).toBeGreaterThan(BACKDATED)
+    expect(updatedAt('b')).toBeGreaterThan(BACKDATED)
+  })
+
+  it('stops at the depth limit on a chain longer than any real hierarchy', () => {
+    // 20 links, cap is 16: the walk has to stop on its own rather than run the chain out.
+    const ids = Array.from({ length: 20 }, (_, i) => `c${i}`)
+    ids.forEach((id, i) => createKanbanCard({ id, title: id, parent_id: i === 0 ? undefined : ids[i - 1] }))
+    ids.forEach((id) => backdate(id))
+
+    addKanbanComment(ids[ids.length - 1], 'sanyiba', 'work note')
+
+    // The 16 nearest ancestors are stamped; the far end of the chain is not reached.
+    expect(updatedAt(ids[ids.length - 2])).toBeGreaterThan(BACKDATED)
+    expect(updatedAt(ids[0])).toBe(BACKDATED)
+  })
+})

--- a/src/__tests__/kanban-parent-activity.test.ts
+++ b/src/__tests__/kanban-parent-activity.test.ts
@@ -130,7 +130,10 @@ describe('parent updated_at follows subcard activity', () => {
 
   // --- the deliberate exclusion, asserted so a future change to it is a measured decision ---
 
-  it('does NOT bubble up from archiving -- tidying a thread is not advancing it', () => {
+  // Scope: this covers archiveKanbanCard, the dedicated function. It says nothing about an
+  // `archived_at` arriving through PUT /api/kanban/:id, which has no field whitelist and therefore
+  // reaches updateKanbanCard -- the bubbling path. That gap belongs to the endpoint (card 531c6500).
+  it('does NOT bubble up from archiveKanbanCard -- tidying a thread is not advancing it', () => {
     seedThread()
     archiveKanbanCard('child')
     expect(updatedAt('parent')).toBe(BACKDATED)

--- a/src/__tests__/kanban-parent-activity.test.ts
+++ b/src/__tests__/kanban-parent-activity.test.ts
@@ -117,6 +117,17 @@ describe('parent updated_at follows subcard activity', () => {
     expect(updatedAt('old-parent')).toBeGreaterThan(BACKDATED)
   })
 
+  it('stamps the old parent when a card is pulled out of a thread entirely', () => {
+    // The un-parenting shape: the new parent is null, so only the old-thread branch can fire.
+    createKanbanCard({ id: 'parent', title: 'Thread', status: 'in_progress' })
+    createKanbanCard({ id: 'child', title: 'Subtask', parent_id: 'parent' })
+    backdate('parent'); backdate('child')
+
+    updateKanbanCard('child', { parent_id: null })
+
+    expect(updatedAt('parent')).toBeGreaterThan(BACKDATED)
+  })
+
   // --- the deliberate exclusion, asserted so a future change to it is a measured decision ---
 
   it('does NOT bubble up from archiving -- tidying a thread is not advancing it', () => {

--- a/src/__tests__/token-usage.test.ts
+++ b/src/__tests__/token-usage.test.ts
@@ -359,6 +359,46 @@ describe('correlateWithKanban', () => {
     // Cleanup
     db.prepare("DELETE FROM kanban_cards WHERE id = 'test-kanban-1'").run()
   })
+
+  it('attributes the spend to the subcard, not to the parent that shares its timestamp', async () => {
+    // Since a subcard write also stamps its ancestors (db.ts, touchAncestorChain), a parent and
+    // its child carry the SAME updated_at. This correlation treats consecutive card timestamps as
+    // work windows, so a tie used to hand the tokens to whichever row the scan returned first --
+    // an ordering, not a fact. The parent is a container; the leaf is what was worked on.
+    const db = getDb()
+    const ts = 1716400000
+
+    // The correlation only considers cards whose updated_at falls inside the agent's token-row
+    // window, so the spend has to straddle the cards: one row before, one after.
+    const usage = db.prepare(`
+      INSERT INTO token_usage (agent, session_id, timestamp, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, content_preview, task_title)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `)
+    usage.run('test-thread', 'sess-thread', ts, 100, 50, 0, 0, 'before', null)
+    usage.run('test-thread', 'sess-thread', ts + 10, 100, 50, 0, 0, 'work', null)
+
+    const card = db.prepare(`
+      INSERT INTO kanban_cards (id, title, status, priority, assignee, project, parent_id, created_at, updated_at, sort_order)
+      VALUES (?, ?, 'in_progress', 'normal', 'test-thread', 'test-project', ?, ?, ?, 0)
+    `)
+    card.run('test-thread-parent', 'Parent thread', null, ts, ts + 5)
+    card.run('test-thread-child', 'Subtask actually worked on', 'test-thread-parent', ts, ts + 5)
+
+    // Cleanup in `finally`: these tests share one database, so rows left behind by a failing
+    // assertion surface as a failure in an unrelated test further down the file.
+    try {
+      const { correlateWithKanban } = await import('../web/token-usage.js')
+      correlateWithKanban()
+
+      const row = db.prepare(
+        "SELECT task_title FROM token_usage WHERE agent = 'test-thread' AND timestamp = ?",
+      ).get(ts + 10) as { task_title: string | null }
+      expect(row.task_title).toBe('Subtask actually worked on')
+    } finally {
+      db.prepare("DELETE FROM kanban_cards WHERE id IN ('test-thread-parent', 'test-thread-child')").run()
+      db.prepare("DELETE FROM token_usage WHERE agent = 'test-thread'").run()
+    }
+  })
 })
 
 describe('tryHandleTokenUsage route handler', () => {

--- a/src/db.ts
+++ b/src/db.ts
@@ -1794,10 +1794,11 @@ const ANCESTOR_DEPTH_LIMIT = 16
 // grew past anything we would call a hierarchy. Both are loud, because either one means the
 // parent_id data is broken and something else needs fixing.
 function touchAncestorChain(parentId: string | null | undefined, now: number, startedAt: string): void {
+  if (!parentId) return // root card: the common case, and it costs nothing
   const readParent = db.prepare('SELECT parent_id FROM kanban_cards WHERE id = ?')
   const stamp = db.prepare('UPDATE kanban_cards SET updated_at = ? WHERE id = ?')
   const seen = new Set<string>([startedAt])
-  let current = parentId ?? null
+  let current: string | null = parentId
   let depth = 0
   while (current) {
     if (seen.has(current)) {

--- a/src/db.ts
+++ b/src/db.ts
@@ -1780,9 +1780,18 @@ export function getKanbanCard(id: string): KanbanCard | undefined {
 // the ones that existed when this landed are listed in the card (68763e8f) and in
 // correlateWithKanban(), which had to be taught the difference.
 //
-// WHAT IS DELIBERATELY NOT HERE. Archive, unarchive and delete do NOT bubble up: those tidy a
-// thread rather than advance it, and a parent that looks "active" because a subcard was filed away
-// is the same false signal in a new costume. Left out on purpose, not forgotten.
+// WHAT IS DELIBERATELY NOT HERE, AND HOW FAR THAT HOLDS. Archive, unarchive and delete do NOT
+// bubble up: those tidy a thread rather than advance it, and a parent that looks "active" because
+// a subcard was filed away is the same false signal in a new costume. Left out on purpose, not
+// forgotten -- but only for the three dedicated functions (archiveKanbanCard, unarchiveKanbanCard,
+// deleteKanbanCard), which is what the test asserts.
+//
+// It does NOT hold at the HTTP boundary. PUT /api/kanban/:id hands the raw JSON body to
+// updateKanbanCard() with no field whitelist (routes/kanban.ts), so an `archived_at` arriving that
+// way travels the bubbling path like any other field -- and this is live, not theoretical:
+// web/app.js sends whole `{...card}` objects on the assignee and parent edits, so editing an
+// already-archived card stamps its parent today. The fix belongs to the endpoint rather than here
+// (card 531c6500, field whitelist on the write routes); when it lands, this second half goes.
 const ANCESTOR_DEPTH_LIMIT = 16
 
 // Stamps `now` on every ancestor starting at `parentId`, walking upward.

--- a/src/db.ts
+++ b/src/db.ts
@@ -1766,6 +1766,54 @@ export function getKanbanCard(id: string): KanbanCard | undefined {
   return db.prepare('SELECT rowid AS seq, * FROM kanban_cards WHERE id = ?').get(id) as KanbanCard | undefined
 }
 
+// A szülő-kártya updated_at-je a SZÁLRÓL szól, nem csak magáról a kártyáról.
+//
+// WHY. The stuck-card detector selects `status='in_progress' AND updated_at < last_audit_at`.
+// A parent's updated_at used to move only when the parent row itself was written, so a thread
+// whose work happens on its subcards looked frozen: three consecutive audits (2026-08-14 08:00,
+// 08-14 16:00, 08-15 08:00) flagged the same card while the work was visibly moving underneath it.
+// The damage is not the noise but the numbing: once "artefact" is the standing answer for a card,
+// a REAL stall on that card reads as an artefact too.
+//
+// WHAT THIS CHANGES ABOUT THE DATA. After this, a parent's updated_at means "something happened on
+// this THREAD", not "this card was written". Every reader of that column inherits the new meaning;
+// the ones that existed when this landed are listed in the card (68763e8f) and in
+// correlateWithKanban(), which had to be taught the difference.
+//
+// WHAT IS DELIBERATELY NOT HERE. Archive, unarchive and delete do NOT bubble up: those tidy a
+// thread rather than advance it, and a parent that looks "active" because a subcard was filed away
+// is the same false signal in a new costume. Left out on purpose, not forgotten.
+const ANCESTOR_DEPTH_LIMIT = 16
+
+// Stamps `now` on every ancestor starting at `parentId`, walking upward.
+//
+// NOT a `while (parent)` loop, and the reason is a second, still-missing check: nothing guards
+// kanban_cards.parent_id against a cycle -- updateKanbanCard() writes whatever it is handed, so
+// A -> B -> A is constructible through the public API. A plain walk would spin forever inside a
+// write path. The visited set makes the cycle terminate and the depth cap catches a chain that
+// grew past anything we would call a hierarchy. Both are loud, because either one means the
+// parent_id data is broken and something else needs fixing.
+function touchAncestorChain(parentId: string | null | undefined, now: number, startedAt: string): void {
+  const readParent = db.prepare('SELECT parent_id FROM kanban_cards WHERE id = ?')
+  const stamp = db.prepare('UPDATE kanban_cards SET updated_at = ? WHERE id = ?')
+  const seen = new Set<string>([startedAt])
+  let current = parentId ?? null
+  let depth = 0
+  while (current) {
+    if (seen.has(current)) {
+      console.warn(`[kanban] parent_id cycle at ${current} (from ${startedAt}) -- ancestor stamping stopped`)
+      return
+    }
+    if (++depth > ANCESTOR_DEPTH_LIMIT) {
+      console.warn(`[kanban] parent chain deeper than ${ANCESTOR_DEPTH_LIMIT} from ${startedAt} -- ancestor stamping stopped`)
+      return
+    }
+    seen.add(current)
+    stamp.run(now, current)
+    current = (readParent.get(current) as { parent_id: string | null } | undefined)?.parent_id ?? null
+  }
+}
+
 export function createKanbanCard(card: {
   id: string
   title: string
@@ -1792,6 +1840,8 @@ export function createKanbanCard(card: {
     card.assignee ?? null, card.priority ?? 'normal',
     card.project ?? null, card.parent_id ?? null, card.due_date ?? null, sortOrder, now, now
   )
+  // Filing a new subcard is work on the thread.
+  touchAncestorChain(card.parent_id, now, card.id)
 }
 
 export function updateKanbanCard(id: string, fields: Partial<Omit<KanbanCard, 'id' | 'created_at'>>): boolean {
@@ -1799,10 +1849,18 @@ export function updateKanbanCard(id: string, fields: Partial<Omit<KanbanCard, 'i
   if (!card) return false
   const now = Math.floor(Date.now() / 1000)
   const f = { ...card, ...fields, updated_at: now }
-  return db.prepare(
+  const changed = db.prepare(
     `UPDATE kanban_cards SET title=?, description=?, status=?, assignee=?, priority=?, project=?, parent_id=?, due_date=?, sort_order=?, updated_at=?, archived_at=?
      WHERE id=?`
   ).run(f.title, f.description, f.status, f.assignee, f.priority, f.project, f.parent_id, f.due_date, f.sort_order, f.updated_at, f.archived_at, id).changes > 0
+  if (changed) {
+    touchAncestorChain(f.parent_id, now, id)
+    // Re-parenting is activity on BOTH threads: the old one lost a card, the new one gained it.
+    // Stamping only the new parent would leave the old one looking frozen -- the very bug this
+    // function is fixing, just rarer and therefore harder to notice.
+    if (card.parent_id && card.parent_id !== f.parent_id) touchAncestorChain(card.parent_id, now, id)
+  }
+  return changed
 }
 
 export function getChildCards(parentId: string): KanbanCard[] {
@@ -1813,10 +1871,16 @@ export function moveKanbanCard(id: string, status: KanbanCard['status'], sortOrd
   const now = Math.floor(Date.now() / 1000)
   // Read the previous status first so we only record an audit event on a real
   // status transition (not a pure sort_order reorder within the same column).
-  const prev = (db.prepare('SELECT status FROM kanban_cards WHERE id=?').get(id) as { status: string } | undefined)?.status
+  // parent_id comes along in the same read: the ancestor chain has to be stamped too, and this
+  // path (drag / status change) is the most common subcard event there is -- an subcard moved to
+  // done. Leaving it out would make the false alarm rarer instead of gone.
+  const row = db.prepare('SELECT status, parent_id FROM kanban_cards WHERE id=?').get(id) as
+    { status: string; parent_id: string | null } | undefined
+  const prev = row?.status
   const changed = db.prepare(
     'UPDATE kanban_cards SET status=?, sort_order=?, updated_at=? WHERE id=?'
   ).run(status, sortOrder, now, id).changes > 0
+  if (changed) touchAncestorChain(row?.parent_id, now, id)
   if (changed && prev !== undefined && prev !== status) {
     db.prepare(
       'INSERT INTO kanban_card_events (card_id, from_status, to_status, actor, created_at) VALUES (?, ?, ?, ?, ?)'
@@ -1978,6 +2042,9 @@ export function addKanbanComment(cardId: string, author: string, content: string
     'INSERT INTO kanban_comments (card_id, author, content, created_at) VALUES (?, ?, ?, ?)'
   ).run(cardId, author, content, now)
   db.prepare('UPDATE kanban_cards SET updated_at = ? WHERE id = ?').run(now, cardId)
+  const parentId = (db.prepare('SELECT parent_id FROM kanban_cards WHERE id = ?').get(cardId) as
+    { parent_id: string | null } | undefined)?.parent_id
+  touchAncestorChain(parentId, now, cardId)
   return { id: Number(info.lastInsertRowid), card_id: cardId, author, content, created_at: now }
 }
 

--- a/src/web/token-usage.ts
+++ b/src/web/token-usage.ts
@@ -496,11 +496,19 @@ export function correlateWithKanban(): void {
   `).all() as { agent: string; minTs: number; maxTs: number }[]
 
   for (const row of uncorrelated) {
+    // PARENT CARDS ARE NOT WORK ITEMS HERE. This correlation reads updated_at as "the agent was
+    // working on this card at that moment" and uses consecutive timestamps as window boundaries.
+    // Since a subcard write now also stamps its ancestors (db.ts, touchAncestorChain), a parent
+    // carries the SAME timestamp as the child that caused it -- and with a tie, which title won
+    // the token rows came down to row order, not to what was worked on. Parents are skipped so the
+    // leaf card keeps the attribution; a parent's own timestamp can no longer tell us whether it
+    // was written or merely bubbled, and separating those would take a column we are not adding.
     const cards = db.prepare(`
       SELECT id, title, project, assignee, updated_at
       FROM kanban_cards
       WHERE (assignee = ? OR assignee LIKE '%' || ? || '%')
         AND updated_at BETWEEN ? AND ?
+        AND NOT EXISTS (SELECT 1 FROM kanban_cards child WHERE child.parent_id = kanban_cards.id)
       ORDER BY updated_at ASC
     `).all(row.agent, row.agent, row.minTs, row.maxTs) as any[]
 


### PR DESCRIPTION
A subcard write left its ancestors' `updated_at` untouched, so a parent card whose
whole thread moved all day still looked idle. Any check that asks "what has not
moved?" reported the parent as stuck -- and the more correctly the tree was built,
the more reliably it lied.

`updateKanbanCard` now walks the ancestor chain, including the **old** parent on a
re-parent (a card leaving is activity too). A root card returns before it prepares
anything, so the common case costs nothing.

### Test baseline, measured -- please read before judging the red

`main` at `1f13ff1` is **not green on its own**. Measured in the same worktree,
same command, minutes apart:

| | test files | failing | passing |
|---|---|---|---|
| `origin/main` (1f13ff1), untouched | 298 | **24** | 3958 |
| this branch (90bd1c3) | 299 | **24** | 3970 |

The 24 failures are identical and pre-existing (`hook-path-guard`,
`kanban-write-gate` and four others); this branch neither fixes nor worsens them.
What it adds is **+1 test file and +12 passing tests**, and `npm run typecheck`
exits 0.

I am flagging this rather than reporting "green", because a PR that says green
against a red base teaches the next reader to stop reading the numbers.

### What the tests cover

- a subcard write moves the ancestors' timestamp
- un-parenting moves the **old** parent too (the other shape of the same branch)
- the guard that fires is named in the assertion, so a passing test says *which*
  path it took
- the archive exclusion is asserted where it actually holds -- in the functions,
  not at the endpoint

