### PR TITLE
fix(channels): per-install channel state -- two installs on one host must not silence each other

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -358,6 +358,19 @@ Minden feladat egy önálló mappa, benne két fájl. Részletes leírás: [sche
 | `~/.claude/channels/telegram/access.json` | Telegram allowFrom lista, párosított senderek |
 | `~/.claude/channels/slack/access.json` | Slack allowFrom lista |
 
+**Több telepítés egy gépen:** a fő ágens csatorna-állapota telepítésenként külön
+könyvtárban él (`~/.claude/channels/<provider>-<MAIN_AGENT_ID>`), különben a
+második telepítés átvenné az első bot-tokenjét és felülírná az `access.json`-ját.
+A feloldás sorrendje -- ezt követi a csatorna-plugin, a dashboard és a
+`channels.sh` watchdog is:
+
+1. `<PROVIDER>_STATE_DIR` környezeti változó (pl. `TELEGRAM_STATE_DIR`),
+2. `CLAUDE_CONFIG_DIR/channels/<provider>` (az izolált config dir),
+3. `~/.claude/channels/<provider>` -- a fenti táblázat útja, egyetlen telepítésnél.
+
+Meglévő, egytelepítéses gépen semmi nem változik: a telepítésenkénti könyvtárra
+csak akkor vált át, ha az már létezik.
+
 ---
 
 ## .mcp.json -- MCP szerverek

--- a/docs/en/config-reference.md
+++ b/docs/en/config-reference.md
@@ -338,6 +338,19 @@ Each task lives in its own folder with two files. Detailed description: [schedul
 | `~/.claude/channels/telegram/access.json` | Telegram allowFrom list, paired senders |
 | `~/.claude/channels/slack/access.json` | Slack allowFrom list |
 
+**Multiple installs on one host:** the main agent's channel state lives in a
+per-install directory (`~/.claude/channels/<provider>-<MAIN_AGENT_ID>`), otherwise
+a second install would take over the first one's bot token and overwrite its
+`access.json`. Resolution order -- followed by the channel plugin, the dashboard
+and the `channels.sh` watchdog alike:
+
+1. the `<PROVIDER>_STATE_DIR` environment variable (e.g. `TELEGRAM_STATE_DIR`),
+2. `CLAUDE_CONFIG_DIR/channels/<provider>` (the isolated config dir),
+3. `~/.claude/channels/<provider>` -- the path in the table above, for a single install.
+
+Nothing changes on an existing single-install host: the per-install directory is
+only used once it exists.
+
 ---
 
 ## .mcp.json -- MCP Servers

--- a/install-linux.sh
+++ b/install-linux.sh
@@ -1316,12 +1316,38 @@ if [ -d "$SEED_CONFIG_DIR" ]; then
 fi
 
 # Channel state directory setup
-CHANNEL_DIR="$HOME/.claude/channels/$CHANNEL_PROVIDER"
+# hu: A fo ugynok csatorna-allapot konyvtara -- TELEPITESENKENT kulon.
+#     Egy gepen tobb telepites is futhat (kulon WEB_PORT, kulon bot). Fix
+#     $HOME/.claude/channels/<provider> mellett a masodik telepites atvette az
+#     elso bot-tokenjet ES kitorolte az access.json csoport-engedelyeit, amitol
+#     az elso telepites csendben elnemult. Az agent-azonosito nelkuli alak a
+#     korabbi globalis utat adja vissza (visszafele kompatibilitas).
+#     Ugyanaz a nevkonvencio, amit a dashboard is hasznal
+#     (src/web/agent-process.ts mainAgentChannelsLinkTarget).
+# en: Main agent's channel state dir, PER INSTALL. A fixed path let a second
+#     install take over the first one's bot token and wipe its access.json
+#     groups. Without an agent id it returns the previous global path.
+# $1 = provider, $2 = main agent id ("" -> legacy global path)
+resolve_channel_state_dir() {
+  if [ -n "$2" ]; then
+    printf '%s' "$HOME/.claude/channels/$1-$2"
+  else
+    printf '%s' "$HOME/.claude/channels/$1"
+  fi
+}
+
+CHANNEL_DIR="$(resolve_channel_state_dir "$CHANNEL_PROVIDER" "${MAIN_AGENT_ID:-}")"
 mkdir -p "$CHANNEL_DIR"
 
 if [ "$CHANNEL_PROVIDER" = "telegram" ] && [ -n "$BOT_TOKEN" ]; then
   (umask 077 && echo "TELEGRAM_BOT_TOKEN=$BOT_TOKEN" >"$CHANNEL_DIR/.env")
   chmod 600 "$CHANNEL_DIR/.env"
+# hu: A meglevo access.json a parositasokat ES a jovahagyott csoportokat
+#     hordozza -- egy ujratelepites nem irhatja felul, mert az csendben
+#     elnemitana egy mar mukodo csatornat.
+# en: An existing access.json carries pairings and approved groups; a
+#     re-install must not overwrite it.
+if [ ! -f "$CHANNEL_DIR/access.json" ]; then
   cat >"$CHANNEL_DIR/access.json" <<ACCESSEOF
 {
   "dmPolicy": "pairing",
@@ -1330,6 +1356,7 @@ if [ "$CHANNEL_PROVIDER" = "telegram" ] && [ -n "$BOT_TOKEN" ]; then
   "pending": {}
 }
 ACCESSEOF
+fi
   ok "$(_t linux.tg_channel_configured)"
 elif [ "$CHANNEL_PROVIDER" = "slack" ] && [ -n "$SLACK_BOT_TOKEN" ]; then
   (umask 077 && cat >"$CHANNEL_DIR/.env" <<SLACKENVEOF
@@ -1338,6 +1365,12 @@ SLACK_APP_TOKEN=$SLACK_APP_TOKEN
 SLACKENVEOF
   )
   chmod 600 "$CHANNEL_DIR/.env"
+# hu: A meglevo access.json a parositasokat ES a jovahagyott csoportokat
+#     hordozza -- egy ujratelepites nem irhatja felul, mert az csendben
+#     elnemitana egy mar mukodo csatornat.
+# en: An existing access.json carries pairings and approved groups; a
+#     re-install must not overwrite it.
+if [ ! -f "$CHANNEL_DIR/access.json" ]; then
   cat >"$CHANNEL_DIR/access.json" <<ACCESSEOF
 {
   "dmPolicy": "pairing",
@@ -1346,6 +1379,7 @@ SLACKENVEOF
   "pending": {}
 }
 ACCESSEOF
+fi
   ok "$(_t linux.slack_channel_configured)"
 elif [ "$CHANNEL_PROVIDER" = "discord" ] && [ -n "$DISCORD_BOT_TOKEN" ]; then
   (umask 077 && cat >"$CHANNEL_DIR/.env" <<DISCORDENVEOF
@@ -1354,6 +1388,12 @@ DISCORD_CHANNEL_ID=$DISCORD_CHANNEL_ID
 DISCORDENVEOF
   )
   chmod 600 "$CHANNEL_DIR/.env"
+# hu: A meglevo access.json a parositasokat ES a jovahagyott csoportokat
+#     hordozza -- egy ujratelepites nem irhatja felul, mert az csendben
+#     elnemitana egy mar mukodo csatornat.
+# en: An existing access.json carries pairings and approved groups; a
+#     re-install must not overwrite it.
+if [ ! -f "$CHANNEL_DIR/access.json" ]; then
   cat >"$CHANNEL_DIR/access.json" <<ACCESSEOF
 {
   "dmPolicy": "pairing",
@@ -1362,6 +1402,7 @@ DISCORDENVEOF
   "pending": {}
 }
 ACCESSEOF
+fi
   ok "$(_t linux.discord_channel_configured)"
 fi
 

--- a/install-macos.sh
+++ b/install-macos.sh
@@ -880,12 +880,38 @@ if [ -d "$SCHED_TPL_DIR" ]; then
 fi
 
 # Setup channel state directory
-CHANNEL_DIR="$HOME/.claude/channels/$CHANNEL_PROVIDER"
+# hu: A fo ugynok csatorna-allapot konyvtara -- TELEPITESENKENT kulon.
+#     Egy gepen tobb telepites is futhat (kulon WEB_PORT, kulon bot). Fix
+#     $HOME/.claude/channels/<provider> mellett a masodik telepites atvette az
+#     elso bot-tokenjet ES kitorolte az access.json csoport-engedelyeit, amitol
+#     az elso telepites csendben elnemult. Az agent-azonosito nelkuli alak a
+#     korabbi globalis utat adja vissza (visszafele kompatibilitas).
+#     Ugyanaz a nevkonvencio, amit a dashboard is hasznal
+#     (src/web/agent-process.ts mainAgentChannelsLinkTarget).
+# en: Main agent's channel state dir, PER INSTALL. A fixed path let a second
+#     install take over the first one's bot token and wipe its access.json
+#     groups. Without an agent id it returns the previous global path.
+# $1 = provider, $2 = main agent id ("" -> legacy global path)
+resolve_channel_state_dir() {
+  if [ -n "$2" ]; then
+    printf '%s' "$HOME/.claude/channels/$1-$2"
+  else
+    printf '%s' "$HOME/.claude/channels/$1"
+  fi
+}
+
+CHANNEL_DIR="$(resolve_channel_state_dir "$CHANNEL_PROVIDER" "${MAIN_AGENT_ID:-}")"
 mkdir -p "$CHANNEL_DIR"
 
 if [ "$CHANNEL_PROVIDER" = "telegram" ] && [ -n "$BOT_TOKEN" ]; then
   (umask 077 && echo "TELEGRAM_BOT_TOKEN=$BOT_TOKEN" > "$CHANNEL_DIR/.env")
   chmod 600 "$CHANNEL_DIR/.env"
+# hu: A meglevo access.json a parositasokat ES a jovahagyott csoportokat
+#     hordozza -- egy ujratelepites nem irhatja felul, mert az csendben
+#     elnemitana egy mar mukodo csatornat.
+# en: An existing access.json carries pairings and approved groups; a
+#     re-install must not overwrite it.
+if [ ! -f "$CHANNEL_DIR/access.json" ]; then
   cat > "$CHANNEL_DIR/access.json" << ACCESSEOF
 {
   "dmPolicy": "pairing",
@@ -894,6 +920,7 @@ if [ "$CHANNEL_PROVIDER" = "telegram" ] && [ -n "$BOT_TOKEN" ]; then
   "pending": {}
 }
 ACCESSEOF
+fi
   echo -e "  ${GREEN}✓${NC} $(_t macos.tg_channel_configured)"
 elif [ "$CHANNEL_PROVIDER" = "slack" ] && [ -n "$SLACK_BOT_TOKEN" ]; then
   (umask 077 && cat > "$CHANNEL_DIR/.env" << SLACKENVEOF
@@ -902,6 +929,12 @@ SLACK_APP_TOKEN=$SLACK_APP_TOKEN
 SLACKENVEOF
   )
   chmod 600 "$CHANNEL_DIR/.env"
+# hu: A meglevo access.json a parositasokat ES a jovahagyott csoportokat
+#     hordozza -- egy ujratelepites nem irhatja felul, mert az csendben
+#     elnemitana egy mar mukodo csatornat.
+# en: An existing access.json carries pairings and approved groups; a
+#     re-install must not overwrite it.
+if [ ! -f "$CHANNEL_DIR/access.json" ]; then
   cat > "$CHANNEL_DIR/access.json" << ACCESSEOF
 {
   "dmPolicy": "pairing",
@@ -910,6 +943,7 @@ SLACKENVEOF
   "pending": {}
 }
 ACCESSEOF
+fi
   echo -e "  ${GREEN}✓${NC} $(_t macos.slack_channel_configured)"
 fi
 

--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -458,6 +458,12 @@ MODEL_FLAG=""
 # prints nothing, CFG_ENV stays EMPTY and the agent keeps the shared ~/.claude --
 # strict no-op for existing installs (no setting, no fleet token, no dist build).
 CFG_ENV=""
+# hu: A kiszamolt izolalt CLAUDE_CONFIG_DIR tartos masolata -- a _cfg_dir a blokk
+#     vegen unset-elodik, a csatorna-allapot konyvtar feloldasahoz viszont kesobb
+#     is kell (lasd resolve_main_chan_state_dir).
+# en: Durable copy of the resolved isolated CLAUDE_CONFIG_DIR; _cfg_dir is unset
+#     at the end of the block but the channel-state resolution needs it later.
+MAIN_CFG_DIR=""
 mkdir -p "$INSTALL_DIR/store" 2>/dev/null || true
 _node_bin="$(command -v node || true)"
 if [ -n "$_node_bin" ] && [ -f "$INSTALL_DIR/dist/web/agent-process.js" ]; then
@@ -465,6 +471,7 @@ if [ -n "$_node_bin" ] && [ -f "$INSTALL_DIR/dist/web/agent-process.js" ]; then
   _cfg_mode="${_cfg_line%%	*}"
   _cfg_dir="${_cfg_line#*	}"
   if [ -n "$_cfg_line" ] && [ -d "$_cfg_dir" ]; then
+    MAIN_CFG_DIR="$_cfg_dir"
     if [ "$_cfg_mode" = "explicit" ]; then
       CFG_ENV="export CLAUDE_CONFIG_DIR='$_cfg_dir' && "
     else
@@ -577,7 +584,6 @@ $TMUX kill-session -t "$SESSION" 2>/dev/null
 # poller env contains *_STATE_DIR=<this main agent's channel dir>; argv does
 # not, so `pkill -f` against the env var never matches. We grep `ps eww -e`
 # instead, which surfaces each process environment on macOS BSD ps.
-MAIN_CHAN_DIR="$INSTALL_DIR/.claude/channels/$CHANNEL_PROVIDER"
 case "$CHANNEL_PROVIDER" in
   slack)    STATE_ENV_VAR="SLACK_STATE_DIR" ;;
   whatsapp) STATE_ENV_VAR="WHATSAPP_STATE_DIR" ;;
