### PR TITLE
feat(fleet-helper): mdv2b escaper that keeps hand-written bold and pre-checks the gate

### DIFF
--- a/seed-skills/fleet-helper/SKILL.md
+++ b/seed-skills/fleet-helper/SKILL.md
@@ -25,6 +25,13 @@ No secrets or personal data are baked in: the dashboard token is read from
 ## Scripts
 - `scripts/fleet.py` - dashboard API + kanban read helpers + MarkdownV2 escaper
   (CLI and importable module).
+  - **KET escaper van, es a rossz valasztas nemitja a formazast (2026-08-28-i meres).**
+    `mdv2` MINDENT escapel, a `*`-ot IS: az `*felkover*` markereidbol `\*felkover\*`
+    lesz, tehat sima szoveg. Ez akkor helyes, ha PROGRAMBOL rakod ossze az uzenetet
+    (escapeled a dinamikus reszt, aztan te teszed ra a `*`-ot). KEZZEL IRT hosszu
+    uzenethez (reggeli napindito) `mdv2b` kell: az a `*`-ot meghagyja, minden mast
+    escapel, ES kuldes elott lefuttatja az `outgoing_gate_check`-et (em dash,
+    ` -- `, paratlan csillag). Ha talal valamit, exit 2 es NEM ad kimenetet.
 - `scripts/mail_triage.py` - rule-based unread Mail.app filter (macOS), JSON out,
   never sends and never marks read.
 - `scripts/gate_example.py` - reference heartbeat gate; its shell invocation IS
@@ -47,7 +54,8 @@ agents each ran a root-level `find / -iname fleet.py` trying to locate this
 script -- a 10+ minute runaway search under macOS/iCloud folders.)
 ```bash
 P=../../seed-skills/fleet-helper/scripts
-python3 $P/fleet.py mdv2 "Tomorrow (8:00) - report!"   # escaped MarkdownV2
+python3 $P/fleet.py mdv2 "Tomorrow (8:00) - report!"   # escaped MarkdownV2 (kills *bold*)
+cat brief.txt | python3 $P/fleet.py mdv2b            # keeps *bold*, refuses em dash / " -- "
 python3 $P/fleet.py kanban-due
 python3 $P/mail_triage.py 90                            # unread <= 90 min -> JSON
 ```

--- a/seed-skills/fleet-helper/scripts/fleet.py
+++ b/seed-skills/fleet-helper/scripts/fleet.py
@@ -131,6 +131,32 @@ def escape_mdv2(text):
     return "".join("\\" + ch if ch in _MDV2_SPECIAL else ch for ch in str(text))
 
 
+def escape_mdv2_keep_bold(text):
+    """Escape for MarkdownV2 but leave '*' untouched, so hand-authored '*bold*'
+    markers survive. Use this for long, hand-written messages (e.g. the morning
+    brief) where the formatting is inline in the prose rather than wrapped around
+    programmatic labels. Only '*' is preserved: every other special is escaped,
+    so pair your asterisks or Telegram rejects the message with a 400."""
+    return "".join(
+        ch if ch == "*" else ("\\" + ch if ch in _MDV2_SPECIAL else ch)
+        for ch in str(text)
+    )
+
+
+def outgoing_gate_check(text):
+    """Return a list of problems the outgoing-copy-gate hook would reject.
+    Cheaper to run here than to have the send blocked."""
+    problems = []
+    if "\u2014" in text or "\u2013" in text:
+        problems.append("em/en dash present (the gate rejects it)")
+    if " -- " in text.replace("\\-", "-"):
+        problems.append("space-hyphen-hyphen-space present (the gate rejects it)")
+    stars = text.count("*") - text.count("\\*")
+    if stars % 2:
+        problems.append("odd number of unescaped '*' (Telegram 400: unclosed entity)")
+    return problems
+
+
 def _out(v):
     print(json.dumps(v, ensure_ascii=False, indent=2) if isinstance(v, (dict, list)) else v)
 
