### PR TITLE
fix(kanban): a comment for a non-existent card is a 404, not a stored 200

### DIFF
--- a/src/__tests__/kanban-comment-requires-card.test.ts
+++ b/src/__tests__/kanban-comment-requires-card.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { Readable } from 'node:stream'
+
+// A comment posted to a card id that does not exist used to be STORED, with
+// HTTP 200. The row hangs off an id no board view resolves, so the comment is
+// invisible -- while the caller's only success signal says it landed. It
+// happened twice in production from two unrelated mistakes (a truncated id
+// column; a loop body that kept its literal placeholder), which is why the
+// guard belongs in the endpoint and not in the instructions: the written
+// warning had been in CLAUDE.md the whole time and did not carry.
+const getKanbanCard = vi.fn()
+const addKanbanComment = vi.fn(() => ({ id: 1, card_id: 'CARD0001' }))
+
+vi.mock('../db.js', () => ({
+  listKanbanCards: vi.fn(() => []),
+  createKanbanCard: vi.fn(),
+  updateKanbanCard: vi.fn(),
+  deleteKanbanCard: vi.fn(),
+  moveKanbanCard: vi.fn(),
+  archiveKanbanCard: vi.fn(),
+  unarchiveKanbanCard: vi.fn(),
+  getKanbanComments: vi.fn(() => []),
+  addKanbanComment,
+  getKanbanCardEvents: vi.fn(() => []),
+  listKanbanProjects: vi.fn(() => []),
+  getKanbanCard,
+  getChildCards: vi.fn(() => []),
+  getDb: vi.fn(),
+  createAgentMessage: vi.fn(),
+  markKanbanCardDispatched: vi.fn(),
+  getKanbanSeqByIdPrefix: vi.fn(() => undefined),
+  listLabels: vi.fn(() => []),
+  getLabel: vi.fn(),
+  createLabel: vi.fn(),
+  updateLabel: vi.fn(),
+  deleteLabel: vi.fn(),
+  addLabelToCard: vi.fn(),
+  removeLabelFromCard: vi.fn(),
+  getLabelsForAllCards: vi.fn(() => ({})),
+  getLabelsForCard: vi.fn(() => []),
+  listArchivedKanbanCards: vi.fn(() => []),
+  revertIdeaFromKanban: vi.fn(),
+  getHeartbeatKanbanSummary: vi.fn(() => ({})),
+}))
+
+const { tryHandleKanban } = await import('../web/routes/kanban.js')
+
+function postComment(cardId: string, payload: unknown) {
+  const req = Readable.from([Buffer.from(JSON.stringify(payload))]) as any
+  const captured: { status?: number; body?: string } = {}
+  const res: any = {
+    writeHead: (status: number) => { captured.status = status; return res },
+    end: (chunk?: unknown) => { if (chunk !== undefined) captured.body = String(chunk) },
+    setHeader: () => {},
+  }
+  const path = `/api/kanban/${cardId}/comments`
+  return tryHandleKanban({
+    req, res, path, method: 'POST',
+    url: new URL(`http://localhost${path}`),
+  } as any).then(handled => ({ handled, ...captured }))
+}
+
+describe('POST /api/kanban/:id/comments -- the card must exist', () => {
+  beforeEach(() => {
+    getKanbanCard.mockReset()
+    addKanbanComment.mockClear()
+  })
+
+  it('404s instead of storing an invisible comment when the card does not exist', async () => {
+    getKanbanCard.mockReturnValue(undefined)
+
+    const out = await postComment('CARDID', { author: 'sanyiba', content: 'a body that must not be stored' })
+
+    expect(out.handled).toBe(true)
+    expect(out.status).toBe(404)
+    // The write must not have happened -- the whole failure mode was a 200 next
+    // to a stored row nobody can read.
+    expect(addKanbanComment).not.toHaveBeenCalled()
+  })
+
+  it('names the id it could not find, so the caller can see WHICH id was wrong', async () => {
+    getKanbanCard.mockReturnValue(undefined)
+
+    const out = await postComment('CARDID', { author: 'sanyiba', content: 'x' })
+
+    // Both real occurrences were mistakes ABOUT THE ID (a truncated one, a
+    // placeholder). An error that does not echo the id leaves the caller
+    // guessing which of a loop's iterations went wrong.
+    expect(out.body).toContain('CARDID')
+    expect(out.body).toContain('NEM jött létre')
+  })
+
+  // POSITIVE CONTROL. Without this, a mock (or a future refactor) that makes
+  // EVERY request 404 would keep the two tests above green while the endpoint
+  // is broken for its normal use. The guard has to reject the bad id and let
+  // the good one through -- one of those alone is not the requirement.
+  it('POZITÍV KONTROLL: an existing card still gets its comment', async () => {
+    getKanbanCard.mockReturnValue({ id: 'CARD0001', title: 'valódi kártya' })
+
+    const out = await postComment('CARD0001', { author: 'sanyiba', content: 'ez elmegy' })
+
+    expect(out.handled).toBe(true)
+    expect(out.status).toBe(200)
+    expect(addKanbanComment).toHaveBeenCalledTimes(1)
+    expect(addKanbanComment).toHaveBeenCalledWith('CARD0001', 'sanyiba', 'ez elmegy')
+  })
+
+  // The 400 for a missing author/content predates this guard and must survive
+  // it: the card lookup was inserted ABOVE that check, so a bad payload on a
+  // real card has to still say 400, not 200 and not 404.
+  it('keeps the existing 400 for a payload without author or content', async () => {
+    getKanbanCard.mockReturnValue({ id: 'CARD0001', title: 'valódi kártya' })
+
+    const out = await postComment('CARD0001', { author: 'sanyiba' })
+
+    expect(out.status).toBe(400)
+    expect(addKanbanComment).not.toHaveBeenCalled()
+  })
+})

