### PR TITLE
Audit kanban status changes made through the update path, not only the drag

### DIFF
--- a/src/__tests__/kanban-update-audit.test.ts
+++ b/src/__tests__/kanban-update-audit.test.ts
@@ -1,0 +1,105 @@
+// Contract tests for the kanban status-change audit trail on the UPDATE path.
+//
+// moveKanbanCard (the dashboard's drag-and-drop) has always recorded a
+// kanban_card_events row. updateKanbanCard -- the path behind PUT
+// /api/kanban/:id, which is what every agent and every script uses -- recorded
+// none. Measured 2026-08-29 on the live board: 8 events in the whole table, the
+// newest 6 weeks old, so "when did this card become in_progress" could not be
+// answered for essentially any card.
+//
+// These tests call the real production entry points on an in-memory database,
+// the same way kanban-move-audit.test.ts does for the move path.
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  initDatabase,
+  createKanbanCard,
+  updateKanbanCard,
+  moveKanbanCard,
+  getKanbanCard,
+  getKanbanCardEvents,
+} from '../db.js'
+
+beforeEach(() => {
+  initDatabase(':memory:')
+})
+
+describe('kanban update audit trail', () => {
+  it('records one event with correct from/to status and actor on a status change', () => {
+    createKanbanCard({ id: 'card-a', title: 'Audited card' })
+
+    expect(updateKanbanCard('card-a', { status: 'in_progress' }, 'devy')).toBe(true)
+
+    const events = getKanbanCardEvents('card-a')
+    expect(events).toHaveLength(1)
+    expect(events[0].card_id).toBe('card-a')
+    expect(events[0].from_status).toBe('planned')
+    expect(events[0].to_status).toBe('in_progress')
+    expect(events[0].actor).toBe('devy')
+    expect(typeof events[0].created_at).toBe('number')
+  })
+
+  it('records no event when a non-status field changes', () => {
+    createKanbanCard({ id: 'card-b', title: 'Renamed card' })
+
+    expect(updateKanbanCard('card-b', { title: 'New title', priority: 'high' }, 'devy')).toBe(true)
+    expect(getKanbanCardEvents('card-b')).toHaveLength(0)
+    expect(getKanbanCard('card-b')?.title).toBe('New title')
+  })
+
+  it('records no event when the caller echoes the unchanged status back', () => {
+    // The dashboard's edit form PUTs the whole card, status included. Treating
+    // that as a transition would bury the real ones in noise.
+    createKanbanCard({ id: 'card-c', title: 'Full-card PUT' })
+
+    expect(updateKanbanCard('card-c', { title: 'Edited', status: 'planned' }, 'devy')).toBe(true)
+    expect(getKanbanCardEvents('card-c')).toHaveLength(0)
+  })
+
+  it('records no event when no row matches', () => {
+    expect(updateKanbanCard('nonexistent-card', { status: 'done' }, 'devy')).toBe(false)
+    expect(getKanbanCardEvents('nonexistent-card')).toHaveLength(0)
+  })
+
+  it('leaves actor null when none is supplied (existing callers pass two args)', () => {
+    createKanbanCard({ id: 'card-d', title: 'No actor' })
+
+    expect(updateKanbanCard('card-d', { status: 'waiting' })).toBe(true)
+
+    const events = getKanbanCardEvents('card-d')
+    expect(events).toHaveLength(1)
+    expect(events[0].actor).toBeNull()
+  })
+
+  it('interleaves with move events into one chronological history per card', () => {
+    // The two paths write the same table, so a card picked up by an agent (PUT)
+    // and later dragged by the owner (move) reads as a single timeline.
+    createKanbanCard({ id: 'card-e', title: 'Mixed path card' })
+
+    updateKanbanCard('card-e', { status: 'in_progress' }, 'devy')
+    moveKanbanCard('card-e', 'waiting', 0, 'zsolt')
+    updateKanbanCard('card-e', { status: 'done' }, 'devy')
+
+    const events = getKanbanCardEvents('card-e')
+    expect(events.map((e) => e.to_status)).toEqual(['in_progress', 'waiting', 'done'])
+    expect(events.map((e) => e.from_status)).toEqual(['planned', 'in_progress', 'waiting'])
+    expect(events.map((e) => e.actor)).toEqual(['devy', 'zsolt', 'devy'])
+    for (let i = 1; i < events.length; i++) {
+      expect(events[i].created_at).toBeGreaterThanOrEqual(events[i - 1].created_at)
+      expect(events[i].id).toBeGreaterThan(events[i - 1].id)
+    }
+  })
+
+  it('answers how long a card has been in its current status', () => {
+    // The question the empty table could not answer. Kept as a test so the
+    // guarantee survives even if no dashboard ever renders it.
+    createKanbanCard({ id: 'card-f', title: 'Timing card' })
+    updateKanbanCard('card-f', { status: 'in_progress' }, 'devy')
+
+    const events = getKanbanCardEvents('card-f')
+    const enteredCurrent = events.filter((e) => e.to_status === 'in_progress').at(-1)
+    expect(enteredCurrent).toBeDefined()
+    expect(getKanbanCard('card-f')?.status).toBe('in_progress')
+    expect(enteredCurrent!.created_at).toBeLessThanOrEqual(Math.floor(Date.now() / 1000))
+  })
+})

