### PR TITLE
fix(kanban,router): silent dispatch gaps, a repeating main-agent wake-up, and /clear continuity

### DIFF
--- a/docs/conversation-continuity.md
+++ b/docs/conversation-continuity.md
@@ -140,3 +140,51 @@ no `jq`). Take effect on the next session start after the settings change.
   `LEDGER_DB_PATH` + `LEDGER_OWNER_CHAT`.
 - `npx vitest run src/__tests__/conversation-ledger-schema.test.ts` — schema-drift
   guard (db.ts migration == ledger_lib.py).
+
+## The `/clear` path (every agent, not just the channel ones)
+
+The ledger above carries a **channel** conversation across a respawn. A `/clear`
+is a different event with a different blast radius: it wipes the session in
+place, and it used to be unprotected at **both** ends.
+
+- **Nothing saved before it.** The `PreCompact` agent-hook (memory save, skill
+  reflection, task-state) is wired to the *compact* path. A `/clear` does not
+  fire `PreCompact`, so nothing wrote a record.
+- **Nothing restored after it.** The harness restarts the session with
+  `source=clear`, but the sub-agent `SessionStart` hook was registered on
+  `compact|resume` and `REPLAY_SOURCES` in `agent-taskstate.ts` excluded
+  `clear`, so the task-state replay stayed silent. `ledger-replay.py` handles
+  `clear`, but it is wired in the **repo's project settings** only (the main
+  agent) and a sub-agent's `conversation_log` is empty anyway unless its channel
+  turns are being captured.
+
+That gap also sat under the **context-restart gate**, which sends `/clear`
+itself and then nudges the fresh session to read the restored blocks.
+
+The pair that closes it:
+
+| Hook | Event | Fires on | Does |
+| --- | --- | --- | --- |
+| `scripts/hooks/clear-capture.py` | `SessionEnd` | `reason == "clear"` | Extracts the owner's last prompts + the agent's last reply from the session transcript and writes `store/agent-clearstate/<agent>.json` |
+| `scripts/hooks/clear-replay.py` | `SessionStart` | `source == "clear"` | Injects that record as `additionalContext`, then deletes it (single replay) |
+
+Notes that matter when touching this:
+
+- **`SessionEnd` is registered without a matcher on purpose.** The script filters
+  on `reason` itself, so the wiring stays correct regardless of what the harness
+  matches `SessionEnd` groups against. The reasons the harness emits are
+  `clear`, `resume`, `logout`, `prompt_input_exit`, `other`.
+- **Agent resolution is stricter than the ledger's.** The main agent's hooks live
+  in the user-global `~/.claude/settings.json`, so they fire for the owner's own
+  Claude Code sessions in unrelated repositories too. `clearstate_lib.agent_id_from_cwd()`
+  returns `None` for a cwd outside the install instead of falling back to the
+  main agent, so an unrelated `/clear` elsewhere on the machine cannot write a
+  record the real main agent then reads back as its own.
+- **The injected block is deliberately non-directive.** A `/clear` can be a
+  deliberate fresh start as easily as a gate-driven restart, and the hook cannot
+  tell them apart. The block states what the previous thread was; the next
+  prompt (the owner's, or the gate's wake nudge) decides what to do with it.
+- **A matcher-only template change does not reach existing agents by itself.**
+  `ensureAgentHooks()` dedupes on the exact command string, so the group is
+  considered present and its stale matcher survives. `syncHookMatchers()` in
+  `agent-scaffold.ts` is what carries a widened matcher onto the fleet.

