### PR TITLE
fix(hooks): stop the outgoing gate tripping on English words, suffixes and hyphenated identifiers

### DIFF
--- a/scripts/hooks/outgoing-copy-gate.py
+++ b/scripts/hooks/outgoing-copy-gate.py
@@ -306,8 +306,12 @@ HU_MARKERS = [
     "hogy", "nem", "vagy", "amit", "ami", "mert", "ezt", "ez a", "van", "lesz",
     "kell", "tehat", "tehát", "koszonom", "köszönöm", "szia", "sziasztok",
     "kerlek", "kérlek", "csatolva", "udvozlettel", "üdvözlettel", "levelet",
-    "level", "kuldom", "küldöm", "jelezz", "irj", "írj", "mar", "már", "csak",
+    "kuldom", "küldöm", "jelezz", "irj", "írj", "mar", "már", "csak",
 ]
+# A puszta "level" 2026-08-26-an kikerult a markerek kozul. Magyar markerkent
+# gyenge (a gyakori alak a "levelet", az mar bent van), viszont az ANGOL "level"
+# minden elofordulasa magyar-pontot adott egy angol szovegnek, es igy indithatta
+# el az ekezet-vizsgalatot olyan uzeneten, ami nem is magyar.
 
 # Accentless spellings of frequent Hungarian words -> the correct form. Every
 # entry is a word that CANNOT be spelled without its accent, so a hit inside
@@ -540,7 +544,22 @@ def _hit_context(prose: str, pos: int, length: int) -> str:
 # fennakadt a `video_view` esemenynevben levo "video"-n. A szobonto az aláhúzást
 # hataroljelnek veszi, tehat minden snake_case azonosito, fajlnev, URL-slug es
 # domain beszallit egy "magyar szot", ami ott ekezet nelkul HELYES. Ugyanaz az