@@ -585,6 +591,41 @@ case "$CHANNEL_PROVIDER" in
   discord)  STATE_ENV_VAR="DISCORD_STATE_DIR" ;;
   *)        STATE_ENV_VAR="TELEGRAM_STATE_DIR" ;;
 esac
+
+# hu: A FO ugynok csatorna-allapot konyvtara. A csatorna-plugin sajat feloldasi
+#     sorrendjet tukrozi (a plugin server.ts-eben:
+#     <PROVIDER>_STATE_DIR ?? CLAUDE_CONFIG_DIR/channels/<provider>), hogy a
+#     plugin es a watchdog UGYANARRA a konyvtarra nezzen.
+#
+#     Miert nem fix $HOME-ut: egy gepen tobb telepites is futhat (kulon WEB_PORT,
+#     kulon bot). Fix $HOME/.claude/channels/<provider> mellett mindket telepites
+#     fo ugynoke ugyanazt a .env-t, bot.pid-et es access.json-t hasznalta -- a
+#     masodik telepito felulirta az elso bot-tokenjet, a plugin orphan-killere a
+#     kozos bot.pid alapjan kiloette a masik pollert, a watchdog pedig a masik
+#     telepites PID-jenek eltuneset latta sajat halalanak es ujraindult.
+#     Az izolalt CLAUDE_CONFIG_DIR telepitesenkent kulon (.channels-config), ezert
+#     ez valasztja szet a ket telepitest kod-modositas nelkul is.
+# en: Main agent's channel state dir, mirroring the plugin's own resolution order
+#     so plugin and watchdog look at the SAME directory. A fixed $HOME path made
+#     two installs on one host share one .env/bot.pid/access.json -- token
+#     overwrite, mutual orphan-kill, and a watchdog restart loop.
+# $1 = provider, $2 = state env var name, $3 = isolated CLAUDE_CONFIG_DIR ("" if none)
+resolve_main_chan_state_dir() {
+  _rmcsd_env="$(eval "printf '%s' \"\${$2-}\"")"
+
+  if [ -n "$_rmcsd_env" ]; then
+    printf '%s' "$_rmcsd_env"
+  elif [ -n "$3" ]; then
+    printf '%s' "$3/channels/$1"
+  else
+    printf '%s' "$HOME/.claude/channels/$1"
+  fi
+
+  unset _rmcsd_env
+}
+
+MAIN_CHAN_STATE_DIR="$(resolve_main_chan_state_dir "$CHANNEL_PROVIDER" "$STATE_ENV_VAR" "$MAIN_CFG_DIR")"
+MAIN_CHAN_DIR="$MAIN_CHAN_STATE_DIR"
 ORPHAN_PIDS="$(/bin/ps eww -e 2>/dev/null | awk -v needle="${STATE_ENV_VAR}=${MAIN_CHAN_DIR}" '$0 ~ needle { print $1 }')"
 if [ -n "$ORPHAN_PIDS" ]; then
   # shellcheck disable=SC2086