@@ -142,6 +168,13 @@ def main(argv):
     cmd, rest = argv[0], argv[1:]
     if cmd == "mdv2":
         print(escape_mdv2(rest[0] if rest else sys.stdin.read()))
+    elif cmd == "mdv2b":
+        src = rest[0] if rest else sys.stdin.read()
+        bad = outgoing_gate_check(src)
+        if bad:
+            sys.stderr.write("BLOCKED before send:\n- " + "\n- ".join(bad) + "\n")
+            return 2
+        print(escape_mdv2_keep_bold(src))
     elif cmd == "mem-save":
         _out(save_memory(rest[0], rest[1], rest[2] if len(rest) > 2 else "warm",
                          rest[3] if len(rest) > 3 else ""))


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [ ] Bug fix (hibajavítás / bug fix)
- [x] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

**HU.** Az `escape_mdv2` a `*` karaktert is escapeli, mindennel együtt. Ez helyes akkor, ha az üzenetet **programból** rakjuk össze (escapeljük a dinamikus részt, aztán mi tesszük rá a `*` markereket), de némán ellaposít egy **kézzel írt** üzenetet: a `*félkövér*` markerekből `\*félkövér\*` lesz, és az egész brief sima szövegként jelenik meg. A reggeli napindítónál pontosan ez történt.

- `escape_mdv2_keep_bold` / `mdv2b` CLI: minden MarkdownV2 speciális karaktert escapel, a `*` kivételével.
- `outgoing_gate_check`: em dash / en dash, ` -- `, és páratlan escapeletlen `*` (ez utóbbi Telegram 400, lezáratlan entity). Az `mdv2b` ezt **először** futtatja le, és inkább `exit 2`-vel kilép kimenet nélkül, mint hogy olyan szöveget adjon, amit a kimenő kapu úgyis visszadob.
- A `SKILL.md` kimondja, melyik escaper melyik üzenettípushoz való, mert a kettő közötti választás eddig kimondatlan volt.

**EN.** `escape_mdv2` escapes `*` along with everything else, which is correct for programmatically assembled messages but silently flattens a hand-written one: the `*bold*` markers come out as literal `\*bold\*`. This PR adds `escape_mdv2_keep_bold` / `mdv2b` (escapes every MarkdownV2 special except `*`) plus `outgoing_gate_check` (em/en dash, ` -- `, odd unescaped `*`), which `mdv2b` runs first, exiting 2 with no output rather than emitting text the outgoing gate would reject. `SKILL.md` now spells out which escaper belongs to which kind of message.

Megjegyzés: a `SKILL.md` új szakasza magyarul íródott, a fájl meglévő stílusához igazodva a projekt kétnyelvűsége miatt. Ha egységesen angolt kértek a seed-skillekben, átírom. / Note: the new `SKILL.md` section is in Hungarian, matching the file's surrounding style. Happy to switch it to English if seed-skills should be English-only.

## Kapcsolódó issue / Related issue

Nincs kapcsolódó issue. / No related issue.

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors. — A napi reggeli napindító `mdv2b`-vel megy ki, a félkövér szekciócímek rendben renderelnek, és a kapu-ellenőrzés fogott is már em dash-t küldés előtt. / The daily morning brief goes out through `mdv2b`; bold section headers render correctly and the gate check has already caught an em dash before send.
- [x] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture. — A skill saját dokumentációja (`seed-skills/fleet-helper/SKILL.md`) frissült, ez a képesség leírásának a helye; a `docs/` mappa telepítés/architektúra tartalmát a változás nem érinti. / The skill's own doc was updated; the change does not touch install/architecture content under `docs/`.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).

## Titok-kapu / Secret gate

- [x] Nincs a valtoztatasban bizonyitek-/artefaktum-mappa, titok-alaku string vagy idezett csatorna-uzenet. / No evidence or artifact directory, secret-shaped string, or quoted channel message in this change.
