### PR TITLE
fix(mcp-catalog): replace the dead google-calendar entry with a verified npm package

### DIFF
--- a/mcp-catalog.json
+++ b/mcp-catalog.json
@@ -24,21 +24,26 @@
     "args": ["-y", "gmail-mcp-server"],
     "env": {},
     "authType": "oauth",
-    "authNote": "Első használatkor OAuth bejelentkezés szükséges a böngészőben",
-    "infoUrl": "https://github.com/ArtyMcLabin/Gmail-MCP-Server"
+    "authNote": "Google Cloud OAuth kliens kell hozzá (client ID + secret). UGYANAZ az OAuth-app használható a Naptár összekötőhöz is.",
+    "infoUrl": "https://github.com/ArtyMcLabin/Gmail-MCP-Server",
+    "verifiedAt": "2026-08-27",
+    "verifiedNote": "npm-csomag ellenőrizve: gmail-mcp-server v1.0.30 létezik."
   },
   {
     "id": "google-calendar",
     "name": "Google Calendar",
     "description": "Naptár események létrehozása, módosítása, lekérdezése, meghívók kezelése",
-    "type": "remote",
+    "type": "local",
     "category": "productivity",
     "icon": "📅",
-    "url": "https://gcal.mcp.claude.com/mcp",
+    "command": "npx",
+    "args": ["-y", "@cocal/google-calendar-mcp"],
     "env": {},
     "authType": "oauth",
-    "authNote": "Első használatkor a Claude.ai-on kell engedélyezni a Calendar hozzáférést",
-    "infoUrl": "https://docs.anthropic.com/en/docs/agents-and-tools/remote-mcp-servers"
+    "authNote": "Google Cloud OAuth kliens kell hozzá (client ID + secret). UGYANAZ az OAuth-app használható a Gmail összekötőhöz is, tehát elég egyszer regisztrálni.",
+    "infoUrl": "https://github.com/nspady/google-calendar-mcp",
+    "verifiedAt": "2026-08-27",
+    "verifiedNote": "A korábbi remote bejegyzés (https://gcal.mcp.claude.com/mcp) HALOTT volt: a host DNS-ben nem oldható fel (ENOTFOUND), a telepítés mégis sikeresnek látszott. Lecserélve ellenőrzött npm-csomagra: @cocal/google-calendar-mcp v2.6.2, utolsó frissítés 2026-06-01."
   },
   {
     "id": "notion",


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

**HU.** A katalógus `google-calendar` bejegyzése a `https://gcal.mcp.claude.com/mcp` címre mutatott. Ez a host DNS-ben nem oldható fel (`ENOTFOUND`), a szerver tehát soha nem tudott csatlakozni. A dashboard Galériából történő telepítés viszont **sikeresnek látszott**: a bejegyzés bekerült a `~/.claude.json`-be, és egyetlen tool sem töltődött be. Kívülről ez pontosan úgy néz ki, mint egy OAuth-probléma, ezért a hibakeresés arra megy el, hogy a gazdát oda küldjük bejelentkezni, ahol nincs mibe.

- `google-calendar`: `remote` -> `local`, `npx @cocal/google-calendar-mcp` (v2.6.2, utolsó publikálás 2026-06-01). Ellenőrizve: csatlakozik és visszaad eseményeket.
- Mindkét Google bejegyzés (Gmail és Naptár) ugyanazt mondja az auth-ról: egyetlen Google Cloud OAuth kliens (client id + secret) lefedi mindkettőt, tehát a gazdának egyszer kell regisztrálnia, nem kétszer.
- `verifiedAt` / `verifiedNote` mindkét bejegyzésen, hogy a következő olvasó meg tudja különböztetni az ellenőrzött bejegyzést az örököltől.

**EN.** The catalog's `google-calendar` entry pointed at `https://gcal.mcp.claude.com/mcp`, a host that does not resolve in DNS (`ENOTFOUND`). Installing it from the dashboard Gallery still reported success: the server landed in `~/.claude.json` and not a single tool ever loaded, which looks exactly like an OAuth problem. This PR replaces it with a verified npm package (`@cocal/google-calendar-mcp` v2.6.2), states the shared-OAuth-client fact on both Google entries, and adds `verifiedAt`/`verifiedNote` so a checked entry is distinguishable from an inherited one.

Megjegyzés a felülvizsgálathoz: a `verifiedAt`/`verifiedNote` mezők újak a sémában. Ha nem kéritek őket, szívesen kiveszem és marad a tiszta `remote` -> `local` csere. / Note for review: `verifiedAt`/`verifiedNote` are new fields. Happy to drop them and keep only the `remote` -> `local` swap if you would rather not carry them.

## Kapcsolódó issue / Related issue

Nincs kapcsolódó issue, a hibát éles telepítés közben találtuk. / No related issue; found while installing on a live host.

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors. — A régi bejegyzés `ENOTFOUND`-dal némán elhalt, az újjal a naptár toolok betöltenek és eseményt adnak vissza. / The old entry died silently with `ENOTFOUND`; with the new one the calendar tools load and return events.
- [ ] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture. — Nem frissítettem: egy katalógus-bejegyzés adatai változtak, a telepítés menete és az architektúra nem. / Not updated: this changes one catalog entry's data, not the install flow or architecture.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).

## Titok-kapu / Secret gate

- [x] Nincs a valtoztatasban bizonyitek-/artefaktum-mappa, titok-alaku string vagy idezett csatorna-uzenet. / No evidence or artifact directory, secret-shaped string, or quoted channel message in this change.
