### PR TITLE
test(fleet): positive caller-chain tests for the feedback-modal wiring (MODALPOSTEST831)

### DIFF
--- a/src/__tests__/feedback-modal-positive-router.test.ts
+++ b/src/__tests__/feedback-modal-positive-router.test.ts
@@ -1,0 +1,137 @@
+// MODALPOSTEST831: the POSITIVE half of the #1123 wiring, message-router leg.
+//
+// The seven injector fixtures stub clearFeedbackModalAndRecheck to false (no
+// modal), so until now "helper=true -> the caller PROCEEDS" stood only on code
+// reading -- the second half of tested-is-not-wired. This pins it by driving
+// runMessageRouterTick through the real refusal branch:
+//
+//   tick 1: session exists, NOT ready, helper returns true (modal cleared)
+//           -> the message is NOT failed, NOT delivered yet (continue;
+//              delivery belongs to the next tick), and the helper was
+//              actually consulted;
+//   tick 2: session now ready -> the SAME message is delivered.
+//
+// The negative control keeps the helper at false on a not-ready session and
+// asserts nothing is delivered -- so a regression that short-circuits before
+// the helper (an earlier readiness gate, the exact bug class #1123 fixed)
+// turns tick 1's helper-consulted assertion red.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockGetPendingMessages = vi.fn()
+const mockMarkDelivered = vi.fn((..._a: unknown[]) => true)
+const mockMarkFailed = vi.fn((..._a: unknown[]) => true)
+const mockSessionExistsOnHost = vi.fn((..._a: unknown[]) => true)
+const mockIsReady = vi.fn(() => false)
+const mockClearModal = vi.fn(() => false)
+const mockSendPrompt = vi.fn()
+
+vi.mock('../logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+}))
+
+vi.mock('../config.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../config.js')>()),
+  MAIN_AGENT_ID: 'orin',
+  // Keep the telegram wake watcher off so this test stays isolated to the
+  // router's own refusal branch.
+  SUBAGENT_TELEGRAM_WAKE_ENABLED: false,
+}))
+
+vi.mock('../db.js', () => ({
+  getPendingMessages: (toAgent?: string) => {
+    if (toAgent) return []
+    return mockGetPendingMessages()
+  },
+  markMessageDelivered: (...a: unknown[]) => mockMarkDelivered(...a),
+  markMessageFailed: (...a: unknown[]) => mockMarkFailed(...a),
+  markMessageDone: (..._a: unknown[]) => true,
+  createAgentMessage: (..._a: unknown[]) => ({ id: 999 }),
+  stampMessageTrace: (..._a: unknown[]) => false,
+  upsertOtelSpan: (..._a: unknown[]) => undefined,
+  closeOtelSpan: (..._a: unknown[]) => false,
+}))
+
+vi.mock('../web/voice-directive.js', () => ({
+  resolveAgentChannelStateDir: () => '/tmp/none',
+}))
+
+vi.mock('../web/agent-config.js', () => ({
+  readAgentRemoteHost: () => null,
+  readAgentVoiceConfig: () => ({ responseMode: 'text' }),
+  isKnownAgent: () => true,
+  agentDir: () => '/tmp/none-agentdir',
+}))
+
+vi.mock('../web/agent-process.js', () => ({
+  clearFeedbackModalAndRecheck: (...a: unknown[]) => mockClearModal(...(a as [])),
+  agentSessionName: (name: string) => `agent-${name}`,
+  isSessionReadyForPrompt: (...a: unknown[]) => mockIsReady(...(a as [])),
+  clearStaleParkedInput: vi.fn(() => false),
+  sendPromptToSession: (...a: unknown[]) => mockSendPrompt(...(a as [])),
+  sessionExistsOnHost: (...a: unknown[]) => mockSessionExistsOnHost(...a),
+}))
+
+vi.mock('../web/voice-modality.js', () => ({
+  setLastInboundModality: vi.fn(),
+}))
+
+vi.mock('../web/main-agent.js', () => ({
+  MAIN_CHANNELS_SESSION: 'orin-channels',
+}))
+
+import { runMessageRouterTick } from '../web/message-router.js'
+
+function pendingMsg(id: number) {
+  return {
+    id,
+    from_agent: 'marveen',
+    to_agent: 'samu',
+    content: 'held behind the modal',
+    status: 'pending',
+    created_at: Math.floor(Date.now() / 1000),
+  }
+}
+
+describe('message router: modal cleared on the refusal branch -> delivery proceeds', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSessionExistsOnHost.mockReturnValue(true)
+  })
+
+  it('helper=true: message survives the tick unfailed and delivers on the next one', async () => {
+    mockGetPendingMessages.mockReturnValue([pendingMsg(1)])
+    mockIsReady.mockResolvedValue(false as never)
+    mockClearModal.mockResolvedValue(true as never)
+
+    await runMessageRouterTick()
+
+    // The refusal branch actually reached the helper (no earlier gate turned
+    // the caller back) ...
+    expect(mockClearModal).toHaveBeenCalled()
+    // ... and a cleared modal is neither a failure nor an instant delivery.
+    expect(mockMarkFailed).not.toHaveBeenCalled()
+    expect(mockMarkDelivered).not.toHaveBeenCalled()
+
+    // Next tick: the pane is ready, the SAME message goes out.
+    mockIsReady.mockResolvedValue(true as never)
+    await runMessageRouterTick()
+
+    expect(mockSendPrompt).toHaveBeenCalledTimes(1)
+    expect(mockMarkDelivered).toHaveBeenCalledTimes(1)
+  })
+
+  it('negative control, helper=false: not-ready stays a skip, nothing delivers', async () => {
+    mockGetPendingMessages.mockReturnValue([pendingMsg(2)])
+    mockIsReady.mockResolvedValue(false as never)
+    mockClearModal.mockResolvedValue(false as never)
+
+    await runMessageRouterTick()
+
+    expect(mockClearModal).toHaveBeenCalled()
+    expect(mockSendPrompt).not.toHaveBeenCalled()
+    expect(mockMarkDelivered).not.toHaveBeenCalled()
+    // Held (not failed): the stuck bookkeeping owns this case, not failure.
+    expect(mockMarkFailed).not.toHaveBeenCalled()
+  })
+})

