### PR TITLE
feat(fetch-budget): measure how heavy a guest we have been on each source, before a sweep

### DIFF
--- a/scripts/fetch-budget.py
+++ b/scripts/fetch-budget.py
@@ -4,7 +4,8 @@ How heavy a guest have we been on each source? Read it BEFORE a fetch sweep.
 
 Why this exists
 ---------------
-On 2026-08-28 `learn.kregtool.com` started returning 403 to everything. It was not
+On 2026-08-28 one free, public documentation site started returning 403 to
+everything. It was not
 broken and it had not changed its mind about the allowlist: we had taken 140 pages
 off it in three days, 83 of them on 08-26 alone. It is a free, public source. We
 used it up.
@@ -81,9 +82,9 @@ MULTI_SUFFIX = {
 def host_of(url):
     """Group by the REGISTRABLE domain, not the exact hostname.
 
-    Measured 2026-08-28: counting exact hostnames put learn.kregtool.com at 140
-    and www.kregtool.com at 1, so the source read as 140 when the site had in
-    fact served us 141. One record is nothing; the unit being wrong is not.
+    Measured 2026-08-28: counting exact hostnames put `learn.<site>` at 140 and
+    `www.<site>` at 1, so the source read as 140 when the site had in fact
+    served us 141. One record is nothing; the unit being wrong is not.
     The allowlist matches a base domain OR ANY SUBDOMAIN of it, and the site
     operator sees one site -- so a per-hostname counter can sit under the cap on
     every subdomain while the site as a whole is well over it. Count the thing
@@ -116,6 +117,12 @@ def read(path):
     """
     rows = []
     skipped = 0
+    if not os.path.exists(path):
+        # A fresh install has taken no traffic yet, so the gate has written no
+        # log. That is "nothing measured", not an error: crashing here would
+        # make the tool unusable exactly where it is safest to sweep, and a
+        # caller that gates on it would refuse every first run.
+        return rows, skipped
     with open(path, encoding="utf-8", errors="replace") as fh:
         for line in fh:
             m = LINE.match(line)
@@ -194,7 +201,7 @@ def main(argv=None):
         # How many distinct minutes carried any traffic at all, on the peak day.
         # Without it a peak of 8/min reads as relentless when it may be one cluster
         # in an otherwise silent afternoon -- which is exactly how two of us
-        # misread the kregtool log before measuring it.
+        # misread that log before measuring it.
         active = sum(1 for (d, t, h) in per_min if h == host and d == peak_day)
         flag = ""
         if peak_n > a.warn_per_day or peak_min > a.warn_per_min:
@@ -209,7 +216,8 @@ def main(argv=None):
         print("A hozzaferes nem ujratermelodo eroforras. Ha egy oldal kizar, azt a")
         print("domain-lista bovitesevel NEM lehet megjavitani.")
         print("Es a megoldas NEM az, hogy ugyanannyi kerest teritunk szet tobb orara:")
-        print("a kregtoolnal a span-re vetitett atlag 0,4/perc volt, megis kizart. A")
+        print("a kizart forrasnal a span-re vetitett atlag 0,4/perc volt, megis")
+        print("kizart. A")
         print("kotolelek a DARABSZAM. Kevesebb oldalt akarj, ne udvariasabban ugyanannyit.")
         return 1
     return 0

--- a/scripts/fetch-budget.py
+++ b/scripts/fetch-budget.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""
+How heavy a guest have we been on each source? Read it BEFORE a fetch sweep.
+
+Why this exists
+---------------
+On 2026-08-28 `learn.kregtool.com` started returning 403 to everything. It was not
+broken and it had not changed its mind about the allowlist: we had taken 140 pages
+off it, 83 of them in one day, and on 08-27 fifty-two requests inside fourteen
+minutes -- six to seven a minute, sustained. It is a free, public source. We used
+it up.
+
+The rule that came out of it lives in the quarantine-reader's own prompt: behave
+like a guest, no more than about a dozen pages from one host in a run. But that
+rule is PER RUN, and the damage was not done in one run. It was done by a caller
+spawning sweep after sweep, each one individually modest. A per-run cap cannot see
+across runs, so it cannot stop what actually happened.
+
+This closes that gap on the caller's side, where the whole picture is. It counts
+what the egress gate already logged, so it is a measurement, not a good intention.
+
+Usage
+-----
+  fetch-budget.py [--host HOST] [--days N] [--warn-per-day 40] [--warn-per-min 3]
+
+Exit code 1 if any host is over a threshold, so it can gate a step.
+"""
+import argparse
+import collections
+import datetime as dt
+import re
+import sys
+import os
+
+LOG = os.path.join(os.path.dirname(__file__), "..", "store", "egress-blocked.log")
+LINE = re.compile(r'^(\S+) (\w+) url="([^"]+)"')
+
+
+def host_of(url):
+    if "://" not in url:
+        return "?"
+    return re.sub(r"^www\.", "", url.split("/")[2]).lower()
+
+
+def read(path):
+    rows = []
+    with open(path, encoding="utf-8", errors="replace") as fh:
+        for line in fh:
+            m = LINE.match(line)
+            if not m:
+                continue
+            ts, verdict, url = m.groups()
+            # Only fetches that actually left the machine count against a source.
+            # A BLOCKED line never reached it and is not our footprint there.
+            if not verdict.startswith("ALLOWED"):
+                continue
+            rows.append((ts[:10], ts[11:16], host_of(url)))
+    return rows
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--host", help="csak ez a host")
+    ap.add_argument("--days", type=int, default=7)
+    ap.add_argument("--warn-per-day", type=int, default=40)
+    ap.add_argument("--warn-per-min", type=int, default=3)
+    a = ap.parse_args(argv)
+
+    rows = read(LOG)
+    if not rows:
+        print("Nincs meg engedelyezett letoltes a naploban.")
+        return 0
+
+    cutoff = (dt.date.today() - dt.timedelta(days=a.days - 1)).isoformat()
+    rows = [r for r in rows if r[0] >= cutoff]
+    if a.host:
+        want = re.sub(r"^www\.", "", a.host.lower())
+        rows = [r for r in rows if r[2] == want]
+    if not rows:
+        print(f"Nincs talalat az utolso {a.days} napban.")
+        return 0
+
+    per_day = collections.Counter((d, h) for d, _, h in rows)
+    per_min = collections.Counter((d, t, h) for d, t, h in rows)
+    totals = collections.Counter(h for _, _, h in rows)
+
+    print(f"LETOLTESEK, utolso {a.days} nap")
+    print(f"{'HOST':<34}{'OSSZ':>6}  {'CSUCSNAP':>10}  {'/NAP':>5}  {'CSUCS/PERC':>10}")
+    print("-" * 74)
+    over = []
+    for host, total in totals.most_common():
+        days = {d: n for (d, h), n in per_day.items() if h == host}
+        peak_day, peak_n = max(days.items(), key=lambda x: x[1])
+        peak_min = max((n for (d, t, h), n in per_min.items() if h == host), default=0)
+        flag = ""
+        if peak_n > a.warn_per_day or peak_min > a.warn_per_min:
+            flag = "  <-- SOK"
+            over.append(host)
+        print(f"{host:<34}{total:>6}  {peak_day:>10}  {peak_n:>5}  {peak_min:>10}{flag}")
+
+    if over:
+        print()
+        print("Ezekre a hostokra NEHEZ vendegek voltunk: " + ", ".join(over))
+        print("A hozzaferes nem ujratermelodo eroforras. Ha egy oldal kizar, azt a")
+        print("domain-lista bovitesevel NEM lehet megjavitani. Oszd el napokra, vagy")
+        print("kerdezd meg a gazdat, hogy megeri-e egyaltalan.")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/fetch-budget.py
+++ b/scripts/fetch-budget.py
@@ -6,9 +6,20 @@ Why this exists
 ---------------
 On 2026-08-28 `learn.kregtool.com` started returning 403 to everything. It was not
 broken and it had not changed its mind about the allowlist: we had taken 140 pages
-off it, 83 of them in one day, and on 08-27 fifty-two requests inside fourteen
-minutes -- six to seven a minute, sustained. It is a free, public source. We used
-it up.
+off it in three days, 83 of them on 08-26 alone. It is a free, public source. We
+used it up.
+
+The shape of it matters, because two people described it two different wrong ways
+before anyone measured it. It was NOT one fourteen-minute hammering, and it was NOT
+two hours of sustained pressure either. Averaged over the span it is 0.4 requests a
+minute, which is nothing: on 08-26 the traffic sat inside 22 distinct minutes out of
+212, on 08-27 inside 14 out of 125. Roughly nine tenths of the window is silent, and
+the rest is clusters of four to eight in a single minute.
+
+So spreading the SAME number of requests over more hours would not have saved the
+source. The binding number was the volume itself -- 83 pages in a day off one free
+site -- with the bursts making it more visible. The remedy is to want fewer pages,
+not to trickle the same ones more politely.
 
 The rule that came out of it lives in the quarantine-reader's own prompt: behave
 like a guest, no more than about a dozen pages from one host in a run. But that
@@ -22,6 +33,12 @@ what the egress gate already logged, so it is a measurement, not a good intentio
 Usage
 -----
   fetch-budget.py [--host HOST] [--days N] [--warn-per-day 40] [--warn-per-min 3]
+  fetch-budget.py --budget HOST [--cap 12]      # may I fetch from it right now?
+
+`--budget` answers the only question a caller actually has before a sweep: how many
+pages have I already taken off this host TODAY, and how many are left. It reports
+the remaining allowance and exits 1 when there is none, so a sweep can be gated on
+it instead of on somebody remembering.
 
 Exit code 1 if any host is over a threshold, so it can gate a step.
 """
@@ -36,26 +53,66 @@ LOG = os.path.join(os.path.dirname(__file__), "..", "store", "egress-blocked.log
 LINE = re.compile(r'^(\S+) (\w+) url="([^"]+)"')
 
 
+# Second-level suffixes where the registrable domain is the LAST THREE labels.
+# Without this, ukworkshop.co.uk collapses to "co.uk" and every British source
+# lands in one bucket -- which would be a worse error than the one this fixes.
+MULTI_SUFFIX = {
+    "co.uk", "org.uk", "me.uk", "ltd.uk", "plc.uk", "net.uk", "sch.uk", "ac.uk",
+    "com.au", "net.au", "org.au", "co.nz", "com.br", "co.za", "co.jp", "com.mx",
+}
+
+
 def host_of(url):
+    """Group by the REGISTRABLE domain, not the exact hostname.
+
+    Measured 2026-08-28: counting exact hostnames put learn.kregtool.com at 140
+    and www.kregtool.com at 1, so the source read as 140 when the site had in
+    fact served us 141. One record is nothing; the unit being wrong is not.
+    The allowlist matches a base domain OR ANY SUBDOMAIN of it, and the site
+    operator sees one site -- so a per-hostname counter can sit under the cap on
+    every subdomain while the site as a whole is well over it. Count the thing
+    that actually binds.
+    """
     if "://" not in url:
         return "?"
-    return re.sub(r"^www\.", "", url.split("/")[2]).lower()
+    host = url.split("/")[2].lower().split(":")[0]
+    labels = host.split(".")
+    if len(labels) <= 2:
+        return host
+    if ".".join(labels[-2:]) in MULTI_SUFFIX:
+        return ".".join(labels[-3:])
+    return ".".join(labels[-2:])
 
 
 def read(path):
+    """Returns (rows, skipped_selftest).
+
+    Only fetches that actually left the machine count against a source. A BLOCKED
+    line never reached it. A SELFTEST_ line did not either: the gate writes those
+    when EGRESS_GATE_SELFTEST is set and a payload is piped through it dry.
+
+    The skipped count comes back with the rows and is ALWAYS printed, because a
+    silent skip is the failure mode here. If that variable ever sticks on in a
+    live session, real fetches get logged as SELFTEST_ and vanish from this
+    tally -- the counter would report a smaller number and look healthy, which is
+    exactly the shape of the two counting bugs this file already documents. A
+    number that quietly excludes things is worse than no number.
+    """
     rows = []
+    skipped = 0
     with open(path, encoding="utf-8", errors="replace") as fh:
         for line in fh:
             m = LINE.match(line)
             if not m:
                 continue
             ts, verdict, url = m.groups()
-            # Only fetches that actually left the machine count against a source.
-            # A BLOCKED line never reached it and is not our footprint there.
+            if verdict.startswith("SELFTEST"):
+                skipped += 1
+                continue
             if not verdict.startswith("ALLOWED"):
                 continue
             rows.append((ts[:10], ts[11:16], host_of(url)))
-    return rows
+    return rows, skipped
 
 
 def main(argv=None):
@@ -64,9 +121,32 @@ def main(argv=None):
     ap.add_argument("--days", type=int, default=7)
     ap.add_argument("--warn-per-day", type=int, default=40)
     ap.add_argument("--warn-per-min", type=int, default=3)
+    ap.add_argument("--budget", metavar="HOST",
+                    help="mennyit vittem el MA errol a hostrol, es mennyi maradt")
+    ap.add_argument("--cap", type=int, default=12,
+                    help="napi plafon egy hostra (alap 12)")
     a = ap.parse_args(argv)
 
-    rows = read(LOG)
+    rows, selftest_skipped = read(LOG)
+    if selftest_skipped:
+        print(f"[selftest] {selftest_skipped} sor kihagyva a naplobol (SELFTEST_, "
+              f"halozati keres nem tortent). Ha ez a szam EL, akkor az "
+              f"EGRESS_GATE_SELFTEST bent ragadt, es VALODI letoltesek esnek ki "
+              f"a szamolasbol.")
+
+    if a.budget:
+        want = host_of("https://" + re.sub(r"^[a-z]+://", "", a.budget.strip().lower()))
+        today = dt.date.today().isoformat()
+        used = sum(1 for d, _, h in rows if h == want and d == today)
+        left = a.cap - used
+        print(f"{want}: ma {used} letoltes, napi plafon {a.cap}.")
+        if left > 0:
+            print(f"MEHET meg {left}.")
+            return 0
+        print("ELFOGYOTT MARA. Ne innen szedd tovabb: vagy holnap, vagy masik forrasbol.")
+        print("A darabszam a kotoelem, nem a sebesseg. Lasd a fenti magyarazatot.")
+        return 1
+
     if not rows:
         print("Nincs meg engedelyezett letoltes a naploban.")
         return 0
@@ -74,7 +154,7 @@ def main(argv=None):
     cutoff = (dt.date.today() - dt.timedelta(days=a.days - 1)).isoformat()
     rows = [r for r in rows if r[0] >= cutoff]
     if a.host:
-        want = re.sub(r"^www\.", "", a.host.lower())
+        want = host_of("https://" + re.sub(r"^[a-z]+://", "", a.host.strip().lower()))
         rows = [r for r in rows if r[2] == want]
     if not rows:
         print(f"Nincs talalat az utolso {a.days} napban.")
@@ -85,25 +165,33 @@ def main(argv=None):
     totals = collections.Counter(h for _, _, h in rows)
 
     print(f"LETOLTESEK, utolso {a.days} nap")
-    print(f"{'HOST':<34}{'OSSZ':>6}  {'CSUCSNAP':>10}  {'/NAP':>5}  {'CSUCS/PERC':>10}")
-    print("-" * 74)
+    print(f"{'HOST':<30}{'OSSZ':>6}  {'CSUCSNAP':>10}  {'/NAP':>5}  {'CSUCS/PERC':>10}  {'AKTIV PERC':>10}")
+    print("-" * 88)
     over = []
     for host, total in totals.most_common():
         days = {d: n for (d, h), n in per_day.items() if h == host}
         peak_day, peak_n = max(days.items(), key=lambda x: x[1])
         peak_min = max((n for (d, t, h), n in per_min.items() if h == host), default=0)
+        # How many distinct minutes carried any traffic at all, on the peak day.
+        # Without it a peak of 8/min reads as relentless when it may be one cluster
+        # in an otherwise silent afternoon -- which is exactly how two of us
+        # misread the kregtool log before measuring it.
+        active = sum(1 for (d, t, h) in per_min if h == host and d == peak_day)
         flag = ""
         if peak_n > a.warn_per_day or peak_min > a.warn_per_min:
             flag = "  <-- SOK"
             over.append(host)
-        print(f"{host:<34}{total:>6}  {peak_day:>10}  {peak_n:>5}  {peak_min:>10}{flag}")
+        print(f"{host:<30}{total:>6}  {peak_day:>10}  {peak_n:>5}  {peak_min:>10}  "
+              f"{active:>10}{flag}")
 
     if over:
         print()
         print("Ezekre a hostokra NEHEZ vendegek voltunk: " + ", ".join(over))
         print("A hozzaferes nem ujratermelodo eroforras. Ha egy oldal kizar, azt a")
-        print("domain-lista bovitesevel NEM lehet megjavitani. Oszd el napokra, vagy")
-        print("kerdezd meg a gazdat, hogy megeri-e egyaltalan.")
+        print("domain-lista bovitesevel NEM lehet megjavitani.")
+        print("Es a megoldas NEM az, hogy ugyanannyi kerest teritunk szet tobb orara:")
+        print("a kregtoolnal a span-re vetitett atlag 0,4/perc volt, megis kizart. A")
+        print("kotolelek a DARABSZAM. Kevesebb oldalt akarj, ne udvariasabban ugyanannyit.")
         return 1
     return 0
 

--- a/scripts/fetch-budget.py
+++ b/scripts/fetch-budget.py
@@ -30,6 +30,22 @@ across runs, so it cannot stop what actually happened.
 This closes that gap on the caller's side, where the whole picture is. It counts
 what the egress gate already logged, so it is a measurement, not a good intention.
 
+WHAT IT CANNOT SEE, and the number has to say so
+------------------------------------------------
+The egress gate is a PreToolUse hook matched on "WebFetch" and nothing else. Its
+own header says it: it does not intercept WebSearch, curl or Bash network calls,
+or MCP outbound. So this counts WebFetch traffic and only that.
+
+Measured 2026-08-29: the roxy and cody profiles both carry Bash(curl:*), and
+roxy's whole purpose is calling an outside image service. Those requests never
+reach the log, so they never reach this tally -- and a clean report here would
+mean "nobody used WebFetch heavily", not "we were light on that source".
+
+That is the same failure this file already fixes one level down, where a
+SELFTEST_ line would have vanished from the count in silence. A number that
+quietly excludes things is worse than no number, so the scope is printed with
+every report rather than left in a docstring nobody opens.
+
 Usage
 -----
   fetch-budget.py [--host HOST] [--days N] [--warn-per-day 40] [--warn-per-min 3]
@@ -165,6 +181,9 @@ def main(argv=None):
     totals = collections.Counter(h for _, _, h in rows)
 
     print(f"LETOLTESEK, utolso {a.days} nap")
+    print("  [hatokor] CSAK a WebFetch hivasok. Az egress-kapu 'WebFetch' matcherre")
+    print("  fut, tehat a Bash/curl es az MCP forgalom NEM latszik itt. Amelyik")
+    print("  agensen van Bash(curl:*), annak a hivasai ebbol a szambol hianyoznak.")
     print(f"{'HOST':<30}{'OSSZ':>6}  {'CSUCSNAP':>10}  {'/NAP':>5}  {'CSUCS/PERC':>10}  {'AKTIV PERC':>10}")
     print("-" * 88)
     over = []


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [ ] Bug fix (hibajavítás / bug fix)
- [x] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

HU: Új eszköz: `scripts/fetch-budget.py`. Megmondja, milyen nehéz vendégek voltunk eddig az egyes forrásokon, a letöltés-sorozat ELŐTT.

**Miért.** 2026-08-28-án egy ingyenes, publikus dokumentációs oldal mindenre 403-at kezdett adni. Nem romlott el, és nem gondolta meg magát: három nap alatt 141 oldalt vittünk el róla, ebből 84-et egyetlen napon. Elhasználtuk.

A quarantine-reader promptjában már benne volt a szabály, hogy vendégként kell viselkedni, egy futásban legfeljebb tucatnyi oldal egy hostról. Csakhogy az a szabály FUTÁSONKÉNT szól, a kár pedig nem egy futásban keletkezett: egy hívó indított sweepet sweep után, mindegyik külön-külön szerény volt. Egy futásonkénti plafon nem lát át a futások között, tehát pont azt nem tudja megfogni, ami történt.

Ez a hívó oldalán zárja be a rést, ahol a teljes kép van. Azt számolja, amit az egress-kapu amúgy is naplózott, tehát mérés és nem jó szándék, és 1-gyel lép ki, ha egy host átlépte a küszöböt, így egy lépést kapuzni lehet vele.

Két dolog, amit a mérés közben tanultunk, és amit a kód is hordoz:

- **A regisztrálható domain a mértékegység, nem a pontos hostnév.** Pontos hostnevekkel számolva `learn.<oldal>` 140-nél állt, `www.<oldal>` 1-nél, tehát a forrás 140-nek látszott, miközben 141-et szolgált ki. Az egy rekord semmi; az, hogy rossz a mértékegység, nem semmi. Az allowlist alapdomaint VAGY bármely aldomaint illeszt, az üzemeltető pedig egy oldalt lát, tehát egy hostnevenkénti számláló minden aldomainen a plafon alatt ülhet, miközben az oldal egésze bőven fölötte van.
- **A kötőelem a napi darabszám, nem a sebesség.** A span-re vetített átlag 0,4 kérés/perc volt, és mégis kizárt. Ugyanannak a mennyiségnek a széterítése több órára nem mentette volna meg. Kevesebb oldalt kell akarni, nem udvariasabban ugyanannyit.

EN: New tool that reports how heavy a guest we have been on each source, to be read BEFORE a fetch sweep. A free public site started 403-ing after we took 141 pages in three days. The existing "behave like a guest" rule is per-run, but the damage came from a caller spawning modest sweep after modest sweep, which a per-run cap cannot see. This counts what the egress gate already logged and exits 1 over threshold, so a step can gate on it. It counts by registrable domain (per-hostname counting undercounts a site that spans subdomains) and treats the daily volume as the binding number, not the rate.

Az utolsó commit két dolgot javít, amit már az upstreamre készítés közben találtam: friss telepítésen nem létezik a napló, és a script `FileNotFoundError`-ral elszállt ahelyett hogy "nincs mit mérni"-t mondana (ez pont ott a legrosszabb, ahol a legbiztonságosabb gyűjteni); illetve a kommentár megnevezte a konkrét oldalt, amit kiváltott -- a számok maradtak, a név lement. / The last commit fixes a crash on a missing log (a fresh install would have had every first sweep refused) and drops the specific site name from the commentary.

## Kapcsolódó issue / Related issue

Nincs / none.

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben. / Tested locally. — valódi egress-naplón futtatva (7 nap, 9 host), üres és hiányzó naplóval is, mindkét ágon (`--budget` és összesítő). / Run against a real egress log (7 days, 9 hosts) and against an empty and a missing log, on both the summary and `--budget` paths.
- [ ] Frissítettem a `docs/` mappát. / Updated `docs/`. — a script önmagát dokumentálja a docstringben és a `--help`-ben. Ha kértek külön `docs/` bejegyzést, megírom. / The script documents itself; happy to add a `docs/` entry if you want one.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot. / No hardcoded secrets.
- [x] Saját, beszédes nevű branch-ről nyitom. / Opened from an own branch.

## Titok-kapu / Secret gate

- [x] Nincs a valtoztatasban bizonyitek-/artefaktum-mappa, titok-alaku string vagy idezett csatorna-uzenet. / No evidence or artifact directory, secret-shaped string, or quoted channel message.