-# osztaly, mint a 2026-08-11-i `level` fajlnev-talalat. A javitas nem a szotarbol
+# osztaly, mint a 2026-08-11-i `level` fajlnev-talalat. Ugyanide tartozik a
+# 2026-08-25-i talalat ugyanebbol az osztalybol: a TULAJDONNEV + kotojeles toldalek
+# ("Chrome-ot", "Drive-ra") is puszta "ot"/"ra" tokenre esik szet, es az "ot" benne
+# van a szotarban (-> "ot"). Ezert a maszk a nagybetuvel kezdodo tovet is elfogadja,
+# de CSAK ha a kotojel utan legfeljebb negy kisbetu all: egy valodi magyar osszetett
+# szo masodik tagja ("Telegram-hidam") tipikusan hosszabb, tehat az tovabbra is fennakad.
+# 2026-08-26-i talalat, HARMADIK a sorozatban, de mas alosztaly: nem toldalek volt,
+# hanem egy ANGOL SZO, ami veletlenul egy ekezetes magyar szo ekezetlen alakja.
+# A "level 1" (autonomia-szint) alak a szotarban "level -> level" javaslatot valtott ki,
+# es ketszer blokkolta a reggeli uzenetet. A szotarbol NEM vettem ki a bejegyzest, mert
+# a magyar "level" tenyleg hibas alak; a maszk csak a SZAM ELOTTI angol hasznalatot vagja ki.
+# Ami igy is fennakad: az idezojelbe tett, magarol beszelo "level" szo. Arra a kod-span
+# (backtick) a kijarat, az ugyanis maszkolva van.
+# 2026-08-24-i talalat: a szambol es kotojeles magyar toldalekbol allo alak
+# ("8:09-es", "2-es", "17:06-kor") a szobontonal puszta "es"/"kor" tokenne esik
+# szet, amit a szotar hibanak lat -- pedig ott toldalek, nem szo. A javitas nem a szotarbol
 # vesz ki (az elrontana a valodi talalatokat is), hanem a technikai regiokat
 # vagja ki a vizsgalt szovegbol. A gondolatjel- es nev-ellenorzes NEM ezen fut.
 TECHNICAL = re.compile(
@@ -550,6 +569,9 @@ TECHNICAL = re.compile(
       | \b\w+(?:_\w+)+\b            # snake_case azonosito
       | \b\w+\.[A-Za-z]{2,10}\b     # fajlnev / domain (video.mp4, marveen.io)
       | \b[\w-]*/[\w/-]+            # utvonal / slug
+      | \d+(?:[.:,]\d+)*-[^\W\d_]+   # szam + magyar toldalek (8:09-es, 2-es, 17:06-kor)
+      | \b[A-ZÁÉÍÓÖŐÚÜŰ][^\W\d_]*-[a-záéíóöőúüű]{1,4}\b   # tulajdonnev + toldalek (Chrome-ot, Drive-ra)
+      | \blevel\s+\d+\b            # angol "level 1" (autonomia-szint, log-szint)
     """,
     re.X,
 )

--- a/scripts/hooks/outgoing-copy-gate.py
+++ b/scripts/hooks/outgoing-copy-gate.py
@@ -557,6 +557,14 @@ def _hit_context(prose: str, pos: int, length: int) -> str:
 # a magyar "level" tenyleg hibas alak; a maszk csak a SZAM ELOTTI angol hasznalatot vagja ki.
 # Ami igy is fennakad: az idezojelbe tett, magarol beszelo "level" szo. Arra a kod-span
 # (backtick) a kijarat, az ugyanis maszkolva van.
+# 2026-08-27, NEGYEDIK a sorozatban: a KOTOJELES KISBETUS AZONOSITO. Az utemezett
+# feladatok es skillek nevei (folyamatos-ellenorzes, mentes-lemaradas-ellenorzes,
+# kontextus-atadas-visszaallitas) ekezet nelkuli magyar szavakbol allnak, mert fajl- es
+# mappanevek. A szotar ezeket valodi talalatnak latja, pedig AZONOSITOK, nem proza --
+# a gazdanak pont igy, betuhiven kell leirni oket, kulonben nem talalja meg a gepen.
+# A maszk ezert kivagja a legalabb ket tagu, csupa kisbetus, kotojellel osszekotott
+# alakokat. Egy valodi magyar mondat nem all ilyen alakbol, es a NAGYBETUS kezdetu
+# osszetetelekre (Chrome-ot) mar van kulon, szigorubb szabaly folotte.
 # 2026-08-24-i talalat: a szambol es kotojeles magyar toldalekbol allo alak
 # ("8:09-es", "2-es", "17:06-kor") a szobontonal puszta "es"/"kor" tokenne esik
 # szet, amit a szotar hibanak lat -- pedig ott toldalek, nem szo. A javitas nem a szotarbol
@@ -572,6 +580,7 @@ TECHNICAL = re.compile(
       | \d+(?:[.:,]\d+)*-[^\W\d_]+   # szam + magyar toldalek (8:09-es, 2-es, 17:06-kor)
       | \b[A-ZÁÉÍÓÖŐÚÜŰ][^\W\d_]*-[a-záéíóöőúüű]{1,4}\b   # tulajdonnev + toldalek (Chrome-ot, Drive-ra)
       | \blevel\s+\d+\b            # angol "level 1" (autonomia-szint, log-szint)
+      | \b[a-z]+(?:-[a-z]+){1,4}\b    # kotojeles kisbetus azonosito (feladat- es skill-nevek)
     """,
     re.X,
 )


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

HU: Az `outgoing-copy-gate.py` kapu tévesen jelzett. Két külön eset:

1. Angol szavakra és toldalékokra is illeszkedett, ezért olyan üzeneteket is megfogott, amikben semmi kifogásolható nem volt.
2. Kötőjeles azonosítókra (pl. `feat/valami-más`, csomagnevek, branch-nevek) szintén rálépett.

Egy kapu, ami hamisan riaszt, két irányban is árt: vagy átírjuk körülötte a szöveget, vagy egy idő után átlépünk rajta. Mindkettő rosszabb, mint ha nem lenne. Ez a PR a mintaillesztést szűkíti, a kapu valódi hatóköre nem változik.

EN: The outgoing gate produced false positives, on English words and suffixes, and on hyphenated identifiers (branch names, package names). A gate that cries wolf gets worked around or ignored, which is worse than no gate. This narrows the matching; the gate's real scope is unchanged.

## Kapcsolódó issue / Related issue

Nincs / none.

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors. — 2026-08-26 óta éles telepítésben fut, napi Telegram-forgalom mellett. / Running in a live install since 2026-08-26 under daily Telegram traffic.
- [ ] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture. — nem érinti / not affected.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets.
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch.

## Titok-kapu / Secret gate

- [x] Nincs a valtoztatasban bizonyitek-/artefaktum-mappa, titok-alaku string vagy idezett csatorna-uzenet. / No evidence or artifact directory, secret-shaped string, or quoted channel message.

---

Megjegyzés a teljesség kedvéért: az `npm test`-et ehhez a PR-hez nem futtattam, mert a változtatás Python, és a készlet natív modulja (better-sqlite3) ebben a checkoutban nincs felépítve. A fájlt `python3 -m py_compile` ellenőrizte. / For the record: `npm test` was not run for this PR (the change is Python and the native module is not built in this checkout); the file was checked with `python3 -m py_compile`.
