### PR TITLE
fix(cli): a MARVEEN_ANON_KEY hibauzenete csak VALODI utakat nevez meg

### DIFF
--- a/scripts/skill.ts
+++ b/scripts/skill.ts
@@ -58,7 +58,7 @@ interface Args {
   apiBase: string
   accessToken?: string
   rotate: boolean
-  /** (B) ut: a webfeluletrol beillesztett kulcs. Kapcsolo, nem alapertelmezes. */
+  /** (B) ut: MAS GEPEN mar kiadott kulcs atvitele. Kapcsolo, nem alapertelmezes. */
   keyId?: string
   attestKey?: string
   memberId?: string
@@ -96,8 +96,9 @@ function sugo(): void {
       Hitelesites: MARVEEN_ACCESS_TOKEN vagy --access-token; enelkul email+jelszo bekerese.
 
   npm run skill -- enroll --key-id <id> --attest-key <titok> --member-id <uuid>
-      Ugyanaz, de a webfeluletrol MASOLT kulccsal, szerver-hivas nelkul.
-      Akkor hasznos, ha a gepnek nincs bejelentkezese, csak a kulcs.
+      Ugyanaz, de egy MAR KIADOTT kulccsal, szerver-hivas nelkul.
+      Ez a kulcs atvitele: egy masik gepen az enroll paranccsal kiadatod,
+      majd ide beirod. Fej nelkuli gepnek, aminek nincs bejelentkezese.
 
   npm run skill -- upload <fajl>
       Helyi szken, majd tiszta eredmeny eseten alairt feltoltes.
@@ -167,16 +168,23 @@ function anonKulcs(): string {
         '    npm run skill -- enroll --access-token <token>\n' +
         '      (vagy MARVEEN_ACCESS_TOKEN kornyezeti valtozokent)\n' +
         '    npm run skill -- enroll --key-id <id> --attest-key <titok> --member-id <uuid>\n' +
-        '      (a kulcsot a marveen.io feluleten kapod meg)',
+        '      (egy MASIK gepen kiadott kulcs atvitele; a kulcsot ott az\n' +
+        '       `enroll --access-token` adja ki, egyszer)',
     )
   }
   return k
 }
 
 async function enroll(args: Args): Promise<void> {
-  // (B) UT: a tag a webfeluleten kapta a kulcsot es beilleszti. Nem
-  // alapertelmezes, hanem kapcsolo -- de valodi ut: egy gepnek lehet, hogy
-  // sosem lesz marveen.io-bejelentkezese, csak a kulcsa.
+  // (B) UT: EGY MAR KIADOTT KULCS ATVITELE MASIK GEPRE. Nem alapertelmezes,
+  // hanem kapcsolo -- de valodi ut: egy fej nelkuli gepnek lehet, hogy sosem
+  // lesz marveen.io-bejelentkezese, csak a kulcsa.
+  //
+  // ES NEM WEBFELULETROL JON. Megmerve (Samu leletebol, sajat kontrollal
+  // ismetelve): az `attest` szo 0 TALALAT az apps/app/src egeszeben,
+  // mikozben mas edge-fn-hivasok OT fajlban ott vannak -- tehat a mero nem
+  // vak, es attest-kulcs UI egyszeruen NINCS. A kulcsot ma KIZAROLAG az
+  // `enroll --access-token` ut adja ki, egyszer, plaintextben.
   if (args.attestKey || args.keyId || args.memberId) {
     if (!args.attestKey || !args.keyId || !args.memberId) {
       fail('a beillesztett bekoteshez MINDHAROM kell: --key-id, --attest-key, --member-id')

--- a/scripts/skill.ts
+++ b/scripts/skill.ts
@@ -141,12 +141,33 @@ async function felhasznaloiToken(args: Args): Promise<string> {
   }
 }
 
+/**
+ * Az anon kulcs CSAK az interaktiv (email+jelszo) bejelentkezeshez kell -- a
+ * masik ket bekotesi ut nelkule is megy.
+ *
+ * MIERT NINCS BEEGETETT ALAPERTELMEZESE, holott a kulcs PUBLIKUS (megmerve:
+ * benne van a kiszolgalt kliens-bundle-ben): a repo secret-gate-jenek van
+ * JWT-mintaja, es az nem tudja megkulonboztetni alak alapjan a publikus anon
+ * kulcsot a service_role kulcstol. Egy beegetett default miatt EZT A
+ * PRODUCTION FAJLT kellene allowlistelni JWT-re -- vagyis pont ott nyitnank
+ * lyukat, ahova kesobb egy VALODI titok kerulhet eszrevetlenul. A kenyelem
+ * nem eri meg a vak foltot.
+ */
 function anonKulcs(): string {
   const k = process.env.MARVEEN_ANON_KEY
   if (!k) {
+    // NEM MONDJUK MEG, HOL TALALJA, MERT NEM TUDJUK. Megmerve: a
+    // MARVEEN_ANON_KEY sem a doksikban, sem a telepitokben, sem a
+    // dashboardon nem szerepel. Egy talalgatott hely rosszabb a hianynal:
+    // a tag keresne valamit, ami nincs ott. Helyette a ket ut, ami MA
+    // mukodik.
     fail(
-      'hianyzik a MARVEEN_ANON_KEY (a marveen.io publikus anon kulcsa).\n' +
-        '  A bekoteshez ez kell; a dashboardon vagy a telepitesi utmutatoban talalod.',
+      'az interaktiv bejelentkezeshez a MARVEEN_ANON_KEY kornyezeti valtozo kell,\n' +
+        '  es az ezen a gepen nincs beallitva. Ket ut mukodik nelkule:\n' +
+        '    npm run skill -- enroll --access-token <token>\n' +
+        '      (vagy MARVEEN_ACCESS_TOKEN kornyezeti valtozokent)\n' +
+        '    npm run skill -- enroll --key-id <id> --attest-key <titok> --member-id <uuid>\n' +
+        '      (a kulcsot a marveen.io feluleten kapod meg)',
     )
   }
   return k


### PR DESCRIPTION
Sajat hiba, ugyanabbol az osztalybol, amit a #1119-ben epp javitottam -- es UGYANABBAN A FAJLBAN maradt egy masodik peldany. Az `enroll` interaktiv aga azt mondta a tagnak, hogy a `MARVEEN_ANON_KEY`-t **"a dashboardon vagy a telepitesi utmutatoban talalod"**.

**Megmerve: egyik helyen sincs.** Sem a `docs/`, sem a README, sem a telepitok, sem a dashboard-kod nem emliti a `MARVEEN_ANON_KEY`-t (se barmilyen anon kulcsot). A tag ket olyan helyen kereste volna, ahol nincs -- pontosan az a defektus, amit egy oraval korabban a `npm run skill -- update`-re iranyitasnal mar kijavitottam.

## Miert NEM beegetett alapertelmezes a megoldas

Hogy a kulcs publikus, azt MERTEM, nem a nevebol kovetkeztettem: Playwrighttal vegignezve a kiszolgalt app MINDEN valaszat (9 db), a kulcs ott van a `login/page-*.js` bundle-ben. **Elso nekifutasra hat chunkot mintaztam es nem talaltam** -- az minta volt, nem leltar; a teljes szken mutatta meg.

Publikus ide, publikus oda, beegetett defaultot megsem kap: a repo secret-gate-jenek van JWT-mintaja, es ALAK alapjan nem tudja megkulonboztetni a publikus anon kulcsot a `service_role` kulcstol. Egy default miatt EZT A PRODUCTION FAJLT kellene JWT-re allowlistelni -- vagyis pont oda kerulne a vak folt, ahova kesobb egy VALODI titok kerulhet eszrevetlenul. Ugyanaz a merleg, mint a #1119 allowlist-donteseben: egy nem szukseges kivetel nem ingyenes.

## Amit a hibauzenet most mond

Nem talalgat helyet. Azt a KET utat nevezi meg, ami anon kulcs nelkul is mukodik ma:

```
npm run skill -- enroll --access-token <token>      (vagy MARVEEN_ACCESS_TOKEN)
npm run skill -- enroll --key-id <id> --attest-key <titok> --member-id <uuid>
```

Mindketto valodi, implementalt es tesztelt ut.

## Ami NYITOTT marad, kimondva

Az interaktiv email+jelszo bejelentkezes gyakorlatilag **nem hasznalhato**, amig az anon kulcs nincs valahol dokumentalva. Hogy hova valo (telepitesi doksi, dashboard vagy enrolment-oldal), az termek-dontes, nem kod-kerdes -- ezert nevesitem, nem palastolom.

## Verify

65 teszt a negy skill-teszt-fajlban zold, secret-gate PASS 897 fajlon, `tsc --noEmit` tiszta, em-dash 0.

**NEM MERGELEM.**