--- a/scripts/hooks/clear-capture.py
+++ b/scripts/hooks/clear-capture.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""SessionEnd hook: save the thread a /clear is about to erase.
+
+The SAVE half of the /clear path. A /clear does NOT fire PreCompact, so the
+PreCompact agent-hook that writes the structured task-state never runs -- the
+cleared session left no trace at all, not even on the context-restart gate's
+own path, which sends /clear deliberately and then tells the fresh session to
+read blocks that were never written.
+
+Fires on reason=clear only. The other SessionEnd reasons (logout,
+prompt_input_exit, resume, other) end a session that nothing is about to
+restart in place, so there is no fresh session to hand anything to.
+
+Deterministic: the record is extracted from the session transcript by plain
+parsing -- no model turn (a SessionEnd hook has no time for one), no dashboard
+dependency. Never breaks session teardown (always exit 0).
+
+Its counterpart is clear-replay.py on SessionStart(source=clear).
+"""
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import clearstate_lib  # noqa: E402
+
+
+def main():
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)
+    if not isinstance(payload, dict):
+        sys.exit(0)
+
+    if (payload.get("reason") or "") != "clear":
+        sys.exit(0)
+
+    agent = clearstate_lib.agent_id_from_cwd(payload.get("cwd"))
+    if not agent:
+        sys.exit(0)  # not one of our agents (the main hooks are user-global)
+
+    transcript = payload.get("transcript_path") or ""
+    turns = clearstate_lib.extract_turns(transcript)
+    if not turns["prompts"] and not turns["lastReply"]:
+        sys.exit(0)  # nothing worth carrying across
+
+    try:
+        clearstate_lib.write_record(agent, transcript, turns)
+    except Exception:
+        pass  # best effort: a failed save must not hold up the teardown
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/hooks/clear-replay.py
+++ b/scripts/hooks/clear-replay.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""SessionStart hook: hand the cleared thread to the fresh session.
+
+The RESTORE half of the /clear path, reading what clear-capture.py wrote at
+SessionEnd(reason=clear). Fires on source=clear only -- the compact / resume /
+startup sources have their own replay (taskstate-replay.py) and must not get a
+second, older block on top of it.
+
+Ordering (deliberate, mirrors taskstate-replay): read -> inject(print) -> drop.
+Dying before the print leaves the record on disk, so the next start still
+catches it.
+
+Never breaks session start (always exit 0).
+"""
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import clearstate_lib  # noqa: E402
+import ledger_lib  # noqa: E402
+
+
+def main():
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)
+    if not isinstance(payload, dict):
+        sys.exit(0)
+
+    if (payload.get("source") or "") != "clear":
+        sys.exit(0)
+
+    agent = clearstate_lib.agent_id_from_cwd(payload.get("cwd"))
+    if not agent:
+        sys.exit(0)
+
+    record = clearstate_lib.read_record(agent)
+    if not clearstate_lib.is_replayable(record):
+        sys.exit(0)
+
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "SessionStart",
+            "additionalContext": clearstate_lib.build_injection(
+                record, ledger_lib.owner_name()),
+        }
+    }, ensure_ascii=False))
+    sys.stdout.flush()
+
+    # Single-replay guard: only AFTER a successful print.
+    clearstate_lib.drop_record(agent)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/hooks/clearstate_lib.py
+++ b/scripts/hooks/clearstate_lib.py
@@ -1,0 +1,264 @@
+"""Shared helpers for the /clear continuity record.
+
+The /clear path used to be unprotected at BOTH ends: nothing wrote state before
+the wipe (a /clear does NOT fire PreCompact, so the PreCompact agent-hook that
+saves the task-state never runs), and nothing read state after it (the
+SessionStart replay hooks were wired to compact|resume only). A session cleared
+in a sub-agent's window therefore vanished without a trace -- including on the
+context-restart gate's OWN path, which sends /clear deliberately and then tells
+the fresh session to "read the restored blocks".
+
+This module backs the two hooks that close that gap:
+  clear-capture.py  SessionEnd(reason=clear) -> write the record
+  clear-replay.py   SessionStart(source=clear) -> inject it, then drop it
+
+Deterministic by construction: the record is extracted from the session
+transcript with plain parsing (no model, no dashboard, no network), the same
+way the conversation ledger works. Pure stdlib.
+
+Records are returned as DICTS, never tuples: a widened return value can then
+never break a caller's unpack (HOOKARITAS821).
+"""
+import json
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import ledger_lib  # noqa: E402  (main_agent_id / owner_name resolution)
+
+# How many of the owner's most recent prompts to carry across the clear. The
+# continuity failure mode is not a too-short window -- it is having nothing at
+# all -- so a handful of turns plus the transcript pointer is enough.
+MAX_PROMPTS = 5
+
+# Per-prompt char cap. One runaway paste must not dominate the injected block.
+MAX_PROMPT_CHARS = 400
+
+# Char cap for the agent's own last message (what it was doing when cleared).
+MAX_REPLY_CHARS = 600
+
+# Orphan guard: a record older than this is ignored on replay. Matches the
+# task-state TTL. In practice the gap between the SessionEnd and the
+# SessionStart of a /clear is seconds; the TTL only catches a record whose
+# replay never ran (hook error, dashboard down, session never restarted).
+TTL_SECONDS = 12 * 60 * 60
+
+# Transcript entries that are harness bookkeeping rather than something the
+# owner typed. A <system-reminder> or a slash-command echo is not a prompt.
+_NOISE_PREFIXES = (
+    "<system-reminder>",
+    "<local-command-stdout>",
+    "<command-name>",
+    "<command-message>",
+    "Caveat: The messages below were generated",
+)
+
+
+def _install_dir():
+    here = os.path.dirname(os.path.abspath(__file__))
+    return os.path.dirname(os.path.dirname(here))
+
+
+def store_dir():
+    """Where the records live. Test override: CLEARSTATE_DIR."""
+    override = os.environ.get("CLEARSTATE_DIR")
+    if override:
+        return override
+    return os.path.join(_install_dir(), "store", "agent-clearstate")
+
+
+def agent_id_from_cwd(cwd):
+    """Which agent is this session, or None when it is not one of ours.
+
+    STRICTER than the conversation ledger's resolver on purpose. The main
+    agent's hooks live in the USER-GLOBAL ~/.claude/settings.json, so they also
+    fire for the owner's own Claude Code sessions in unrelated repositories.
+    The ledger falls back to the main agent for those; a clear-record must not,
+    or an unrelated /clear elsewhere on the machine would write a record that
+    the real main agent then reads back as its own cleared thread.
+
+      <install>/agents/<id>[/...]  -> <id>
+      <install> (or below it)      -> the main agent
+      anywhere else                -> None (the hooks no-op)
+    """
+    if not cwd:
+        return None
+    install = os.path.normpath(_install_dir())
+    norm = os.path.normpath(cwd)
+    agents_root = os.path.join(install, "agents")
+    if norm.startswith(agents_root + os.sep):
+        rel = norm[len(agents_root) + 1:]
+        first = rel.split(os.sep)[0]
+        return first or None
+    if norm == install or norm.startswith(install + os.sep):
+        return ledger_lib.main_agent_id()
+    return None
+
+
+def _sanitize(agent):
+    # The agent id becomes a filename; allow only the safe charset.
+    return "".join(c for c in (agent or "") if c.isalnum() or c in "_-")
+
+
+def record_path(agent):
+    return os.path.join(store_dir(), _sanitize(agent) + ".json")
+
+
+def _text_of(content):
+    """The plain text of a transcript message's content field.
+
+    A string is the message itself. A list is a block array -- only 'text'
+    blocks count, so a tool_result turn (the harness's way of feeding tool
+    output back as a 'user' message) yields nothing and is skipped by the
+    caller.
+    """
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "text":
+                parts.append(str(block.get("text") or ""))
+        return "\n".join(parts)
+    return ""
+
+
+def _clip(text, limit):
+    s = " ".join((text or "").split())
+    if limit > 0 and len(s) > limit:
+        s = s[:limit].rstrip() + " [...]"
+    return s
+
+
+def extract_turns(transcript_path, max_prompts=MAX_PROMPTS):
+    """Read a session transcript (JSONL) and return
+    {'prompts': [...oldest-first...], 'lastReply': str}.
+
+    Fail-soft: an unreadable or malformed file yields empty lists rather than
+    raising -- a SessionEnd hook must never be the reason a session hangs.
+    """
+    prompts = []
+    last_reply = ""
+    try:
+        with open(transcript_path, "r", encoding="utf-8", errors="replace") as f:
+            for line in f:
+                try:
+                    entry = json.loads(line)
+                except Exception:
+                    continue
+                if not isinstance(entry, dict):
+                    continue
+                kind = entry.get("type")
+                message = entry.get("message")
+                if not isinstance(message, dict):
+                    continue
+                text = _text_of(message.get("content"))
+                if not text.strip():
+                    continue
+                if kind == "user":
+                    # isMeta marks a harness-injected turn, not a typed prompt.
+                    if entry.get("isMeta"):
+                        continue
+                    stripped = text.lstrip()
+                    if stripped.startswith(_NOISE_PREFIXES):
+                        continue
+                    prompts.append(_clip(text, MAX_PROMPT_CHARS))
+                elif kind == "assistant":
+                    last_reply = _clip(text, MAX_REPLY_CHARS)
+    except Exception:
+        return {"prompts": [], "lastReply": ""}
+    if max_prompts > 0:
+        prompts = prompts[-max_prompts:]
+    return {"prompts": prompts, "lastReply": last_reply}
+
+
+def write_record(agent, transcript_path, turns, now=None):
+    """Persist the record for `agent`. One file per agent, overwritten, so the
+    store stays bounded by the fleet size and needs no sweep."""
+    now = int(now if now is not None else time.time())
+    record = {
+        "agent": _sanitize(agent),
+        "ts": now,
+        "transcriptPath": transcript_path or "",
+        "prompts": list(turns.get("prompts") or []),
+        "lastReply": turns.get("lastReply") or "",
+    }
+    directory = store_dir()
+    os.makedirs(directory, exist_ok=True)
+    path = record_path(agent)
+    tmp = path + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(record, f, ensure_ascii=False, indent=2)
+    os.replace(tmp, path)
+    return record
+
+
+def read_record(agent):
+    """The stored record, or None when there is none / it is unreadable."""
+    try:
+        with open(record_path(agent), "r", encoding="utf-8") as f:
+            record = json.load(f)
+    except Exception:
+        return None
+    if not isinstance(record, dict):
+        return None
+    return record
+
+
+def drop_record(agent):
+    """Best-effort delete. Called AFTER a successful injection, so a crash
+    before that leaves the record injectable on the next start."""
+    try:
+        os.unlink(record_path(agent))
+    except Exception:
+        pass
+
+
+def is_replayable(record, now=None, ttl=TTL_SECONDS):
+    """A record replays only when it exists, is within the TTL, and actually
+    carries something. An empty record is not worth a block."""
+    if not isinstance(record, dict):
+        return False
+    ts = record.get("ts")
+    if not isinstance(ts, (int, float)) or ts <= 0:
+        return False
+    now = now if now is not None else time.time()
+    if now - ts > ttl:
+        return False
+    return bool(record.get("prompts") or record.get("lastReply"))
+
+
+def build_injection(record, owner="A felhasználó"):
+    """The SessionStart additionalContext text for a cleared thread.
+
+    Deliberately NON-directive: a /clear can be a deliberate fresh start as
+    easily as a gate-driven restart, and the hook cannot tell the two apart. So
+    the block states what the previous thread was and lets the next prompt (the
+    owner's, or the context-restart gate's wake nudge) decide what to do with
+    it. It must not order the agent to resume work nobody asked for.
+    """
+    lines = [
+        "=== TOROLT SZAL (/clear elotti kontextus) ===",
+        "Az elozo beszelgetes-szalat egy /clear torolte, ezert ez a session nem "
+        "emlekszik ra. Az alabbi kivonat determinisztikusan az elozo szal "
+        "atiratabol keszult. Ha a folytatasrol van szo, innen folytasd, es ne "
+        "kezdd elolrol ami mar kesz. Ha viszont uj feladatot kapsz, ez csak "
+        "hatter -- ne eleszd ujra a regi szalat magatol.",
+    ]
+    prompts = record.get("prompts") or []
+    if prompts:
+        lines.append(
+            "%s UTOLSO KERESEI (idorendben):\n" % owner
+            + "\n".join("  - %s" % p for p in prompts)
+        )
+    last_reply = record.get("lastReply") or ""
+    if last_reply:
+        lines.append("AMIT UTOLJARA MONDTAL: %s" % last_reply)
+    transcript = record.get("transcriptPath") or ""
+    if transcript:
+        lines.append(
+            "A TELJES ATIRAT megmaradt: %s -- olvasd be, ha a folytatashoz "
+            "tobb kell, mint a fenti kivonat." % transcript
+        )
+    return "\n\n".join(lines)

