### PR TITLE
fix(hooks): ledger agent identity anchored to the session transcript, not the mutable cwd (LEDGERCWD828)

### DIFF
--- a/scripts/__tests__/ledger-agent-id.test.py
+++ b/scripts/__tests__/ledger-agent-id.test.py
@@ -55,6 +55,98 @@ print(f"  [{'PASS' if ok else 'FAIL'}] MARVEEN_AGENT_ID override for out-of-tree
       f"got={got!r} want='explicit-agent'")
 os.environ.pop("MARVEEN_AGENT_ID", None)
 
+# ---------------------------------------------------------------------------
+# agent_id_from_payload (LEDGERCWD828): the cwd is MUTABLE within a session --
+# the main agent cd-ing into agents/iris/... re-attributed its OWN replies to
+# iris, the reply guard found no outbound under the real id and triple-sent an
+# answered link. The transcript_path (derived from the session's config dir)
+# is immutable per session, so it must win over the cwd.
+# ---------------------------------------------------------------------------
+MAIN_TRANSCRIPT = os.path.join(INSTALL, ".channels-config", "projects", "x", "sess.jsonl")
+SUB_TRANSCRIPT = os.path.join(INSTALL, "agents", "iris", ".claude-config", "projects", "x", "s.jsonl")
+HOME_TRANSCRIPT = os.path.join(os.path.expanduser("~"), ".claude", "projects", "x", "s.jsonl")
+
+PAYLOAD_CASES = [
+    # (a) THE INCIDENT, as a known positive: main-agent session whose cwd
+    # wandered into a sub-agent's tree must STAY the main agent.
+    ("main session cd-ed into agents/<x> stays MAIN (the incident)",
+     {"transcript_path": MAIN_TRANSCRIPT, "cwd": os.path.join(INSTALL, "agents", "iris", "workspace", "v3")}, MAIN),
+    # (b) NEGATIVE CONTROL: a real sub-agent's own reply keeps its own name.
+    ("real sub-agent keeps its own id",
+     {"transcript_path": SUB_TRANSCRIPT, "cwd": os.path.join(INSTALL, "agents", "iris")}, "iris"),
+    ("sub-agent that cd-ed elsewhere STILL keeps its own id",
+     {"transcript_path": SUB_TRANSCRIPT, "cwd": os.path.join(INSTALL, "store")}, "iris"),
+    ("home-config transcript is the main agent",
+     {"transcript_path": HOME_TRANSCRIPT, "cwd": os.path.join(INSTALL, "agents", "boni")}, MAIN),
+    ("no transcript falls back to the old cwd semantics (sub-agent)",
+     {"cwd": os.path.join(INSTALL, "agents", "boni", "x")}, "boni"),
+    ("no transcript, install-subdir cwd falls back to MAIN",
+     {"cwd": os.path.join(INSTALL, "store")}, MAIN),
+    ("empty payload resolves to MAIN, never invents",
+     {}, MAIN),
+    ("None payload resolves to MAIN, never invents",
+     None, MAIN),
+    ("out-of-tree transcript says nothing -> cwd chain decides",
+     {"transcript_path": "/tmp/elsewhere/t.jsonl", "cwd": os.path.join(INSTALL, "agents", "dia")}, "dia"),
+]
+
+for name, payload, want in PAYLOAD_CASES:
+    got = ledger_lib.agent_id_from_payload(payload)
+    ok = got == want
+    if not ok:
+        failed.append(name)
+    print(f"  [{'PASS' if ok else 'FAIL'}] {name}: got={got!r} want={want!r}")
+
+# Env override sits BETWEEN transcript and cwd: it wins when the transcript is
+# silent, and loses when the transcript speaks.
+os.environ["MARVEEN_AGENT_ID"] = "explicit-agent"
+got = ledger_lib.agent_id_from_payload({"transcript_path": "/tmp/none/t.jsonl", "cwd": "/tmp/none"})
+if got != "explicit-agent":
+    failed.append("env override when transcript silent")
+print(f"  [{'PASS' if got == 'explicit-agent' else 'FAIL'}] env override when transcript silent: got={got!r}")
+got = ledger_lib.agent_id_from_payload({"transcript_path": SUB_TRANSCRIPT})
+if got != "iris":
+    failed.append("transcript beats env override")
+print(f"  [{'PASS' if got == 'iris' else 'FAIL'}] transcript beats env override: got={got!r}")
+os.environ.pop("MARVEEN_AGENT_ID", None)
+
+# ---------------------------------------------------------------------------
+# End-to-end through the REAL outbound hook: same incident shape, but the row
+# that lands in the (temp) ledger DB is what gets asserted -- not the resolver
+# in isolation. LEDGER_DB_PATH keeps this off the live store.
+# ---------------------------------------------------------------------------
+import json
+import sqlite3
+import subprocess
+import tempfile
+
+HOOK = os.path.join(HOOKS, "ledger-outbound.py")
+with tempfile.TemporaryDirectory() as tmp:
+    db = os.path.join(tmp, "ledger.db")
+    env = dict(os.environ, LEDGER_DB_PATH=db, MAIN_AGENT_ID="mainagent")
+    env.pop("MARVEEN_AGENT_ID", None)
+
+    def run_hook(transcript, cwd):
+        payload = {
+            "tool_name": "mcp__plugin_telegram_telegram__reply",
+            "cwd": cwd,
+            "transcript_path": transcript,
+            "tool_input": {"chat_id": "111", "text": "e2e probe"},
+        }
+        subprocess.run(["python3", HOOK], input=json.dumps(payload).encode(),
+                       env=env, timeout=30, check=False)
+
+    run_hook(MAIN_TRANSCRIPT, os.path.join(INSTALL, "agents", "iris", "workspace"))
+    run_hook(SUB_TRANSCRIPT, os.path.join(INSTALL, "agents", "iris"))
+    rows = sqlite3.connect(db).execute(
+        "SELECT agent_id FROM conversation_log WHERE direction='out' ORDER BY id").fetchall()
+    got_ids = [r[0] for r in rows]
+    want_ids = [MAIN, "iris"]
+    ok = got_ids == want_ids
+    if not ok:
+        failed.append("end-to-end outbound rows")
+    print(f"  [{'PASS' if ok else 'FAIL'}] end-to-end outbound rows: got={got_ids!r} want={want_ids!r}")
+
 print()
 if failed:
     print(f"{len(failed)} FAILED: {failed}", file=sys.stderr)

