### PR TITLE
fix(fleet): dismiss the feedback modal on the not-ready path, where it actually blocks

### DIFF
--- a/src/__tests__/channel-health-monitor.test.ts
+++ b/src/__tests__/channel-health-monitor.test.ts
@@ -37,6 +37,9 @@ vi.mock('../web/agent-config.js', () => ({
 
 const mockCapturePane = vi.fn<(session: string) => string | null>()
 vi.mock('../web/agent-process.js', () => ({
+  // The not-ready-path modal clear: false = no modal, so every caller keeps
+  // its existing skip/busy behaviour and these fixtures are unaffected.
+  clearFeedbackModalAndRecheck: () => false,
   isAgentRunning: (name: string) => name === 'samu',
   capturePane: (session: string) => mockCapturePane(session),
   agentSessionName: (name: string) => `agent-${name}`,

--- a/src/__tests__/channel-mcp-reconnect.test.ts
+++ b/src/__tests__/channel-mcp-reconnect.test.ts
@@ -32,6 +32,9 @@ vi.mock('../web/agent-config.js', () => ({
 
 const mockCapturePane = vi.fn<(session: string) => string | null>()
 vi.mock('../web/agent-process.js', () => ({
+  // The not-ready-path modal clear: false = no modal, so every caller keeps
+  // its existing skip/busy behaviour and these fixtures are unaffected.
+  clearFeedbackModalAndRecheck: () => false,
   agentSessionName: (name: string) => `agent-${name}`,
   capturePane: (session: string) => mockCapturePane(session),
 }))

--- a/src/__tests__/context-guard-hidden-worker.test.ts
+++ b/src/__tests__/context-guard-hidden-worker.test.ts
@@ -33,6 +33,9 @@ vi.mock('../web/channel-monitor.js', () => ({
 }))
 vi.mock('../web/stuck-tool-call-watcher.js', () => ({ shouldDeferForRecentRespawn: () => false }))
 vi.mock('../web/agent-process.js', () => ({
+  // The not-ready-path modal clear: false = no modal, so every caller keeps
+  // its existing skip/busy behaviour and these fixtures are unaffected.
+  clearFeedbackModalAndRecheck: () => false,
   agentRunState: () => 'stopped',
   agentSessionName: (n: string) => `agent-${n}`,
   restartAgentProcess: vi.fn(),

--- a/src/__tests__/context-guard-resume-prompt.test.ts
+++ b/src/__tests__/context-guard-resume-prompt.test.ts
@@ -27,6 +27,9 @@ vi.mock('../web/channel-monitor.js', () => ({
 }))
 vi.mock('../web/stuck-tool-call-watcher.js', () => ({ shouldDeferForRecentRespawn: () => false }))
 vi.mock('../web/agent-process.js', () => ({
+  // The not-ready-path modal clear: false = no modal, so every caller keeps
+  // its existing skip/busy behaviour and these fixtures are unaffected.
+  clearFeedbackModalAndRecheck: () => false,
   agentRunState: () => 'stopped',
   agentSessionName: (n: string) => `agent-${n}`,
   restartAgentProcess: vi.fn(),

--- a/src/__tests__/feedback-draft-modal.test.ts
+++ b/src/__tests__/feedback-draft-modal.test.ts
@@ -91,6 +91,28 @@ const BORDER_QUOTED_IN_SCROLLBACK_PANE = [
   '  ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents',
 ].join('\n')
 
+// The SECOND live rendering, captured during the 09:07 stall: the modal is
+// taller (a second draft is queued behind it) and the idle footer is NOT on
+// screen -- the pane ends at the prompt marker. This is the variant that made
+// the readiness gate refuse, which is why the dismissal cannot live only in
+// the send path: the gate short-circuits before any send is attempted.
+const REAL_MODAL_NO_FOOTER_PANE = [
+  '  szerint még nem kartyázom (a negyediknél), de ha eljön, felveszem.',
+  '',
+  '✻ Brewed for 4m 25s · done 9:02',
+  '',
+  '╭──────────────────────────────────────────────────────────────────────────────╮',
+  '│ ✻ Bug report drafted: Diagnosed a red test from its output name, without re… │',
+  '│ │ What happened: A shell test printed "MAIN_AGENT_ID NOT substituted in      │',
+  '│ │ SKILL.md buktatok" (19/20). I took the output name literally and reported  │',
+  '│ 1 to review · 2 to send · 0 to dismiss · +1 more queued                      │',
+  '╰──────────────────────────────────────────────────────────────────────────────╯',
+  '',
+  '',
+  '───────────────────────────────────────────────────────────────────────── Samu ─',
+  '❯',
+].join('\n')
+
 describe('detectsFeedbackDraftModal', () => {
   it('fires on the real captured modal (known positive)', () => {
     expect(detectsFeedbackDraftModal(REAL_MODAL_PANE)).toBe(true)
@@ -132,6 +154,15 @@ describe('detectsFeedbackDraftModal', () => {
     const noPrompt = REAL_MODAL_PANE.replace('❯ ', '  ')
     expect(noPrompt).not.toBe(REAL_MODAL_PANE)
     expect(detectsFeedbackDraftModal(noPrompt)).toBe(false)
+  })
+
+  it('fires on the footerless live rendering, and that pane does NOT read idle', () => {
+    // Both halves matter. The detector must see the modal in this variant too,
+    // AND the pane state explains why delivery refused: without the idle footer
+    // the state is not 'idle', so isSessionReadyForPrompt says not-ready and
+    // the send path -- where the pre-flight dismissal lives -- is never reached.
+    expect(detectsFeedbackDraftModal(REAL_MODAL_NO_FOOTER_PANE)).toBe(true)
+    expect(detectPaneState(REAL_MODAL_NO_FOOTER_PANE)).not.toBe('idle')
   })
 
   it('does NOT fire on an empty or blank pane', () => {

--- a/src/__tests__/message-router-tick-cap.test.ts
+++ b/src/__tests__/message-router-tick-cap.test.ts
@@ -56,6 +56,9 @@ vi.mock('../web/agent-config.js', () => ({
 }))
 
 vi.mock('../web/agent-process.js', () => ({
+  // The not-ready-path modal clear: false = no modal, so every caller keeps
+  // its existing skip/busy behaviour and these fixtures are unaffected.
+  clearFeedbackModalAndRecheck: () => false,
   agentSessionName: (name: string) => `agent-${name}`,
   isSessionReadyForPrompt: vi.fn(() => false),
   clearStaleParkedInput: vi.fn(() => false),

--- a/src/__tests__/schedule-runner-parked-janitor.test.ts
+++ b/src/__tests__/schedule-runner-parked-janitor.test.ts
@@ -73,6 +73,9 @@ vi.mock('../web/scheduled-tasks-io.js', () => ({
 }))
 
 vi.mock('../web/agent-process.js', () => ({
+  // The not-ready-path modal clear: false = no modal, so every caller keeps
+  // its existing skip/busy behaviour and these fixtures are unaffected.
+  clearFeedbackModalAndRecheck: () => false,
   agentSessionName: (name: string) => `agent-${name}`,
   isAgentRunning: () => true,
   isSessionReadyForPrompt: () => mockSessionReady(),

--- a/src/__tests__/schedule-runner-retry-missing.test.ts
+++ b/src/__tests__/schedule-runner-retry-missing.test.ts
@@ -79,6 +79,9 @@ vi.mock('../web/scheduled-tasks-io.js', () => ({
 }))
 
 vi.mock('../web/agent-process.js', () => ({
+  // The not-ready-path modal clear: false = no modal, so every caller keeps
+  // its existing skip/busy behaviour and these fixtures are unaffected.
+  clearFeedbackModalAndRecheck: () => false,
   agentSessionName: (name: string) => `agent-${name}`,
   isAgentRunning: () => true,
   isSessionReadyForPrompt: () => true,

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -1532,6 +1532,32 @@ export async function dismissResumeSummaryModalIfPresent(session: string, host: 
 // drafting for that agent, so the follow-up is answered with Esc (keep) -- and
 // only when its own detector fires, never blind: a bare Esc into a prompt box
 // that holds a parked delivery is not a keystroke worth firing on spec.
+// The not-ready-path companion to the pre-flight dismissal above, and the
+// reason it exists: every prompt injector asks isSessionReadyForPrompt FIRST
+// and gives up before any send is attempted, so a dismissal that lives only in
+// the send path never runs for the case it was written for (measured twice on
+// 2026-08-31 -- see the detector's note in pane-state.ts). Four injectors share
+// that shape: message-router, schedule-runner, inbox-nudge-watcher and
+// telegram-inbox-wake. They call this on their refusal branch instead of each
+// re-implementing the probe, so the fifth injector added later has one obvious
+// thing to call rather than three lines to remember.
+//
+// Returns true only if the modal was actually there AND the pane became ready
+// after clearing it -- a false keeps the caller on its existing skip path, so
+// nothing about the busy case changes.
+export async function clearFeedbackModalAndRecheck(session: string, host: string | null = null): Promise<boolean> {
+  try {
+    const pane = capturePane(session, host)
+    if (pane == null || !detectsFeedbackDraftModal(pane)) return false
+    logger.warn({ session }, 'pane held by a Claude Code feedback-draft modal on the not-ready path, dismissing')
+    await dismissFeedbackDraftModalIfPresent(session, host)
+    return await isSessionReadyForPrompt(session, host)
+  } catch (err) {
+    logger.warn({ err, session }, 'Failed to clear the feedback-draft modal on the not-ready path')
+    return false
+  }
+}
+
 export async function dismissFeedbackDraftModalIfPresent(session: string, host: string | null = null): Promise<void> {
   try {
     const pane = captureTmux(host, ['capture-pane', '-t', session, '-p'])

--- a/src/web/inbox-nudge-watcher.ts
+++ b/src/web/inbox-nudge-watcher.ts
@@ -49,7 +49,7 @@ import { MAIN_AGENT_ID } from '../config.js'
 import { getPendingMessages } from '../db.js'
 import { getEffectiveSettingValue } from '../settings-store.js'
 import { MAIN_CHANNELS_SESSION } from './main-agent.js'
-import { isSessionReadyForPrompt, sendPromptToSession, sessionExistsOnHost } from './agent-process.js'
+import { isSessionReadyForPrompt, sendPromptToSession, sessionExistsOnHost, clearFeedbackModalAndRecheck } from './agent-process.js'
 import { sendAlert } from './channel-monitor.js'
 
 export const INBOX_NUDGE_INITIAL_DELAY_MS = 55_000 // free slot (taken: 5/10/20/25/30/35/40/45/50/90s)
@@ -230,7 +230,12 @@ async function tick(): Promise<void> {
     }
     if (state.absenceLogged) state = { ...state, absenceLogged: false }
 
-    if (!(await isSessionReadyForPrompt(MAIN_CHANNELS_SESSION, null))) {
+    if (!(await isSessionReadyForPrompt(MAIN_CHANNELS_SESSION, null))
+      // A self-drafted feedback modal reads as not-ready and would otherwise
+      // park the nudge forever: the pre-flight dismissal lives in the send
+      // path, which this branch never reaches. Same three-line shape as the
+      // other injectors -- see clearFeedbackModalAndRecheck.
+      && !(await clearFeedbackModalAndRecheck(MAIN_CHANNELS_SESSION, null))) {
       // Busy is the NORMAL skip path (silent); surface a long busy-wait spell
       // at a slow rate so it is distinguishable from a dead watcher.
       if (now - state.lastBusyLogAt > BUSY_WAIT_LOG_INTERVAL_MS) {

--- a/src/web/message-router.ts
+++ b/src/web/message-router.ts
@@ -25,9 +25,9 @@ import {
   sendPromptToSession,
   sessionExistsOnHost,
   capturePane,
-  dismissFeedbackDraftModalIfPresent,
+  clearFeedbackModalAndRecheck,
 } from './agent-process.js'
-import { detectPaneState, detectsFeedbackDraftModal, type PaneState } from '../pane-state.js'
+import { detectPaneState, type PaneState } from '../pane-state.js'
 import { setLastInboundModality } from './voice-modality.js'
 import { classifyAgentMessage, wrapAgentMessageForDelivery } from './agent-message-wrap.js'
 import { MAIN_CHANNELS_SESSION } from './main-agent.js'
@@ -575,15 +575,10 @@ export async function runMessageRouterTick(): Promise<void> {
         // dismissal had shipped -- the fix was in the wrong place for this
         // path. Clear it here and re-read readiness ONCE; only a still-held
         // pane falls through to the stuck bookkeeping below.
-        const fbPane = capturePane(session, host)
-        if (fbPane != null && detectsFeedbackDraftModal(fbPane)) {
-          logger.warn({ to: msg.to_agent, session }, 'message-router: pane held by a Claude Code feedback-draft modal, dismissing')
-          await dismissFeedbackDraftModalIfPresent(session, host)
-          if (await isSessionReadyForPrompt(session, host)) {
-            agentStuckSince.delete(msg.to_agent)
-            routerLoggedMisses.delete(msg.id)
-            continue // cleared; deliver on the next tick
-          }
+        if (await clearFeedbackModalAndRecheck(session, host)) {
+          agentStuckSince.delete(msg.to_agent)
+          routerLoggedMisses.delete(msg.id)
+          continue // cleared; deliver on the next tick
         }
         // ---- session-stuck detection (card 2922e380 thread a) ----
         // Track how long this session has been continuously not-ready.

--- a/src/web/message-router.ts
+++ b/src/web/message-router.ts
@@ -25,8 +25,9 @@ import {
   sendPromptToSession,
   sessionExistsOnHost,
   capturePane,
+  dismissFeedbackDraftModalIfPresent,
 } from './agent-process.js'
-import { detectPaneState, type PaneState } from '../pane-state.js'
+import { detectPaneState, detectsFeedbackDraftModal, type PaneState } from '../pane-state.js'
 import { setLastInboundModality } from './voice-modality.js'
 import { classifyAgentMessage, wrapAgentMessageForDelivery } from './agent-message-wrap.js'
 import { MAIN_CHANNELS_SESSION } from './main-agent.js'
@@ -566,6 +567,24 @@ export async function runMessageRouterTick(): Promise<void> {
       }
 
       if (!(await isSessionReadyForPrompt(session, host))) {
+        // A self-drafted feedback modal ("Bug report drafted ... 0 to dismiss")
+        // holds the pane in a not-ready state, and the pre-flight dismissal in
+        // sendPromptToSession never runs because this gate short-circuits
+        // first. Measured twice on 2026-08-31 on agent-samu: 10 minutes
+        // not-ready, 10 queued messages, the second time AFTER the pre-flight
+        // dismissal had shipped -- the fix was in the wrong place for this
+        // path. Clear it here and re-read readiness ONCE; only a still-held
+        // pane falls through to the stuck bookkeeping below.
+        const fbPane = capturePane(session, host)
+        if (fbPane != null && detectsFeedbackDraftModal(fbPane)) {
+          logger.warn({ to: msg.to_agent, session }, 'message-router: pane held by a Claude Code feedback-draft modal, dismissing')
+          await dismissFeedbackDraftModalIfPresent(session, host)
+          if (await isSessionReadyForPrompt(session, host)) {
+            agentStuckSince.delete(msg.to_agent)
+            routerLoggedMisses.delete(msg.id)
+            continue // cleared; deliver on the next tick
+          }
+        }
         // ---- session-stuck detection (card 2922e380 thread a) ----
         // Track how long this session has been continuously not-ready.
         const stuckStart = agentStuckSince.get(msg.to_agent)

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -47,12 +47,13 @@ import {
   sendEnterToSession,
   clearStaleParkedInput,
   resolveAgentProvider,
+  dismissFeedbackDraftModalIfPresent,
 } from './agent-process.js'
 import { MAIN_CHANNELS_SESSION } from './main-agent.js'
 import { runCommandTask } from './command-task.js'
 import { decideQuotaAction, type QuotaWorkClass } from '../quota-gate.js'
 import { readQuotaSnapshot } from '../quota-snapshot.js'
-import { paneShowsContextSaturation, detectsFirstRunGate, detectPaneState, type PaneState } from '../pane-state.js'
+import { paneShowsContextSaturation, detectsFirstRunGate, detectsFeedbackDraftModal, detectPaneState, type PaneState } from '../pane-state.js'
 import { withSessionSendLock } from './session-send-lock.js'
 
 // How many bare-Enter attempts the post-send resubmit tries before escalating
@@ -680,8 +681,26 @@ async function attemptFireTask(
       logger.warn({ task: task.name, agent: agentName, session, gate }, 'Schedule target session parked on a Claude Code first-run dialog, deferring to retry queue')
       return 'first-run'
     }
-    logger.warn({ task: task.name, agent: agentName, session }, 'Schedule target session busy or has pending input, will retry')
-    return 'busy'
+    // A self-drafted feedback modal reads as not-ready here, and the pre-flight
+    // dismissal in sendPromptToSession never gets the chance to clear it --
+    // this gate short-circuits first. Measured twice on 2026-08-31: agent-samu
+    // sat not-ready for 10 minutes with 10 queued messages while the modal held
+    // the pane, AFTER the pre-flight dismissal had already shipped. So the
+    // dismissal has to live on the refusal path too, the same way the first-run
+    // gate is answered above, and readiness is then re-read ONCE.
+    if (notReadyPane != null && detectsFeedbackDraftModal(notReadyPane)) {
+      logger.warn({ task: task.name, agent: agentName, session }, 'Schedule target session held by a Claude Code feedback-draft modal, dismissing and re-reading readiness')
+      await dismissFeedbackDraftModalIfPresent(session, host)
+      if (await isSessionReadyForPrompt(session, host)) {
+        logger.info({ task: task.name, agent: agentName, session }, 'Feedback-draft modal cleared, session is ready -- proceeding')
+      } else {
+        logger.warn({ task: task.name, agent: agentName, session }, 'Schedule target session still not ready after dismissing the feedback-draft modal, will retry')
+        return 'busy'
+      }
+    } else {
+      logger.warn({ task: task.name, agent: agentName, session }, 'Schedule target session busy or has pending input, will retry')
+      return 'busy'
+    }
   }
 
   if (task.forceSend) {

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -47,13 +47,13 @@ import {
   sendEnterToSession,
   clearStaleParkedInput,
   resolveAgentProvider,
-  dismissFeedbackDraftModalIfPresent,
+  clearFeedbackModalAndRecheck,
 } from './agent-process.js'
 import { MAIN_CHANNELS_SESSION } from './main-agent.js'
 import { runCommandTask } from './command-task.js'
 import { decideQuotaAction, type QuotaWorkClass } from '../quota-gate.js'
 import { readQuotaSnapshot } from '../quota-snapshot.js'
-import { paneShowsContextSaturation, detectsFirstRunGate, detectsFeedbackDraftModal, detectPaneState, type PaneState } from '../pane-state.js'
+import { paneShowsContextSaturation, detectsFirstRunGate, detectPaneState, type PaneState } from '../pane-state.js'
 import { withSessionSendLock } from './session-send-lock.js'
 
 // How many bare-Enter attempts the post-send resubmit tries before escalating
@@ -688,15 +688,8 @@ async function attemptFireTask(
     // the pane, AFTER the pre-flight dismissal had already shipped. So the
     // dismissal has to live on the refusal path too, the same way the first-run
     // gate is answered above, and readiness is then re-read ONCE.
-    if (notReadyPane != null && detectsFeedbackDraftModal(notReadyPane)) {
-      logger.warn({ task: task.name, agent: agentName, session }, 'Schedule target session held by a Claude Code feedback-draft modal, dismissing and re-reading readiness')
-      await dismissFeedbackDraftModalIfPresent(session, host)
-      if (await isSessionReadyForPrompt(session, host)) {
-        logger.info({ task: task.name, agent: agentName, session }, 'Feedback-draft modal cleared, session is ready -- proceeding')
-      } else {
-        logger.warn({ task: task.name, agent: agentName, session }, 'Schedule target session still not ready after dismissing the feedback-draft modal, will retry')
-        return 'busy'
-      }
+    if (await clearFeedbackModalAndRecheck(session, host)) {
+      logger.info({ task: task.name, agent: agentName, session }, 'Feedback-draft modal cleared, session is ready -- proceeding')
     } else {
       logger.warn({ task: task.name, agent: agentName, session }, 'Schedule target session busy or has pending input, will retry')
       return 'busy'

--- a/src/web/telegram-inbox-wake.ts
+++ b/src/web/telegram-inbox-wake.ts
@@ -7,6 +7,7 @@ import { listAgentNames, readAgentRemoteHost } from './agent-config.js'
 import {
   agentSessionName,
   isSessionReadyForPrompt,
+  clearFeedbackModalAndRecheck,
   sendPromptToSession,
   sessionExistsOnHost,
 } from './agent-process.js'
@@ -195,7 +196,12 @@ export async function maybeWakeSubAgentsForTelegram(now: number): Promise<void> 
       // isSessionReadyForPrompt already reports a widget-over-idle ('unknown')
       // pane as NOT ready, so a TodoWrite-widget session is conservatively left
       // alone rather than nudged mid-widget -- the safe default for injection.
-      const sessionIdle = sessionExists && await isSessionReadyForPrompt(session, host)
+      // A feedback-draft modal reads as not-ready here too, and this branch
+      // never reaches the send path where the pre-flight dismissal lives --
+      // so clear it once and re-read before treating the pane as busy.
+      const sessionIdle = sessionExists
+        && ((await isSessionReadyForPrompt(session, host))
+          || (await clearFeedbackModalAndRecheck(session, host)))
 
       if (!shouldWakeForTelegramInbox({
         inboxAgeMs,


### PR DESCRIPTION
## A mai javitas rossz helyen volt

A #1120-ban szallitott pre-flight dismissal a `sendPromptToSession`-ben ul. A mai masodik elakadas megmutatta, hogy AZ INCIDENS ESETERE SOSEM FUT LE: mindket kezbesitesi ut eloszor `isSessionReadyForPrompt`-ot kerdez, es a not-ready verdikt utan **fel sem hivja** a kuldest.

Mert eset, 2026-08-31 09:07 (a masodik ugyanaznap): `agent-samu` 10 percig not-ready, 10 uzenet a sorban, es a log ezt ismetli 15 masodpercenkent:

```
WARN: Schedule target session busy or has pending input, will retry
  task: "installer-drift-orszem" agent: "samu" session: "agent-samu"
```

Ekkor a #1120 fixe MAR ELES VOLT a hoston (dashboard restart 08:54, a detektor a futo `dist`-ben). Vagyis nem a detektor hibazott -- a javitas nem azon az uton allt, ahol a blokkolas tortenik.

## Mit valtoztat

Mindket refuzalo ut (schedule-runner + message-router) most **eltakaritja a modalt a not-ready agon**, ugyanugy, ahogy a schedule-runner mar ma is valaszol a first-run dialogusra, majd **egyszer** ujraolvassa a keszenletet. Csak a tovabbra is fogott pane esik at a retry/stuck konyvelesre.

## A teszt a MIERT-et rogziti, nem csak a MIT-et

A masodik elakadaskor rogzitett pane-en **NINCS idle foter** (a modal magasabb, mert egy masodik draft var mogotte, es a pane a prompt-markernel er veget). Ezert a `detectPaneState` NEM `idle`-t ad, a keszenlet-kapu elutasit, es a kuldes-ut fel sem merul.

A #1120 fixture-je a MASIK renderelés (foter jelen, allapot `idle`). Mindketto valodi, es mostantol mindketto fedve van:

- `fires on the footerless live rendering, and that pane does NOT read idle` -- a ket allitas egyutt magyarazza a blokkolast
- a korabbi 12 teszt valtozatlanul zold (border-quote, pozicio-szabaly, mutacios kontrollok)

## Verify

- `npm run typecheck` tiszta
- `npm test`: 321 fajl / 4347 teszt zold (13 a modal-fajlban)
- A ket elakadast kezzel oldottam fel (`0`, majd `Esc` ha jon a kikapcsolo-kerdes); a masodik utan a sor azonnal elindult

🤖 Generated with [Claude Code](https://claude.com/claude-code)