--- a/src/__tests__/agent-taskstate.test.ts
+++ b/src/__tests__/agent-taskstate.test.ts
@@ -38,8 +38,15 @@ describe('shouldReplayTaskState', () => {
   it('replays on startup too (crash respawn mid-task)', () => {
     expect(shouldReplayTaskState(rec(), 'startup', NOW + 1000)).toBe(true)
   })
+  // A /clear restarts the session in place, so from this record's point of view
+  // it is a restart like any other. Withholding it made the context-restart
+  // gate's own path silent -- the gate sends /clear, then tells the fresh
+  // session to read a TASK-FOLYTATAS block that never got emitted.
+  it('replays on clear too (the gate restarts agents this way)', () => {
+    expect(shouldReplayTaskState(rec(), 'clear', NOW + 1000)).toBe(true)
+  })
   it('does NOT replay an unknown source', () => {
-    expect(shouldReplayTaskState(rec(), 'clear', NOW + 1000)).toBe(false)
+    expect(shouldReplayTaskState(rec(), 'other', NOW + 1000)).toBe(false)
   })
   it('does NOT replay an empty record on startup either', () => {
     const empty = rec({ doneSteps: [], alreadyDelegated: [], nextAction: '', pendingDecision: '', summary: 'idle' })

--- a/src/__tests__/clear-continuity.test.ts
+++ b/src/__tests__/clear-continuity.test.ts
@@ -1,0 +1,246 @@
+// The /clear path used to be unprotected at BOTH ends:
+// nothing saved the thread before the wipe (a /clear does not fire PreCompact,
+// so the agent-hook that writes the task-state never ran) and nothing restored
+// one after it (the SessionStart replay was wired to compact|resume). A cleared
+// sub-agent session vanished without a trace -- including on the
+// context-restart gate's own path, which sends /clear deliberately and then
+// tells the fresh session to read blocks nobody had written.
+//
+// Behavioural tests run the python hooks as subprocesses (deterministic, no
+// LLM). Static tests lock the wiring (template + KNOWN_HOOK_SCRIPTS) and the
+// matcher migration that carries a widened matcher to the existing fleet.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync, readdirSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { syncHookMatchers } from '../web/agent-scaffold.js'
+import { KNOWN_HOOK_SCRIPTS } from '../web/hook-registration-guard.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ROOT = join(__dirname, '..', '..')
+const CAPTURE = join(ROOT, 'scripts', 'hooks', 'clear-capture.py')
+const REPLAY = join(ROOT, 'scripts', 'hooks', 'clear-replay.py')
+// The hooks resolve the agent id from cwd relative to their own install dir,
+// so the payload cwd must sit under THIS checkout.
+const AGENT_CWD = join(ROOT, 'agents', 'tester')
+
+let store: string
+let transcript: string
+
+function runHook(script: string, payload: unknown): string {
+  try {
+    return execFileSync('python3', [script], {
+      input: JSON.stringify(payload),
+      encoding: 'utf-8',
+      env: { ...process.env, CLEARSTATE_DIR: store },
+    })
+  } catch {
+    return ''
+  }
+}
+
+function jsonl(entries: unknown[]): string {
+  return entries.map((e) => JSON.stringify(e)).join('\n') + '\n'
+}
+
+const OWNER_TURN = (text: string) => ({ type: 'user', message: { content: text } })
+const AGENT_TURN = (text: string) => ({ type: 'assistant', message: { content: [{ type: 'text', text }] } })
+
+beforeEach(() => {
+  store = mkdtempSync(join(tmpdir(), 'clearstate-'))
+  transcript = join(store, 'session.jsonl')
+  writeFileSync(transcript, jsonl([
+    // Harness noise: an injected reminder is not something the owner typed.
+    { type: 'user', isMeta: true, message: { content: '<system-reminder>zaj</system-reminder>' } },
+    OWNER_TURN('Javitsd meg a kanban szurot'),
+    AGENT_TURN('Megnezem a route-ot.'),
+    // Tool output arrives as a 'user' turn with a tool_result block, not a prompt.
+    { type: 'user', message: { content: [{ tool_use_id: 'x', type: 'tool_result', content: 'kimenet' }] } },
+    OWNER_TURN('A tesztet is ird meg hozza'),
+    AGENT_TURN('Kesz a javitas, jon a teszt.'),
+  ]))
+})
+
+afterEach(() => rmSync(store, { recursive: true, force: true }))
+
+function capture(over: Record<string, unknown> = {}): void {
+  runHook(CAPTURE, { reason: 'clear', cwd: AGENT_CWD, transcript_path: transcript, ...over })
+}
+
+function record(): Record<string, unknown> | null {
+  const path = join(store, 'tester.json')
+  return existsSync(path) ? JSON.parse(readFileSync(path, 'utf-8')) : null
+}
+
+describe('clear-capture hook (SessionEnd)', () => {
+  it('saves the owner prompts and the last reply of a cleared thread', () => {
+    capture()
+    const r = record()
+    expect(r?.prompts).toEqual(['Javitsd meg a kanban szurot', 'A tesztet is ird meg hozza'])
+    expect(r?.lastReply).toBe('Kesz a javitas, jon a teszt.')
+    expect(r?.transcriptPath).toBe(transcript)
+  })
+
+  it('skips harness noise: meta turns and tool_result turns are not prompts', () => {
+    capture()
+    const prompts = (record()?.prompts ?? []) as string[]
+    expect(prompts.join(' ')).not.toContain('system-reminder')
+    expect(prompts.join(' ')).not.toContain('kimenet')
+  })
+
+  it('writes nothing for a SessionEnd that is not a /clear', () => {
+    capture({ reason: 'logout' })
+    expect(record()).toBeNull()
+  })
+
+  it('writes nothing for a session outside the install (the main hooks are user-global)', () => {
+    capture({ cwd: '/Users/somebody/unrelated-repo' })
+    expect(readdirSync(store).filter((f) => f.endsWith('.json'))).toEqual([])
+  })
+
+  it('survives an unreadable transcript without writing a record', () => {
+    capture({ transcript_path: join(store, 'does-not-exist.jsonl') })
+    expect(record()).toBeNull()
+  })
+})
+
+describe('clear-replay hook (SessionStart)', () => {
+  function replay(over: Record<string, unknown> = {}): string {
+    return runHook(REPLAY, { source: 'clear', cwd: AGENT_CWD, ...over })
+  }
+
+  it('injects the cleared thread into the fresh session', () => {
+    capture()
+    const out = JSON.parse(replay())
+    expect(out.hookSpecificOutput.hookEventName).toBe('SessionStart')
+    const ctx = out.hookSpecificOutput.additionalContext as string
+    expect(ctx).toContain('Javitsd meg a kanban szurot')
+    expect(ctx).toContain('Kesz a javitas, jon a teszt.')
+    expect(ctx).toContain(transcript)
+  })
+
+  it('replays once: the record is dropped after a successful injection', () => {
+    capture()
+    expect(replay()).not.toBe('')
+    expect(replay()).toBe('')
+    expect(record()).toBeNull()
+  })
+
+  it('stays silent on the other SessionStart sources (taskstate-replay owns those)', () => {
+    capture()
+    expect(replay({ source: 'startup' })).toBe('')
+    expect(replay({ source: 'compact' })).toBe('')
+    expect(record()).not.toBeNull() // and leaves the record for the real clear
+  })
+
+  it('stays silent when nothing was captured', () => {
+    expect(replay()).toBe('')
+  })
+
+  it('ignores a record past the TTL instead of injecting a stale thread', () => {
+    capture()
+    const stale = record() as Record<string, unknown>
+    stale.ts = Math.floor(Date.now() / 1000) - 13 * 60 * 60
+    writeFileSync(join(store, 'tester.json'), JSON.stringify(stale))
+    expect(replay()).toBe('')
+  })
+
+  it('does not order the fresh session to resume work on its own', () => {
+    capture()
+    const ctx = JSON.parse(replay()).hookSpecificOutput.additionalContext as string
+    // A /clear can be a deliberate fresh start; the block informs, the next
+    // prompt decides. Anything stronger would invent work nobody asked for.
+    expect(ctx).toContain('ne eleszd ujra a regi szalat magatol')
+  })
+})
+
+describe('/clear wiring', () => {
+  const tpl = JSON.parse(
+    readFileSync(join(ROOT, 'templates', 'settings.json.template'), 'utf-8')
+      .replaceAll('{{PROJECT_ROOT}}', '/install')
+      .replaceAll('{{WEB_PORT}}', '3420')
+      .replaceAll('{{BOT_NAME}}', 'Bot'),
+  ) as { hooks: Record<string, Array<{ matcher?: string; hooks: Array<{ command: string }> }>> }
+
+  function commandsFor(event: string, matcher: string | undefined): string[] {
+    return (tpl.hooks[event] ?? [])
+      .filter((g) => g.matcher === matcher)
+      .flatMap((g) => g.hooks.map((h) => h.command))
+  }
+
+  it('replays the task-state on clear as well as compact and resume', () => {
+    expect(commandsFor('SessionStart', 'compact|resume|clear').join(' ')).toContain('taskstate-replay.py')
+  })
+
+  it('registers the clear-replay hook on the clear source', () => {
+    expect(commandsFor('SessionStart', 'clear').join(' ')).toContain('clear-replay.py')
+  })
+
+  it('registers the clear-capture hook on SessionEnd without a matcher', () => {
+    // Deliberate: the SessionEnd matcher semantics are the reason to NOT rely on
+    // them here. The hook itself filters on reason=clear, so the wiring stays
+    // correct whatever the harness matches SessionEnd groups against.
+    const group = tpl.hooks.SessionEnd ?? []
+    expect(group).toHaveLength(1)
+    expect(group[0].matcher).toBeUndefined()
+    expect(group[0].hooks.map((h) => h.command).join(' ')).toContain('clear-capture.py')
+  })
+
+  it('knows both hooks as ours, so a stale entry is self-healed not orphaned', () => {
+    expect(KNOWN_HOOK_SCRIPTS).toContain('clear-capture.py')
+    expect(KNOWN_HOOK_SCRIPTS).toContain('clear-replay.py')
+  })
+})
+
+// The migration gap that kept every existing agent on the old matcher: the add pass
+// dedupes on the COMMAND string, so a matcher-only template change reached
+// nobody and nothing errored.
+describe('syncHookMatchers', () => {
+  const tplHooks = () => ({
+    SessionStart: [{ matcher: 'compact|resume|clear', hooks: [{ type: 'command', command: 'python3 /i/taskstate-replay.py' }] }],
+  })
+
+  it('widens a stale matcher on a group whose command is unchanged', () => {
+    const existing = {
+      SessionStart: [{ matcher: 'compact|resume', hooks: [{ type: 'command', command: 'python3 /i/taskstate-replay.py' }] }],
+    }
+    expect(syncHookMatchers(existing, tplHooks())).toBe(true)
+    expect(existing.SessionStart[0].matcher).toBe('compact|resume|clear')
+  })
+
+  it('is idempotent once the matcher already matches', () => {
+    const existing = {
+      SessionStart: [{ matcher: 'compact|resume|clear', hooks: [{ type: 'command', command: 'python3 /i/taskstate-replay.py' }] }],
+    }
+    expect(syncHookMatchers(existing, tplHooks())).toBe(false)
+  })
+
+  it('leaves a group a human extended with their own hook alone', () => {
+    const existing = {
+      SessionStart: [{
+        matcher: 'compact|resume',
+        hooks: [
+          { type: 'command', command: 'python3 /i/taskstate-replay.py' },
+          { type: 'command', command: 'python3 /i/my-own-hook.py' },
+        ],
+      }],
+    }
+    expect(syncHookMatchers(existing, tplHooks())).toBe(false)
+    expect(existing.SessionStart[0].matcher).toBe('compact|resume')
+  })
+
+  it('never removes a matcher when the template group has none', () => {
+    const existing = {
+      UserPromptSubmit: [{ matcher: 'Bash', hooks: [{ type: 'command', command: 'python3 /i/guard.py' }] }],
+    }
+    const tpl = { UserPromptSubmit: [{ hooks: [{ type: 'command', command: 'python3 /i/guard.py' }] }] }
+    expect(syncHookMatchers(existing, tpl)).toBe(false)
+    expect(existing.UserPromptSubmit[0].matcher).toBe('Bash')
+  })
+
+  it('ignores events the agent does not have', () => {
+    expect(syncHookMatchers({}, tplHooks())).toBe(false)
+  })
+})

--- a/src/__tests__/hook-registration-completeness.test.ts
+++ b/src/__tests__/hook-registration-completeness.test.ts
@@ -41,6 +41,8 @@ const REGISTRATION_SURFACES = [
 const EXEMPT: Record<string, string> = {
   'ledger_lib.py':
     'shared library imported by the ledger hooks; not itself a hook',
+  'clearstate_lib.py':
+    'shared library imported by clear-capture.py / clear-replay.py; not itself a hook',
   'memory-save.sh':
     'legacy: referenced only by a historical rebuild prompt, wired nowhere; kept pending a maintainer decision to remove it',
   'telegram-ack.py':

--- a/src/__tests__/kanban-dispatch-rearm.test.ts
+++ b/src/__tests__/kanban-dispatch-rearm.test.ts
@@ -1,0 +1,118 @@
+// Contract tests: `dispatched_at` is the once-only guard for ONE in_progress
+// spell, not a permanent tombstone.
+//
+// Root cause: fireKanbanDispatch bails on `card.dispatched_at` and
+// markKanbanCardDispatched only ever SETS the column -- nothing in the codebase
+// clears it. So a card pulled to in_progress and then put BACK
+// (planned/waiting) burned its dispatch forever: the board showed it alive, the
+// next in_progress pull woke nobody. Observed live: a card bounced back to
+// planned a couple of minutes after activation stayed silent from then on.
+//
+// The two re-arm assertions, plus the control that the original purpose (one
+// activation -> one message, not two) survives.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { Readable } from 'node:stream'
+import type http from 'node:http'
+
+const mockCreateAgentMessage = vi.fn()
+
+vi.mock('../logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+}))
+
+vi.mock('../config.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../config.js')>()),
+  MAIN_AGENT_ID: 'orin',
+  BOT_NAME: 'Orin',
+  OWNER_NAME: 'Owner',
+}))
+
+// Real database (in-memory), real move/dispatch bookkeeping -- only the
+// outbound inter-agent message is spied on, since "did the assignee get woken"
+// is exactly the question these tests ask.
+vi.mock('../db.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../db.js')>()
+  return { ...actual, createAgentMessage: (...a: unknown[]) => mockCreateAgentMessage(...a) }
+})
+
+vi.mock('../web/agent-config.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../web/agent-config.js')>()),
+  listAgentNames: () => ['dex'],
+  readAgentDisplayName: (n: string) => n,
+}))
+
+vi.mock('../web/agent-process.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../web/agent-process.js')>()),
+  isAgentRunning: () => true,
+}))
+
+import { initDatabase, createKanbanCard, getKanbanCard } from '../db.js'
+import { tryHandleKanban } from '../web/routes/kanban.js'
+
+/** Drive the real POST /api/kanban/<id>/move route. */
+async function move(id: string, status: string, actor?: string): Promise<void> {
+  const req = Readable.from([Buffer.from(JSON.stringify({ status, sort_order: 0, actor }))]) as unknown as http.IncomingMessage
+  const res = { writeHead: vi.fn(), end: vi.fn(), setHeader: vi.fn() } as unknown as http.ServerResponse
+  const handled = await tryHandleKanban({
+    req,
+    res,
+    path: `/api/kanban/${id}/move`,
+    method: 'POST',
+    url: new URL(`http://localhost/api/kanban/${id}/move`),
+  } as never)
+  expect(handled).toBe(true)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  initDatabase(':memory:')
+})
+
+describe('kanban dispatch re-arm', () => {
+  it('clears dispatched_at when the card leaves in_progress', async () => {
+    createKanbanCard({ id: 'card-1', title: 'Bounced card', assignee: 'dex' })
+
+    await move('card-1', 'in_progress', 'orin')
+    expect(getKanbanCard('card-1')?.dispatched_at).toBeTypeOf('number') // dispatched once
+
+    await move('card-1', 'planned', 'orin') // put back -- the bounce that burned the dispatch
+    expect(getKanbanCard('card-1')?.dispatched_at).toBeNull()
+  })
+
+  it('dispatches AGAIN when a put-back card is pulled to in_progress once more', async () => {
+    createKanbanCard({ id: 'card-2', title: 'Bounced card', assignee: 'dex' })
+
+    await move('card-2', 'in_progress', 'orin')
+    expect(mockCreateAgentMessage).toHaveBeenCalledTimes(1)
+
+    await move('card-2', 'planned', 'orin')
+    await move('card-2', 'in_progress', 'orin')
+
+    // The bug: this stayed at 1 -- the card looked alive, nobody was told.
+    expect(mockCreateAgentMessage).toHaveBeenCalledTimes(2)
+    expect(mockCreateAgentMessage.mock.calls[1][1]).toBe('dex')
+  })
+
+  it('still sends only ONE message per activation (the guard is not weakened)', async () => {
+    createKanbanCard({ id: 'card-3', title: 'Reordered in place', assignee: 'dex' })
+
+    await move('card-3', 'in_progress', 'orin')
+    // A pure sort_order reorder inside the in_progress column re-enters the
+    // dispatch path; the guard must still hold.
+    await move('card-3', 'in_progress', 'orin')
+
+    expect(mockCreateAgentMessage).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-arms from waiting too (an escalated card that gets picked up again)', async () => {
+    createKanbanCard({ id: 'card-4', title: 'Escalated card', assignee: 'dex' })
+
+    await move('card-4', 'in_progress', 'orin')
+    await move('card-4', 'waiting', 'dex')
+    expect(getKanbanCard('card-4')?.dispatched_at).toBeNull()
+
+    await move('card-4', 'in_progress', 'orin')
+    expect(mockCreateAgentMessage).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/__tests__/kanban-dispatch-silent-noop.test.ts
+++ b/src/__tests__/kanban-dispatch-silent-noop.test.ts
@@ -1,0 +1,129 @@
+// Contract tests: a card activated for an agent whose session is DOWN must not
+// go quiet.
+//
+// Root cause: the card flips to in_progress first and the wake-up message is
+// attempted after -- and when resolveKanbanDispatchTarget finds the assignee's
+// session not running it returns null, which fireKanbanDispatch treats as
+// "nothing to do" and returns silently. The board then shows a card that is
+// in_progress with nobody working it, and status-driven monitoring skips on
+// exactly that status, so the false in_progress SUSTAINS ITSELF: a single
+// missed message can hold a card open for hours with a green log and no signal
+// anywhere.
+//
+// The stricter contract -- message first, in_progress only after successful
+// delivery -- is not available here. createAgentMessage only ENQUEUES -- the
+// router delivers later, asynchronously -- so "after successful delivery" is
+// not knowable at move time. What is enforceable, and what these tests pin, is
+// that the failure is never SILENT: it lands on the card and in the main
+// agent's inbox.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { Readable } from 'node:stream'
+import type http from 'node:http'
+
+const mockCreateAgentMessage = vi.fn()
+const runningAgents = new Set<string>()
+
+vi.mock('../logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+}))
+
+vi.mock('../config.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../config.js')>()),
+  MAIN_AGENT_ID: 'orin',
+  BOT_NAME: 'Orin',
+  OWNER_NAME: 'Owner',
+}))
+
+vi.mock('../db.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../db.js')>()
+  return { ...actual, createAgentMessage: (...a: unknown[]) => mockCreateAgentMessage(...a) }
+})
+
+vi.mock('../web/agent-config.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../web/agent-config.js')>()),
+  listAgentNames: () => ['dex'],
+  readAgentDisplayName: (n: string) => n,
+}))
+
+vi.mock('../web/agent-process.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../web/agent-process.js')>()),
+  isAgentRunning: (n: string) => runningAgents.has(n),
+}))
+
+import { initDatabase, createKanbanCard, getKanbanComments } from '../db.js'
+import { tryHandleKanban } from '../web/routes/kanban.js'
+
+async function move(id: string, status: string, actor?: string): Promise<void> {
+  const req = Readable.from([Buffer.from(JSON.stringify({ status, sort_order: 0, actor }))]) as unknown as http.IncomingMessage
+  const res = { writeHead: vi.fn(), end: vi.fn(), setHeader: vi.fn() } as unknown as http.ServerResponse
+  const handled = await tryHandleKanban({
+    req,
+    res,
+    path: `/api/kanban/${id}/move`,
+    method: 'POST',
+    url: new URL(`http://localhost/api/kanban/${id}/move`),
+  } as never)
+  expect(handled).toBe(true)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  runningAgents.clear()
+  initDatabase(':memory:')
+})
+
+describe('silent dispatch no-op on a down agent', () => {
+  it('tells the main agent when an activated card could not wake its assignee', async () => {
+    createKanbanCard({ id: 'card-1', title: 'Night round', assignee: 'dex' }) // dex is NOT running
+
+    await move('card-1', 'in_progress', 'orin')
+
+    // The incident: zero messages, zero logs, zero board signal.
+    expect(mockCreateAgentMessage).toHaveBeenCalledTimes(1)
+    const [from, to, content] = mockCreateAgentMessage.mock.calls[0] as string[]
+    expect(from).toBe('system')
+    expect(to).toBe('orin') // MAIN_AGENT_ID -- the delegator triages
+    expect(content).toContain('card-1')
+    expect(content).toContain('dex')
+  })
+
+  it('leaves the evidence on the card itself, where the board shows it', async () => {
+    createKanbanCard({ id: 'card-2', title: 'Night round', assignee: 'dex' })
+
+    await move('card-2', 'in_progress', 'orin')
+
+    const comments = getKanbanComments('card-2')
+    expect(comments).toHaveLength(1)
+    expect(comments[0].content).toContain('dex')
+  })
+
+  it('stays silent when the no-op is CORRECT: self-move, owner, no assignee', async () => {
+    // The control. These three are deliberate no-dispatch cases -- turning them
+    // into alerts would bury the real one.
+    runningAgents.add('dex')
+    createKanbanCard({ id: 'card-3', title: 'Self pickup', assignee: 'dex' })
+    createKanbanCard({ id: 'card-4', title: 'Human card', assignee: 'Owner' })
+    createKanbanCard({ id: 'card-5', title: 'Unassigned' }) // no assignee at all
+
+    await move('card-3', 'in_progress', 'dex') // agent picks up its own card
+    await move('card-4', 'in_progress', 'orin')
+    await move('card-5', 'in_progress', 'orin')
+
+    expect(mockCreateAgentMessage).not.toHaveBeenCalled()
+    expect(getKanbanComments('card-3')).toHaveLength(0)
+    expect(getKanbanComments('card-4')).toHaveLength(0)
+    expect(getKanbanComments('card-5')).toHaveLength(0)
+  })
+
+  it('dispatches normally (and adds no noise) when the agent is up', async () => {
+    runningAgents.add('dex')
+    createKanbanCard({ id: 'card-6', title: 'Normal round', assignee: 'dex' })
+
+    await move('card-6', 'in_progress', 'orin')
+
+    expect(mockCreateAgentMessage).toHaveBeenCalledTimes(1)
+    expect((mockCreateAgentMessage.mock.calls[0] as string[])[1]).toBe('dex')
+    expect(getKanbanComments('card-6')).toHaveLength(0)
+  })
+})