--- a/scripts/__tests__/ledger-agent-id.test.py
+++ b/scripts/__tests__/ledger-agent-id.test.py
@@ -88,6 +88,23 @@ PAYLOAD_CASES = [
      None, MAIN),
     ("out-of-tree transcript says nothing -> cwd chain decides",
      {"transcript_path": "/tmp/elsewhere/t.jsonl", "cwd": os.path.join(INSTALL, "agents", "dia")}, "dia"),
+    # The MIRROR family (review finding on #1100): every fleet agent's tmux
+    # session runs on the DEFAULT ~/.claude config root, whose project dir is
+    # keyed by the flattened starting cwd -- the agent id is IN the segment.
+    # Measured live 2026-08-28: the running samu session's transcript sits
+    # exactly here. Mapping this family to MAIN would mirror the original bug.
+    ("~/.claude fleet-session transcript keeps the agent id (the mirror case)",
+     {"transcript_path": os.path.join(os.path.expanduser("~"), ".claude", "projects",
+                                      INSTALL.replace(os.sep, "-") + "-agents-iris", "s.jsonl"),
+      "cwd": os.path.join(INSTALL, "store")}, "iris"),
+    ("~/.claude session started DEEP in an agent tree still maps to the agent",
+     {"transcript_path": os.path.join(os.path.expanduser("~"), ".claude", "projects",
+                                      INSTALL.replace(os.sep, "-") + "-agents-geri-workspace-hideghivas", "s.jsonl"),
+      "cwd": "/tmp"}, "geri"),
+    ("~/.claude session started at the install root is the MAIN agent",
+     {"transcript_path": os.path.join(os.path.expanduser("~"), ".claude", "projects",
+                                      INSTALL.replace(os.sep, "-"), "s.jsonl"),
+      "cwd": os.path.join(INSTALL, "agents", "iris")}, MAIN),
 ]
 
 for name, payload, want in PAYLOAD_CASES:
@@ -136,12 +153,15 @@ with tempfile.TemporaryDirectory() as tmp:
         subprocess.run(["python3", HOOK], input=json.dumps(payload).encode(),
                        env=env, timeout=30, check=False)
 
+    HOME_FLEET_TRANSCRIPT = os.path.join(os.path.expanduser("~"), ".claude", "projects",
+                                         INSTALL.replace(os.sep, "-") + "-agents-iris", "s.jsonl")
     run_hook(MAIN_TRANSCRIPT, os.path.join(INSTALL, "agents", "iris", "workspace"))
     run_hook(SUB_TRANSCRIPT, os.path.join(INSTALL, "agents", "iris"))
+    run_hook(HOME_FLEET_TRANSCRIPT, os.path.join(INSTALL, "store"))
     rows = sqlite3.connect(db).execute(
         "SELECT agent_id FROM conversation_log WHERE direction='out' ORDER BY id").fetchall()
     got_ids = [r[0] for r in rows]
-    want_ids = [MAIN, "iris"]
+    want_ids = [MAIN, "iris", "iris"]
     ok = got_ids == want_ids
     if not ok:
         failed.append("end-to-end outbound rows")

--- a/scripts/hooks/channel-inbox-drain.py
+++ b/scripts/hooks/channel-inbox-drain.py
@@ -42,13 +42,14 @@ def _is_main_session(payload):
     """Return True when running inside the main agent session.
 
     Resolution order (mirrors inbox-drain.py / ledger_lib.agent_id_from_cwd):
-    1. ledger_lib.agent_id_from_cwd + main_agent_id() comparison (preferred).
+    1. ledger_lib.agent_id_from_payload + main_agent_id() comparison (preferred;
+       transcript-anchored, LEDGERCWD828 -- the cwd mutates within a session).
     2. Fallback: MAIN_AGENT_ID env var vs cwd-derived agent name.
     """
     cwd = (payload or {}).get("cwd") or ""
     if _HAS_LEDGER:
         try:
-            agent_id = ledger_lib.agent_id_from_cwd(cwd)
+            agent_id = ledger_lib.agent_id_from_payload(payload)
             return agent_id == ledger_lib.main_agent_id()
         except Exception:
             pass

--- a/scripts/hooks/inbox-drain.py
+++ b/scripts/hooks/inbox-drain.py
@@ -48,7 +48,7 @@ def main():
     except Exception:
         sys.exit(0)
 
-    agent_id = ledger_lib.agent_id_from_cwd(payload.get("cwd"))
+    agent_id = ledger_lib.agent_id_from_payload(payload)
     if agent_id != ledger_lib.main_agent_id():
         sys.exit(0)  # sub-agents are delivered by the router push path
 

--- a/scripts/hooks/ledger-capture.py
+++ b/scripts/hooks/ledger-capture.py
@@ -42,7 +42,7 @@ def main():
         payload = json.load(sys.stdin)
     except Exception:
         sys.exit(0)
-    agent_id = ledger_lib.agent_id_from_cwd(payload.get("cwd"))
+    agent_id = ledger_lib.agent_id_from_payload(payload)
     prompt = payload.get("prompt") or ""
     for m in CHANNEL_RX.finditer(prompt):
         attrs, text = m.group(1), m.group(2)

