### PR TITLE
fix(fleet): dismiss Claude Code's self-drafted feedback modal before delivery

### DIFF
--- a/src/__tests__/feedback-draft-modal.test.ts
+++ b/src/__tests__/feedback-draft-modal.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest'
+import { detectsFeedbackDraftModal, detectsFeedbackOptOutPrompt, detectPaneState } from '../pane-state.js'
+
+// Captured verbatim from agent-samu on 2026-08-31, the incident that motivated
+// the detector: the session sat not-ready for 10 minutes with 5 inter-agent
+// messages queued while this modal swallowed every keystroke.
+const REAL_MODAL_PANE = [
+  '  Geri aktív köre a scan-fix (#1119 ALLOWLISTED_PATHS), ami független a',
+  '  kerettől. Nálam nincs blokkoló; a soak napi riportja ~08:20-kor jön.',
+  '',
+  '✻ Crunched for 4m 19s · done 7:48',
+  '',
+  '╭──────────────────────────────────────────────────────────────────────────────╮',
+  "│ ✻ Bug report drafted: Adopted a peer's rebuttal and applied it to a differe… │",
+  '│ │ What happened: A peer agent proposed excluding the rate-limit\'s OWN 429    │',
+  '│ │ rows from the daily-cap count. The coordinator had separately rebut…       │',
+  '│ 1 to review · 2 to send · 0 to dismiss                                       │',
+  '╰──────────────────────────────────────────────────────────────────────────────╯',
+  '',
+  '───────────────────────────────────────────────────────────────────────── Samu ─',
+  '❯ ',
+  '────────────────────────────────────────────────────────────────────────────────',
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents · 1 feedback d…',
+].join('\n')
+
+// The follow-up frame after the dismiss key. Note it renders ~7 lines above the
+// footer, outside LIVE_FOOTER_REGION_LINES -- the reason the opt-out detector
+// scopes to the wider live region.
+const OPT_OUT_PANE = [
+  '✻ Crunched for 4m 19s · done 7:48',
+  '',
+  'Turn off Claude-drafted feedback? 0 to turn off · Esc to keep',
+  '',
+  '',
+  '───────────────────────────────────────────────────────────────────────── Samu ─',
+  '❯ ',
+  '────────────────────────────────────────────────────────────────────────────────',
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents · 1 feedback d…',
+].join('\n')
+
+// The false positive the detector must survive: a peer message that QUOTES the
+// modal's option line, parked in the prompt input. This is not hypothetical --
+// an inter-agent report describing this very incident contains that string.
+const QUOTED_IN_INPUT_PANE = [
+  '✻ Crunched for 2m 1s · done 8:02',
+  '',
+  '───────────────────────────────────────────────────────────────────────── Samu ─',
+  '❯ A pane-en ez allt: "1 to review · 2 to send · 0 to dismiss" -- ezert akadt el',
+  '  a kezbesites, a modal nyelte a billentyuket.',
+  '────────────────────────────────────────────────────────────────────────────────',
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents',
+].join('\n')
+
+const BUSY_WITH_MODAL_TEXT_PANE = [
+  '╭──────────────────────────────────────────────────────────────────────────────╮',
+  '│ 1 to review · 2 to send · 0 to dismiss                                       │',
+  '╰──────────────────────────────────────────────────────────────────────────────╯',
+  '✻ Brewing… (23s · ↓ 1.4k tokens)',
+  '───────────────────────────────────────────────────────────────────────── Samu ─',
+  '❯ ',
+  '────────────────────────────────────────────────────────────────────────────────',
+  '  ⏵⏵ bypass permissions on · esc to interrupt · ← for agents',
+].join('\n')
+
+describe('detectsFeedbackDraftModal', () => {
+  it('fires on the real captured modal (known positive)', () => {
+    expect(detectsFeedbackDraftModal(REAL_MODAL_PANE)).toBe(true)
+  })
+
+  it('does NOT fire when a message merely quotes the option line in the input box', () => {
+    expect(detectsFeedbackDraftModal(QUOTED_IN_INPUT_PANE)).toBe(false)
+  })
+
+  it('does NOT fire on a busy pane', () => {
+    expect(detectsFeedbackDraftModal(BUSY_WITH_MODAL_TEXT_PANE)).toBe(false)
+  })
+
+  // Mutation control: the ONLY thing separating the real modal from a quoted
+  // line is the box border on the option line. Strip it from the otherwise
+  // identical capture and the detector must go dark -- otherwise the negative
+  // above would be passing for some unrelated reason.
+  it('goes dark when the option line loses its box border', () => {
+    const unboxed = REAL_MODAL_PANE.replace(
+      '│ 1 to review · 2 to send · 0 to dismiss                                       │',
+      '  1 to review · 2 to send · 0 to dismiss',
+    )
+    expect(unboxed).not.toBe(REAL_MODAL_PANE)
+    expect(detectsFeedbackDraftModal(unboxed)).toBe(false)
+  })
+
+  it('does NOT fire on an empty or blank pane', () => {
+    expect(detectsFeedbackDraftModal('')).toBe(false)
+    expect(detectsFeedbackDraftModal('   \n  \n')).toBe(false)
+  })
+
+  it('documents WHY the detector is needed: the pane still reads idle', () => {
+    // This is the whole hazard. detectPaneState sees a normal idle footer, so
+    // delivery believes the pane is ready and writes into a swallowing modal.
+    expect(detectPaneState(REAL_MODAL_PANE)).toBe('idle')
+  })
+})
+
+describe('detectsFeedbackOptOutPrompt', () => {
+  it('fires on the follow-up frame after the dismiss key', () => {
+    expect(detectsFeedbackOptOutPrompt(OPT_OUT_PANE)).toBe(true)
+  })
+
+  it('does NOT fire on the draft modal itself', () => {
+    expect(detectsFeedbackOptOutPrompt(REAL_MODAL_PANE)).toBe(false)
+  })
+
+  it('does NOT fire on a mention buried in scrollback', () => {
+    const buried = ['Turn off Claude-drafted feedback? 0 to turn off · Esc to keep', ...Array(20).fill('  filler line')].join('\n')
+    expect(detectsFeedbackOptOutPrompt(buried)).toBe(false)
+  })
+})