--- a/src/web/routes/kanban.ts
+++ b/src/web/routes/kanban.ts
@@ -395,6 +395,29 @@ export async function tryHandleKanban(ctx: RouteContext): Promise<boolean> {
   }
   if (kanbanCommentsMatch && method === 'POST') {
     const cardId = decodeURIComponent(kanbanCommentsMatch[1])
+    // A comment for a card that does not exist used to be STORED, with HTTP 200:
+    // `addKanbanComment` writes whatever card_id it is handed, and this branch
+    // never looked the card up. The row then hangs off an id no board view
+    // resolves -- the comment is invisible -- while the caller's only success
+    // signal says it landed. The `/breakdown` branch below has always guarded
+    // this way; the comment branch had not.
+    //
+    // This is not a hypothetical typo. `templates/CLAUDE.md.template` hands the
+    // agent a curl with a literal `KARTYA_ID` to substitute; an agent that
+    // forgets to substitute it gets a 200 and a comment on a card called
+    // "KARTYA_ID". The same shape reaches the endpoint from a truncated id
+    // column, or from a loop whose body kept its placeholder. Every one of
+    // those is silent today.
+    //
+    // The lookup is exact, matching `getKanbanCard` everywhere else: no caller
+    // in this repo constructs a prefix id (the dispatch instructions in
+    // `kanbanMoveInstructions` interpolate the full id), so rejecting a
+    // non-resolving id turns away only writes that were already lost.
+    const card = getKanbanCard(cardId)
+    if (!card) {
+      json(res, { error: `Kártya nem található: ${cardId}. A komment NEM jött létre. Teljes azonosító kell, a rövidített (prefix) alak nem működik.` }, 404)
+      return true
+    }
     const body = await readBody(req)
     const { author, content } = JSON.parse(body.toString())
     if (!author || !content) { json(res, { error: 'Szerző és tartalom kötelező' }, 400); return true }


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

**HU.** A `POST /api/kanban/:id/comments` ág eddig nem nézte meg, hogy a kártya létezik-e. Az `addKanbanComment` azt a `card_id`-t írja be, amit kap, tehát egy elgépelt, csonkolt vagy le nem cserélt azonosító **eltárolt, de láthatatlan** kommentet hozott létre — HTTP **200**-zal. A sor egy olyan id-n lóg, amit egyetlen tábla-nézet sem old fel, miközben a hívó egyetlen visszajelzése azt mondja, hogy sikerült.

A hibamód a termékkel együtt szállítódik: a `templates/CLAUDE.md.template` egy `KARTYA_ID` **helyőrzőt** tartalmazó curl-t ad az ágens kezébe. Ha az ágens elfelejti kicserélni, ma 200-at kap, és keletkezik egy komment egy `KARTYA_ID` nevű "kártyán". Ugyanez az alak jön egy csonkolt id-oszlopból (`substr(id,1,16)`) vagy egy olyan ciklusból, amelynek a törzsében bennmaradt a helyőrző.

**A megközelítés:** ugyanaz az őrzés, amit a `/breakdown` ág 25 sorral lejjebb már régóta csinál — `getKanbanCard` → 404. A keresés pontos egyezés, mint mindenhol máshol; a repóban egyetlen hívó sem állít elő prefix-azonosítót (a `kanbanMoveInstructions` a teljes id-t interpolálja), tehát a kapu csak olyan írásokat utasít el, amelyek amúgy is elvesztek. A hibaüzenet **megnevezi az azonosítót** és kimondja, hogy a komment nem jött létre, mert a valóságban minden előfordulás **az azonosítóról szóló** tévedés volt.

**EN.** `POST /api/kanban/:id/comments` never looked the card up, so a mistyped, truncated or unsubstituted id produced a stored-but-invisible comment with HTTP 200. The guard now matches the `/breakdown` branch below it (`getKanbanCard` → 404). The lookup is exact, no caller in this repo builds a prefix id, and the error names the id and states that the comment was not created.

**A GET ág szándékosan változatlan.** Nem létező kártyára ma üres listát ad; ugyanaz a "néma nulla" család, de a kár aszimmetrikus: az írás oldalán hamis rekord **keletkezik**, ami túléli a hívót és a következő olvasót félrevezeti, az olvasás oldalán viszont semmi nem jön létre. Egy ottani 404 ezen felül eltörhet egy felület-hívást, amelyik épp létrejövő kártyára kérdez rá — azt előbb meg kellene mérni.

## Kapcsolódó issue / Related issue

Nincs kapcsolódó issue. / No related issue.

## Ellenőrzőlista / Checklist

- [ ] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.

  **Ezt a négyzetet szándékosan nem pipáltam ki, mert nem futtattam a teljes dashboardot ezzel a build-del.** Amit ténylegesen elvégeztem: `npm test` külön worktree-ben, Node 22 (`.nvmrc`), **4273 teszt zöld**; egyetlen bukó fájl a `channels-never-started-backoff`, ami **a commitom nélkül, tiszta `origin/develop`-on is bukik**, és `uid 0`-ként futunk (a teszt `chmod 500`-zal tesz írhatatlanná egy könyvtárat, amit a root figyelmen kívül hagy). `tsc --noEmit` RC=0, és `--listFiles`-szal ellenőriztem, hogy az új teszt-fájl benne van a tsc programjában.

  Mutációs ellenőrzés a tesztre: a kapu **eltávolítása** a két kapu-tesztet pirosítja; az `if (!card)` → `if (true)` csere (vagyis egy mindent elutasító kapu) a **pozitív kontrollt** és a 400-as ágat pirosítja. A két irány külön-külön bukik el, tehát a teszt nem tud úgy zöld maradni, hogy a kapu bármelyik irányban elromlik.
- [x] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.

  Nem érinti: egy meglévő végpont hibakezelése változik, a telepítés és az architektúra nem.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).

## Titok-kapu / Secret gate

- [x] Nincs a változtatásban bizonyíték-/artefaktum-mappa, titok-alakú string vagy idézett csatorna-üzenet.
      / No evidence or artifact directory, secret-shaped string, or quoted channel message in this change.

Helyben lefuttatva a CI-vel azonos módon: `npx tsx scripts/secret-gate.ts --range origin/develop..HEAD` → `PASS: no denied path, no secret shape, no channel material in 2 file(s).`