--- a/src/__tests__/router-main-agent-wakeup.test.ts
+++ b/src/__tests__/router-main-agent-wakeup.test.ts
@@ -1,0 +1,145 @@
+// Contract test: the message router must NOT type a blind wakeup into the
+// main agent's channels session.
+//
+// Root cause: inter-agent messages addressed to the main agent stayed
+// 'pending' while the router fired
+// `sendPromptToSession(..., { waitForIdle: false })` at the channels pane once
+// per MAIN_AGENT_WAKEUP_COOLDOWN_MS, logging "main-agent wakeup fired" on every
+// retry. The pane was mid-turn, so each wakeup landed as a queued mid-turn message
+// instead of a fresh prompt submit -- no UserPromptSubmit, therefore no
+// drain-inbox call, therefore no claim. The rows stayed pending, the cooldown
+// re-armed, and the loop burned five main-agent turns without delivering
+// anything.
+//
+// Main-agent wakeups belong to the inbox-nudge-watcher (added later, #557),
+// which fires ONLY on double-capture-confirmed idle, aborts if the pane turns
+// busy in the gap, escalates a stale spell and finally alerts the owner. The
+// router's older, undisciplined duplicate is what looped.
+//
+// The invariant pinned here: whatever the router does with a main-agent
+// message, it never drives the main channels session.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockGetPendingMessages = vi.fn()
+const mockSendPromptToSession = vi.fn(async (..._a: unknown[]) => {})
+const mockMarkFailed = vi.fn((..._a: unknown[]) => true)
+
+vi.mock('../logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+}))
+
+vi.mock('../config.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../config.js')>()),
+  MAIN_AGENT_ID: 'orin',
+  SUBAGENT_TELEGRAM_WAKE_ENABLED: false,
+}))
+
+vi.mock('../db.js', () => ({
+  getPendingMessages: (toAgent?: string) => {
+    if (toAgent) return [] // per-agent query for the reconnect pre-pass
+    return mockGetPendingMessages()
+  },
+  markMessageDelivered: (..._a: unknown[]) => true,
+  markMessageFailed: (...a: unknown[]) => mockMarkFailed(...a),
+  markMessageDone: (..._a: unknown[]) => true,
+  markPendingFederatedFailed: (..._a: unknown[]) => true,
+  setMessageResult: (..._a: unknown[]) => true,
+  createAgentMessage: (..._a: unknown[]) => ({ id: 999 }),
+  stampMessageTrace: (..._a: unknown[]) => false,
+  upsertOtelSpan: (..._a: unknown[]) => undefined,
+  closeOtelSpan: (..._a: unknown[]) => false,
+}))
+
+vi.mock('../web/voice-directive.js', () => ({
+  resolveAgentChannelStateDir: () => '/tmp/none',
+}))
+
+vi.mock('../web/agent-config.js', () => ({
+  readAgentRemoteHost: () => null,
+  readAgentVoiceConfig: () => ({ responseMode: 'text' }),
+}))
+
+vi.mock('../web/agent-process.js', () => ({
+  agentSessionName: (name: string) => `agent-${name}`,
+  // The channels pane is mid-turn -- the exact state of the incident.
+  isSessionReadyForPrompt: vi.fn(async () => false),
+  clearStaleParkedInput: vi.fn(() => false),
+  sendPromptToSession: (...a: unknown[]) => mockSendPromptToSession(...a),
+  sessionExistsOnHost: vi.fn(() => true),
+  capturePane: vi.fn(async () => ''),
+}))
+
+vi.mock('../web/voice-modality.js', () => ({
+  setLastInboundModality: vi.fn(),
+}))
+
+vi.mock('../web/main-agent.js', () => ({
+  MAIN_CHANNELS_SESSION: 'orin-channels',
+}))
+
+vi.mock('../web/agent-message-wrap.js', () => ({
+  classifyAgentMessage: () => ({ category: 'trusted-peer', safeFrom: 'dex' }),
+  wrapAgentMessageForDelivery: () => ({ prefix: '', wrapped: '' }),
+}))
+
+import { runMessageRouterTick } from '../web/message-router.js'
+
+function pendingToMain(id: number) {
+  return {
+    id,
+    from_agent: 'dex',
+    to_agent: 'orin', // MAIN_AGENT_ID -> the PULL path
+    content: 'ping',
+    created_at: Math.floor(Date.now() / 1000),
+  }
+}
+
+describe('router main-agent wakeup loop', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSendPromptToSession.mockResolvedValue(undefined)
+  })
+
+  it('never drives the main channels session for a pending main-agent message', async () => {
+    mockGetPendingMessages.mockReturnValue([pendingToMain(1)])
+
+    await runMessageRouterTick()
+
+    // The incident: this call happened, into a busy pane, with waitForIdle:false.
+    expect(mockSendPromptToSession).not.toHaveBeenCalled()
+  })
+
+  it('does not re-fire across cooldown windows while the same message stays pending', async () => {
+    // The message stayed pending for four consecutive cooldown windows and
+    // each one produced another injection.
+    // The router's cooldown is module state keyed on Date.now(), so the clock
+    // must actually move for this to reproduce the loop rather than the
+    // (order-dependent) single-window case above.
+    const created = Math.floor(Date.now() / 1000)
+    mockGetPendingMessages.mockReturnValue([{
+      id: 1, from_agent: 'dex', to_agent: 'orin', content: 'ping', created_at: created,
+    }])
+    vi.useFakeTimers()
+    try {
+      for (let i = 0; i < 4; i++) {
+        vi.setSystemTime(created * 1000 + i * 46_000) // past MAIN_AGENT_WAKEUP_COOLDOWN_MS (45s)
+        await runMessageRouterTick()
+      }
+    } finally {
+      vi.useRealTimers()
+    }
+
+    expect(mockSendPromptToSession).not.toHaveBeenCalled()
+  })
+
+  it('leaves the main-agent message pending for the drain to claim', async () => {
+    // The router must not fail/consume it either: the PULL path (drain-inbox
+    // + inbox-nudge-watcher) owns the row.
+    mockGetPendingMessages.mockReturnValue([pendingToMain(1)])
+
+    await runMessageRouterTick()
+
+    expect(mockMarkFailed).not.toHaveBeenCalled()
+  })
+})