@@ -956,9 +997,11 @@ START_TS=$(date +%s)
 # Thresholds are deliberately COARSER than the dashboard monitor's (~60-120s)
 # so in normal operation the dashboard acts FIRST and this only fires when the
 # dashboard couldn't -- avoids double-restart races. bot.pid lives at the
-# main-agent channelStateDir(): ~/.claude/channels/<provider>/bot.pid (HOME-,
-# not INSTALL_DIR-relative; see src/channel-provider.ts channelStateDir()).
-MAIN_BOT_PID_FILE="$HOME/.claude/channels/$CHANNEL_PROVIDER/bot.pid"
+# main-agent channel state dir resolved above (resolve_main_chan_state_dir),
+# which mirrors the plugin's own order: <PROVIDER>_STATE_DIR >
+# CLAUDE_CONFIG_DIR/channels/<provider> > $HOME/.claude/channels/<provider>.
+# Telepitesenkent kulon -- lasd src/channel-provider.ts channelStateDir().
+MAIN_BOT_PID_FILE="$MAIN_CHAN_STATE_DIR/bot.pid"
 # Never-started budget: generous so a slow cold-start (WSL first-run, MCP
 # handshake + /mcp unlock retries) is never killed prematurely. The plugin
 # normally writes bot.pid within ~1-2 min; 10 min is a safe ceiling.

--- a/scripts/set-bot-menu.sh
+++ b/scripts/set-bot-menu.sh
@@ -19,8 +19,14 @@ if [ "$CHANNEL_PROVIDER" != "telegram" ]; then
 fi
 
 # Load bot token
-if [ -f "$HOME/.claude/channels/telegram/.env" ]; then
-  BOT_TOKEN=$(grep TELEGRAM_BOT_TOKEN "$HOME/.claude/channels/telegram/.env" | cut -d= -f2)
+# hu: A csatorna-allapot konyvtar telepitesenkent kulon lehet (tobb Marveen egy
+#     gepen). A TELEGRAM_STATE_DIR-t a channels.sh adja at; enelkul a regi
+#     globalis ut marad.
+# en: The channel state dir is per-install; TELEGRAM_STATE_DIR comes from
+#     channels.sh, else the previous global path.
+CHAN_STATE_DIR="${TELEGRAM_STATE_DIR:-$HOME/.claude/channels/telegram}"
+if [ -f "$CHAN_STATE_DIR/.env" ]; then
+  BOT_TOKEN=$(grep TELEGRAM_BOT_TOKEN "$CHAN_STATE_DIR/.env" | cut -d= -f2)
 elif [ -f "$INSTALL_DIR/.env" ]; then
   BOT_TOKEN=$(grep TELEGRAM_BOT_TOKEN "$INSTALL_DIR/.env" | cut -d= -f2)
 fi

--- a/src/__tests__/channel-state-dir-per-install.test.ts
+++ b/src/__tests__/channel-state-dir-per-install.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { homedir } from 'os'
+import { join } from 'path'
+import { channelStateDir } from '../channel-provider.js'
+
+// hu: Egy gepen tobb Marveen-telepites is futhat (kulon WEB_PORT, kulon bot).
+//     A fo ugynok csatorna-allapota eddig FIX ~/.claude/channels/<provider> volt,
+//     igy ket telepites ugyanabban a .env-ben, bot.pid-ben es access.json-ben
+//     dolgozott: a masodik telepito felulirta az elso bot-tokenjet, a plugin
+//     orphan-killere pedig a kozos bot.pid alapjan kiloette a masik pollert.
+// en: Multiple installs can share a host. The main agent's channel state was a
+//     fixed ~/.claude/channels/<provider>, so two installs shared one .env,
+//     bot.pid and access.json -- the second install overwrote the first's token
+//     and the plugin's orphan-killer shot down the other install's poller.
+describe('channelStateDir -- telepitesenkenti elkulonites', () => {
+  const saved = { ...process.env }
+
+  afterEach(() => {
+    for (const k of ['TELEGRAM_STATE_DIR', 'SLACK_STATE_DIR', 'DISCORD_STATE_DIR']) {
+      if (saved[k] === undefined) delete process.env[k]
+      else process.env[k] = saved[k]
+    }
+  })
+
+  it('a fo ugynok a provider-specifikus STATE_DIR env-et hasznalja, ha be van allitva', () => {
+    process.env['TELEGRAM_STATE_DIR'] = '/Users/x/.claude/channels/telegram-marveen'
+    expect(channelStateDir('telegram')).toBe('/Users/x/.claude/channels/telegram-marveen')
+  })
+
+  it('env nelkul a globalis alapertelmezes marad (visszafele kompatibilitas)', () => {
+    delete process.env['TELEGRAM_STATE_DIR']
+    expect(channelStateDir('telegram')).toBe(join(homedir(), '.claude', 'channels', 'telegram'))
+  })
+
+  // A LENYEGI NEGATIV ESET: a dashboard a fo session env-jebol orokli a
+  // TELEGRAM_STATE_DIR-t, es ugyanaz a folyamat szamolja a SUB-agentek utjat is.
+  // Ha az env a sub-agent agat is felulirna, minden fej egyetlen konyvtarba
+  // omlana -- egy bot.pid, egy token, kolcsonos kiloves az egesz flottaban.
+  it('a sub-agent ag NEM veszi at az env-et -- az agentDir gyoz', () => {
+    process.env['TELEGRAM_STATE_DIR'] = '/Users/x/.claude/channels/telegram-marveen'
+    expect(channelStateDir('telegram', '/Users/x/Marveen/agents/delphi'))
+      .toBe(join('/Users/x/Marveen/agents/delphi', '.claude', 'channels', 'telegram'))
+  })
+
+  it('provideenkent kulon env: a slack a SLACK_STATE_DIR-t nezi, nem a telegramet', () => {
+    process.env['TELEGRAM_STATE_DIR'] = '/Users/x/.claude/channels/telegram-marveen'
+    process.env['SLACK_STATE_DIR'] = '/Users/x/.claude/channels/slack-marveen'
+    expect(channelStateDir('slack')).toBe('/Users/x/.claude/channels/slack-marveen')
+    expect(channelStateDir('discord')).toBe(join(homedir(), '.claude', 'channels', 'discord'))
+  })
+})

