### PR TITLE
fix(usage): make the reset-stamp timezone configurable (MARVEEN_TZ), Budapest stays the default

### DIFF
--- a/scripts/usage-collect.py
+++ b/scripts/usage-collect.py
@@ -95,7 +95,9 @@ LATEST_PATH = os.path.join(STORE_DIR, "usage-latest.json")
 STATE_PATH = os.path.join(STORE_DIR, "usage-alert-state.json")
 ENV_PATH = os.path.join(REPO_ROOT, ".env")
 
-BUDAPEST = ZoneInfo("Europe/Budapest")
+# Display timezone for reset stamps. Defaults to the project's Europe/Budapest;
+# override with MARVEEN_TZ for an install whose owner lives elsewhere.
+LOCAL_TZ = ZoneInfo(os.environ.get("MARVEEN_TZ", "Europe/Budapest"))
 
 TOKEN_FIELDS = (
     "input_tokens",
@@ -118,7 +120,7 @@ def fmt_reset(resets_at, now_utc=None):
     except (ValueError, OSError, OverflowError, TypeError):
         return "unknown", "unknown"
     now_utc = now_utc or datetime.now(timezone.utc)
-    local_str = dt_utc.astimezone(BUDAPEST).strftime("%Y-%m-%d %H:%M %Z")
+    local_str = dt_utc.astimezone(LOCAL_TZ).strftime("%Y-%m-%d %H:%M %Z")
     secs = (dt_utc - now_utc).total_seconds()
     if secs <= 0:
         rel = "now"
@@ -589,7 +591,7 @@ def build_snapshot():
     now = datetime.now(timezone.utc)
     return {
         "generated_at": now.isoformat(),
-        "generated_at_local": now.astimezone(BUDAPEST).strftime("%Y-%m-%d %H:%M:%S %Z"),
+        "generated_at_local": now.astimezone(LOCAL_TZ).strftime("%Y-%m-%d %H:%M:%S %Z"),
         "codex": collect_codex(),
         "claude": collect_claude(),
     }


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

HU: A `usage-collect.py` a reset-időket beleégetett `Europe/Budapest` szerint bélyegezte. Ez a projekt felhasználóinak nagy részére igaz, de arra a telepítésre nem, aminek a gazdája más zónában él: Londonból nézve minden reset egy órával korábbinak látszik.

A default MARAD `Europe/Budapest`, tehát annak, aki nem kéri, semmi nem változik. A `MARVEEN_TZ` környezeti változó írja felül. A konstans neve `LOCAL_TZ` lett, mert már nem egy várost nevez meg.

EN: Reset times were stamped in a hard-coded `Europe/Budapest`. Right for most users, wrong for an install whose owner lives elsewhere: from London every reset reads an hour early. The default stays `Europe/Budapest` so nothing changes for anyone who does not ask; `MARVEEN_TZ` overrides it. The constant is renamed `LOCAL_TZ` because it no longer names one city.

## Kapcsolódó issue / Related issue

Nincs / none.

## Ellenőrzőlista / Checklist

- [ ] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard). / Tested locally. — Őszintén: a MŰKÖDÉS éles telepítésen fut (ott London a beállított zóna), de ez a commit nem szó szerint az: az upstreamnek szánt változatban visszaállítottam a budapesti defaultot, és azt a pontos formát csak `python3 -m py_compile` ellenőrizte. / Honestly: the behaviour runs in a live install (with London configured), but this exact commit is not that one -- the upstream version restores the Budapest default, and that precise form was only checked with `py_compile`.
- [ ] Frissítettem a `docs/` mappát. / Updated `docs/`. — a `MARVEEN_TZ` dokumentálását szívesen hozzáteszem, ha megmondjátok melyik fájlba kéritek. / Happy to document `MARVEEN_TZ` if you tell me which file you want it in.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot. / No hardcoded secrets.
- [x] Saját, beszédes nevű branch-ről nyitom. / Opened from an own branch.

## Titok-kapu / Secret gate

- [x] Nincs a valtoztatasban bizonyitek-/artefaktum-mappa, titok-alaku string vagy idezett csatorna-uzenet. / No evidence or artifact directory, secret-shaped string, or quoted channel message.