--- a/scripts/hooks/ledger-outbound.py
+++ b/scripts/hooks/ledger-outbound.py
@@ -122,7 +122,7 @@ def main():
     # that merely contains "reply" cannot write a bogus turn into the ledger.
     if not REPLY_TOOL_RX.match(tool):
         sys.exit(0)
-    agent_id = ledger_lib.agent_id_from_cwd(payload.get("cwd"))
+    agent_id = ledger_lib.agent_id_from_payload(payload)
     tool_input = payload.get("tool_input") or {}
     chat_id = tool_input.get("chat_id")
     chat_id = "" if chat_id is None else str(chat_id).strip()

--- a/scripts/hooks/ledger-replay.py
+++ b/scripts/hooks/ledger-replay.py
@@ -202,13 +202,12 @@ def _fit_output(transcript, open_q, owner, byte_budget):
 
 
 def main():
-    cwd = None
+    payload = None
     try:
         payload = json.load(sys.stdin)
-        cwd = payload.get("cwd")
     except Exception:
         pass
-    agent_id = ledger_lib.agent_id_from_cwd(cwd)
+    agent_id = ledger_lib.agent_id_from_payload(payload)
 
     try:
         rows = ledger_lib.recent(agent_id, _window_limit())

--- a/scripts/hooks/ledger_lib.py
+++ b/scripts/hooks/ledger_lib.py
@@ -100,9 +100,64 @@ def owner_name():
     return "A felhasználó"
 
 
+def agent_id_from_payload(payload):
+    """Session-stable agent identity from a hook payload (LEDGERCWD828).
+
+    The shell cwd is MUTABLE within a session: when the main agent stepped into
+    agents/iris/... for a measurement, its OWN replies to the owner ledgered
+    under iris, the reply guard then found no outbound under the real id and
+    triple-sent an already-answered link. Measured blast radius on the owner
+    chat: 51 outbound rows under 7 names, several of them plain directory
+    names, not agents.
+
+    The session's transcript_path is derived from the agent's own config dir
+    (CLAUDE_CONFIG_DIR), which never changes within a session -- that is the
+    identity anchor. Resolution order:
+      1. transcript_path  (immutable per session)
+      2. MARVEEN_AGENT_ID (explicit launcher override)
+      3. cwd              (last resort, for callers that have nothing else)
+    """
+    payload = payload or {}
+    agent = _agent_id_from_config_path(payload.get("transcript_path"))
+    if agent:
+        return agent
+    env_id = os.environ.get("MARVEEN_AGENT_ID", "").strip()
+    if env_id:
+        return env_id
+    return agent_id_from_cwd(payload.get("cwd"))
+
+
+def _agent_id_from_config_path(path):
+    """Map a transcript/config path to an agent id, or None when the path says
+    nothing (caller falls through to the env/cwd chain).
+
+      <install>/agents/<id>/...  -> <id>            (a sub-agent's config dir)
+      anywhere else in the tree  -> MAIN_AGENT_ID   (.channels-config etc.)
+      under ~/.claude            -> MAIN_AGENT_ID   (non-isolated main session)
+      anything else / empty      -> None
+    """
+    if not path or not isinstance(path, str):
+        return None
+    path = os.path.abspath(path.strip())
+    install = _install_dir().rstrip("/")
+    agents_root = os.path.join(install, "agents")
+    if path.startswith(agents_root + os.sep):
+        rel = path[len(agents_root) + 1:]
+        head = rel.split(os.sep)[0]
+        return head or None
+    if path == install or path.startswith(install + os.sep):
+        return main_agent_id()
+    home_claude = os.path.join(os.path.expanduser("~"), ".claude")
+    if path == home_claude or path.startswith(home_claude + os.sep):
+        return main_agent_id()
+    return None
+
+
 def agent_id_from_cwd(cwd):
