### PR TITLE
fix(update): being ahead is not a divergence, and it locked the install out of its own updater

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -327,15 +327,26 @@ OLD_VERSION=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 # of NEW, so reset --hard $OLD_VERSION_FULL reverts without a force-push.
 OLD_VERSION_FULL=$(git rev-parse HEAD 2>/dev/null || echo "")
 
-# Ahead-detect: local commits not on upstream make ff-only refuse. Report it
-# actionably instead of dying silently under set -e (the dominant failure).
+# Divergence-detect: ff-only refuses only when the two sides have BOTH moved.
+# Being merely AHEAD is not a divergence -- it is the normal state of an install
+# that also develops locally, and there is nothing to fast-forward TO, so the
+# pull below is a no-op ("Already up to date") rather than a failure. Refusing
+# on ahead alone locked such an install out of its own updater: the operator's
+# checkout sat 53 commits ahead / 0 behind on 2026-08-30, having just merged
+# upstream, and the updater still would not run -- no build, no migration, no
+# restart, on a tree that was in fact current. Only ahead AND behind together
+# mean the histories have parted and a human has to reconcile them.
 RESULT_PHASE="pull"
 AHEAD=$(git rev-list --count '@{u}..HEAD' 2>/dev/null || echo 0)
-if [ "${AHEAD:-0}" -gt 0 ]; then
-  RESULT_MSG="A helyi checkout ${AHEAD} committal elore van az upstreamhez kepest; a fast-forward frissites nem lehetseges. Nezd meg: git log @{u}..HEAD"
-  echo -e "${RED}HIBA:${NC} a helyi checkout ${AHEAD} committal elore van az upstreamhez kepest; fast-forward nem lehetseges. Nezd: git log @{u}..HEAD"
+BEHIND=$(git rev-list --count 'HEAD..@{u}' 2>/dev/null || echo 0)
+if [ "${AHEAD:-0}" -gt 0 ] && [ "${BEHIND:-0}" -gt 0 ]; then
+  RESULT_MSG="A helyi checkout ${AHEAD} committal elore es ${BEHIND} committal hatra van az upstreamhez kepest (szetvalt elozmeny); a fast-forward frissites nem lehetseges. Nezd meg: git log @{u}..HEAD"
+  echo -e "${RED}HIBA:${NC} a helyi checkout ${AHEAD} committal elore es ${BEHIND} committal hatra van (szetvalt elozmeny); fast-forward nem lehetseges. Nezd: git log @{u}..HEAD"
   restore_stash_before_exit
   exit 5
+fi
+if [ "${AHEAD:-0}" -gt 0 ]; then
+  echo -e "  ${ORANGE}Megjegyzes:${NC} a helyi checkout ${AHEAD} committal elore van, lemaradas nincs -- a letoltes nem hoz ujat, a frissites folytatodik."
 fi
 
 # Pull latest, NON-fatal under set -e so a diverged/network failure is reported.


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

HU: Az `update.sh` minden olyan checkoutban megtagadta a futást, amiben volt helyi commit, azzal az indokkal, hogy a fast-forward nem lehetséges. Ez két különböző állapotot mos össze.

A fast-forward csak akkor bukik, ha MINDKÉT oldal elmozdult. Az a checkout, ami csak előre van, nincs mihez fast-forwardolni: a pull no-op, és utána minden -- build, migráció, seed, újraindítás, health check -- ok nélkül maradt ki.

Mérve 2026-08-30-án: az upstream összefésülése UTÁN a checkout 53 committal előre, 0-val hátra állt, tehát naprakész volt, és a frissítő így sem indult el.

Mostantól csak az előre ÉS hátra együtt tagadja meg, ami a tényleges szétvált előzmény, és kiír egy sort, amikor előre állva mégis továbbmegy, hogy a döntés látható legyen.

EN: The updater refused to run whenever the checkout had local commits. Fast-forward only fails when both sides moved; a checkout that is merely ahead has nothing to fast-forward to, so the pull is a no-op and everything after it was skipped for nothing. Measured on 2026-08-30: 53 ahead / 0 behind, fully current, updater still would not start. It now refuses only on ahead AND behind together, and prints a note when it proceeds while ahead.

## Kapcsolódó issue / Related issue

Nincs / none.

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally. — a hibát éles telepítésen mértük, a javítás ott van azóta. / The bug was measured on a live install and the fix has been in place there since.
- [ ] Frissítettem a `docs/` mappát. / Updated `docs/`. — nem érinti / not affected.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot. / No hardcoded secrets.
- [x] Saját, beszédes nevű branch-ről nyitom. / Opened from an own branch.

## Titok-kapu / Secret gate

- [x] Nincs a valtoztatasban bizonyitek-/artefaktum-mappa, titok-alaku string vagy idezett csatorna-uzenet. / No evidence or artifact directory, secret-shaped string, or quoted channel message.

---

`bash -n update.sh` rendben. Az `npm test` ehhez nem futott (shell-változtatás, és a natív modul ebben a checkoutban nincs felépítve). / `bash -n` passes; `npm test` was not run for this shell-only change.
