### PR TITLE
A parked scheduled tick is not a wedge (STUCKSCHED831)

### DIFF
--- a/src/__tests__/stuck-tool-call.test.ts
+++ b/src/__tests__/stuck-tool-call.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it } from 'vitest'
 import {
   stuckToolCallSignature,
   decideStuckToolCallRecovery,
+  detectPaneState,
+  parkedChannelInput,
+  parkedMachineOriginInput,
   type StuckToolCallState,
   type StuckToolCallThresholds,
 } from '../pane-state.js'
@@ -378,6 +381,43 @@ describe('stuck-tool-call-watcher wiring contract', () => {
     const cpuGuardCall = watcherSrc.indexOf('!confirmsWedgeProfile(cpuPercent, WEDGE_MAX_CPU_PERCENT)')
     expect(cpuGuardCall, 'CPU guard call site not found').toBeGreaterThan(-1)
     expect(watcherSrc.indexOf('parkedChannelInput(pane)')).toBeLessThan(cpuGuardCall)
+  })
+
+  it('skips recovery while a SCHEDULED-TASK injection is parked in the prompt (STUCKSCHED831)', () => {
+    // The 2026-08-15 guard above was written for `<channel source="plugin:`
+    // blocks and matched nothing else, which left the far more frequent park
+    // uncovered: a scheduled-task tick (heartbeat, kanban audit, dream engine).
+    // Measured on the Marveen install 2026-08-18: 14:11:08 the idle-prompt
+    // guard correctly skipped the residual footer, 14:15:08 this watcher
+    // respawned a session that was merely IDLE, and the first input after the
+    // respawn arrived truncated and fused with the next command.
+    //
+    // Prove the gap on the SHIPPED predicates, not on a copy: the same pane
+    // must read false for the channel-only check and true for the machine-
+    // origin one. If these two ever agree, the widening below is pointless.
+    const SEP = '─'.repeat(80)
+    const parkedScheduledTick = [
+      '',
+      SEP,
+      '❯ SCHEDULED TASK NOTICE -- the next <scheduled-task source="..."> ...',
+      '  </scheduled-task> block is one of YOUR OWN scheduled tasks. It was authored',
+      '  by the operator and fired by the local scheduler. <scheduled-task',
+      '  source="scheduled-task:memoria-heartbeat"> # Memoria-heartbeat',
+      '  ... </scheduled-task>',
+      SEP,
+      '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+    ].join('\n')
+    expect(detectPaneState(parkedScheduledTick)).toBe('typing')
+    expect(parkedChannelInput(parkedScheduledTick), 'channel-only check must MISS a scheduled tick').toBeNull()
+    expect(parkedMachineOriginInput(parkedScheduledTick), 'machine-origin check must CATCH it').toBe(true)
+
+    // And the watcher must consult the widened predicate, still ahead of the
+    // CPU guard (a freshly parked tick has not started burning CPU yet, so a
+    // later position would let it walk straight through to the respawn).
+    expect(watcherSrc).toMatch(/parkedMachineOriginInput\(pane\)/)
+    const cpuGuardCall = watcherSrc.indexOf('!confirmsWedgeProfile(cpuPercent, WEDGE_MAX_CPU_PERCENT)')
+    expect(cpuGuardCall, 'CPU guard call site not found').toBeGreaterThan(-1)
+    expect(watcherSrc.indexOf('parkedMachineOriginInput(pane)')).toBeLessThan(cpuGuardCall)
   })
 
   it('the owner-facing alert does not present the frozen counter as a duration', () => {

--- a/src/web/stuck-tool-call-watcher.ts
+++ b/src/web/stuck-tool-call-watcher.ts
@@ -50,6 +50,7 @@ import {
   decideStuckToolCallRecovery,
   detectPaneState,
   parkedChannelInput,
+  parkedMachineOriginInput,
   type StuckToolCallState,
   type StuckToolCallThresholds,
 } from '../pane-state.js'
@@ -231,10 +232,26 @@ async function checkSession(label: string, session: string): Promise<void> {
     // about to be driven, and that case belongs to stuck-input-watcher, which
     // has its own escalation (Enter -> clear+re-inject -> respawn). Clear the
     // stale spell so the residual cannot re-arm on the next poll.
-    if (pane != null && parkedChannelInput(pane) != null) {
+    // STUCKSCHED831: the guard was CHANNEL-ONLY, and that is narrower than the
+    // reason it exists. parkedChannelInput() matches `<channel source="plugin:`
+    // and nothing else, so a parked SCHEDULED-TASK injection (heartbeat, audit,
+    // dream-engine) slipped through every gate: the pane is no longer 'idle'
+    // (so the idle-prompt guard above stops applying), it is not a channel
+    // block (so this guard missed it), and CPU is still low because the turn
+    // has not started yet. Measured on this install 2026-08-18: 14:11:08 the
+    // idle-prompt guard correctly skipped, 14:15:08 the watcher respawned an
+    // idle session, and the first input after the respawn came back TRUNCATED
+    // and fused with the next command -- the same damage shape as the
+    // 2026-08-15 channel-message case this guard was written for.
+    // The discriminator was never "is it a channel message" but "is something
+    // machine-injected parked in the box", i.e. the session is about to be
+    // driven. parkedMachineOriginInput() is exactly that predicate and is a
+    // strict superset (its prefix list includes the channel regex), so the
+    // 2026-08-15 behaviour is preserved.
+    if (pane != null && (parkedChannelInput(pane) != null || parkedMachineOriginInput(pane))) {
       logger.info(
         { label, session, tag: next.tag, seconds: next.lastSeconds, spellPeakSeconds: next.spellPeakSeconds },
-        'stuck-tool-call-watcher: counter stagnant but an inbound channel message is parked in the prompt (stuck-input-watcher owns this) -- skipping recovery',
+        'stuck-tool-call-watcher: counter stagnant but machine-injected input is parked in the prompt (stuck-input-watcher owns this) -- skipping recovery',
       )
       watchState.delete(session)
       return


### PR DESCRIPTION
## What

The parked-input guard in `stuck-tool-call-watcher` was written for `<channel source="plugin:` blocks and matched nothing else, so the far more frequent park went uncovered: a **scheduled-task tick** (heartbeat, kanban audit, dream engine).

## Why it slips through every gate

| Gate | Why it misses |
|---|---|
| idle-prompt guard | the pane is no longer `idle` once the tick is parked |
| parked-input guard | the tick is not a `<channel>` block |
| CPU-profile guard | CPU is still low, the turn has not started yet |

So the watcher respawns a session that is merely idle.

## Measured, on a live install

2026-08-18, `store/dashboard.log`:

```
14:11:08  counter stagnant but pane is at the idle prompt ... skipping recovery
14:15:08  TUI counter stagnant past freeze threshold + idle wedge profile -- recovering
14:15:12  Marveen session respawned with --continue
```

Nothing was wedged. Quiet heartbeat rounds had been running, each closing cleanly; the TUI counter stood still because there was no work. The first input after the respawn came back **truncated and fused with the following command** -- the same damage shape as the 2026-08-15 channel-message incident that this guard was written for.

## The fix

The discriminator was never "is it a channel message" but "is something machine-injected parked in the box", i.e. the session is about to be driven, which is `stuck-input-watcher`'s job. `parkedMachineOriginInput()` is exactly that predicate and is already exported; its prefix list includes the channel regex, so it is a strict superset and the 2026-08-15 behaviour is preserved.

## Verification

The new test proves the gap on the **shipped** predicates rather than a copy: the same pane fixture must read `null` for `parkedChannelInput` and `true` for `parkedMachineOriginInput`. If those two ever agree, the widening is pointless and the test says so.

- control run with the fix reverted: that one test fails, the other 44 pass
- with the fix: 45 pass
- full suite: **4349 passed, 1 skipped, 321 files**
- `tsc --noEmit` clean

## What this does not fix

The truncated-and-fused input after a respawn is a separate defect in the respawn path. This change removes one frequent trigger; it does not make the respawn itself safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UtBVdpj9gYnRBXAnfTpxJx