-    """Which channel agent is this session? Derived from cwd so the hooks are
-    generic across every agent and never cross-contaminate:
+    """Which channel agent is this session? Derived from cwd. LAST-RESORT ONLY:
+    the cwd changes within a session (a `cd` into agents/<x>/ re-attributes
+    every later row), so payload-carrying hooks must call agent_id_from_payload
+    instead -- its docstring carries the measured incident (LEDGERCWD828).
       <install>/agents/<id>[/...]  -> <id>           (a sub-agent)
       anywhere else in the tree    -> MAIN_AGENT_ID   (the main channels agent)
     """

--- a/scripts/hooks/ledger_lib.py
+++ b/scripts/hooks/ledger_lib.py
@@ -141,14 +141,62 @@ def _agent_id_from_config_path(path):
     path = os.path.abspath(path.strip())
     install = _install_dir().rstrip("/")
     agents_root = os.path.join(install, "agents")
+    # 1. The CONFIG OWNER is authoritative: a transcript under
+    #    <install>/agents/<id>/... is that agent's isolated config dir, no
+    #    matter where the session's cwd wandered.
     if path.startswith(agents_root + os.sep):
         rel = path[len(agents_root) + 1:]
         head = rel.split(os.sep)[0]
         return head or None
+    # 2. Non-isolated config roots (~/.claude and friends) key the project dir
+    #    by the session's STARTING cwd, flattened: /a/b -> "-a-b". Every fleet
+    #    agent's tmux session runs this way (measured 2026-08-28: the live
+    #    samu session's transcript sits under
+    #    ~/.claude/projects/-Users-marvin-ClaudeClaw-agents-samu/), so the
+    #    agent id is IN the path -- mapping the whole family to the main agent
+    #    would be the original bug mirrored. Parse the segment instead.
+    seg_agent = _agent_id_from_project_segment(path, install)
+    if seg_agent is not None:
+        return seg_agent
     if path == install or path.startswith(install + os.sep):
         return main_agent_id()
     home_claude = os.path.join(os.path.expanduser("~"), ".claude")
     if path == home_claude or path.startswith(home_claude + os.sep):
+        return main_agent_id()
+    return None
+
+
+def _agent_id_from_project_segment(path, install):
+    """Read the agent id out of a flattened projects/<segment>/ component.
+
+      .../projects/-Users-...-ClaudeClaw-agents-<id>[-...]/x.jsonl -> <id>
+      .../projects/-Users-...-ClaudeClaw[-...]/x.jsonl             -> MAIN
+      no /projects/ component, or a foreign segment                -> None
+
+    Agent ids may in principle contain hyphens, which the flattening makes
+    ambiguous; when <install>/agents exists its entries disambiguate (longest
+    match wins), otherwise the first hyphen-delimited hunk is taken -- correct
+    for every current fleet name.
+    """
+    marker = os.sep + "projects" + os.sep
+    i = path.find(marker)
+    if i < 0:
+        return None
+    seg = path[i + len(marker):].split(os.sep)[0]
+    flat_install = install.replace(os.sep, "-")
+    agents_prefix = flat_install + "-agents-"
+    if seg.startswith(agents_prefix):
+        rest = seg[len(agents_prefix):]
+        try:
+            names = sorted(os.listdir(os.path.join(install, "agents")), key=len, reverse=True)
+        except OSError:
+            names = []
+        for name in names:
+            if rest == name or rest.startswith(name + "-"):
+                return name
+        head = rest.split("-")[0]
+        return head or None
+    if seg == flat_install or seg.startswith(flat_install + "-"):
         return main_agent_id()
     return None
 

--- a/scripts/hooks/skill-usage-capture.py
+++ b/scripts/hooks/skill-usage-capture.py
@@ -61,8 +61,9 @@ def _dashboard_token() -> str:
         return ""
 
 
-# Kept as a module-level name so callers and tests address ONE symbol; the
-# implementation is the shared resolver, not a local copy.
+# Kept as a module-level alias for the tests (they pin that this file has no
+# private copy of the resolver); the hook itself resolves from the PAYLOAD
+# (transcript-anchored, LEDGERCWD828), not from this cwd-only fallback.
 _agent_id_from_cwd = ledger_lib.agent_id_from_cwd
 
 
@@ -102,7 +103,7 @@ def main() -> None:
         sys.exit(0)
 
     skill_name, trigger_type = result
-    agent_id = _agent_id_from_cwd(cwd)
+    agent_id = ledger_lib.agent_id_from_payload(payload)
 
     token = _dashboard_token()
     if not token:

--- a/scripts/hooks/taskstate-replay.py
+++ b/scripts/hooks/taskstate-replay.py
@@ -20,6 +20,13 @@ import os
 import json
 import urllib.request
 
+# Agent identity comes from the ledger library -- ONE resolver for every hook
+# (LEDGERCWD828: the cwd is mutable within a session, so this file's private
+# cwd-based copy could re-attribute a session that merely cd-ed somewhere; the
+# shared resolver anchors on the session's transcript_path instead).
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import ledger_lib  # noqa: E402
+
 def _project_root():
     # scripts/hooks/ -> project root is two up.
     return os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -66,27 +73,6 @@ def _main_agent_id():
     return "marveen"
 
 
-def _agent_id_from_cwd(cwd):
-    # agents/<name>/... -> <name>; the project root -> the MAIN agent.
-    #
-    # The main agent used to return None here, i.e. it silently never got its
-    # task-state back (2026-07-27). That was never a deliberate exclusion: the
-    # record is written per agent_id and the main agent writes one exactly like
-    # a sub-agent does, so there was nothing to protect against -- only a
-    # missing branch. It matters most for the main agent, which is the one
-    # holding the owner-facing threads when a respawn hits.
-    if not cwd:
-        return None
-    root = os.path.normpath(_project_root())
-    norm = os.path.normpath(cwd)
-    parts = norm.split(os.sep)
-    if "agents" in parts:
-        i = parts.index("agents")
-        if i + 1 < len(parts):
-            return parts[i + 1]
-    if norm == root:
-        return _main_agent_id()
-    return None
 
 
 def _req(method, path, token):
@@ -102,7 +88,7 @@ def main():
     except Exception:
         sys.exit(0)
     source = payload.get("source") or ""
-    agent = _agent_id_from_cwd(payload.get("cwd"))
+    agent = ledger_lib.agent_id_from_payload(payload)
     if not agent:
         sys.exit(0)  # main agent / unknown -> not a sub-agent task-state target
     token = _token()

--- a/scripts/hooks/telegram-reply-guard.py
+++ b/scripts/hooks/telegram-reply-guard.py
@@ -100,7 +100,7 @@ def main():
     except Exception:
         sys.exit(0)
 
-    agent_id = ledger_lib.agent_id_from_cwd(payload.get("cwd"))
+    agent_id = ledger_lib.agent_id_from_payload(payload)
 
     try:
         oq = ledger_lib.open_question_with_age(agent_id)

--- a/scripts/hooks/tool-log-capture.py
+++ b/scripts/hooks/tool-log-capture.py
@@ -114,7 +114,7 @@ def main():
         'tool_name': tool_name,
         'input_summary': _input_summary(tool_input, tool_name),
         'success': success,
-        'agent_id': ledger_lib.agent_id_from_cwd(cwd),
+        'agent_id': ledger_lib.agent_id_from_payload(payload),
         # trace_id holds the CC-native tool_use_id: stable, unique per call,
         # present in both Pre and PostToolUse payloads (empirically verified).
         # No PreToolUse hook needed -- CC already gives us the correlation key

--- a/src/__tests__/ledger-agent-identity.test.ts
+++ b/src/__tests__/ledger-agent-identity.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { spawnSync } from 'node:child_process'
+import { join } from 'node:path'
+
+// LEDGERCWD828: the outbound ledger derived agent_id from the session's shell
+// cwd, which is MUTABLE -- the main agent stepping into agents/<x>/ for a
+// measurement re-attributed its own replies to <x> (51 rows under 7 names on
+// the owner chat, several of them plain directory names), and the reply guard
+// then triple-sent an already-answered link. The python suite asserts the
+// transcript-anchored resolver: the incident shape as a known positive, a real
+// sub-agent as the negative control, and an end-to-end run of the actual
+// ledger-outbound hook into a temp DB. This wrapper makes that suite a CI
+// gate -- before it, nothing executed scripts/__tests__/ledger-agent-id.test.py.
+const ROOT = join(__dirname, '..', '..')
+
+describe('ledger agent identity is anchored to the session, not the cwd', () => {
+  it('the python suite passes (resolver cases + end-to-end outbound rows)', () => {
+    const res = spawnSync('python3', [join(ROOT, 'scripts', '__tests__', 'ledger-agent-id.test.py')], {
+      encoding: 'utf-8',
+      timeout: 120_000,
+    })
+    if (res.status !== 0) {
+      // Surface the python output so a failure names the exact case.
+      console.error(res.stdout)
+      console.error(res.stderr)
+    }
+    expect(res.status).toBe(0)
+  })
+})


### PR DESCRIPTION
## Élő hook-okat érint: mind a 9 payload-os hook (ledger-outbound, reply-guard, drain-ek, capture-k, replay-ek)

## A hiba
Az agent_id a shell CWD-ből jött (`agent_id_from_cwd`), ami session-en BELÜL változik: amikor a fő agens mérés közben belépett az `agents/iris/...` alá, a SAJÁT válaszai iris nevére ledgerelődtek, a reply-guard nem talált outboundot a valódi néven, és harmadszor is elküldte a már megválaszolt linket. Mért hatókör a gazda chatjén: **51 sor 7 néven**, köztük nem létező "agensek" (könyvtárnevek). A `agent_id_from_cwd` docstringje szó szerint azt állította: "never cross-contaminate" -- a mérés cáfolta.

## A fix
- **`ledger_lib.agent_id_from_payload`**: a session `transcript_path`-ja az elsődleges horgony (a session config-könyvtárából származik, session-en belül immutábilis): `agents/<id>/...` -> `<id>`; install-fa / `~/.claude` -> fő agens. Sorrend: transcript -> `MARVEEN_AGENT_ID` -> régi cwd-lánc (utolsó menedék).
- **Mind a 9 payload-os hívóhely átállítva**; a taskstate-replay saját (driftelt) másolata törölve -- ugyanaz a lépés, amit a skill-usage-capture már megtett.
- `agent_id_from_cwd` megmarad az egyetlen payload-nélküli hívónak (ledger-live-drain: per-futás process-cwd, nem a session-en belüli mutáció osztálya) és dokumentált fallbacknek.
- **A meglévő 51 hibás sort NEM írja át** -- az adat-javítás külön döntés (a kártya kikötése).

## Verify (a kártya két kötelező ága)
- **(a) Ismert pozitív**: fő-agens transcript + `agents/iris/workspace` cwd -> resolver ÉS a valódi ledger-outbound hook end-to-end (temp DB, `LEDGER_DB_PATH`) is a fő agens nevére ír. ✅
- **(b) Negatív kontroll**: valódi sub-agent (saját transcript) válasza a saját nevére megy -- akkor is, ha a cwd-je máshol jár. ✅
- **Red-before**: a bővített suite exit 1 a régi hookokon.
- Új vitest-wrapper: a `scripts/__tests__/ledger-agent-id.test.py` mostantól CI-kapu (eddig semmi nem futtatta).
- Teljes suite: **315 fájl / 4199 passed / 1 skipped**; tsc clean; mind a 10 érintett py szintaxis-tiszta; a szomszéd python-tesztek (skill-usage, reply-guard) zöldek.

Kártya: LEDGERCWD828. A merge a RELEASE827 promote utánra sorolandó (merge-fagy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)