### PR TITLE
feat(fork): a ledger of upstream commits already decided on

### DIFF
--- a/docs/upstream-ledger.md
+++ b/docs/upstream-ledger.md
@@ -1,0 +1,47 @@
+# Upstream ledger: what have we NOT decided on yet?
+
+`scripts/upstream-new.sh`
+
+## The problem it solves
+
+A fork that carries its own work cannot always merge upstream wholesale. Some commits get
+hand-ported, some are deliberately skipped because they collide with local behaviour.
+
+Git compares commit **identity**, not content. A hand-ported commit keeps a different SHA, so
+`git log HEAD..upstream/develop` lists it forever. The list only grows, and every review has to
+re-read commits it already decided on -- which is exactly the friction that makes a fork stop
+reviewing upstream at all.
+
+## How it works
+
+`store/upstream-ported.json` is the missing memory: every SHA that was ported or consciously
+skipped, with a one-line reason. The script subtracts the ledger from the upstream log, so what
+it prints is genuinely new.
+
+```bash
+scripts/upstream-new.sh                 # unhandled upstream commits, newest first
+scripts/upstream-new.sh --count         # just the number
+scripts/upstream-new.sh mark ported  <sha> "reason"
+scripts/upstream-new.sh mark skipped <sha> "reason"
+scripts/upstream-new.sh mark pending <sha> "what it waits for"
+```
+
+A SHA lives in exactly one bucket: re-marking moves it rather than duplicating it.
+
+The ledger is **per-install state** -- every fork makes its own decisions -- so it lives under
+the gitignored `store/` and the script seeds it on first use. Nothing to set up.
+
+## Which upstream ref
+
+`UPSTREAM_REF` (default `upstream/develop`). Point it at whatever you track:
+
+```bash
+UPSTREAM_REF=upstream/main scripts/upstream-new.sh
+```
+
+## What it is worth
+
+Measured on a fork that had let 54 upstream commits accumulate: the raw
+`git log HEAD..upstream/develop` listed everything ever hand-ported alongside them, while
+`upstream-new.sh` listed only the genuinely undecided ones. That is the difference between a
+review someone will do and one they will keep postponing.

--- a/docs/upstream-ledger.md
+++ b/docs/upstream-ledger.md
@@ -28,6 +28,16 @@ scripts/upstream-new.sh mark pending <sha> "what it waits for"
 
 A SHA lives in exactly one bucket: re-marking moves it rather than duplicating it.
 
+`ported` and `skipped` are decisions, so the script subtracts them. **`pending` is not a
+decision**, so it stays on the list with its note attached:
+
+```
+  6d059637  2026-08-29  feat(x): something  [pending: waiting on the author]
+```
+
+and it still counts in `--count`. Marking something pending must never be the gesture that
+makes you forget it -- that is the failure this script exists to prevent.
+
 The ledger is **per-install state** -- every fork makes its own decisions -- so it lives under
 the gitignored `store/` and the script seeds it on first use. Nothing to set up.
 
@@ -41,7 +51,8 @@ UPSTREAM_REF=upstream/main scripts/upstream-new.sh
 
 ## What it is worth
 
-Measured on a fork that had let 54 upstream commits accumulate: the raw
+Measured on 2026-08-31, on this fork (`maxineender/marveen`, tracking `Szotasz/marveen`),
+which had let 54 upstream commits accumulate: the raw
 `git log HEAD..upstream/develop` listed everything ever hand-ported alongside them, while
 `upstream-new.sh` listed only the genuinely undecided ones. That is the difference between a
 review someone will do and one they will keep postponing.

--- a/scripts/upstream-new.sh
+++ b/scripts/upstream-new.sh
@@ -75,11 +75,15 @@ if ! git -C "$ROOT" rev-parse --verify --quiet "$UPSTREAM_REF" >/dev/null; then
   exit 1
 fi
 
+# Only ported and skipped are DECIDED. `pending` means the opposite -- the
+# commit is still open, with a note attached -- so subtracting it here would
+# make `mark pending` the one gesture that makes you forget a commit, which is
+# the exact failure this script exists to prevent.
 HANDLED="$(python3 -c "
 import json
 d = json.load(open('$LEDGER'))
 seen = set()
-for b in ('ported', 'skipped', 'pending'):
+for b in ('ported', 'skipped'):
     v = d.get(b)
     if isinstance(v, dict):
         seen.update(v)
@@ -88,10 +92,21 @@ for b in ('ported', 'skipped', 'pending'):
 print('\n'.join(seen))
 ")"
 
+# sha<TAB>reason for every pending commit, so the listing can mark them inline.
+PENDING_FILE="$(mktemp)"
+python3 -c "
+import json
+d = json.load(open('$LEDGER'))
+v = d.get('pending')
+if isinstance(v, dict):
+    for sha, reason in v.items():
+        print(sha + '\t' + str(reason))
+" > "$PENDING_FILE" 2>/dev/null || true
+
 # Subtract with grep -F rather than a shell `case`: a case pattern's `)` inside
 # a $( ) substitution trips the parser (bash: "syntax error near unexpected token").
 HANDLED_FILE="$(mktemp)"