--- a/src/__tests__/channel-state-dir-siblings.test.ts
+++ b/src/__tests__/channel-state-dir-siblings.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync } from 'node:fs'
+import { tmpdir, homedir } from 'node:os'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { readMarveenTelegramConfig } from '../web/telegram.js'
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+
+// hu: A fo ugynok csatorna-allapotanak elkulonitese (channelStateDir) csak akkor
+//     ER valamit, ha MINDEN olvaso ugyanazt a feloldast hasznalja. Egy megmaradt
+//     fix $HOME/.claude/channels/telegram ut azt jelenti, hogy az adott komponens
+//     a MASIK telepites bot-tokenjet olvassa -- a Jarvis dashboardja a Marveen
+//     bot-jat jelentene csatlakozottnak, a Jarvis bot-menuje a Marveen bot-jara
+//     kerulne.
+// en: Isolating the main agent's channel state only pays off if EVERY reader
+//     resolves it the same way. A leftover fixed $HOME path means that component
+//     reads the OTHER install's bot token.
+describe('channelStateDir testverek: minden olvaso a feloldott konyvtarat hasznalja', () => {
+  const dirs: string[] = []
+  const savedEnv = process.env['TELEGRAM_STATE_DIR']
+
+  afterEach(() => {
+    if (savedEnv === undefined) delete process.env['TELEGRAM_STATE_DIR']
+    else process.env['TELEGRAM_STATE_DIR'] = savedEnv
+    for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true })
+  })
+
+  function sandboxStateDir(token: string): string {
+    const root = mkdtempSync(join(tmpdir(), 'chan-state-'))
+    dirs.push(root)
+    const stateDir = join(root, 'telegram-testinstall')
+    mkdirSync(stateDir, { recursive: true })
+    writeFileSync(join(stateDir, '.env'), `TELEGRAM_BOT_TOKEN=${token}\n`)
+    return stateDir
+  }
+
+  it('readMarveenTelegramConfig a sajat telepites STATE_DIR-jebol olvas', () => {
+    process.env['TELEGRAM_STATE_DIR'] = sandboxStateDir('111111:SAJAT-TOKEN')
+    expect(readMarveenTelegramConfig().hasTelegram).toBe(true)
+  })
+
+  it('ures STATE_DIR-nel nem talal tokent -- nem esik vissza a masik telepitesere', () => {
+    const root = mkdtempSync(join(tmpdir(), 'chan-state-'))
+    dirs.push(root)
+    const empty = join(root, 'telegram-ures')
+    mkdirSync(empty, { recursive: true })
+    process.env['TELEGRAM_STATE_DIR'] = empty
+    expect(readMarveenTelegramConfig().hasTelegram).toBe(false)
+  })
+
+  // A maradek ket testver statikusan: a fix homedir()-ut, illetve a fix $HOME-ut
+  // eltunese a bizonyitek, hogy a feloldason mennek keresztul.
+  it('a scheduler riasztas-tokenje nem fix homedir()-utrol jon', () => {
+    const src = readFileSync(join(REPO_ROOT, 'src', 'web', 'schedule-runner.ts'), 'utf-8')
+    const fn = src.slice(src.indexOf('function resolveSchedulerAlertToken'))
+    const body = fn.slice(0, fn.indexOf('\n}'))
+    expect(body).not.toContain(`homedir(), '.claude', 'channels'`)
+    expect(body).toContain('channelStateDir(')
+  })
+
+  it('a set-bot-menu.sh a STATE_DIR-t tiszteli', () => {
+    const sh = readFileSync(join(REPO_ROOT, 'scripts', 'set-bot-menu.sh'), 'utf-8')
+    expect(sh).toContain('TELEGRAM_STATE_DIR')
+    expect(sh).not.toContain('$HOME/.claude/channels/telegram/.env')
+  })
+
+  it('a telegram.ts fo-ugynok olvasoi nem drotozzak be a homedir() utat', () => {
+    const src = readFileSync(join(REPO_ROOT, 'src', 'web', 'telegram.ts'), 'utf-8')
+    expect(src).not.toContain(`join(homedir(), '.claude', 'channels'`)
+  })
+
+  it('a homedir() alapertelmezes maga megmarad a feloldoban (visszafele kompatibilitas)', () => {
+    delete process.env['TELEGRAM_STATE_DIR']
+    const src = readFileSync(join(REPO_ROOT, 'src', 'channel-provider.ts'), 'utf-8')
+    expect(src).toContain(`join(homedir(), '.claude', 'channels')`)
+    expect(homedir()).toBeTruthy()
+  })
+})

