### PR TITLE
The same bypass in a different IP encoding (ISINWARDENC830)

### DIFF
--- a/src/__tests__/quarantine-allowlist-render.test.ts
+++ b/src/__tests__/quarantine-allowlist-render.test.ts
@@ -189,6 +189,48 @@ describe('isPublicFetchHost', () => {
     }
   })
 
+  /* The same bypass in a different IP encoding. The wildcard-DNS services
+     resolve all of these, so a decimal-only parser is not a narrower guard,
+     it is an incomplete one. Measured against the shipped function. */
+  it('rejects the alternative encodings of the same inward address', () => {
+    for (const bad of [
+      '2130706433.nip.io',        // 127.0.0.1 packed into one decimal
+      '7f000001.nip.io',          // the same, hex
+      '0x7f000001.nip.io',        // the same, 0x-prefixed
+      '017700000001.nip.io',      // the same, octal
+      '3232235777.nip.io',        // 192.168.1.1 packed
+      '2852039166.nip.io',        // 169.254.169.254, the metadata endpoint
+      '0177.0.0.1.nip.io',        // octal first octet
+      '012.0.0.1.nip.io',         // octal 10.0.0.1
+      '0x7f.0.0.1.nip.io',        // hex first octet
+    ]) {
+      expect(isPublicFetchHost(bad)).toBe(false)
+    }
+  })
+
+  /* sslip.io writes IPv6 with dashes, which is neither a dotted quad nor a
+     dash quad, so both existing checks walked straight past it. */
+  it('rejects the dashed IPv6 form of loopback and private ranges', () => {
+    for (const bad of ['0--1.sslip.io', '--1.sslip.io', 'fe80--1.sslip.io', 'fc00--1.sslip.io']) {
+      expect(isPublicFetchHost(bad)).toBe(false)
+    }
+  })
+
+  /* The bound on the packed form exists for these: a numeric label that does
+     not encode four octets stays an ordinary label, and a public address in
+     any encoding stays public. */
+  it('leaves public names alone in every encoding', () => {
+    for (const good of [
+      '123.example.com',
+      '134744072.nip.io',   // 8.8.8.8 packed: public, so it stays reachable
+      'deadbeef.example.com',
+      '2001-db8--1.sslip.io',
+      'abc-def.example.com',
+    ]) {
+      expect(isPublicFetchHost(good)).toBe(true)
+    }
+  })
+
   it('rejects in-cluster service names', () => {
     for (const bad of ['kubernetes.default.svc', 'api.prod.svc', 'db.svc.cluster.local', 'redis.ns.cluster']) {
       expect(isPublicFetchHost(bad)).toBe(false)

--- a/src/web/agent-scaffold.ts
+++ b/src/web/agent-scaffold.ts
@@ -585,6 +585,8 @@ export function isPublicFetchHost(value: string): boolean {
   // this is defence-in-depth rather than an open door -- but it is the same
   // class of bypass the literal check already rejects, and it costs one pass.
   if (labels.some((l) => isInwardDashQuad(l))) return false
+  if (labels.some((l) => isInwardPackedLabel(l))) return false
+  if (labels.some((l) => isInwardIPv6Label(l))) return false
   for (let i = 0; i + 3 < labels.length; i++) {
     if (isInwardQuad(labels[i], labels[i + 1], labels[i + 2], labels[i + 3])) return false
   }
@@ -607,10 +609,83 @@ function isInwardIPv4(o: number[]): boolean {
   return false
 }
 
+/* One part of a dotted address, the way inet_aton reads it: 0x-prefixed is
+   hex, a leading zero is OCTAL, everything else decimal. This is not pedantry:
+   the resolvers behind the wildcard-DNS services use the same rules, so
+   0177.0.0.1.nip.io answers with 127.0.0.1 while a decimal-only parser sees
+   four harmless-looking labels. */
+function inetAtonPart(part: string): number | null {
+  if (/^0[xX][0-9a-fA-F]{1,8}$/.test(part)) return parseInt(part.slice(2), 16)
+  if (/^0[0-7]{1,11}$/.test(part)) return parseInt(part, 8)
+  if (/^(0|[1-9]\d{0,9})$/.test(part)) return parseInt(part, 10)
+  return null
+}
+
 function isInwardQuad(a: string, b: string, c: string, d: string): boolean {
-  const parts = [a, b, c, d]
-  if (!parts.every((p) => /^\d{1,3}$/.test(p))) return false
-  return isInwardIPv4(parts.map((p) => parseInt(p, 10)))
+  const parts = [a, b, c, d].map(inetAtonPart)
+  if (parts.some((n) => n == null)) return false
+  return isInwardIPv4(parts as number[])
+}
+
+/* A single label that IS the whole address, packed into one number:
+   2130706433.nip.io and 7f000001.nip.io both resolve to 127.0.0.1.
+
+   The lower bound is deliberate. Anything under 2^24 does not encode all four
+   octets, and treating it as an address would reject 123.example.com, which is
+   an ordinary public name and exactly what the guard promises not to touch.
+   Nothing is lost by the bound: those values decode into 0.0.0.0/8, which is
+   not routable anyway. */
+const PACKED_MIN = 0x01000000
+function isInwardPackedLabel(label: string): boolean {
+  let n: number | null = null
+  if (/^0[xX][0-9a-fA-F]{1,8}$/.test(label)) n = parseInt(label.slice(2), 16)
+  else if (/^0[0-7]{9,12}$/.test(label)) n = parseInt(label, 8)
+  else if (/^\d{8,10}$/.test(label)) n = Number(label)
+  else if (/^[0-9a-fA-F]{8}$/.test(label) && /[a-fA-F]/.test(label)) n = parseInt(label, 16)
+  if (n == null || !Number.isInteger(n) || n < PACKED_MIN || n > 0xffffffff) return false
+  return isInwardIPv4([(n >>> 24) & 255, (n >>> 16) & 255, (n >>> 8) & 255, n & 255])
+}
+
+/* sslip.io writes IPv6 with dashes instead of colons, so 0--1.sslip.io is ::1.
+   The dotted-quad and dash-quad checks above never see it, because it is
+   neither. */
+function isInwardIPv6Label(label: string): boolean {
+  if (!/^[0-9a-fA-F-]+$/.test(label) || !label.includes('-')) return false
+  const addr = label.replace(/-/g, ':')
+  if ((addr.match(/::/g) ?? []).length > 1) return false
+  const groups = addr.split(':')
+  if (groups.length < 3 || groups.length > 8) return false
+  if (groups.some((g) => g !== '' && !/^[0-9a-fA-F]{1,4}$/.test(g))) return false
+  const filled = expandIPv6(groups)
+  if (filled == null) return false
+  const [h0] = filled
+  if (filled.every((g, i) => g === (i === 7 ? 1 : 0))) return true // ::1 loopback
+  if (filled.every((g) => g === 0)) return true // :: unspecified
+  if ((h0 & 0xffc0) === 0xfe80) return true // fe80::/10 link-local
+  if ((h0 & 0xfe00) === 0xfc00) return true // fc00::/7 unique local
+  // ::ffff:a.b.c.d and ::a.b.c.d carry an IPv4 inside
+  if (filled.slice(0, 5).every((g) => g === 0) && (filled[5] === 0xffff || filled[5] === 0)) {
+    const v4 = [(filled[6] >>> 8) & 255, filled[6] & 255, (filled[7] >>> 8) & 255, filled[7] & 255]
+    if (isInwardIPv4(v4)) return true
+  }
+  return false
+}
+
+/** '::' filled out to eight 16-bit groups, or null when it does not fit. */
+function expandIPv6(groups: string[]): number[] | null {
+  const gapAt = groups.indexOf('')
+  let parts: string[]
+  if (gapAt === -1) {
+    if (groups.length !== 8) return null
+    parts = groups
+  } else {
+    const head = groups.slice(0, gapAt).filter((g) => g !== '')
+    const tail = groups.slice(gapAt + 1).filter((g) => g !== '')
+    const missing = 8 - head.length - tail.length
+    if (missing < 1) return null
+    parts = [...head, ...Array(missing).fill('0'), ...tail]
+  }
+  return parts.map((g) => parseInt(g || '0', 16))
 }
 
 function isInwardDashQuad(label: string): boolean {


### PR DESCRIPTION
A #1000-ben szállított `isPublicFetchHost` guard egy IP-kódolást olvasott, és azt egy osztálynak hitte. A wildcard-DNS szolgáltatások többet olvasnak, tehát a `127.0.0.1.nip.io` elutasítva, a `2130706433.nip.io`, a `0177.0.0.1.nip.io` és a `0--1.sslip.io` viszont átment, és pontosan ugyanoda oldódik fel. Ez nem szűkebb guard, hanem hiányos.

## Amit a PR csinál

- A pontozott részek mostantól úgy olvasódnak, ahogy az `inet_aton` olvassa őket: vezető nulla oktális, `0x` hexa.
- Az egyetlen labelbe csomagolt teljes cím dekódolva, decimálisan, hexában, `0x`-szel és oktálisan.
- Az sslip.io kötőjeles IPv6-alakja dekódolva, és ellenőrizve a loopbackre, a meghatározatlan címre, az `fe80::/10`-re, az `fc00::/7`-re és az IPv4-be ágyazott tartományra.

## A csomagolt alaknál a 2^24-es alsó korlát szándékos

Alatta a szám nem kódol négy oktettet, és címként kezelve a `123.example.com`-ot utasítaná el, ami hétköznapi publikus név, és pont az, amihez a guard ígérete szerint nem nyúl. Nem veszítünk vele semmit: azok az értékek a `0.0.0.0/8`-ba dekódolnak.

## Mérés, kontrollal kezdve

A szállított függvényen futtatva, nem másolaton:

```
KONTROLL   127.0.0.1.nip.io  -> false      claude.com -> true
ELUTASITVA 2130706433.nip.io, 7f000001.nip.io, 0x7f000001.nip.io,
           017700000001.nip.io, 3232235777.nip.io, 2852039166.nip.io,
           0177.0.0.1.nip.io, 012.0.0.1.nip.io, 0x7f.0.0.1.nip.io,
           0--1.sslip.io, --1.sslip.io, fe80--1.sslip.io, fc00--1.sslip.io
ATENGEDVE  123.example.com, 8.8.8.8.nip.io, 134744072.nip.io (a 8.8.8.8
           csomagolva), api.example.co.uk, v2.api.example.com,
           2001-db8--1.sslip.io, abc-def.example.com, deadbeef.example.com
```

3985 teszt zöld, `tsc` zöld.

## Két rés MARAD, mérve és szándékosan

1. A rövidített `inet_aton` alakok (`127.1.nip.io`, `127.0.1.nip.io`) továbbra is átmennek. A bezárásuk azt jelentené, hogy bármely két vezető numerikus labelt címként olvasunk, ami elutasítaná a verziószámozott aldomaineket, például a `10.5.docs.example.com`-ot. Ez más kompromisszum, és külön döntés.
2. Egy valódi hoszt, aminek a labelje tényleg tízjegyű szám és privát tartományba dekódol, mostantól elutasításra kerül. Ezt vállalom: a guard egy engedélylista ELŐTT áll, nem helyette.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