--- a/src/__tests__/feedback-draft-modal.test.ts
+++ b/src/__tests__/feedback-draft-modal.test.ts
@@ -62,6 +62,35 @@ const BUSY_WITH_MODAL_TEXT_PANE = [
   '  ⏵⏵ bypass permissions on · esc to interrupt · ← for agents',
 ].join('\n')
 
+// The hole review found: the option line quoted WITH its border. This is the
+// exact shape of the code comment documenting the modal, so a diff of the
+// detector pasted into the prompt would otherwise arm it against its author.
+const BORDER_QUOTED_IN_INPUT_PANE = [
+  '✻ Crunched for 2m 1s · done 8:22',
+  '',
+  '───────────────────────────────────────────────────────────────────────── Samu ─',
+  '❯ A modal anatomiaja a kommentben:',
+  '  ╭──────────────────────────────────────────────╮',
+  '  │ ✻ Bug report drafted: <one-line summary>…    │',
+  '  │ 1 to review · 2 to send · 0 to dismiss       │',
+  '  ╰──────────────────────────────────────────────╯',
+  '────────────────────────────────────────────────────────────────────────────────',
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents · 1 feedback d…',
+].join('\n')
+
+// Same content, but rendered in the TRANSCRIPT above the prompt and pushed out
+// of the live region by later output. Distance is what disarms this one.
+const BORDER_QUOTED_IN_SCROLLBACK_PANE = [
+  '  ╭──────────────────────────────────────────────╮',
+  '  │ 1 to review · 2 to send · 0 to dismiss       │',
+  '  ╰──────────────────────────────────────────────╯',
+  ...Array(14).fill('  a valasz tobbi resze, sorrol sorra'),
+  '───────────────────────────────────────────────────────────────────────── Samu ─',
+  '❯ ',
+  '────────────────────────────────────────────────────────────────────────────────',
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents',
+].join('\n')
+
 describe('detectsFeedbackDraftModal', () => {
   it('fires on the real captured modal (known positive)', () => {
     expect(detectsFeedbackDraftModal(REAL_MODAL_PANE)).toBe(true)
@@ -86,6 +115,23 @@ describe('detectsFeedbackDraftModal', () => {
     )
     expect(unboxed).not.toBe(REAL_MODAL_PANE)
     expect(detectsFeedbackDraftModal(unboxed)).toBe(false)
+  })
+
+  it('does NOT fire on a border-quoted option line parked in the input box', () => {
+    expect(detectsFeedbackDraftModal(BORDER_QUOTED_IN_INPUT_PANE)).toBe(false)
+  })
+
+  it('does NOT fire on a bordered reproduction that scrolled out of the live region', () => {
+    expect(detectsFeedbackDraftModal(BORDER_QUOTED_IN_SCROLLBACK_PANE)).toBe(false)
+  })
+
+  // Mutation control for the position rule specifically: take the real modal
+  // and strip the prompt marker below the box. Without a prompt underneath,
+  // the box cannot be sitting above the input, and the detector must go dark.
+  it('goes dark when no prompt marker follows the box', () => {
+    const noPrompt = REAL_MODAL_PANE.replace('❯ ', '  ')
+    expect(noPrompt).not.toBe(REAL_MODAL_PANE)
+    expect(detectsFeedbackDraftModal(noPrompt)).toBe(false)
   })
 
   it('does NOT fire on an empty or blank pane', () => {

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -613,6 +613,53 @@ export function detectsModelConsentDialog(pane: string): boolean {
     && MODEL_CONSENT_CONFIRM_RX.test(footerRegion)
 }
 
+// Claude Code's self-drafted feedback modal (first observed 2026-08-31 on
+// agent-samu, which sat not-ready for 10 minutes with 5 inter-agent messages
+// queued behind it). When the model drafts a feedback report it parks the TUI
+// on a bordered box above the prompt:
+//   ╭──────────────────────────────────────────────╮
+//   │ ✻ Bug report drafted: <one-line summary>…    │
+//   │ 1 to review · 2 to send · 0 to dismiss       │
+//   ╰──────────────────────────────────────────────╯
+// Unlike the resume/consent modals this one leaves the NORMAL IDLE FOOTER on
+// screen ("bypass permissions on … · 1 feedback draft"), so detectPaneState
+// still reads the pane as idle and delivery keeps "succeeding" into a pane
+// that swallows the keystrokes. IDLE_FOOTER_RX is therefore NOT usable as a
+// negative guard here, and quote-proofing has to come from somewhere else:
+// the option line must sit INSIDE the modal's box border. A message that
+// merely quotes "1 to review · 2 to send · 0 to dismiss" renders in the
+// prompt input (no box border on that line) and can never trigger a
+// keystroke. The busy guard follows detectsModelConsentDialog's discipline:
+// a pane mid-turn is never an actionable modal.
+const FEEDBACK_DRAFT_OPTIONS_RX = /^[^\S\n]*│.*?\d+ to review\b.*?\d+ to send\b.*?\d+ to dismiss\b/m
+
+export function detectsFeedbackDraftModal(pane: string): boolean {
+  if (!pane || !pane.trim()) return false
+  const lines = pane.split('\n')
+  const busyRegion = lines.slice(-BUSY_LIVE_REGION_LINES).join('\n')
+  for (const rx of BUSY_INDICATORS) {
+    if (rx.test(busyRegion)) return false
+  }
+  const footerRegion = lines.slice(-LIVE_FOOTER_REGION_LINES).join('\n')
+  if (BUSY_ESC_TO_INTERRUPT_RX.test(footerRegion)) return false
+  return FEEDBACK_DRAFT_OPTIONS_RX.test(pane)
+}
+
+// The follow-up Claude Code shows immediately after the draft modal is
+// dismissed: "Turn off Claude-drafted feedback? 0 to turn off · Esc to keep".
+// Only ever consulted in the frame right after we send the dismiss key. It
+// renders ABOVE the prompt box (measured: ~7 lines up from the footer, so
+// LIVE_FOOTER_REGION_LINES is too narrow for it) and is scoped to the live
+// region so a quoted mention in scrollback cannot answer it. Answering it with a second "0" would silently disable
+// feedback drafting for that agent -- the dismisser answers Esc (keep).
+const FEEDBACK_OPTOUT_RX = /Turn off Claude-drafted feedback/
+
+export function detectsFeedbackOptOutPrompt(pane: string): boolean {
+  if (!pane || !pane.trim()) return false
+  const liveRegion = pane.split('\n').slice(-BUSY_LIVE_REGION_LINES).join('\n')
+  return FEEDBACK_OPTOUT_RX.test(liveRegion)
+}
+
 export interface DetectPaneStateOptions {
   /** If true, the 'typing' state (text parked in input box) is
    * merged into 'busy'. Default false -- callers that care about

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -631,7 +631,27 @@ export function detectsModelConsentDialog(pane: string): boolean {
 // prompt input (no box border on that line) and can never trigger a
 // keystroke. The busy guard follows detectsModelConsentDialog's discipline:
 // a pane mid-turn is never an actionable modal.
-const FEEDBACK_DRAFT_OPTIONS_RX = /^[^\S\n]*│.*?\d+ to review\b.*?\d+ to send\b.*?\d+ to dismiss\b/m
+//
+// The border alone is NOT enough, and the hole was found in review: an option
+// line quoted WITH its border ("  │ 1 to review · 2 to send · 0 to dismiss  │")
+// matches it -- and the very code comment above is that shape, so a diff of
+// this file pasted into a prompt would arm the detector against its author.
+// Two further conditions close it:
+//   1. POSITION. The real modal renders ABOVE the prompt input; anything a
+//      person or agent parks in the box renders at or below the `❯` marker.
+//      The option line must therefore precede the last prompt marker.
+//   2. ADJACENCY. The modal sits directly on top of the input (measured: 6
+//      lines up); scrollback quotes drift further away. Scoping to the live
+//      region keeps an old transcript quote from arming anything.
+// Residual vector, stated rather than hidden: a faithfully bordered
+// reproduction rendered in the live region ABOVE the prompt still matches.
+// The blast radius is one stray "0" character typed into an idle prompt --
+// the Esc follow-up cannot fire without its own detector -- which is the
+// cheaper failure. Gating on the footer's "N feedback draft" counter would
+// prune it, but that string TRUNCATES on a narrow pane, and a false negative
+// here costs a 10-minute silent stall.
+const FEEDBACK_DRAFT_OPTIONS_RX = /^[^\S\n]*│.*?\d+ to review\b.*?\d+ to send\b.*?\d+ to dismiss\b/
+const PROMPT_MARKER_RX = /^[^\S\n]*❯/
 
 export function detectsFeedbackDraftModal(pane: string): boolean {
   if (!pane || !pane.trim()) return false
@@ -642,7 +662,21 @@ export function detectsFeedbackDraftModal(pane: string): boolean {
   }
   const footerRegion = lines.slice(-LIVE_FOOTER_REGION_LINES).join('\n')
   if (BUSY_ESC_TO_INTERRUPT_RX.test(footerRegion)) return false
-  return FEEDBACK_DRAFT_OPTIONS_RX.test(pane)
+
+  const liveFrom = Math.max(0, lines.length - BUSY_LIVE_REGION_LINES)
+  let optionsAt = -1
+  for (let i = lines.length - 1; i >= liveFrom; i--) {
+    if (FEEDBACK_DRAFT_OPTIONS_RX.test(lines[i])) { optionsAt = i; break }
+  }
+  if (optionsAt < 0) return false
+
+  let lastPromptAt = -1
+  for (let i = lines.length - 1; i > optionsAt; i--) {
+    if (PROMPT_MARKER_RX.test(lines[i])) { lastPromptAt = i; break }
+  }
+  // No prompt marker below the box means the option line is inside the input
+  // box (or the pane is mid-render): not an actionable modal.
+  return lastPromptAt > optionsAt
 }
 
 // The follow-up Claude Code shows immediately after the draft modal is

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -21,6 +21,8 @@ import {
   idleConsideringDimGhost,
   detectsFirstRunGate,
   detectsModelConsentDialog,
+  detectsFeedbackDraftModal,
+  detectsFeedbackOptOutPrompt,
   type FirstRunGateKind,
 } from '../pane-state.js'
 import { agentDir, listAgentNames, readAgentModel, readAgentClaudeConfigDir, readAgentClaudePlan, readAgentChannelProvider, readAgentAuthMode, readAgentDisplayName, readAgentRemoteConfig, readAgentRemoteHost, readAgentMemoryIsolation } from './agent-config.js'
@@ -1515,6 +1517,38 @@ export async function dismissResumeSummaryModalIfPresent(session: string, host: 
   }
 }
 
+// Claude Code drafts feedback reports on its own and parks them in a bordered
+// modal above the prompt input ("Bug report drafted: …" + "1 to review · 2 to
+// send · 0 to dismiss"). It swallows the next keystroke exactly like the
+// session-rating modal, but it is NASTIER to detect: it leaves the normal idle
+// footer on screen, so detectPaneState() reports the pane idle, deliveries are
+// marked delivered, and the messages pile up in the input box unsent. Measured
+// live on agent-samu 2026-08-31: 10 minutes not-ready, 5 queued messages, and
+// a peer's report parked unsubmitted in the prompt.
+//
+// Dismissal takes TWO steps, measured on that same pane: "0" closes the draft,
+// then Claude Code immediately offers "Turn off Claude-drafted feedback? 0 to
+// turn off · Esc to keep". A second "0" there would silently disable feedback
+// drafting for that agent, so the follow-up is answered with Esc (keep) -- and
+// only when its own detector fires, never blind: a bare Esc into a prompt box
+// that holds a parked delivery is not a keystroke worth firing on spec.
+export async function dismissFeedbackDraftModalIfPresent(session: string, host: string | null = null): Promise<void> {
+  try {
+    const pane = captureTmux(host, ['capture-pane', '-t', session, '-p'])
+    if (!detectsFeedbackDraftModal(pane)) return
+    runTmux(host, ['send-keys', '-t', session, '0'], { timeout: 5000 })
+    await delay(300)
+    const after = captureTmux(host, ['capture-pane', '-t', session, '-p'])
+    if (detectsFeedbackOptOutPrompt(after)) {
+      runTmux(host, ['send-keys', '-t', session, 'Escape'], { timeout: 5000 })
+      await delay(300)
+    }
+    logger.info({ session }, 'Dismissed Claude Code feedback-draft modal before sending prompt (feedback drafting left ON)')
+  } catch (err) {
+    logger.warn({ err, session }, 'Failed to probe/dismiss feedback-draft modal')
+  }
+}
+
 // Runtime backstop for the model overage-consent dialog ("Fable 5 now uses
 // usage credits" -- see detectsModelConsentDialog in pane-state.ts for the
 // full anatomy and the drift root cause). The stampFableOverageConsent
@@ -1622,6 +1656,7 @@ export async function scheduleIdentitySetup(session: string, displayName: string
         await dismissSurveyModalIfPresent(session, host)
         await dismissResumeSummaryModalIfPresent(session, host)
         await dismissModelConsentDialogIfPresent(session, host)
+        await dismissFeedbackDraftModalIfPresent(session, host)
       } catch (err) {
         logger.warn({ err, session }, 'Post-restart modal dismiss failed')
       }
@@ -1804,6 +1839,7 @@ export async function sendPromptToSession(
     await dismissSurveyModalIfPresent(session, host)
     await dismissResumeSummaryModalIfPresent(session, host)
     await dismissModelConsentDialogIfPresent(session, host)
+    await dismissFeedbackDraftModalIfPresent(session, host)
   } else {
     const releaseDismissLane = tryAcquireSessionSendLane(session, host)
     if (releaseDismissLane) {
@@ -1811,6 +1847,7 @@ export async function sendPromptToSession(
         await dismissSurveyModalIfPresent(session, host)
         await dismissResumeSummaryModalIfPresent(session, host)
         await dismissModelConsentDialogIfPresent(session, host)
+        await dismissFeedbackDraftModalIfPresent(session, host)
       } finally {
         releaseDismissLane()
       }


### PR DESCRIPTION
## Mit fog meg

Mert eset, 2026-08-31 07:44-07:54: az `agent-samu` session 10 percig `not-ready` volt, 5 inter-agent uzenettel a sorban, mert egy Claude Code altal MAGATOL rajzolt visszajelzes-modal ("Bug report drafted: ...") nyelte a billentyuket. Egy tars jelentese kozben parkolva ult a prompt-boxban, elkuldetlenul.

## Miert nem fogta meg a meglevo ket dismisser

A session-rating es a resume-summary modal a footert is atirja, ezert a `detectPaneState()` `unknown`-ra vagy busy-ra tesz. **Ez a modal nem**: a normal idle footer a helyen marad (`bypass permissions on ... · 1 feedback draft`), tehat

- `detectPaneState()` **idle**-t mond,
- a kezbesites sikeresnek konyveli el magat,
- az uzenet a modal moge irodik.

A teszt ezt a veszelyt kimondottan alliciti (`detectPaneState(REAL_MODAL_PANE) === 'idle'`).

## Quote-proofing: a box-hataron, nem a footeren

Mivel a foter nem hasznalhato negativ orkent, a detektor a modal SAJAT keret-karakteret koveteli meg az opciosoron. Egy uzenet, ami csak IDEZI a `1 to review · 2 to send · 0 to dismiss` sort (ilyen uzenet letezik: epp errol az incidensrol szolo jelentes), a prompt-inputban rendezodik, keret nelkul -> nem sul el.

Mutacios kontroll a teszben: ugyanaz a capture, csak az opciosorrol levett kerettel -> a detektor elsotetul.

## A ket lepeses dismissal (mindketto merve azon a pane-en)

1. `0` -> bezarja a draftot
2. Claude Code AZONNAL felajanlja: `Turn off Claude-drafted feedback? 0 to turn off · Esc to keep`

Egy masodik `0` itt **csendben kikapcsolna a visszajelzes-draftolast** annak az agensnek. Ezert a folytatas `Esc` (keep), es CSAK akkor, ha a sajat detektora tuzel. A follow-up ~7 sorral a foter felett renderelodik, ezert a `LIVE_FOOTER_REGION_LINES` szuk hozza -- a szelesebb live-regiot hasznalja.

## Verify

- `npm run typecheck` tiszta
- `npm test`: 317 fajl / 4279 teszt zold (a 9 uj is)
- Az elo incidenst kezzel a fenti `0` + `Esc` sorozattal oldottam fel; a pane azonnal feldolgozta a parkolt uzenetet

🤖 Generated with [Claude Code](https://claude.com/claude-code)