--- a/src/__tests__/channels-main-state-dir.test.ts
+++ b/src/__tests__/channels-main-state-dir.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+const channelsSh = readFileSync(join(REPO_ROOT, 'scripts', 'channels.sh'), 'utf-8')
+
+// hu: A fo ugynok csatorna-allapot konyvtara eddig FIX $HOME/.claude/channels/
+//     <provider> volt (MAIN_BOT_PID_FILE). Egy gepen ket telepites igy UGYANAZT
+//     a bot.pid-et figyelte: a masik telepites pollere latszott sajatnak, es
+//     amikor az cserelodott, a watchdog "eltunt a botom"-ot latott es ujraindult
+//     -- kolcsonos restart-ciklus.
+// en: The main agent's channel state dir was a fixed $HOME path, so two installs
+//     on one host watched the SAME bot.pid and restart-looped against each other.
+//
+// A feloldas a csatorna-plugin sajat sorrendjet tukrozi (server.ts):
+//   <PROVIDER>_STATE_DIR  >  CLAUDE_CONFIG_DIR/channels/<provider>  >  $HOME/...
+function extractResolver(): string {
+  const m = channelsSh.match(/resolve_main_chan_state_dir\(\)\s*\{[\s\S]*?\n\}/)
+  if (!m) throw new Error('resolve_main_chan_state_dir() not found in channels.sh')
+  return m[0]
+}
+
+function resolve(provider: string, envVarName: string, envValue: string, cfgDir: string): string {
+  const script = [
+    'set -u',
+    'HOME=/home/tester',
+    extractResolver(),
+    envValue ? `export ${envVarName}='${envValue}'` : `unset ${envVarName} 2>/dev/null || true`,
+    `resolve_main_chan_state_dir '${provider}' '${envVarName}' '${cfgDir}'`,
+  ].join('\n')
+  return execFileSync('bash', ['-c', script], { encoding: 'utf-8' }).trim()
+}
+
+function assignmentLine(name: string): string | undefined {
+  for (const l of channelsSh.split('\n')) {
+    if (l.trimStart().startsWith(name + '=')) return l
+  }
+  return undefined
+}
+
+describe('channels.sh: a fo ugynok csatorna-allapot konyvtara telepitesenkent', () => {
+  it('a <PROVIDER>_STATE_DIR env gyoz, ha be van allitva', () => {
+    expect(resolve('telegram', 'TELEGRAM_STATE_DIR', '/x/.claude/channels/telegram-marveen', '/x/Marveen/.channels-config'))
+      .toBe('/x/.claude/channels/telegram-marveen')
+  })
+
+  it('env nelkul a telepites sajat CLAUDE_CONFIG_DIR-jebol szarmazik -- ez valasztja szet a ket telepitest', () => {
+    expect(resolve('telegram', 'TELEGRAM_STATE_DIR', '', '/x/Marveen/.channels-config'))
+      .toBe('/x/Marveen/.channels-config/channels/telegram')
+    expect(resolve('telegram', 'TELEGRAM_STATE_DIR', '', '/x/Jarvis/.channels-config'))
+      .toBe('/x/Jarvis/.channels-config/channels/telegram')
+  })
+
+  it('izolalt config nelkul a regi globalis ut marad (visszafele kompatibilitas)', () => {
+    expect(resolve('telegram', 'TELEGRAM_STATE_DIR', '', ''))
+      .toBe('/home/tester/.claude/channels/telegram')
+  })
+
+  it('provider-fuggetlen: slack a SLACK_STATE_DIR-t es a sajat alkonyvtarat kapja', () => {
+    expect(resolve('slack', 'SLACK_STATE_DIR', '/x/.claude/channels/slack-marveen', '/x/M/.channels-config'))
+      .toBe('/x/.claude/channels/slack-marveen')
+    expect(resolve('slack', 'SLACK_STATE_DIR', '', '/x/M/.channels-config'))
+      .toBe('/x/M/.channels-config/channels/slack')
+  })
+
+  // A watchdog PID-fajlja ebbol a feloldasbol szarmazzon, ne fix $HOME utbol --
+  // kulonben a szetvalasztas a plugin oldalan megvan, a watchdog viszont
+  // tovabbra is a masik telepites bot.pid-jet figyeli.
+  it('a MAIN_BOT_PID_FILE a feloldott konyvtarbol szarmazik, nem fix $HOME utbol', () => {
+    const line = assignmentLine('MAIN_BOT_PID_FILE')
+    expect(line, 'MAIN_BOT_PID_FILE assignment not found').toBeTruthy()
+    expect(line).not.toContain('$HOME/.claude/channels')
+    expect(line).toContain('MAIN_CHAN_STATE_DIR')
+  })
+
+  // Ugyanez az orphan-reap celpontjara: eddig $INSTALL_DIR/.claude/channels/...
+  // volt, ami egyik telepitesnel sem letezik -- a reap ezert sosem talalt semmit.
+  it('a MAIN_CHAN_DIR is a feloldott konyvtar (a reap kulonben vak marad)', () => {
+    const line = assignmentLine('MAIN_CHAN_DIR')
+    expect(line, 'MAIN_CHAN_DIR assignment not found').toBeTruthy()
+    expect(line).toContain('MAIN_CHAN_STATE_DIR')
+  })
+})

--- a/src/__tests__/installer-channel-state-dir.test.ts
+++ b/src/__tests__/installer-channel-state-dir.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+const INSTALLERS = ['install-macos.sh', 'install-linux.sh'] as const
+
+// hu: MERT eset (2026-08-31): egy MASODIK telepites ugyanarra a gepre elnemitotta
+//     az elsot. A telepito a csatorna-allapotot a FIX $HOME/.claude/channels/
+//     <provider> utra irja, es ott FELTETEL NELKUL felulirja a .env-et (bot-token)
+//     es az access.json-t. A masodik telepites igy
+//       - atvette az elso bot-tokenjet (az elso bot senkit nem szolgalt ki), es
+//       - kitorolte az access.json "groups" tartalmat -- a munkacsoportbol erkezo
+//         uzenetek (99 db, aug 11 -- aug 31 17:29) egy csapasra eldobodtak,
+//         mert a plugin ismeretlen csoportot csendben eldob.
+//     Ket kulon hiba, ket kulon javitas kell:
+//       A) a konyvtar legyen telepitesenkent kulon, es
+//       B) a mar meglevo access.json ne irodjon felul (parositasok, csoportok).
+// en: A second install on the same host silently took over the first one's bot
+//     token and wiped its access.json groups. Fix A: per-install directory.
+//     Fix B: never overwrite an existing access.json.
+describe('telepito: csatorna-allapot konyvtar telepitesenkent', () => {
+  function extractResolver(sh: string): string {
+    const m = sh.match(/resolve_channel_state_dir\(\)\s*\{[\s\S]*?\n\}/)
+    if (!m) throw new Error('resolve_channel_state_dir() not found')
+    return m[0]
+  }
+
+  function resolve(sh: string, provider: string, agentId: string): string {
+    const script = ['set -u', 'HOME=/home/tester', extractResolver(sh),
+      `resolve_channel_state_dir '${provider}' '${agentId}'`].join('\n')
+    return execFileSync('bash', ['-c', script], { encoding: 'utf-8' }).trim()
+  }
+
+  for (const installer of INSTALLERS) {
+    describe(installer, () => {
+      const sh = readFileSync(join(REPO_ROOT, installer), 'utf-8')
+
+      it('ket telepites ket kulon konyvtarat kap', () => {
+        expect(resolve(sh, 'telegram', 'marveen')).toBe('/home/tester/.claude/channels/telegram-marveen')
+        expect(resolve(sh, 'telegram', 'jarvis')).toBe('/home/tester/.claude/channels/telegram-jarvis')
+      })
+
+      it('agent-azonosito nelkul a regi globalis ut marad (visszafele kompatibilitas)', () => {
+        expect(resolve(sh, 'telegram', '')).toBe('/home/tester/.claude/channels/telegram')
+      })
+
+      it('providerenkent kulon', () => {
+        expect(resolve(sh, 'slack', 'marveen')).toBe('/home/tester/.claude/channels/slack-marveen')
+      })
+
+      it('a CHANNEL_DIR ebbol a feloldasbol szarmazik, nem fix $HOME utbol', () => {
+        const line = sh.split('\n').find((l) => l.startsWith('CHANNEL_DIR='))
+        expect(line, 'CHANNEL_DIR assignment not found').toBeTruthy()
+        expect(line).toContain('resolve_channel_state_dir')
+        expect(line).not.toContain('$HOME/.claude/channels/$CHANNEL_PROVIDER')
+      })
+
+      // B) A meglevo access.json a parositasokat ES a jovahagyott csoportokat
+      //    hordozza. Egy ujratelepites (vagy egy masodik telepites) nem irhatja
+      //    felul -- az csendben elnemitja a mar mukodo csatornakat.
+      it('a meglevo access.json-t nem irja felul', () => {
+        const writes = sh.split('\n')
+          .map((l, i) => ({ l, i }))
+          .filter((x) => /^\s*cat\s*>\s*"?\$CHANNEL_DIR\/access\.json"?/.test(x.l))
+        expect(writes.length, 'access.json write not found').toBeGreaterThan(0)
+        for (const w of writes) {
+          const before = sh.split('\n').slice(Math.max(0, w.i - 6), w.i).join('\n')
+          expect(before, `access.json write at line ${w.i + 1} is unguarded`)
+            .toMatch(/if\s+\[\s+!\s+-f\s+"?\$CHANNEL_DIR\/access\.json"?\s+\]/)
+        }
+      })
+    })
+  }
+})

