### PR TITLE
fix(kanban): POST /api/kanban reports the id it actually stored

### DIFF
--- a/src/__tests__/kanban-create-id-echo.test.ts
+++ b/src/__tests__/kanban-create-id-echo.test.ts
@@ -1,0 +1,53 @@
+// POST /api/kanban must report the id it actually STORED.
+//
+// The handler generates an id, but callers may supply their own (we use readable
+// slugs for long-lived cards). The spread order used to let the supplied id win in
+// the stored row while the response echoed the generated one -- so a caller that
+// referenced the returned id pointed at a card that does not exist, with HTTP 200.
+// Measured 2026-08-31 (sanyiba): response `0b2a8b32`, stored
+// `juta-nulla-vegosszegu-bizonylatfej`.
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { Readable } from 'node:stream'
+import { initDatabase, getKanbanCard } from '../db.js'
+import { tryHandleKanban } from '../web/routes/kanban.js'
+import type { RouteContext } from '../web/routes/types.js'
+
+function postCtx(payload: unknown): { ctx: RouteContext; out: { status: number; body: any } } {
+  const out: { status: number; body: any } = { status: 200, body: null }
+  const res: any = {
+    writeHead(status: number) { out.status = status; return res },
+    setHeader() { return res },
+    end(chunk?: string) { if (chunk) out.body = JSON.parse(chunk) },
+  }
+  const req: any = Readable.from([Buffer.from(JSON.stringify(payload))])
+  const url = new URL('http://localhost:3420/api/kanban')
+  return { ctx: { req, res, path: url.pathname, method: 'POST', url } as RouteContext, out }
+}
+
+describe('POST /api/kanban -- the reported id is the stored id', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('echoes the CALLER-supplied id, and that id resolves to a real card', async () => {
+    const { ctx, out } = postCtx({ id: 'juta-olvashato-slug', title: 'Slug card' })
+    expect(await tryHandleKanban(ctx)).toBe(true)
+    expect(out.body.id).toBe('juta-olvashato-slug')
+    // the load-bearing half: the reported id must resolve
+    expect(getKanbanCard(out.body.id)?.title).toBe('Slug card')
+  })
+
+  it('generates an id when none is supplied, and that id resolves too', async () => {
+    const { ctx, out } = postCtx({ title: 'Generated card' })
+    expect(await tryHandleKanban(ctx)).toBe(true)
+    expect(typeof out.body.id).toBe('string')
+    expect(out.body.id.length).toBeGreaterThan(0)
+    expect(getKanbanCard(out.body.id)?.title).toBe('Generated card')
+  })
+
+  it('ignores a blank supplied id rather than storing an empty key', async () => {
+    const { ctx, out } = postCtx({ id: '   ', title: 'Blank id card' })
+    expect(await tryHandleKanban(ctx)).toBe(true)
+    expect(out.body.id.trim()).not.toBe('')
+    expect(getKanbanCard(out.body.id)?.title).toBe('Blank id card')
+  })
+})

--- a/src/web/routes/kanban.ts
+++ b/src/web/routes/kanban.ts
@@ -315,8 +315,14 @@ export async function tryHandleKanban(ctx: RouteContext): Promise<boolean> {
   if (path === '/api/kanban' && method === 'POST') {
     const body = await readBody(req)
     const data = JSON.parse(body.toString())
-    const id = randomUUID().slice(0, 8)
-    createKanbanCard({ id, ...data })
+    // The caller may supply its own id (we use readable slugs for long-lived cards).
+    // Resolve it BEFORE the spread so the stored id and the reported id are the same
+    // value: `{ id, ...data }` let a caller-supplied id win in the row while the
+    // response still echoed the generated one, so anything referencing the returned
+    // id pointed at a card that does not exist -- with HTTP 200.
+    const suppliedId = typeof data.id === 'string' ? data.id.trim() : ''
+    const id = suppliedId || randomUUID().slice(0, 8)
+    createKanbanCard({ ...data, id })
     json(res, { ok: true, id })
     return true
   }


### PR DESCRIPTION
`POST /api/kanban` generated an id, then called `createKanbanCard({ id, ...data })`. The spread let a **caller-supplied** id win in the stored row, while the response still echoed the **generated** one. Anything that referenced the returned id therefore pointed at a card that does not exist — with HTTP 200, so nothing failed and nothing logged.

Measured 2026-08-31 while opening a card with a readable slug: response `0b2a8b32`, stored card `juta-nulla-vegosszegu-bizonylatfej`. It only surfaced because the caller read the stored id back instead of trusting the response.

### The change

Resolve the id **before** the spread, so the stored and the reported value are the same:

```ts
const suppliedId = typeof data.id === 'string' ? data.id.trim() : ''
const id = suppliedId || randomUUID().slice(0, 8)
createKanbanCard({ ...data, id })
```

Storage behaviour is unchanged — a caller-supplied slug still wins. Only the response became true. One deliberate addition: a blank or whitespace-only `id` now falls back to a generated one rather than storing an empty key.

### Tests

`src/__tests__/kanban-create-id-echo.test.ts`, three cases: caller-supplied id, generated id, blank id. All three assert that the **returned id resolves** (`getKanbanCard(out.body.id)`), not that it looks plausible — looking plausible was the entire defect.

**Mutation check.** Restoring the old `{ id, ...data }` form turns **two** of the three red (the supplied-id and blank-id cases) and leaves **one** green — the generated-id case, which the bug never touched. That third case is the positive control: without it, a change that rejected every supplied id would also pass.

**Suite.** `tsc --noEmit` clean. The full suite has 8 pre-existing failing files on this checkout (root-user permission assumptions and hook-wiring gates); the failing set is **byte-identical** on `origin/develop` without this commit, so nothing here broke them.

### Scope

Deliberately **not** stacked on #1107, which touches the same file ~90 lines away. They merge cleanly on their own, and keeping them separate means one stalling does not hold up the other.
