### PR TITLE
fix(agents): send /rename, not /name, when naming a spawned session

### DIFF
--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -744,7 +744,7 @@ unset _eperm_restarted
 # longer uses Remote Control.)
 _bot_name="${BOT_NAME:-${MAIN_AGENT_ID:-marveen}}"
 sleep 1
-$TMUX send-keys -t "$SESSION" "/name ${_bot_name}" Enter
+$TMUX send-keys -t "$SESSION" "/rename ${_bot_name}" Enter
 unset _bot_name
 
 # Reset the keep-alive watchdog baseline so a session that was just restarted

--- a/src/__tests__/agent-identity-setup.test.ts
+++ b/src/__tests__/agent-identity-setup.test.ts
@@ -3,11 +3,23 @@ import { identitySlashCommands } from '../web/agent-process.js'
 
 // Locks the identity slash commands sent on every Claude Code session
 // (re)start -- both the normal startup and the channel-monitor recovery
-// respawns route through scheduleIdentitySetup, which uses these. Only `/name`
+// respawns route through scheduleIdentitySetup, which uses these. Only `/rename`
 // is sent now; `/remote-control` was dropped (the operator no longer uses it).
+//
+// The `/name` case below is not a style assertion. `/name` is not a Claude Code
+// command -- the CLI answers "Unknown command: /name. Did you mean /rename?" and
+// leaves the rejected line PARKED in the input box, where it lands only when the
+// current turn ends. A parked input line makes the router read the session as
+// busy, so inter-agent messages stop being delivered and the channel goes quiet
+// with no error. The previous version of this test asserted `/name`, which is
+// why CI stayed green while no session was ever renamed.
 describe('identitySlashCommands', () => {
-  it('returns just /name with the display name', () => {
-    expect(identitySlashCommands('Zoé')).toEqual(['/name Zoé'])
+  it('returns just /rename with the display name', () => {
+    expect(identitySlashCommands('Zoé')).toEqual(['/rename Zoé'])
+  })
+
+  it('never sends /name -- there is no such Claude Code command', () => {
+    expect(identitySlashCommands('Zoé').some((c) => c.startsWith('/name'))).toBe(false)
   })
 
   it('does not send /remote-control', () => {

--- a/src/__tests__/channel-plugin-unlock.test.ts
+++ b/src/__tests__/channel-plugin-unlock.test.ts
@@ -87,7 +87,7 @@ describe('channel-plugin-unlock helper contract', () => {
     // The plugin handshake needs time to complete on cold start; firing
     // the probe too early would always see no bun and trigger a needless
     // unlock cycle. Stay >= 25s to comfortably cover the 8s modal +
-    // 5s /name + plugin spawn window observed in channels.sh.
+    // 5s /rename + plugin spawn window observed in channels.sh.
     const m = helper.match(/const\s+UNLOCK_PROBE_DELAY_MS\s*=\s*([\d_]+)/)
     expect(m, 'UNLOCK_PROBE_DELAY_MS constant not found').not.toBeNull()
     const value = parseInt((m![1] as string).replace(/_/g, ''), 10)

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -582,7 +582,7 @@ export function detectsFirstRunGate(pane: string): FirstRunGateKind | null {
 //   ❯ 2. Switch to Sonnet 5 and continue
 //   Enter to confirm · Esc to cancel
 // with the DEFAULT CURSOR ON THE SWITCH OPTION. Any blind Enter reaching the
-// pane (the post-spawn identity /name, sendPromptToSession's retry-Enter,
+// pane (the post-spawn identity /rename, sendPromptToSession's retry-Enter,
 // a human reflex) silently switches the session to Sonnet. The dialog is
 // detected here (pure, unit-testable) and answered in agent-process.ts by
 // actively selecting option 1 ("Continue with <model>") -- never the switch

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -746,7 +746,7 @@ export function stampProjectTrustForDir(dotClaudePath: string, projectDir: strin
 // Root cause chain (2026-07-23, card b71fc541): a config root without
 // fableOverageConsentV2[<orgUuid>] parks the first Fable 5 turn on a TUI
 // dialog whose DEFAULT option is "Switch to Sonnet 5 and continue". The
-// fleet's own blind Enters (identity /name, sendPromptToSession retry-Enter)
+// fleet's own blind Enters (identity /rename, sendPromptToSession retry-Enter)
 // accept that default, silently switching the session to Sonnet while
 // agent-config still says claude-fable-5 -- the long-unexplained
 // model/activeModel drift. Fleet policy (owner decision 2026-07-23): the
@@ -1595,12 +1595,15 @@ export async function answerFirstRunGates(
 }
 
 // Post-(re)start identity setup. Every freshly spawned Claude Code session is
-// given `/name` so it is identifiable. (`/remote-control` was dropped: the
+// given `/rename <name>` so it is identifiable. NOT `/name`: no such Claude
+// Code command exists (the CLI answers "Unknown command: /name. Did you mean
+// /rename?"), and the failed line then sits PARKED in the input box until the
+// turn ends -- which makes the router read the session as busy. (`/remote-control` was dropped: the
 // operator no longer uses Remote Control, and the agent's inference-only OAuth
 // token can't satisfy it anyway.) Pure helper for the exact slash commands so
 // they are unit-tested; scheduleIdentitySetup wires them to tmux after a wait.
 export function identitySlashCommands(displayName: string): string[] {
-  return [`/name ${displayName}`]
+  return [`/rename ${displayName}`]
 }
 
 // Delays mirror the observed Claude Code first-render timing: the first-run /
@@ -1610,7 +1613,7 @@ const MODAL_DISMISS_DELAY_MS = 8000
 const IDENTITY_SEND_DELAY_MS = 5000
 
 // Schedule the identity setup for a freshly (re)spawned session: once it has
-// had time to render, dismiss any first-run/resume modals, then send `/name`.
+// had time to render, dismiss any first-run/resume modals, then send `/rename`.
 // Shared by startAgentProcess and the channel-monitor recovery respawns
 // (resumeMarveenSession / respawnMarveenSessionFresh), which previously left the
 // main session without its identity after auto-recovery. Fire-and-forget; all
@@ -1632,9 +1635,9 @@ export async function scheduleIdentitySetup(session: string, displayName: string
               runTmux(host, ['send-keys', '-t', session, cmd, 'Enter'], { timeout: 5000 })
               await delay(1000)
             }
-            logger.info({ session, displayName }, 'Set session /name')
+            logger.info({ session, displayName }, 'Set session /rename')
           } catch (err) {
-            logger.warn({ err, session, displayName }, 'Failed to set session /name')
+            logger.warn({ err, session, displayName }, 'Failed to set session /rename')
           }
         })()
       }, IDENTITY_SEND_DELAY_MS)

--- a/src/web/agent-restart-policy.ts
+++ b/src/web/agent-restart-policy.ts
@@ -105,7 +105,7 @@ export type DownAgentAction = 'restart' | 'alert' | 'alert-busy' | 'skip'
 // respawn-pane, or an auth/token fault the watchdog cannot repair -- is
 // hard-restarted forever. Every sub-agent restart is a FRESH session, so the
 // agent loses all of its working context on each cycle (observed: a sub-agent
-// hard-restarted ~10x/hour, re-running /name every time). After this many
+// hard-restarted ~10x/hour, re-running /rename every time). After this many
 // consecutive failed attempts the watchdog stops restarting and alerts the
 // operator instead, turning a silent infinite loop into one actionable ping.
 export const AGENT_MAX_RESTART_ATTEMPTS = 5

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -769,7 +769,7 @@ export function respawnMainSessionFresh(): void {
   writeRespawnStamp()
 
   logger.warn({ provider: provider.type }, 'Main session respawned FRESH (scheduled auto-restart)')
-  // The respawned claude is a brand-new process: it has neither the /name
+  // The respawned claude is a brand-new process: it has neither the /rename
   // identity nor a guaranteed-loaded channel plugin. Both follow-ups mirror the
   // resume path; skipping them is how a restarted session comes back nameless
   // or with the plugin stuck in `◯ disabled`.
@@ -858,7 +858,7 @@ export async function resumeMarveenSession(): Promise<boolean> {
     }
 
     logger.warn({ provider: provider.type }, 'Marveen session respawned with --continue')
-    // Re-establish /name on the brand-new claude process (the prior session's
+    // Re-establish /rename on the brand-new claude process (the prior session's
     // identity is gone after respawn-pane; channels.sh sets it on a normal
     // start). /remote-control was dropped (the operator no longer uses it).
     // scheduleIdentitySetup only SCHEDULES delayed timers and returns immediately;
@@ -1007,7 +1007,7 @@ function checkExternalMainRespawn(): void {
 // works even with the service disabled.
 const CHANNELS_SCRIPT = join(PROJECT_ROOT, 'scripts', 'channels.sh')
 // channels.sh creates the session, runs the first-run dialog auto-accept, sets
-// /name, and brings up the channel plugin -- a cold start that takes minutes.
+// /rename, and brings up the channel plugin -- a cold start that takes minutes.
 // Throttle relaunches so a session that is still booting is not torn down and
 // recreated on the next 60s poll.
 const MAIN_SESSION_CREATE_GRACE_MS = 360_000
@@ -1086,7 +1086,7 @@ function respawnMarveenSessionFresh(): boolean {
     })
     execFileSync(tmuxBin(), ['respawn-pane', '-k', '-t', MAIN_CHANNELS_SESSION, claudeCmd], { timeout: 15000 })
     logger.warn({ provider: provider.type }, 'Hard restart: marveen session respawned fresh (no --continue)')
-    // Re-establish /name on the fresh process (see note in resumeMarveenSession).
+    // Re-establish /rename on the fresh process (see note in resumeMarveenSession).
     // scheduleIdentitySetup only schedules delayed timers -> fire-and-forget.
     void scheduleIdentitySetup(MAIN_CHANNELS_SESSION, BOT_NAME)
     // Same channels.sh-bypass concern as in resumeMarveenSession: this respawn

--- a/src/web/channel-plugin-unlock.ts
+++ b/src/web/channel-plugin-unlock.ts
@@ -43,7 +43,7 @@ const TMUX = resolveFromPath('tmux')
 // Mirror of scripts/channels.sh post-init grace. The plugin handshake
 // (bun spawn + Telegram getMe + sendMessage) usually completes within 15s
 // of the claude TUI being interactive. After scheduleIdentitySetup's
-// 8s modal-dismiss + 5s /name + a ~1s safety buffer, the prompt is ready
+// 8s modal-dismiss + 5s /rename + a ~1s safety buffer, the prompt is ready
 // around T+15s. We wait another 20s on top of that so a healthy plugin
 // has time to write its bot.pid and spawn the bun child before we read.
 // Total: T+35s post-respawn.


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

**HU:** Az `identitySlashCommands()` a `/name <displayName>` parancsot adta vissza, de **ilyen Claude Code parancs nincs**. A CLI ezt válaszolja: `Unknown command: /name. Did you mean /rename?` — vagyis egyetlen session sem kapta meg soha a nevét.

**Ez nem kozmetikai hiba.** Az elutasított sor nem tűnik el: **bent marad a beviteli mezőben parkolva**, és csak az aktuális kör végén csapódik be. A parkolt input-sortól a router **foglaltnak látja a sessiont**, így az ügynökök közti üzenetek kézbesítése leáll, és a csatorna **némán elhallgat** — hibaüzenet nélkül.

A repó már küzd a tünettel: egy ütemezett feladat kifejezetten utasítja az ágenseket, hogy soha ne hagyjanak szöveget a beviteli mezőben, mert *„a router `busy`-nak látja a sessiont → a csatorna NÉMUL felügyelet nélkül"*. Az egyik okozó viszont ebben a függvényben volt.

**Miért élte túl ilyen sokáig:** az `agent-identity-setup.test.ts` a `['/name Zoé']` értéket várta el. A teszt azt rögzítette, amit a kód *előállít*, nem azt, amit a CLI *elfogad* — így a CI végig zöld maradt. A hiba egyébként is majdnem néma: a session elindul és dolgozik, csak nem kapja meg a nevét, a csatorna-némulás pedig ritka és nehezen köthető vissza ide.

**Ellenőrzés** azon a Claude Code verzión, amire a repó pinnel (`CLAUDE_PIN="2.1.110"`):

- a parancs-regiszterben `rename` szerepel, `name` nem
- a `/rename <név>` **inline veszi az argumentumot**: `Session renamed to: <név>`, és a név megjelenik a státuszsorban
- nem platformfüggő: Windowson is `/rename`

**EN:** `identitySlashCommands()` returned `/name <displayName>`, but no such Claude Code command exists — the CLI answers `Unknown command: /name. Did you mean /rename?`, so no session was ever renamed. Not cosmetic: the rejected line stays parked in the input box and lands when the turn ends, which makes the router read the session as busy — inter-agent delivery stops and the channel goes quiet with no error. It survived because the test asserted the produced value rather than the accepted command, keeping CI green. Verified on the pinned 2.1.110: `rename` is in the registry, `name` is not, and `/rename <name>` takes its argument inline. Same on Windows.

### A hiba KÉT helyen élt / The bug lived in TWO places

| Hol | Kit érint |
|---|---|
| `src/web/agent-process.ts` (`identitySlashCommands()`) | al-ügynökök és a channel-monitor respawnjai |
| `scripts/channels.sh` | **a fő csatorna-ágens** — az, amelyik az operátorral beszél |

Az elsőt javítottam, majd **alkalmaztam egy futó telepítésre és újraindítottam** — és a fő ágens **továbbra is** kiírta az `Unknown command: /name` sort. Ekkor derült ki, hogy az nem az `identitySlashCommands()`-on megy keresztül: a `channels.sh` maga nevezi el a sessiont, ugyanazzal a nem létező paranccsal.

Ez azért fontos, mert a fő ágens az, amelyiknél a parkolt input-sor a legtöbbet árt: ott némul el a csatorna az operátor felé.

**Ellenőrizve a javítás után, ugyanazon a telepítésen:** `/rename Suzy` → `Session renamed to: Suzy`, a név megjelenik a státuszsorban, és semmi nem marad a beviteli mezőben.

**EN:** The bug lived in two places. `identitySlashCommands()` covers sub-agents and channel-monitor respawns; the **main channel agent** is named by `channels.sh` itself, with the same non-existent command. Fixing only the TypeScript side left the main agent — the one that talks to the operator, and the session where a parked input line silences the channel — still broken. Found by applying the first commit to a running install and restarting; verified after this change on the same install.

### Mit tartalmaz / What is in it

- `agent-process.ts`: `/name` → `/rename`, és a komment most kimondja, **miért** — hogy ne álljon vissza
- `agent-identity-setup.test.ts`: `/rename` elvárása, **plusz egy regressziós eset**, ami elbukik, ha a `/name` valaha visszatér, és egy megjegyzés arról, hogyan rejtette el a régi teszt a hibát
- `channels.sh`: `/name` → `/rename` a fő ágens session-elnevezésénél
- `/name`-et említő kommentek és log-stringek frissítve: `channel-monitor.ts`, `channel-plugin-unlock.ts`, `agent-restart-policy.ts`, `pane-state.ts`. **A két `logger` sor (`Set session /name`, `Failed to set session /name`) futásidőben íródik ki**, tehát nem kozmetika — a napló eddig egy nem létező parancsot emlegetett.

## Kapcsolódó issue / Related issue

—

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. **Futó telepítésen alkalmazva és újraindítva: a fő ágens megkapja a nevét (`Session renamed to: <BOT_NAME>`), a Telegram-csatorna a javítás után is válaszol.** / Applied to a running install and restarted: the main agent gets its name, and the Telegram channel still answers.
- [x] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).

## Titok-kapu / Secret gate

- [x] Nincs a valtoztatasban bizonyitek-/artefaktum-mappa, titok-alaku string vagy idezett csatorna-uzenet. / No evidence or artifact directory, secret-shaped string, or quoted channel message in this change.