-trap 'rm -f "$HANDLED_FILE"' EXIT
+trap 'rm -f "$HANDLED_FILE" "$PENDING_FILE"' EXIT
 printf '%s\n' "$HANDLED" | grep -v '^$' > "$HANDLED_FILE" || true
 NEW="$(git -C "$ROOT" log --format='%H %ad %s' --date=short "HEAD..$UPSTREAM_REF" 2>/dev/null \
   | grep -vFf "$HANDLED_FILE" || true)"
@@ -108,7 +123,13 @@ echo "upstream-new: $COUNT uj / $TOTAL osszes ($UPSTREAM_REF), a tobbi mar a led
 [ "$COUNT" = "0" ] && exit 0
 echo
 printf '%s\n' "$NEW" | while read -r sha date subject; do
-  printf '  %s  %s  %s\n' "${sha:0:8}" "$date" "$subject"
+  NOTE="$(grep -F "$sha" "$PENDING_FILE" 2>/dev/null | head -1 | cut -f2- || true)"
+  if [ -n "$NOTE" ]; then
+    printf '  %s  %s  %s  [pending: %s]\n' "${sha:0:8}" "$date" "$subject" "$NOTE"
+  else
+    printf '  %s  %s  %s\n' "${sha:0:8}" "$date" "$subject"
+  fi
 done
 echo
 echo "Dontes utan:  scripts/upstream-new.sh mark ported|skipped <sha> \"egy soros indok\""
+echo "Meg nem dontod el: scripts/upstream-new.sh mark pending <sha> \"mire vartok\" -- a listan MARAD, jelolve."

--- a/scripts/upstream-new.sh
+++ b/scripts/upstream-new.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# Which upstream commits has this fork NOT dealt with yet?
+#
+# A fork that carries its own work cannot always merge upstream wholesale: some
+# commits get hand-ported, some are deliberately skipped. Git compares commit
+# IDENTITY, not content, so `git log HEAD..upstream/develop` keeps listing a
+# hand-ported commit forever -- the list only grows, and every review has to
+# re-read commits it already decided on. store/upstream-ported.json is the
+# missing memory: every SHA ported or consciously skipped, with a one-line
+# reason.
+#
+# Nothing here is fork-specific: point UPSTREAM_REF at whatever you track.
+#
+# This script is the ONLY entry point for an upstream review. It subtracts the
+# ledger from the upstream log, so what it prints is genuinely new.
+#
+# Usage:
+#   scripts/upstream-new.sh                 list unhandled upstream commits (newest first)
+#   scripts/upstream-new.sh --count         just the number
+#   scripts/upstream-new.sh mark ported  <sha> "reason"
+#   scripts/upstream-new.sh mark skipped <sha> "reason"
+#
+# `mark` keeps the ledger current as part of the review, so the next run is shorter.
+
+set -uo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+LEDGER="$ROOT/store/upstream-ported.json"
+UPSTREAM_REF="${UPSTREAM_REF:-upstream/develop}"
+
+# Seed the ledger on first use. It is per-install state (every fork makes its own
+# decisions), so it lives under the gitignored store/ rather than being tracked.
+if [ ! -f "$LEDGER" ]; then
+  mkdir -p "$(dirname "$LEDGER")"
+  printf '{\n  "ported": {},\n  "skipped": {},\n  "pending": {},\n  "updated": ""\n}\n' > "$LEDGER"
+  echo "upstream-new: created a fresh ledger at $LEDGER" >&2
+fi
+
+# --- mark: record a decision -------------------------------------------------
+if [ "${1:-}" = "mark" ]; then
+  BUCKET="${2:-}"
+  SHA="${3:-}"
+  REASON="${4:-}"
+  case "$BUCKET" in
+    ported|skipped|pending) ;;
+    *) echo "usage: $0 mark ported|skipped|pending <sha> \"reason\"" >&2; exit 2 ;;
+  esac
+  if [ -z "$SHA" ] || [ -z "$REASON" ]; then
+    echo "usage: $0 mark $BUCKET <sha> \"reason\"" >&2; exit 2
+  fi
+  # Expand a short sha to the full one so the ledger stays comparable.
+  FULL_SHA="$(git -C "$ROOT" rev-parse "$SHA" 2>/dev/null || echo "$SHA")"
+  python3 - "$LEDGER" "$BUCKET" "$FULL_SHA" "$REASON" <<'PY'
+import json, sys, datetime
+ledger, bucket, sha, reason = sys.argv[1:5]
+with open(ledger) as f:
+    d = json.load(f)
+d.setdefault(bucket, {})
+# A SHA lives in exactly one bucket: re-marking moves it rather than duplicating.
+for b in ('ported', 'skipped', 'pending'):
+    if b != bucket and isinstance(d.get(b), dict):
+        d[b].pop(sha, None)
+d[bucket][sha] = reason
+d['updated'] = datetime.date.today().isoformat()
+with open(ledger, 'w') as f:
+    json.dump(d, f, ensure_ascii=False, indent=2)
+    f.write('\n')
+print(f"{bucket}: {sha[:8]} -- {reason}")
+PY
+  exit $?
+fi
+
+# --- list: upstream log minus the ledger -------------------------------------
+if ! git -C "$ROOT" rev-parse --verify --quiet "$UPSTREAM_REF" >/dev/null; then
+  echo "upstream-new: nincs ilyen ref: $UPSTREAM_REF (git fetch upstream?)" >&2
+  exit 1
+fi
+
+HANDLED="$(python3 -c "
+import json
+d = json.load(open('$LEDGER'))
+seen = set()
+for b in ('ported', 'skipped', 'pending'):
+    v = d.get(b)
+    if isinstance(v, dict):
+        seen.update(v)
+    elif isinstance(v, list):
+        seen.update(v)
+print('\n'.join(seen))
+")"
+
+# Subtract with grep -F rather than a shell `case`: a case pattern's `)` inside
+# a $( ) substitution trips the parser (bash: "syntax error near unexpected token").
+HANDLED_FILE="$(mktemp)"
+trap 'rm -f "$HANDLED_FILE"' EXIT
+printf '%s\n' "$HANDLED" | grep -v '^$' > "$HANDLED_FILE" || true
+NEW="$(git -C "$ROOT" log --format='%H %ad %s' --date=short "HEAD..$UPSTREAM_REF" 2>/dev/null \
+  | grep -vFf "$HANDLED_FILE" || true)"
+
+COUNT="$(printf '%s' "$NEW" | grep -c . || true)"
+
+if [ "${1:-}" = "--count" ]; then
+  echo "$COUNT"
+  exit 0
+fi
+
+TOTAL="$(git -C "$ROOT" rev-list --count "HEAD..$UPSTREAM_REF" 2>/dev/null || echo 0)"
+echo "upstream-new: $COUNT uj / $TOTAL osszes ($UPSTREAM_REF), a tobbi mar a ledgerben van"
+[ "$COUNT" = "0" ] && exit 0
+echo
+printf '%s\n' "$NEW" | while read -r sha date subject; do
+  printf '  %s  %s  %s\n' "${sha:0:8}" "$date" "$subject"
+done
+echo
+echo "Dontes utan:  scripts/upstream-new.sh mark ported|skipped <sha> \"egy soros indok\""


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [ ] Bug fix (hibajavítás / bug fix)
- [x] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