--- a/src/__tests__/main-agent-channels-link.test.ts
+++ b/src/__tests__/main-agent-channels-link.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { mainAgentChannelsLinkTarget } from '../web/agent-process.js'
+
+// hu: Az izolalt CLAUDE_CONFIG_DIR-t a fo ugynok MINDEN indulasakor ujragyartja
+//     (provisionIsolatedConfigDir): minden ~/.claude bejegyzest symlinkel, a
+//     'channels'-t is. Emiatt egy kezzel szetvalasztott csatorna-konyvtar az
+//     elso ujraindulasnal visszaallt a KOZOS ~/.claude/channels-re, es a ket
+//     telepites megint egy .env-en/bot.pid-en osztozott.
+//
+//     A javitas: ha letezik a telepiteshez tartozo <provider>-<agentId>
+//     konyvtar, a 'channels/<provider>' arra mutasson. Ha NEM letezik, maradjon
+//     a regi globalis symlink -- kulonben egy meglevo telepites a frissites utan
+//     egy URES konyvtarba nezne, nem talalna a bot-tokent, es NEMA maradna.
+// en: The isolated config dir is re-provisioned on every main-agent start and
+//     symlinks 'channels' to the shared ~/.claude/channels, which undid any
+//     manual per-install split. Switch to <provider>-<agentId> only when that
+//     directory already exists; otherwise keep the global link so an existing
+//     install never loses its bot token.
+describe('mainAgentChannelsLinkTarget', () => {
+  const CH = join(homedir(), '.claude', 'channels')
+
+  it('a telepiteshez tartozo konyvtarra mutat, ha az letezik', () => {
+    const target = join(CH, 'telegram-marveen')
+    expect(mainAgentChannelsLinkTarget('telegram', 'marveen', (p) => p === target)).toBe(target)
+  })
+
+  it('ket telepites ket kulon celt kap', () => {
+    const m = join(CH, 'telegram-marveen')
+    const j = join(CH, 'telegram-jarvis')
+    const both = (p: string) => p === m || p === j
+    expect(mainAgentChannelsLinkTarget('telegram', 'marveen', both)).toBe(m)
+    expect(mainAgentChannelsLinkTarget('telegram', 'jarvis', both)).toBe(j)
+  })
+
+  // A LENYEGI NEGATIV ESET: konyvtar nelkul NEM szabad ratolni a linket egy nem
+  // letezo utra -- az a meglevo telepitesek bot-tokenjet vagna el.
+  it('null, ha a konyvtar meg nem letezik -- marad a globalis symlink', () => {
+    expect(mainAgentChannelsLinkTarget('telegram', 'marveen', () => false)).toBeNull()
+  })
+
+  it('providerenkent kulon konyvtar', () => {
+    const s = join(CH, 'slack-marveen')
+    expect(mainAgentChannelsLinkTarget('slack', 'marveen', (p) => p === s)).toBe(s)
+  })
+
+  it('ures agentId eseten nem talal ki nevet', () => {
+    expect(mainAgentChannelsLinkTarget('telegram', '', () => true)).toBeNull()
+  })
+})

--- a/src/channel-provider.ts
+++ b/src/channel-provider.ts
@@ -595,16 +595,64 @@ export function getProviderType(envValue: string | undefined): ChannelProviderTy
   return 'telegram'
 }
 
