### PR TITLE
fix(update-check): follow the remote we actually ask, not always origin

### DIFF
--- a/src/__tests__/update-checker-branch.test.ts
+++ b/src/__tests__/update-checker-branch.test.ts
@@ -60,3 +60,31 @@ describe('update checker current version', () => {
     expect(currentVersion('/etc')).toBe('') // dir exists, no package.json -> ''
   })
 })
+
+// Regression test for the fork case.
+//
+// "Update" means new commits from the ORIGINAL author, so a checkout that has
+// an `upstream` remote must ask THAT repo, not `origin` -- after a fork origin
+// is the user's own copy and never carries the author's new work. Two things
+// then have to follow the chosen remote, and both used to follow `origin`:
+//   - the BRANCH (a local feature branch does not exist in someone else's repo:
+//     GitHub answers 422 on /commits/<branch>), and
+//   - the compare BASE (a base the remote does not know turns the reported
+//     backlog into a fork-distance -- measured 375 against a real 5).
+import { remoteIsOwnOrigin, parseGitHubRemote, branchOnRemote } from '../web/update-checker.js'
+
+describe('update checker remote selection (fork case)', () => {
+  it('recognises the checkout own origin, and only that', () => {
+    expect(remoteIsOwnOrigin(parseGitHubRemote() + '-not-us')).toBe(false)
+  })
+
+  it('asks a foreign repo about ITS default branch, never our local one', async () => {
+    const remote = parseGitHubRemote()
+    if (remoteIsOwnOrigin(remote)) return // this checkout has no upstream remote
+    const branch = await branchOnRemote(remote)
+    expect(branch).toBeTruthy()
+    // The point of the fix: whatever branch we are on locally, a foreign repo
+    // is asked about a branch that exists THERE.
+    expect(['develop', 'main']).toContain(branch)
+  })
+})