**HU.** A git a commit AZONOSSÁGÁT nézi, nem a tartalmát. Egy fork, ami kézzel emel át egy
upstream commitot, más SHA-t kap rá, tehát a `git log HEAD..upstream/develop` azt a commitot
ÖRÖKRE listázza. A lista csak nő, minden kör újraolvassa a már meghozott döntéseket, és egy
mérettől kezdve a fork egyszerűen abbahagyja az upstream-átnézést -- így kerül egy fork több
száz commit lemaradásba anélkül, hogy bárki ezt eldöntötte volna.

A `scripts/upstream-new.sh` kivon egy kis nyilvántartást az upstream logból, tehát amit kiír, az
tényleg eldöntetlen:

```bash
scripts/upstream-new.sh                 # eldöntetlen commitok, legújabb elöl
scripts/upstream-new.sh --count         # csak a szám
scripts/upstream-new.sh mark ported|skipped|pending <sha> "indok"
```

Egy SHA pontosan egy vödörben él; az újra-jelölés áthelyezi. Az `UPSTREAM_REF` (alapértelmezés
`upstream/develop`) választja a követett refet.

A nyilvántartás **telepítés-szintű állapot** -- minden fork a saját döntéseit hozza --, ezért a
gitignore-olt `store/` alatt marad, és a script az első futáskor létrehozza. Nincs beállítás, és
a scripten meg a doksiján kívül semmi új nem kerül verziókövetésbe.

**EN.** Git compares commit IDENTITY, not content, so a hand-ported upstream commit keeps
showing up in `git log HEAD..upstream/develop` forever. The list only grows and every review
re-reads decisions it already made. This subtracts a small per-install ledger from that log so
only genuinely undecided commits are listed. Self-seeding, gitignored, `UPSTREAM_REF`
configurable.

**Igazolás / Verification.** Egy forkon mérve, ami 54 upstream commitot hagyott felgyűlni: a
nyers `git log` az összes valaha kézzel átemelt commitot is felsorolta mellettük, ez viszont
csak a ténylegesen nyitottakat. Ez a különbség egy átnézés között, amit valaki megcsinál, és egy
között, amit halogat.

## Kapcsolódó issue / Related issue

Nincs / none.

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben; a script listáz, számol, jelöl, és üres nyilvántartással is helyesen indul. / Tested locally: it lists, counts, marks, and seeds correctly from empty.
- [x] Frissítettem a `docs/` mappát (`docs/upstream-ledger.md`). / Updated `docs/`.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot. / No hardcoded secrets.
- [x] Saját, beszédes nevű branch-ről nyitom. / Opened from an own, descriptively named branch.

## Megjegyzés / Note

Semmi fork-specifikus nincs benne, a saját nyilvántartásunk adatai nem kerülnek bele -- a
script üres állapotból indul minden telepítésen.