+/**
+ * hu: A fo ugynok csatorna-allapotat felulbiralo env-valtozo providerenkent.
+ *     Ugyanaz a nev, amit a csatorna-plugin maga is elsobbseggel olvas
+ *     (server.ts: TELEGRAM_STATE_DIR ?? CLAUDE_CONFIG_DIR/channels/telegram),
+ *     igy a plugin es a dashboard ugyanoda mutat.
+ * <br />
+ * en: Per-provider env override for the MAIN agent's channel state dir. Same
+ *     name the channel plugin itself reads with priority, so plugin and
+ *     dashboard resolve to one and the same directory.
+ */
+const CMainStateDirEnvVar: Record<ChannelProviderType, string> = {
+  telegram: 'TELEGRAM_STATE_DIR',
+  slack: 'SLACK_STATE_DIR',
+  discord: 'DISCORD_STATE_DIR',
+  googlechat: 'GOOGLECHAT_STATE_DIR',
+  teams: 'TEAMS_STATE_DIR',
+}
+
+/**
+ * hu: Egy csatorna allapot-konyvtara. Sub-agentnel az agentDir dont; a FO
+ *     ugynoknel a providerenkenti STATE_DIR env, ha be van allitva, kulonben a
+ *     globalis ~/.claude/channels/<provider>.
+ *
+ *     Miert kell az env-ag: egy gepen tobb telepites is futhat (kulon WEB_PORT,
+ *     kulon bot). A fix globalis ut miatt ket telepites fo ugynoke UGYANAZT a
+ *     .env-t, bot.pid-et es access.json-t hasznalta -- a masodik telepito
+ *     felulirta az elso bot-tokenjet, a plugin orphan-killere pedig a kozos
+ *     bot.pid alapjan kiloette a masik telepites polleret (kolcsonos restart-ciklus).
+ *
+ *     Az env a SUB-AGENT agat SZANDEKOSAN nem birlja felul: a dashboard a fo
+ *     session kornyezetebol orokli a valtozot, es ugyanaz a folyamat szamolja a
+ *     fejek utjat is -- felulbiralva minden fej egyetlen konyvtarba omlana.
+ * <br />
+ * en: A channel's state directory. For a sub-agent the agentDir decides; for the
+ *     MAIN agent the per-provider STATE_DIR env wins when set, else the global
+ *     ~/.claude/channels/<provider>. The env deliberately does NOT override the
+ *     sub-agent branch: the dashboard inherits it from the main session, and the
+ *     same process resolves every agent's path -- overriding would collapse the
+ *     whole fleet into one directory.
+ */
 export function channelStateDir(provider: ChannelProviderType, agentDir?: string): string {
-  const base = agentDir
-    ? join(agentDir, '.claude', 'channels')
-    : join(homedir(), '.claude', 'channels')
   const subdir =
     provider === 'slack' ? 'slack'
     : provider === 'discord' ? 'discord'
     : provider === 'googlechat' ? 'googlechat'
     : provider === 'teams' ? 'teams'
     : 'telegram'
+
+  if (!agentDir) {
+    const override = process.env[CMainStateDirEnvVar[provider]]?.trim()
+
+    if (override) return override
+  }
+
+  const base = agentDir
+    ? join(agentDir, '.claude', 'channels')
+    : join(homedir(), '.claude', 'channels')
+
   return join(base, subdir)
 }
 

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -292,6 +292,34 @@ function maybeAlertSharedConfigCollision(name: string): void {
 // falls back to the shared ~/.claude (degraded, but never a launch failure).
 const ISOLATED_CONFIG_SKIP = new Set(['settings.json', 'plugins', '.credentials.json'])
 
+/**
+ * hu: A FO ugynok csatorna-allapot konyvtaranak celja az izolalt config dirben.
+ *     Egy gepen tobb telepites is futhat, ezert a cel telepitesenkent kulon:
+ *     ~/.claude/channels/<provider>-<agentId> (ugyanaz a nevkonvencio, amit a
+ *     voice-directive.ts is ismer).
+ *
+ *     null-t ad, ha a konyvtar MEG NEM letezik -- ilyenkor a hivo a korabbi
+ *     globalis ~/.claude/channels symlinket hagyja meg. Enelkul egy meglevo
+ *     telepites a frissites utan egy URES konyvtarba nezne, nem talalna a
+ *     bot-tokent, es a csatorna NEMA maradna.
+ * <br />
+ * en: Target for the MAIN agent's channel state inside the isolated config dir,
+ *     per install: ~/.claude/channels/<provider>-<agentId>. Returns null while
+ *     that directory does not exist yet, so an existing install keeps the global
+ *     link instead of pointing at an empty dir and losing its bot token.
+ */
+export function mainAgentChannelsLinkTarget(
+  provider: ChannelProviderType,
+  agentId: string,
+  existsFn: (path: string) => boolean = existsSync,
+): string | null {
+  if (!agentId) return null
+
+  const target = join(homedir(), '.claude', 'channels', `${provider}-${agentId}`)
+
+  return existsFn(target) ? target : null
+}
+
 export function ensureIsolatedChannelConfigDir(
   name: string,
   // null = channel-less agent: provision the isolated dir with EVERY channel
@@ -346,6 +374,7 @@ export function ensureMainAgentIsolatedConfigDir(
     PROJECT_ROOT,
     getProviderType(provider),
     MAIN_AGENT_ID,
+    true,
   )
 }
 
@@ -457,6 +486,9 @@ function provisionIsolatedConfigDir(
   cwd: string,
   providerType: ChannelProviderType | null,
   name: string,
+  // hu: true CSAK a fo ugynokre -- a csatorna-allapot telepitesenkenti kotese
+  //     ra vonatkozik. en: true for the MAIN agent only.
+  isMain = false,
 ): string | null {
   try {
     const realClaude = join(homedir(), '.claude')
@@ -468,6 +500,34 @@ function provisionIsolatedConfigDir(
     //    stale non-symlink (e.g. a prior copy, or a .credentials.json left by an
     //    earlier build) is removed so it can never shadow the env-var auth.
     for (const entry of readdirSync(realClaude)) {
+      // A fo ugynok csatorna-allapota telepitesenkent kulon konyvtar, ha az mar
+      // letezik. A globalis symlink itt azert veszelyes, mert ez a provisioning
+      // MINDEN indulaskor lefut -- egy kezzel szetvalasztott allapotot
+      // visszaallitana a kozosre, es a ket telepites ismet egy .env-en es egy
+      // bot.pid-en osztozna (kolcsonos orphan-kill + watchdog restart-ciklus).
+      // A sub-agentek nem ide tartoznak: ok a spawn-kori TELEGRAM_STATE_DIR
+      // env-bol dolgoznak (lasd agent-process spawn), a symlink naluk kozombos.
+      if (entry === 'channels' && isMain && providerType) {
+        const chanTarget = mainAgentChannelsLinkTarget(providerType, name)
+
+        if (chanTarget) {
+          const chanDir = join(cfg, entry)
+          try {
+            if (lstatSync(chanDir).isSymbolicLink()) rmSync(chanDir, { force: true })
+          } catch { /* absent -> create */ }
+          mkdirSync(chanDir, { recursive: true })
+          const provLink = join(chanDir, providerType)
+          let ok = false
+          try { ok = lstatSync(provLink).isSymbolicLink() && realpathSync(provLink) === chanTarget }
+          catch { /* absent or broken -> relink */ }
+          if (!ok) {
+            try { rmSync(provLink, { recursive: true, force: true }) } catch { /* absent */ }
+            try { symlinkSync(chanTarget, provLink) }
+            catch (err) { logger.warn({ err, name, chanTarget }, 'isolated-config: per-install channels symlink failed') }
+          }
+          continue
+        }
+      }
       if (ISOLATED_CONFIG_SKIP.has(entry)) {
         // Defensively drop a real .credentials.json that an older build may have
         // symlinked/copied here, so the env-var token is the only auth source.

--- a/src/web/telegram.ts
+++ b/src/web/telegram.ts
@@ -1,12 +1,12 @@
 import { readFileSync, existsSync } from 'node:fs'
 import { join } from 'node:path'
-import { homedir } from 'node:os'
 import { PROJECT_ROOT } from '../config.js'
 import { resolveOwnerChatId } from '../owner-chat.js'
 import { logger } from '../logger.js'
 import { agentDir, readFileOr, findAvatarForAgent } from './agent-config.js'
 import { TOOL_TIMEOUTS } from '../tool-timeouts.js'
 import { markIfTestRun } from '../test-run-marker.js'
+import { channelStateDir } from '../channel-provider.js'
 
 export function readAgentTelegramConfig(name: string): { hasTelegram: boolean; botUsername?: string } {
   const envPath = join(agentDir(name), '.claude', 'channels', 'telegram', '.env')
@@ -54,11 +54,14 @@ export function readAgentTeamsConfig(name: string): { hasTeams: boolean } {
   return { hasTeams: !!m?.[1]?.trim() }
 }
 
-// Marveen's Telegram channel lives under the global ~/.claude path, not
-// under agents/marveen, because the main agent reuses the system Claude
-// Code channel install. Read it the same way the plugin does.
+// hu: A fo ugynok csatorna-allapota a channelStateDir() feloldasabol jon
+//     (<PROVIDER>_STATE_DIR > CLAUDE_CONFIG_DIR/channels/<p> > ~/.claude/...),
+//     ugyanugy, ahogy a plugin oldja fel -- igy egy gepen tobb telepites sem
+//     olvassa egymas bot-tokenjet.
+// en: Resolved via channelStateDir(), the same order the plugin uses, so two
+//     installs on one host never read each other's bot token.
 export function readMarveenTelegramConfig(): { hasTelegram: boolean; botUsername?: string } {
-  const envPath = join(homedir(), '.claude', 'channels', 'telegram', '.env')
+  const envPath = join(channelStateDir('telegram'), '.env')
   if (!existsSync(envPath)) return { hasTelegram: false }
   const content = readFileOr(envPath, '')
   const tokenMatch = content.match(/TELEGRAM_BOT_TOKEN=(.+)/)
@@ -67,34 +70,34 @@ export function readMarveenTelegramConfig(): { hasTelegram: boolean; botUsername
   return { hasTelegram: true, botUsername: marveenBotUsernameCache.value }
 }
 
-// Discord / Slack mirror of the above: same global ~/.claude/channels path
-// since Marveen's channel session reuses the system install. Lets the
+// Discord / Slack mirror of the above: same channelStateDir() resolution.
+// Lets the
 // dashboard answer "is Marveen connected?" per provider without per-agent
 // state lookup. botUsername omitted -- the Discord/Slack flows don't
 // surface a @username the same way Telegram does.
 export function readMarveenDiscordConfig(): { hasDiscord: boolean } {
-  const envPath = join(homedir(), '.claude', 'channels', 'discord', '.env')
+  const envPath = join(channelStateDir('discord'), '.env')
   if (!existsSync(envPath)) return { hasDiscord: false }
   const tokenMatch = readFileOr(envPath, '').match(/DISCORD_BOT_TOKEN=(.+)/)
   return { hasDiscord: !!tokenMatch?.[1]?.trim() }
 }
 
 export function readMarveenGooglechatConfig(): { hasGooglechat: boolean } {
-  const envPath = join(homedir(), '.claude', 'channels', 'googlechat', '.env')
+  const envPath = join(channelStateDir('googlechat'), '.env')
   if (!existsSync(envPath)) return { hasGooglechat: false }
   const m = readFileOr(envPath, '').match(/GOOGLECHAT_PROJECT_ID=(.+)/)
   return { hasGooglechat: !!m?.[1]?.trim() }
 }
 
 export function readMarveenTeamsConfig(): { hasTeams: boolean } {
-  const envPath = join(homedir(), '.claude', 'channels', 'teams', '.env')
+  const envPath = join(channelStateDir('teams'), '.env')
   if (!existsSync(envPath)) return { hasTeams: false }
   const m = readFileOr(envPath, '').match(/TEAMS_BOT_APP_ID=(.+)/)
   return { hasTeams: !!m?.[1]?.trim() }
 }
 
 export function readMarveenSlackConfig(): { hasSlack: boolean } {
-  const envPath = join(homedir(), '.claude', 'channels', 'slack', '.env')
+  const envPath = join(channelStateDir('slack'), '.env')
   if (!existsSync(envPath)) return { hasSlack: false }
   const tokenMatch = readFileOr(envPath, '').match(/SLACK_BOT_TOKEN=(.+)/)
   return { hasSlack: !!tokenMatch?.[1]?.trim() }
@@ -104,7 +107,7 @@ export function readMarveenSlackConfig(): { hasSlack: boolean } {
 export const marveenBotUsernameCache: { value?: string; fetchedAt: number } = { fetchedAt: 0 }
 
 export async function refreshMarveenBotUsername(): Promise<void> {
-  const envPath = join(homedir(), '.claude', 'channels', 'telegram', '.env')
+  const envPath = join(channelStateDir('telegram'), '.env')
   if (!existsSync(envPath)) return
   const tokenMatch = readFileOr(envPath, '').match(/TELEGRAM_BOT_TOKEN=(.+)/)
   const token = tokenMatch?.[1]?.trim()


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [x] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

**HU** — Két Marveen-telepítés egy gépen (külön `WEB_PORT`, külön bot) elnémítja egymást, mert a **fő ágens** csatorna-állapota fix `~/.claude/channels/<provider>` úton él: egy `.env` (bot-token), egy `bot.pid`, egy `access.json`, egy `inbox` szolgálja ki mindkettőt. A sub-ágensek már ma is példány-specifikus `TELEGRAM_STATE_DIR`-t kapnak — csak a fő ágens maradt ki ebből.

Mérve egy éles gépen:

- a második telepítő felülírta az első **bot-tokenjét** → az első bot senkit nem szolgált ki, miközben a fő ágense a másik bot nevében jelentkezett be;
- a második telepítő felülírta az **`access.json`-t** (`groups: {}`) → a munkacsoportból érkező üzenetek egy csapásra eldobódtak (a plugin ismeretlen csoportot csendben dob), 99 korábban kézbesített üzenet után;
- a két poller a **közös `bot.pid`** alapján kilőtte egymást (a plugin orphan-killere jogosan: egy tokenre a Telegram egy `getUpdates` fogyasztót enged), amit a `channels.sh` watchdog 180 másodperces restart-ciklusa követett.

Négy réteg javítva, mindenhol **a korábbi viselkedés az alapértelmezés**:

| Réteg | Változás |
|---|---|
| `src/web/agent-process.ts` | A fő ágens izolált config-dirjében a `channels` nem a közös `~/.claude/channels`-re linkel, hanem a `<provider>-<agentId>` könyvtárra, **ha az már létezik**. Enélkül a provisioning minden induláskor visszaállította a közös állapotot — egy kézi szétválasztás az első újraindításnál elveszett. |
| `src/channel-provider.ts` | `channelStateDir()` a **fő** ágensre figyelembe veszi a `<PROVIDER>_STATE_DIR` env-et. A sub-ágens ág szándékosan változatlan: a dashboard ugyanabban a folyamatban számolja a fejek útját is, felülbírálva az egész flotta egy könyvtárba omlana. |
| `scripts/channels.sh` | A watchdog `bot.pid`-je és az orphan-reap célja a plugin saját feloldási sorrendjét követi, nem fix `$HOME` utat (a reap célja eddig egy nem létező `$INSTALL_DIR/.claude/channels` út volt, tehát sosem talált semmit). |
| `install-macos.sh`, `install-linux.sh` | A csatorna-könyvtár telepítésenként külön, és a **meglévő `access.json` nem íródik felül** — az a párosításokat és a jóváhagyott csoportokat hordozza. Ez önmagában is hibajavítás: eddig egy sima újratelepítés is elnémította a már működő csoportokat, második telepítés nélkül. |

A testvér-olvasók (`telegram.ts` 6 út, `schedule-runner.ts`, `set-bot-menu.sh`) is a feloldáson mennek át, különben a szétválasztás után is a másik telepítés tokenjét olvasták volna.

**Feloldási sorrend** (a plugin `server.ts`-ét tükrözi, így plugin/dashboard/watchdog ugyanoda mutat):
`<PROVIDER>_STATE_DIR` → `CLAUDE_CONFIG_DIR/channels/<provider>` → `~/.claude/channels/<provider>`

**Visszafelé kompatibilitás.** Egytelepítéses gépen semmi nem változik: a per-install könyvtárra csak akkor vált, ha az már létezik, a telepítő agent-azonosító nélkül a régi utat adja, és a `channelStateDir()` env nélkül a régi alapértelmezést.

**EN** — Two installs on one host silently break each other: the **main** agent's channel state lives at a fixed `~/.claude/channels/<provider>`, so one `.env`, one `bot.pid`, one `access.json` and one `inbox` serve both. Measured on a live host: the second install took over the first one's bot token, wiped its `access.json` groups (group messages then dropped silently), and the two pollers killed each other through the shared `bot.pid`, followed by a 180s watchdog restart loop. Sub-agents already get a per-instance `TELEGRAM_STATE_DIR`; only the main agent was left out.

Fixed in four layers — isolated-config provisioning, `channelStateDir()`, the `channels.sh` watchdog, and both installers (which additionally must never overwrite an existing `access.json`) — each keeping the previous behaviour as its default, plus the sibling readers that would otherwise still read the other install's token.

## Kapcsolódó issue / Related issue

<!-- Nincs kapcsolódó upstream issue. / No related upstream issue. -->

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [x] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).

**Teszt-hatókör, őszintén / Test scope, honestly:**

- **Automata:** 36 új teszt 5 fájlban (TDD, mindegyik bizonyított RED → GREEN). A négy rétegen kívül lefedi a lényegi negatív eseteket is: az env **nem** bírálja felül a sub-ágens ágat; a per-install link `null`-t ad, amíg a könyvtár nem létezik (különben egy meglévő telepítés üres könyvtárba nézne és elvesztené a tokenjét); a telepítő nem írja felül a meglévő `access.json`-t. Teljes készlet: **4382 zöld**.
- **Egy teszt bukik ezen a fejlesztői gépen, a változtatástól függetlenül:** `send-honesty-final.test.ts` — a setupja `git init -b`-t hív, ami git 2.28+ igényel; itt a git 2.23.0. Ugyanígy bukik a PR alapjául szolgáló, változtatás nélküli commiton is (visszamérve). CI-ben friss gittel ez nem jelentkezik.
- **Éles:** két telepítés ugyanazon a gépen, külön bot, külön port. A szétválasztás után két külön poller-PID, két külön könyvtár, két külön token; a restart-ciklus megszűnt (két teljes 180s-os ablakon át egyetlen új WARN sem), és a munkacsoportból érkező üzenet hat perccel a javítás után újra kézbesítődött.
- **Nem teszteltem:** Slack/Discord/Teams/Google Chat providereken csak a kód-út közös, élő próba nem történt. A Linux-telepítő változása statikus teszttel fedett, éles Linux-telepítés nem futott.

## Titok-kapu / Secret gate

- [x] Nincs a valtoztatasban bizonyitek-/artefaktum-mappa, titok-alaku string vagy idezett csatorna-uzenet. / No evidence or artifact directory, secret-shaped string, or quoted channel message in this change.