--- a/src/db.ts
+++ b/src/db.ts
@@ -1794,15 +1794,34 @@ export function createKanbanCard(card: {
   )
 }
 
-export function updateKanbanCard(id: string, fields: Partial<Omit<KanbanCard, 'id' | 'created_at'>>): boolean {
+// A status change made through here is audited exactly like one made through
+// moveKanbanCard. Until this, only the dashboard's drag-and-drop (the /move
+// route) recorded kanban_card_events, while the PUT route -- the one every
+// agent and every script uses -- wrote none. Measured 2026-08-29: 8 events in
+// the whole table, the newest 6 weeks old, so "when did this card become
+// in_progress" was unanswerable for essentially every card on the board.
+export function updateKanbanCard(
+  id: string,
+  fields: Partial<Omit<KanbanCard, 'id' | 'created_at'>>,
+  actor?: string,
+): boolean {
   const card = getKanbanCard(id)
   if (!card) return false
   const now = Math.floor(Date.now() / 1000)
   const f = { ...card, ...fields, updated_at: now }
-  return db.prepare(
+  const changed = db.prepare(
     `UPDATE kanban_cards SET title=?, description=?, status=?, assignee=?, priority=?, project=?, parent_id=?, due_date=?, sort_order=?, updated_at=?, archived_at=?
      WHERE id=?`
   ).run(f.title, f.description, f.status, f.assignee, f.priority, f.project, f.parent_id, f.due_date, f.sort_order, f.updated_at, f.archived_at, id).changes > 0
+  // Only a REAL transition is an event: a PUT that edits the title or the
+  // assignee and echoes the unchanged status back must not log one, or the
+  // history fills with noise that hides the transitions worth reading.
+  if (changed && f.status !== card.status) {
+    db.prepare(
+      'INSERT INTO kanban_card_events (card_id, from_status, to_status, actor, created_at) VALUES (?, ?, ?, ?, ?)'
+    ).run(id, card.status, f.status, actor ?? null, now)
+  }
+  return changed
 }
 
 export function getChildCards(parentId: string): KanbanCard[] {

--- a/src/web/routes/kanban.ts
+++ b/src/web/routes/kanban.ts
@@ -325,8 +325,11 @@ export async function tryHandleKanban(ctx: RouteContext): Promise<boolean> {
   if (kanbanCardMatch && method === 'PUT') {
     const id = decodeURIComponent(kanbanCardMatch[1])
     const body = await readBody(req)
-    const data = JSON.parse(body.toString())
-    if (updateKanbanCard(id, data)) { json(res, { ok: true }); return true }
+    // `actor` is metadata for the audit event, not a card column -- keep it out
+    // of the field set so it can never be mistaken for one. Same name the /move
+    // route already accepts, so callers do not have to learn a second spelling.
+    const { actor, ...data } = JSON.parse(body.toString()) as Record<string, unknown> & { actor?: string }
+    if (updateKanbanCard(id, data, actor)) { json(res, { ok: true }); return true }
     json(res, { error: 'Kártya nem található' }, 404)
     return true
   }


### PR DESCRIPTION
## A lyuk

A `kanban_card_events` tábla létezik, működik, és tesztelve van -- de csak a dashboard drag-and-drop útja (`moveKanbanCard`) ír bele. A `PUT /api/kanban/:id` út, amit **minden agens és minden szkript** használ, egyetlen eseményt sem rögzített.

Mérve 2026-08-29 az élő táblán:

```
SELECT COUNT(*) FROM kanban_card_events;   -- 8
SELECT MAX(datetime(created_at,'unixepoch','localtime')) FROM kanban_card_events;
-- 2026-07-14 21:29:43
```

8 esemény összesen, a legfrissebb 6 hetes. A tábla pontosan arra való, hogy megválaszolja: *mikor lett ez a kártya `in_progress`* -- és lényegében egyetlen kártyára sem tudta.

**Élő igazolás a javítás előtt:** eldobható kártyán a `PUT` átvitte a státuszt `planned` → `in_progress`, és **nulla** esemény keletkezett. (A kártya utána törölve.)

## A változás

- **`updateKanbanCard`**: opcionális `actor` paraméter, és esemény-írás a valódi státuszváltásnál. A függvény eddig is beolvasta a kártya előző állapotát (`getKanbanCard` a legelső sorban), tehát a `from_status` készen állt -- csak senki nem használta.
- **Csak valódi átmenet számít eseménynek.** A dashboard szerkesztő-űrlapja a teljes kártyát vissza-PUT-olja, státusszal együtt. Ha azt is átmenetnek vennénk, a napló tele lenne zajjal, ami eltakarja az olvasásra érdemes átmeneteket. Külön teszt fedi.
- **`routes/kanban.ts`**: az `actor` destrukturálással kikerül a mezőkészletből, mert audit-metaadat, nem kártya-oszlop. Ugyanaz a név, amit a `/move` út már elfogad, hogy a hívóknak ne kelljen második írásmódot tanulniuk.

Visszafelé kompatibilis: az `actor` opcionális, a meglévő kéttagú hívás változatlanul fordul és `actor = NULL`-t ír.

## Egy tábla, egy idővonal

A két út ugyanabba a táblába ír, így egy kártya, amit egy agens vett fel (`PUT`) és később a tulajdonos húzott arrébb (`/move`), **egyetlen idorendi történetként** olvasható. Erre külön teszt van (`interleaves with move events into one chronological history per card`).

## Önmagában teljes

Ez a PR nem függ semmilyen készülő nézettől, és akkor is értelmes marad, ha sosem épül rá UI. Az esemény-napló maga a válasz egy kérdésre, amit ma egyáltalán nem tudunk feltenni: mióta áll ez a kártya ebben a státuszban. Ezért van rá teszt is (`answers how long a card has been in its current status`), hogy a garancia akkor is fennmaradjon, ha renderelő felület sosem készül.

## Verify

- **Red-before**: a `db.ts` és a route visszaállításával 7-ből **4 új teszt bukik**. A három átmenő a negatív kontroll (*"records no event when..."*), ami triviálisan zöld amíg senki nem ír eseményt -- ezt szándékosan így hagytam, mert ezek a nem-regresszió őrei, nem a fix bizonyítékai.
- **Élő mérés** a javítás előtt, a fenti eldobható kártyával, utána takarítva.
- Teljes suite **317 fájl / 4277 teszt zöld**, `tsc --noEmit` tiszta.

## Amit nem tartalmaz

A meglévő 8 esemény és a hiányzó előzmény nem kerül visszamenőleg pótolva -- nincs miből. A napló innentől teljes, visszafelé nem az.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