--- a/src/__tests__/update-checker-branch.test.ts
+++ b/src/__tests__/update-checker-branch.test.ts
@@ -6,7 +6,7 @@
 // the update button could never deliver, and stayed silent about the commits
 // that actually were on the way. trackedBranch() is what keeps the two in sync,
 // so it is pinned here.
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, afterAll } from 'vitest'
 import { execFileSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
@@ -72,19 +72,72 @@ describe('update checker current version', () => {
 //   - the compare BASE (a base the remote does not know turns the reported
 //     backlog into a fork-distance -- measured 375 against a real 5).
 import { remoteIsOwnOrigin, parseGitHubRemote, branchOnRemote } from '../web/update-checker.js'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+
+// A throwaway git repo with the given remotes. Everything below measures against
+// one of these instead of the live checkout: on CI the checkout has no
+// `upstream` remote, so a test that reads PROJECT_ROOT exits before it asserts
+// anything, and stays green even with the fix deleted.
+function repoWithRemotes(remotes: Record<string, string>): string {
+  const dir = mkdtempSync(join(tmpdir(), 'update-checker-'))
+  const git = (...args: string[]) =>
+    execFileSync('/usr/bin/git', args, { cwd: dir, timeout: 5000, encoding: 'utf-8' })
+  git('init', '-q', '-b', 'a-local-feature-branch')
+  // One commit, otherwise `rev-parse --abbrev-ref HEAD` reports the literal
+  // "HEAD" on an unborn branch and the helper's detached-HEAD fallback hides
+  // what we are trying to measure.
+  git('-c', 'user.email=t@example.invalid', '-c', 'user.name=t',
+      'commit', '-q', '--allow-empty', '-m', 'base')
+  for (const [name, url] of Object.entries(remotes)) git('remote', 'add', name, url)
+  return dir
+}
 
 describe('update checker remote selection (fork case)', () => {
-  it('recognises the checkout own origin, and only that', () => {
-    expect(remoteIsOwnOrigin(parseGitHubRemote() + '-not-us')).toBe(false)
+  const dirs: string[] = []
+  const mk = (remotes: Record<string, string>) => {
+    const d = repoWithRemotes(remotes)
+    dirs.push(d)
+    return d
+  }
+  afterAll(() => { for (const d of dirs) rmSync(d, { recursive: true, force: true }) })
+
+  it('keeps a plain, un-forked checkout on origin', () => {
+    // The non-regression half: no `upstream` remote, so nothing changes.
+    const root = mk({ origin: 'https://github.com/Someone/theirrepo.git' })
+    expect(parseGitHubRemote(root)).toBe('Someone/theirrepo')
+    expect(remoteIsOwnOrigin('Someone/theirrepo', root)).toBe(true)
+  })
+
+  it('prefers upstream over origin once a fork configures it', () => {
+    // The actual fix. Deleting the `upstream` entry from the preference list
+    // turns this red -- which the previous version of this test did not.
+    const root = mk({
+      origin: 'git@github.com:TheFork/marveen.git',
+      upstream: 'https://github.com/TheAuthor/marveen.git',
+    })
+    expect(parseGitHubRemote(root)).toBe('TheAuthor/marveen')
+    // ...and the author's repo is NOT our own origin, which is what sends the
+    // branch and the compare base down the foreign path.
+    expect(remoteIsOwnOrigin('TheAuthor/marveen', root)).toBe(false)
+    expect(remoteIsOwnOrigin('TheFork/marveen', root)).toBe(true)
   })
 
   it('asks a foreign repo about ITS default branch, never our local one', async () => {
-    const remote = parseGitHubRemote()
-    if (remoteIsOwnOrigin(remote)) return // this checkout has no upstream remote
-    const branch = await branchOnRemote(remote)
-    expect(branch).toBeTruthy()
-    // The point of the fix: whatever branch we are on locally, a foreign repo
-    // is asked about a branch that exists THERE.
-    expect(['develop', 'main']).toContain(branch)
+    const root = mk({
+      origin: 'git@github.com:TheFork/marveen.git',
+      upstream: 'https://github.com/TheAuthor/marveen.git',
+    })
+    // The remote's answer is injected: the assertion is about which branch we
+    // ask for, not about GitHub being reachable.
+    const branch = await branchOnRemote('TheAuthor/marveen', root, async () => 'their-default')
+    expect(branch).toBe('their-default')
+    expect(branch).not.toBe('a-local-feature-branch')
+  })
+
+  it('asks our OWN fork about the branch this checkout follows', async () => {
+    const root = mk({ origin: 'git@github.com:TheFork/marveen.git' })
+    const branch = await branchOnRemote('TheFork/marveen', root, async () => 'never-used')
+    expect(branch).toBe('a-local-feature-branch')
   })
 })

--- a/src/web/update-checker.ts
+++ b/src/web/update-checker.ts
@@ -91,9 +91,9 @@ export function currentGitHead(): string {
 // that the update button could never deliver, while staying silent about the
 // commits that WERE coming. Falls back to `main` on a detached HEAD, which is
 // also the branch update.sh tells the operator to check out in that state.
-export function trackedBranch(): string {
+export function trackedBranch(root: string = PROJECT_ROOT): string {
   try {
-    const b = execFileSync('/usr/bin/git', ['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: PROJECT_ROOT, timeout: 3000, encoding: 'utf-8' }).trim()
+    const b = execFileSync('/usr/bin/git', ['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: root, timeout: 3000, encoding: 'utf-8' }).trim()
     return b && b !== 'HEAD' ? b : 'main'
   } catch {
     return 'main'
@@ -103,9 +103,9 @@ export function trackedBranch(): string {
 // True when `remote` is the checkout's own origin. Decides whether the branch
 // and the compare base may come from local refs (own repo) or have to be
 // resolved against someone else's default branch.
-export function remoteIsOwnOrigin(remote: string): boolean {
+export function remoteIsOwnOrigin(remote: string, root: string = PROJECT_ROOT): boolean {
   try {
-    const url = execFileSync('/usr/bin/git', ['config', '--get', 'remote.origin.url'], { cwd: PROJECT_ROOT, timeout: 3000, encoding: 'utf-8' }).trim()
+    const url = execFileSync('/usr/bin/git', ['config', '--get', 'remote.origin.url'], { cwd: root, timeout: 3000, encoding: 'utf-8' }).trim()
     const m = url.match(/github\.com[:/]([^/]+\/[^/]+?)(?:\.git)?$/i)
     return !!m && m[1].toLowerCase() === remote.toLowerCase()
   } catch {
@@ -132,18 +132,26 @@ async function fetchDefaultBranch(remote: string): Promise<string> {
 // Which branch to ask the remote about: our own fork answers for the branch this
 // checkout follows (update.sh pulls exactly that), anyone else's repo answers
 // for THEIR default branch -- a local feature branch does not exist there.
-export async function branchOnRemote(remote: string): Promise<string> {
-  return remoteIsOwnOrigin(remote) ? trackedBranch() : await fetchDefaultBranch(remote)
+// `root` and `defaultBranchOf` are injected so a test can point this at a
+// throwaway git repo and decide the remote's answer without touching the
+// network. Without that seam the only measurable assertion is "some string came
+// back", which stays green even if the whole upstream preference is deleted.
+export async function branchOnRemote(
+  remote: string,
+  root: string = PROJECT_ROOT,
+  defaultBranchOf: (r: string) => Promise<string> = fetchDefaultBranch,
+): Promise<string> {
+  return remoteIsOwnOrigin(remote, root) ? trackedBranch(root) : await defaultBranchOf(remote)
 }
 
-export function parseGitHubRemote(): string {
+export function parseGitHubRemote(root: string = PROJECT_ROOT): string {
   // "Update" means new commits from the ORIGINAL author, so an `upstream` remote
   // wins over `origin` when one is configured. After a fork, `origin` points at
   // the user's own copy, which never carries the author's new work: the update
   // check then asks the fork about itself and stays silent forever.
   for (const remoteName of ['upstream', 'origin']) {
     try {
-      const url = execFileSync('/usr/bin/git', ['config', '--get', `remote.${remoteName}.url`], { cwd: PROJECT_ROOT, timeout: 3000, encoding: 'utf-8' }).trim()
+      const url = execFileSync('/usr/bin/git', ['config', '--get', `remote.${remoteName}.url`], { cwd: root, timeout: 3000, encoding: 'utf-8' }).trim()
       // Normalize "git@github.com:Owner/Repo.git" or "https://github.com/Owner/Repo.git" to "Owner/Repo"
       const m = url.match(/github\.com[:/]([^/]+\/[^/]+?)(?:\.git)?$/i)
       if (m) return m[1]

--- a/src/web/update-checker.ts
+++ b/src/web/update-checker.ts
@@ -100,13 +100,55 @@ export function trackedBranch(): string {
   }
 }
 
-export function parseGitHubRemote(): string {
+// True when `remote` is the checkout's own origin. Decides whether the branch
+// and the compare base may come from local refs (own repo) or have to be
+// resolved against someone else's default branch.
+export function remoteIsOwnOrigin(remote: string): boolean {
   try {
     const url = execFileSync('/usr/bin/git', ['config', '--get', 'remote.origin.url'], { cwd: PROJECT_ROOT, timeout: 3000, encoding: 'utf-8' }).trim()
-    // Normalize "git@github.com:Owner/Repo.git" or "https://github.com/Owner/Repo.git" to "Owner/Repo"
     const m = url.match(/github\.com[:/]([^/]+\/[^/]+?)(?:\.git)?$/i)
-    if (m) return m[1]
-  } catch { /* fall through */ }
+    return !!m && m[1].toLowerCase() === remote.toLowerCase()
+  } catch {
+    return false
+  }
+}
+
+// The remote's own default branch, asked of GitHub. Only needed when we are NOT
+// checking our own fork -- our local branch name means nothing over there.
+async function fetchDefaultBranch(remote: string): Promise<string> {
+  try {
+    const res = await fetch(`https://api.github.com/repos/${remote}`, {
+      headers: GH_HEADERS,
+      signal: AbortSignal.timeout(TOOL_TIMEOUTS['github']),
+    })
+    if (!res.ok) return 'develop'
+    const j = await res.json() as { default_branch?: string }
+    return j.default_branch || 'develop'
+  } catch {
+    return 'develop'
+  }
+}
+
+// Which branch to ask the remote about: our own fork answers for the branch this
+// checkout follows (update.sh pulls exactly that), anyone else's repo answers
+// for THEIR default branch -- a local feature branch does not exist there.
+export async function branchOnRemote(remote: string): Promise<string> {
+  return remoteIsOwnOrigin(remote) ? trackedBranch() : await fetchDefaultBranch(remote)
+}
+
+export function parseGitHubRemote(): string {
+  // "Update" means new commits from the ORIGINAL author, so an `upstream` remote
+  // wins over `origin` when one is configured. After a fork, `origin` points at
+  // the user's own copy, which never carries the author's new work: the update
+  // check then asks the fork about itself and stays silent forever.
+  for (const remoteName of ['upstream', 'origin']) {
+    try {
+      const url = execFileSync('/usr/bin/git', ['config', '--get', `remote.${remoteName}.url`], { cwd: PROJECT_ROOT, timeout: 3000, encoding: 'utf-8' }).trim()
+      // Normalize "git@github.com:Owner/Repo.git" or "https://github.com/Owner/Repo.git" to "Owner/Repo"
+      const m = url.match(/github\.com[:/]([^/]+\/[^/]+?)(?:\.git)?$/i)
+      if (m) return m[1]
+    } catch { /* try the next remote */ }
+  }
   return 'Szotasz/marveen'
 }
 
@@ -193,12 +235,21 @@ export function groupByRelease(commits: UpdateCommit[], fullMessages: string[]):
 // the fork point -- an actual upstream commit -- so it can be compared on
 // GitHub even though the local HEAD itself never landed there. Empty string
 // when there is no local upstream ref.
-function upstreamMergeBase(): string {
-  try {
-    return execFileSync('/usr/bin/git', ['merge-base', 'HEAD', `origin/${trackedBranch()}`], { cwd: PROJECT_ROOT, timeout: 3000, encoding: 'utf-8' }).trim()
-  } catch {
-    return ''
+function upstreamMergeBase(remote: string, remoteBranch: string): string {
+  // The base has to be a commit the queried remote KNOWS, otherwise the compare
+  // call is meaningless. Asking `origin/<local branch>` while querying someone
+  // else's repo picks our own pushed commit as the base and reports a
+  // fork-distance instead of the real backlog.
+  const refs = remoteIsOwnOrigin(remote)
+    ? [`origin/${trackedBranch()}`, 'origin/main']
+    : [`upstream/${remoteBranch}`, 'upstream/develop', 'upstream/main']
+  for (const ref of refs) {
+    try {
+      const base = execFileSync('/usr/bin/git', ['merge-base', 'HEAD', ref], { cwd: PROJECT_ROOT, timeout: 3000, encoding: 'utf-8' }).trim()
+      if (base) return base
+    } catch { /* try the next ref */ }
   }
+  return ''
 }
 
 export async function refreshUpdateStatus(): Promise<UpdateStatus> {
@@ -218,8 +269,8 @@ export async function refreshUpdateStatus(): Promise<UpdateStatus> {
     return status
   }
   try {
-    // 1) find HEAD of the branch this checkout follows via the commits endpoint
-    const branch = trackedBranch()
+    // 1) find HEAD of the branch to compare against on THAT remote
+    const branch = await branchOnRemote(remote)
     const latestRes = await fetch(`https://api.github.com/repos/${remote}/commits/${encodeURIComponent(branch)}`, {
       headers: { 'Accept': 'application/vnd.github+json', 'User-Agent': 'marveen-update-check' },
       signal: AbortSignal.timeout(TOOL_TIMEOUTS['github']),
@@ -246,7 +297,7 @@ export async function refreshUpdateStatus(): Promise<UpdateStatus> {
       // `behind`/`commits` reflect genuinely new upstream commits rather than the
       // fork divergence.
       status.fork = true
-      const base = upstreamMergeBase()
+      const base = upstreamMergeBase(remote, branch)
       if (!base || base === status.latest) {
         // No local upstream ref, or the fork point already is the upstream tip:
         // nothing new upstream. A fork being ahead of upstream is expected, not


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

**HU.** A frissítés-ellenőrző mindig az `origin`-t kérdezi. Fork után viszont az `origin` a
felhasználó SAJÁT másolata, ami sosem hozza a szerző új munkáját: a telepítés így magát kérdezi
és véglegesen néma marad -- pont azokon a gépeken, ahol a leginkább tudni kellene, hogy
lemaradtak. A `parseGitHubRemote` mostantól előnyben részesíti az `upstream` távolit, ha van
ilyen beállítva, és változatlanul visszaesik az `origin`-ra, tehát egy nem-forkolt telepítés
viselkedése bitre ugyanaz marad.

Ezután viszont még két dolognak követnie kell a KIVÁLASZTOTT távolit, és mindkettő az `origin`-t
követte:

1. **Az ÁG.** A `trackedBranch()` a saját repónkra helyes (az `update.sh` pont
   `origin/<ez az ág>`-at húz), de egy lokális feature-ág a MÁSIK repóban nem létezik: a GitHub
   422-t ad a `/commits/<branch>` hívásra, és a felületen hibaüzenet jelenik meg a lemaradás
   helyett. Az új `branchOnRemote()` egy idegen repótól az ő saját `default_branch`-ét kérdezi.
2. **Az összehasonlítás BÁZISA.** A `merge-base` az `origin/<lokális ág>`-gal olyan commitot ad,
   amit az idegen távoli sosem látott, tehát a compare a FORK-TÁVOLSÁGOT adja vissza a valódi
   lemaradás helyett. Nálunk lemérve: **375 commit "lemaradás" egy valós 5-ös lemaradás mellett.**
   Az `upstreamMergeBase()` mostantól ugyanarról a távoliról választ referenciát, amelyiken
   összehasonlít.

**EN.** The update check always asked `origin`. On a fork that is the user's own copy, which
never carries the author's new work, so the install asks itself and stays silent forever.
`parseGitHubRemote` now prefers an `upstream` remote when configured and falls back to origin
unchanged, so a plain install is byte-identical in behaviour. Two things then have to follow
the chosen remote and both still followed origin: the branch (a local feature branch does not
exist over there -- GitHub answers 422) and the compare base (a base the remote never saw turns
the reported backlog into a fork distance: measured 375 against a true 5).

**Igazolás / Verification.** Forkolt telepítésen mérve: a hibaüzenet eltűnt, és a `behind` szám
pontosan megegyezik a `git rev-list --count HEAD..upstream/develop` értékével.

## Kapcsolódó issue / Related issue

Nincs / none.

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben (Telegram + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally; the agents communicate without errors.
- [ ] Frissítettem a `docs/` mappát -- nem szükséges, a változtatás nem érinti a telepítést vagy az architektúrát. / Not needed; no installation or architecture change.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot. / No hardcoded secrets.
- [x] Saját, beszédes nevű branch-ről nyitom. / Opened from an own, descriptively named branch.

## Tesztek / Tests

A két tiszta döntési pont (`remoteIsOwnOrigin`, `branchOnRemote`) exportálva és tesztben
rögzítve; a teljes készlet zöld marad (4347 teszt, 321 fájl).