--- a/src/context-restart-gate.ts
+++ b/src/context-restart-gate.ts
@@ -1,8 +1,8 @@
 // Pure logic for the proactive context-restart gate.
 //
-// The ledger-replay, taskstate-replay, and daily-log-digest SessionStart hooks
-// can inject a rich context snapshot into every fresh session -- but only when
-// the session STARTS. This gate decides when a /clear (soft restart via the
+// The clear-replay, taskstate-replay and ledger-replay SessionStart hooks can
+// inject a context snapshot into every fresh session -- but only when the
+// session STARTS. This gate decides when a /clear (soft restart via the
 // send lane) is appropriate so those hooks carry the agent forward cheaply,
 // before the context grows deep enough that the in-TUI auto-compact has to do
 // it the hard (expensive, lossy) way.

--- a/src/db.ts
+++ b/src/db.ts
@@ -1814,8 +1814,17 @@ export function moveKanbanCard(id: string, status: KanbanCard['status'], sortOrd
   // Read the previous status first so we only record an audit event on a real
   // status transition (not a pure sort_order reorder within the same column).
   const prev = (db.prepare('SELECT status FROM kanban_cards WHERE id=?').get(id) as { status: string } | undefined)?.status
+  // dispatched_at guards ONE in_progress spell (one activation -> one wake-up
+  // message), it is not a permanent tombstone. Nothing used to clear it, so a
+  // card pulled to in_progress and put BACK burned its dispatch forever: the
+  // board showed it alive while the next pull woke nobody. Clearing it on
+  // every move that does not land in in_progress re-arms the next activation --
+  // and heals a row already stuck this way, since the clear does not depend on
+  // the previous status.
   const changed = db.prepare(
-    'UPDATE kanban_cards SET status=?, sort_order=?, updated_at=? WHERE id=?'
+    status === 'in_progress'
+      ? 'UPDATE kanban_cards SET status=?, sort_order=?, updated_at=? WHERE id=?'
+      : 'UPDATE kanban_cards SET status=?, sort_order=?, updated_at=?, dispatched_at=NULL WHERE id=?'
   ).run(status, sortOrder, now, id).changes > 0
   if (changed && prev !== undefined && prev !== status) {
     db.prepare(

--- a/src/kanban-dispatch.ts
+++ b/src/kanban-dispatch.ts
@@ -50,19 +50,44 @@ function canonicalAgentId(
   return opts.agentNames.find((n) => n.toLowerCase() === lower) ?? null
 }
 
+/** Why no message went out -- the caller must tell 'nobody to wake' apart from
+ *  'somebody to wake, unreachable'. Only 'session-down' is a fault: the card is
+ *  in_progress for a real fleet agent that was never told. */
+export type DispatchSkipReason = 'not-dispatchable' | 'self-move' | 'session-down'
+
+export interface DispatchDecision {
+  /** Who to wake, or null when no message goes out. */
+  target: string | null
+  /** Set exactly when target is null. */
+  reason?: DispatchSkipReason
+  /** The resolved agent id when the session is down -- for the alert text. */
+  unreachable?: string
+}
+
+export function resolveKanbanDispatch(
+  assignee: string | null | undefined,
+  opts: DispatchResolveOpts,
+): DispatchDecision {
+  const target = canonicalAgentId(assignee, opts)
+  // Empty, unknown, or the human owner: nobody is expected to be woken.
+  if (!target) return { target: null, reason: 'not-dispatchable' }
+
+  // Self-move: the agent that moved the card is the one we would wake.
+  const mover = canonicalAgentId(opts.actor, opts)
+  if (mover && mover === target) return { target: null, reason: 'self-move' }
+
+  // The main agent always has a session; a sub-agent is dispatched only if its
+  // session is running. A down session used to be a SILENT no-op -- the card
+  // sat in in_progress with nobody working it and nothing said so.
+  if (target === opts.mainAgentId) return { target }
+  if (opts.isRunning(target)) return { target }
+  return { target: null, reason: 'session-down', unreachable: target }
+}
+
+/** Target-only view, kept for callers that only need "who, if anyone". */
 export function resolveKanbanDispatchTarget(
   assignee: string | null | undefined,
   opts: DispatchResolveOpts,
 ): string | null {
-  const target = canonicalAgentId(assignee, opts)
-  if (!target) return null
-
-  // Self-move: the agent that moved the card is the one we would wake.
-  const mover = canonicalAgentId(opts.actor, opts)
-  if (mover && mover === target) return null
-
-  // The main agent always has a session; a sub-agent is dispatched only if its
-  // session is running (otherwise the card just stays in in_progress).
-  if (target === opts.mainAgentId) return target
-  return opts.isRunning(target) ? target : null
+  return resolveKanbanDispatch(assignee, opts).target
 }

--- a/src/web/agent-scaffold.ts
+++ b/src/web/agent-scaffold.ts
@@ -131,7 +131,7 @@ export function agentSettingsPath(name: string): string {
 const _TMP_PREFIXES = ['/tmp/', '/var/tmp/', '/private/tmp/', '/dev/shm/']
 
 // Shared hook-entry type used by ensureAgentHooks and upgradeLegacyHookCommands.
-type HookEntry = { hooks?: Array<{ command?: string; timeout?: number; [k: string]: unknown }> }
+type HookEntry = { matcher?: string; hooks?: Array<{ command?: string; timeout?: number; [k: string]: unknown }> }
 
 /**
  * Returns true when the command is unsafe to register in shared settings:
@@ -198,6 +198,54 @@ export function upgradeLegacyHookCommands(
   return changed
 }
 
+/**
+ * In-place matcher sync: when a template hook group's MATCHER changes, carry the
+ * new matcher onto the group an earlier run wrote into an agent's settings.
+ *
+ * Without this, a matcher-only template change never reaches the existing fleet.
+ * The add pass in ensureAgentHooks dedupes on the exact COMMAND string, so a
+ * group whose command is unchanged is considered already present and its stale
+ * matcher is left in place forever -- silently, because nothing errors. That is
+ * how every sub-agent kept `SessionStart: compact|resume` (and stayed deaf to
+ * source=clear) while the template said otherwise.
+ *
+ * Conservative on purpose. A group is only re-matched when EVERY command in it
+ * also appears in the template group -- so a group a human extended with a hook
+ * of their own is left alone -- and a template group with no matcher never
+ * removes one.
+ *
+ * Exported for unit testing.
+ */
+export function syncHookMatchers(
+  existingHooks: Record<string, unknown>,
+  tplHooks: Record<string, unknown>,
+): boolean {
+  let changed = false
+  for (const [event, tplEntries] of Object.entries(tplHooks)) {
+    const existEntries = existingHooks[event]
+    if (!Array.isArray(existEntries) || !Array.isArray(tplEntries)) continue
+    for (const tplEntry of tplEntries as HookEntry[]) {
+      if (typeof tplEntry?.matcher !== 'string') continue
+      const tplCommands = new Set(
+        (tplEntry.hooks ?? []).map((h) => h.command).filter((c): c is string => Boolean(c)),
+      )
+      if (tplCommands.size === 0) continue
+      for (const existEntry of existEntries as HookEntry[]) {
+        if (!existEntry || typeof existEntry !== 'object') continue
+        const existCommands = (existEntry.hooks ?? [])
+          .map((h) => h.command)
+          .filter((c): c is string => Boolean(c))
+        if (existCommands.length === 0) continue
+        if (!existCommands.every((c) => tplCommands.has(c))) continue
+        if (existEntry.matcher === tplEntry.matcher) continue
+        existEntry.matcher = tplEntry.matcher
+        changed = true
+      }
+    }
+  }
+  return changed
+}
+
 // Idempotent migration: every agent's settings.json should carry the
 // PreCompact hook (memory save + skill reflection). Pre-refactor agents
 // were scaffolded before scaffoldAgentDir seeded the template, so their
@@ -248,6 +296,9 @@ export function ensureAgentHooks(name: string): boolean {
     //   3. Sync the timeout of any command hook whose command matches but timeout differs.
     const existingHooks = existing.hooks as Record<string, unknown>
     let changed = upgradeLegacyHookCommands(existingHooks, tplHooks)
+    // Matcher pass: a widened template matcher (e.g. SessionStart gaining
+    // `clear`) must reach agents whose command string is unchanged.
+    if (syncHookMatchers(existingHooks, tplHooks)) changed = true
     for (const [event, handlers] of Object.entries(tplHooks)) {
       if (!existingHooks[event]) {
         existingHooks[event] = handlers

--- a/src/web/agent-scaffold.ts
+++ b/src/web/agent-scaffold.ts
@@ -206,7 +206,7 @@ export function upgradeLegacyHookCommands(
  * The add pass in ensureAgentHooks dedupes on the exact COMMAND string, so a
  * group whose command is unchanged is considered already present and its stale
  * matcher is left in place forever -- silently, because nothing errors. That is
- * how every sub-agent kept `SessionStart: compact|resume` (and stayed deaf to
+ * how an existing sub-agent kept `SessionStart: compact|resume` (and stayed deaf to
  * source=clear) while the template said otherwise.
  *
  * Conservative on purpose. A group is only re-matched when EVERY command in it

--- a/src/web/agent-taskstate.ts
+++ b/src/web/agent-taskstate.ts
@@ -37,7 +37,16 @@ export const TASKSTATE_TTL_MS = 12 * 60 * 60 * 1000
 // planned restart right after finishing work replays nothing (the record was
 // either consumed or is empty), and at worst a stale-but-unconsumed record
 // costs one short injected block that the agent can discard.
-const REPLAY_SOURCES = new Set(['compact', 'resume', 'startup'])
+//
+// 'clear' IS included: a /clear wipes the session in place and the
+// harness restarts it with source=clear, so it is a restart like any other from
+// this record's point of view. Excluding it made the context-restart gate's own
+// path silent -- the gate sends /clear deliberately, then tells the fresh
+// session to read a TASK-FOLYTATAS block that the replay was refusing to emit.
+// The gate additionally never fires while a FRESH record is in flight (see
+// hasLiveTaskStateFile), so what a clear can replay is by construction a
+// settled thread, not work interrupted mid-step.
+const REPLAY_SOURCES = new Set(['compact', 'resume', 'startup', 'clear'])
 
 export interface AgentTaskState {
   agent: string
@@ -104,9 +113,9 @@ export function buildTaskStateInjection(r: AgentTaskState): string {
   const lines: string[] = [
     SENTINEL,
     // Source-neutral wording: the same record is replayed after a compact, a
-    // resume AND a crash respawn (source=startup, added 2026-07-27), so it must
-    // not claim a compact happened.
-    'A sessiond ujraindult egy FOLYAMATBAN LEVO feladat kozben (tomorites, resume vagy osszeomlas utani ujraindulas). Ez NEM uj feladat -- FOLYTASD onnan ahol abbamaradt. NE INDITSD ujra a mar kesz lepeseket, es NE delegald ujra amit mar atadtal.',
+    // resume, a /clear AND a crash respawn (source=startup, added 2026-07-27),
+    // so it must not claim a compact happened.
+    'A sessiond ujraindult egy FOLYAMATBAN LEVO feladat kozben (tomorites, resume, /clear vagy osszeomlas utani ujraindulas). Ez NEM uj feladat -- FOLYTASD onnan ahol abbamaradt. NE INDITSD ujra a mar kesz lepeseket, es NE delegald ujra amit mar atadtal.',
   ]
   if (r.summary.trim()) lines.push(`FELADAT: ${r.summary.trim()}`)
   if (r.doneSteps.length) lines.push('MAR KESZ (NE ismeteld meg):\n' + r.doneSteps.map((s) => `  - ${s}`).join('\n'))

--- a/src/web/context-restart-gate-runner.ts
+++ b/src/web/context-restart-gate-runner.ts
@@ -33,8 +33,9 @@ import {
 // This complements the hard context-guard (context-guard-runner.ts), which
 // acts at 90%/97% of the context window via hard process restarts. The soft
 // gate acts much earlier (default 400k tokens) via /clear -- the SessionStart
-// hooks (ledger-replay, taskstate-replay, daily-log-digest) then inject a rich
-// context snapshot into the fresh session automatically.
+// hooks (clear-replay, taskstate-replay, and ledger-replay for the agents whose
+// channel turns are logged) then inject a context snapshot into the fresh
+// session automatically.
 //
 // The runner starts 3 minutes after dashboard boot (offset from context-guard's
 // 4.5 min so the two sweeps do not fire simultaneously) and then sweeps on each
@@ -53,8 +54,8 @@ const INITIAL_DELAY_MS = 3 * 60_000   // 3 min
 export function gateWakePrompt(): string {
   return (
     '[CONTEXT-RESTART-GATE] Friss kontextussal indultal, mert a kapu ujrainditott (/clear). ' +
-    'A visszatoltott blokkokban ott a beszelgetes vege, a napi naplo kivonata es -- ha volt futo munkad -- ' +
-    'a TASK-FOLYTATAS a mar kesz lepesekkel es a kovetkezo akcioval. ' +
+    'A visszatoltott blokkokban ott a torolt szal vege (utolso keresek, utolso valaszod, az atirat utja) ' +
+    'es -- ha volt futo munkad -- a TASK-FOLYTATAS a mar kesz lepesekkel es a kovetkezo akcioval. ' +
     'Olvasd be oket, ellenorizd a kanban tabladat es a hot memoriaidat, es FOLYTASD onnan ahol abbamaradt. ' +
     'Ne kezdd elolrol ami mar kesz, es ne delegald ujra amit mar atadtal. ' +
     'Ha nem volt futo munkad, az is teljes erteku allapot -- olyankor ne talalj ki magadnak feladatot. ' +

--- a/src/web/hook-registration-guard.ts
+++ b/src/web/hook-registration-guard.ts
@@ -39,6 +39,9 @@ export const KNOWN_HOOK_SCRIPTS: readonly string[] = [
   'channel-inbox-drain.py',
   'ledger-capture.py',
   'skill-usage-capture.py',
+  // The /clear continuity pair: SessionEnd capture + SessionStart replay.
+  'clear-capture.py',
+  'clear-replay.py',
 ]
 
 // Path fragment that marks a checkout as an agent worktree. Kept

--- a/src/web/message-router.ts
+++ b/src/web/message-router.ts
@@ -30,7 +30,6 @@ import {
 import { detectPaneState, type PaneState } from '../pane-state.js'
 import { setLastInboundModality } from './voice-modality.js'
 import { classifyAgentMessage, wrapAgentMessageForDelivery } from './agent-message-wrap.js'
-import { MAIN_CHANNELS_SESSION } from './main-agent.js'
 import { maybeWakeSubAgentsForTelegram } from './telegram-inbox-wake.js'
 
 // A message that cannot be delivered within this window (target session never
@@ -132,13 +131,6 @@ function notifyOrchestratorOfFailedHandoff(msg: AgentMessage, reason: string): v
     logger.warn({ err, id: msg.id }, 'Failed to enqueue handoff-failure notification')
   }
 }
-// Wakeup cooldown for the main agent: the router fires at most one
-// sendPromptToSession wakeup per COOLDOWN_MS window to avoid spamming the
-// channels session. 45s gives enough headroom that a normal turn (typically
-// 5-30s) ends and drain-inbox fires before we would retry.
-let lastMainAgentWakeupMs = 0
-const MAIN_AGENT_WAKEUP_COOLDOWN_MS = 45 * 1000
-
 // Bounce a terminal federated-delivery failure back to the SENDER's inbox as
 // a local 'system' notice, so a delegating agent learns its task never
 // arrived (otherwise the failure only flips a DB row nobody reads, and the
@@ -498,7 +490,6 @@ export async function runMessageRouterTick(): Promise<void> {
     // on their own budget so neither queue starves the other.
     await deliverFederatedBatch(federatedPending, now)
 
-    let mainAgentWakeupFiredThisTick = false
     for (const msg of pending) {
       // Skip messages already batched by the reconnect pre-pass: they are
       // 'done' in the DB now but still appear in our snapshot slice.
@@ -521,24 +512,20 @@ export async function runMessageRouterTick(): Promise<void> {
       // day. Leave the message pending; the next main-agent turn claims it
       // atomically. Sub-agents keep the tmux-inject path (they have idle gaps).
       //
-      // WAKEUP: without an active nudge the main agent only drains on the next
-      // user message or heartbeat -- up to 22+ min latency observed in prod.
-      // Fire one lightweight wakeup per cooldown window so an idle channels
-      // session starts a turn and drain-inbox claims the message immediately.
-      // Busy session: Claude Code queues the wakeup for the next turn boundary.
-      if (isMainAgent) {
-        if (!mainAgentWakeupFiredThisTick && now - lastMainAgentWakeupMs >= MAIN_AGENT_WAKEUP_COOLDOWN_MS) {
-          mainAgentWakeupFiredThisTick = true
-          lastMainAgentWakeupMs = now
-          try {
-            await sendPromptToSession(MAIN_CHANNELS_SESSION, '[inbox-wakeup: pending inter-agent messages]', null, { waitForIdle: false })
-            logger.info({ msgId: msg.id }, 'message-router: main-agent wakeup fired')
-          } catch (err) {
-            logger.warn({ err }, 'message-router: main-agent wakeup injection failed')
-          }
-        }
-        continue
-      }
+      // WAKEUP: owned by the inbox-nudge-watcher, NOT by this router. The
+      // wakeup that used to live here (#538) predates that watcher (#557)
+      // and was never removed, so two engines nudged the
+      // same pane -- and this one fired BLIND: waitForIdle:false, no readiness
+      // check, no staleness tracking, once per 45s cooldown for as long as the
+      // row stayed pending. Against a mid-turn pane that lands as a queued
+      // mid-turn message, not a prompt submit: no UserPromptSubmit, so no
+      // drain-inbox call, so no claim -- the row stays pending and the cooldown
+      // re-arms -- observed as four such injections in three minutes for a
+      // single message, five main-agent turns burned, nothing delivered.
+      // The watcher does the same job correctly (double-capture-confirmed idle,
+      // abort-on-busy send, stale-spell escalation, owner alert, hourly budget),
+      // so the router simply leaves the row for the PULL path to claim.
+      if (isMainAgent) continue
       // Use cached session data from the pre-pass (one sessionExistsOnHost call
       // per unique receiver per tick). Fall back to a direct call for agents not
       // in the pending set (shouldn't happen, but safe).

--- a/src/web/routes/kanban.ts
+++ b/src/web/routes/kanban.ts
@@ -20,7 +20,7 @@ import { normalizeKanbanRefs } from '../kanban-ref-normalize.js'
 import { OWNER_NAME, BOT_NAME, MAIN_AGENT_ID, STORE_DIR, WEB_HOST, WEB_PORT, KANBAN_LABEL_COLORS } from '../../config.js'
 import { listAgentNames, readAgentDisplayName } from '../agent-config.js'
 import { isAgentRunning } from '../agent-process.js'
-import { resolveKanbanDispatchTarget } from '../../kanban-dispatch.js'
+import { resolveKanbanDispatch } from '../../kanban-dispatch.js'
 import { generateBreakdown } from '../llm-breakdown.js'
 import { logger } from '../../logger.js'
 import { readBody, json, jsonMaybeGzip } from '../http-helpers.js'
@@ -100,7 +100,7 @@ function fireKanbanDispatch(id: string, actor?: string | null): void {
   try {
     const card = getKanbanCard(id)
     if (!card || card.dispatched_at) return
-    const target = resolveKanbanDispatchTarget(card.assignee, {
+    const decision = resolveKanbanDispatch(card.assignee, {
       ownerName: OWNER_NAME,
       botName: BOT_NAME,
       mainAgentId: MAIN_AGENT_ID,
@@ -108,7 +108,14 @@ function fireKanbanDispatch(id: string, actor?: string | null): void {
       isRunning: isAgentRunning,
       actor,
     })
-    if (!target) return
+    const target = decision.target
+    if (!target) {
+      // 'not-dispatchable' (no/unknown assignee, human owner) and 'self-move'
+      // are DELIBERATE no-dispatch cases -- staying quiet is correct, and
+      // alerting on them would bury the one case that matters.
+      if (decision.reason === 'session-down') reportUndeliveredDispatch(id, decision.unreachable ?? String(card.assignee))
+      return
+    }
     const desc = (card.description ?? '').trim()
     const content = `[Kanban feladat #${id}]: ${card.title}${desc ? ' — ' + desc : ''}\n\n${kanbanMoveInstructions(id, target)}`
     createAgentMessage(MAIN_AGENT_ID, target, content)
@@ -116,6 +123,43 @@ function fireKanbanDispatch(id: string, actor?: string | null): void {
     logger.info({ id, target, assignee: card.assignee }, 'Kanban in_progress dispatch fired')
   } catch (err) {
     logger.warn({ err, id }, 'Kanban dispatch failed (card move still succeeded)')
+    reportUndeliveredDispatch(id, 'a kiosztás hibára futott')
+  }
+}
+
+// A card that reached in_progress without its assignee being woken must never
+// stay silent: the board shows it running, status-driven monitoring skips on
+// exactly that status, and the false in_progress SUSTAINS ITSELF -- a single
+// missed dispatch can hold a card open for hours behind a green log. So the
+// failure is written where both readers look: a comment on
+// the card (the board) and a notice in the main agent's inbox (the delegator,
+// who triages and can put the card back).
+//
+// Best-effort by construction: this runs inside the move request, and the move
+// itself has already succeeded. A throw here (db locked, inbox write failing)
+// must not turn a completed move into a 500, so it is swallowed after a log --
+// the same contract as the dispatch it reports on.
+function reportUndeliveredDispatch(id: string, unreachable: string): void {
+  logger.warn({ id, unreachable }, 'Kanban card is in_progress but its assignee was NOT woken')
+  try {
+    addKanbanComment(
+      id,
+      'system',
+      `A kártya in_progress lett, de a kiosztott ügynök (${unreachable}) NEM kapott üzenetet -- a session nem fut, vagy a kiosztás hibára futott. ` +
+      'A kártya NEM fut: tedd vissza planned-re, vagy indítsd el az ügynököt és húzd újra in_progress-re.',
+    )
+  } catch (err) {
+    logger.warn({ err, id }, 'Undelivered-dispatch card comment failed')
+  }
+  try {
+    createAgentMessage(
+      'system',
+      MAIN_AGENT_ID,
+      `[kanban-dispatch] A(z) #${id} kártya in_progress lett, de a kiosztott ügynök (${unreachable}) NEM kapott üzenetet. ` +
+      'A tábla futónak mutatja, közben senki nem dolgozik rajta. Tedd vissza planned-re, vagy indítsd el az ügynököt és aktiváld újra.',
+    )
+  } catch (err) {
+    logger.warn({ err, id }, 'Undelivered-dispatch inbox notice failed')
   }
 }
 

--- a/templates/settings.json.template
+++ b/templates/settings.json.template
@@ -18,11 +18,32 @@
     ],
     "SessionStart": [
       {
-        "matcher": "compact|resume",
+        "matcher": "compact|resume|clear",
         "hooks": [
           {
             "type": "command",
             "command": "python3 {{PROJECT_ROOT}}/scripts/hooks/taskstate-replay.py",
+            "timeout": 15
+          }
+        ]
+      },
+      {
+        "matcher": "clear",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 {{PROJECT_ROOT}}/scripts/hooks/clear-replay.py",
+            "timeout": 15
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 {{PROJECT_ROOT}}/scripts/hooks/clear-capture.py",
             "timeout": 15
           }
         ]


### PR DESCRIPTION
Four fixes for the kanban dispatch and the main-agent wake path, plus the missing `/clear` continuity, each with a red-first test.

### Kanban dispatch

- **A card that leaves `in_progress` never gets dispatched again.** `dispatched_at` is a once-only guard that nothing ever clears, so a card moved back to `planned` is silently unassignable from then on: the board lets you move it, the executor is never told.
- **A card is marked in-progress before the message goes out.** If the dispatch fails (agent down, session gone), the card looks busy to every other sweep while nobody works on it. The status change now follows the send, not precedes it.

### Router

- **The main-agent wake-up fired repeatedly for messages already handled.** Two mechanisms nudged the same pane: the router's own wake-up and the inbox-nudge-watcher. The blind wake-up is gone; the watcher owns it. Observed as four such injections in three minutes for a single message.

### Conversation continuity

- **`/clear` was unprotected on both ends.** The thread was not saved before it was erased and not restored after. Every replay path knew `compact` and `resume`; none of them knew `clear`. Adds the capture hook and the replay source, and carries a changed template matcher onto agents that already exist.

### Testing

Each fix has a test that fails on the current code and passes after. The full vitest suite passes (325 files).

### Note for maintainers

The `/clear` change also touches `templates/settings.json.template`. New installs pick it up automatically; existing installs keep their own settings file until someone updates it.