--- a/src/__tests__/feedback-modal-positive-scheduler.test.ts
+++ b/src/__tests__/feedback-modal-positive-scheduler.test.ts
@@ -1,0 +1,169 @@
+// MODALPOSTEST831: the POSITIVE half of the #1123 wiring, schedule-runner leg.
+//
+// The injector fixtures stub clearFeedbackModalAndRecheck to false, so
+// "helper=true -> the scheduler PROCEEDS TO SEND in the same attempt" stood
+// only on code reading. This drives a pending retry against a session that is
+// present but NOT ready:
+//
+//   helper=true  -> the modal was the only blocker: the task fires NOW
+//                   (sendPromptToSession called, retry row deleted);
+//   helper=false -> 'busy' skip as before: no send, the row survives.
+//
+// The helper-consulted assertion doubles as the earlier-gate regression trap:
+// if a future readiness/first-run gate turns the caller back before the
+// helper (the exact bug class #1123 fixed), the positive case goes red.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ScheduledTask } from '../web/scheduled-tasks-io.js'
+
+const mockAppendTaskRun = vi.fn()
+// Mirrors the real DB: a fired retry's delete removes the row, so the next
+// pass of the loop no longer sees it -- without this the fixture re-fires the
+// same row on every pass inside the tick window.
+let pendingRetries: Array<Record<string, unknown>> = []
+const mockDeletePendingRetry = vi.fn((taskName: unknown, _agent?: unknown) => {
+  pendingRetries = pendingRetries.filter((r) => r.task_name !== taskName)
+})
+const mockUpdatePendingRetry = vi.fn(() => true)
+const mockListPendingRetries = vi.fn(() => pendingRetries)
+const mockSendPrompt = vi.fn(() => 'sent')
+const mockSessionExists = vi.fn(() => true)
+const mockStartAgent = vi.fn(() => ({ ok: true }))
+const mockListScheduledTasks = vi.fn(() => [] as ScheduledTask[])
+const mockIsReady = vi.fn(() => false)
+const mockClearModal = vi.fn(() => false)
+let capturePaneCalls = 0
+
+vi.mock('../logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+}))
+
+vi.mock('../web/atomic-write.js', () => ({
+  atomicWriteFileSync: vi.fn(),
+}))
+
+vi.mock('../db.js', () => ({
+  appendTaskRun: (...a: unknown[]) => mockAppendTaskRun(...a),
+  listPendingTaskRetries: () => mockListPendingRetries(),
+  deletePendingTaskRetry: (...a: unknown[]) => mockDeletePendingRetry(a[0], a[1]),
+  updatePendingTaskRetry: mockUpdatePendingRetry,
+  insertPendingTaskRetryIfNew: vi.fn(),
+  markPendingTaskRetryAlert: vi.fn(() => false),
+  clearPendingTaskRetryAlert: vi.fn(),
+  markScheduledTaskKanbanWaiting: vi.fn(),
+}))
+
+// Neutralize the real alert sink (would resolve a real bot token from
+// install-level config) -- same rule as the sibling scheduler fixtures.
+vi.mock('../channel-provider.js', async (importOriginal) => {
+  const real = await importOriginal<typeof import('../channel-provider.js')>()
+  return {
+    ...real,
+    getProvider: (type: Parameters<typeof real.getProvider>[0]) => ({
+      ...real.getProvider(type),
+      sendMessage: vi.fn(async () => {}),
+      sendPhoto: vi.fn(async () => {}),
+    }),
+  }
+})
+
+vi.mock('../web/scheduled-tasks-io.js', () => ({
+  listScheduledTasks: () => mockListScheduledTasks(),
+  SCHEDULED_TASKS_DIR: '/tmp/marveen-modal-positive-no-tasks-dir',
+}))
+
+vi.mock('../web/agent-process.js', () => ({
+  clearFeedbackModalAndRecheck: (...a: unknown[]) => mockClearModal(...(a as [])),
+  agentSessionName: (name: string) => `agent-${name}`,
+  isAgentRunning: () => true,
+  isSessionReadyForPrompt: (...a: unknown[]) => mockIsReady(...(a as [])),
+  sendPromptToSession: (...a: unknown[]) => mockSendPrompt(...(a as [])),
+  startAgentProcess: (...a: unknown[]) => mockStartAgent(...(a as [])),
+  sessionExistsOnHost: () => mockSessionExists(),
+  // First capture (the not-ready branch's first-run gate check) returns a
+  // pane with NO first-run gate on it -- the earlier gate must pass through
+  // to the helper, not swallow the modal case. Every later capture (the
+  // post-send resubmit loop) returns null so the loop sees nothing parked
+  // and stops, same as the sibling fixtures.
+  capturePane: (..._a: unknown[]) => (capturePaneCalls++ === 0 ? 'plain pane\n❯ ' : null),
+  sendEnterToSession: vi.fn(),
+  clearStaleParkedInput: vi.fn(() => false),
+  resolveAgentProvider: () => 'telegram',
+}))
+
+function task(overrides: Partial<ScheduledTask> & { name: string; schedule: string }): ScheduledTask {
+  return {
+    description: 'modal-positive fixture',
+    prompt: 'Do the thing.',
+    agent: 'modalagent',
+    enabled: true,
+    createdAt: 0,
+    type: 'task',
+    targetSession: 'modal-test-session',
+    ...overrides,
+  }
+}
+
+const DAILY = task({ name: 'modal-positive-e2e-daily', schedule: '0 8 * * *' })
+
+function retryRow(overrides: Record<string, unknown> = {}) {
+  return {
+    task_name: DAILY.name,
+    agent_name: 'modalagent',
+    first_attempt: Date.now() - 5 * 60000,
+    last_attempt: Date.now() - 60000,
+    attempt_count: 2,
+    last_reason: 'busy',
+    alerted_at: null,
+    ...overrides,
+  }
+}
+
+async function runOneTick() {
+  vi.resetModules()
+  const { startScheduleRunner } = await import('../web/schedule-runner.js')
+  const stop = startScheduleRunner()
+  await vi.advanceTimersByTimeAsync(61_000)
+  clearInterval(stop)
+}
+
+describe('schedule runner: modal cleared on the refusal branch -> the task fires', () => {
+  beforeEach(() => {
+    vi.stubEnv('SCHEDULER_TZ', 'Europe/Budapest')
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    // Quiet moment (no cron occurrence): only the pending-retry loop acts.
+    vi.setSystemTime(new Date('2026-07-31T10:30:00.000Z'))
+    mockListScheduledTasks.mockReturnValue([DAILY])
+    mockSessionExists.mockReturnValue(true)
+    mockIsReady.mockResolvedValue(false as never)
+    capturePaneCalls = 0
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllEnvs()
+  })
+
+  it('helper=true: the retry fires in the SAME attempt and the row drains', async () => {
+    mockClearModal.mockResolvedValue(true as never)
+    pendingRetries = [retryRow()]
+    await runOneTick()
+
+    // The not-ready branch consulted the helper (no earlier gate turned back)
+    expect(mockClearModal).toHaveBeenCalled()
+    // ...and a cleared modal means the send happens NOW, not on a later retry.
+    expect(mockSendPrompt).toHaveBeenCalledTimes(1)
+    expect(mockDeletePendingRetry).toHaveBeenCalledWith(DAILY.name, 'modalagent')
+  })
+
+  it('negative control, helper=false: busy skip, no send, the row survives', async () => {
+    mockClearModal.mockResolvedValue(false as never)
+    pendingRetries = [retryRow()]
+    await runOneTick()
+
+    expect(mockClearModal).toHaveBeenCalled()
+    expect(mockSendPrompt).not.toHaveBeenCalled()
+    expect(mockDeletePendingRetry).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## What

MODALPOSTEST831: the #1123 review found that all seven injector fixtures stub `clearFeedbackModalAndRecheck` to `false`, so the POSITIVE path (helper=true -> the caller proceeds) stood only on code reading. Two new chain tests pin it:

- **message-router**: not-ready + cleared modal -> the message is neither failed nor delivered that tick (helper consulted, `continue`), then delivers on the next ready tick. Negative control: helper=false delivers nothing.
- **schedule-runner**: a pending retry against a present-but-not-ready session + cleared modal -> the task fires in the SAME attempt and the retry row drains. Negative control: busy skip, row survives.

The helper-consulted assertion doubles as the earlier-gate regression trap (the exact #1123 bug class): an `if (false)` mutation at either call site turns both files red (mutation applied grep-verified before reading the verdict, then restored -- product diff empty).

## Scope stated

telegram-inbox-wake and inbox-nudge-watcher positive paths remain code-verified only: their call sites are single boolean compositions (`ready || clear`, `!ready && !clear`), the branching callers are the two covered here. If full four-leg coverage is wanted, say so and I extend.

## Verify

- 4/4 new tests green; full suite 4352 passed / 1 skipped (323 files); `tsc --noEmit` clean; secret-gate 26/26.
- `scripts/__tests__/stop-start-system-unit.test.sh` fails 6/9 on this macOS host **on the unchanged baseline too** (no systemd) -- environmental, the diff does not touch `scripts/`; CI's ubuntu runner is the instrument of record for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
