### PR TITLE
fix(stuck-input): compare the parked box with whitespace removed, not…

### DIFF
--- a/src/__tests__/injected-prompt-registry.test.ts
+++ b/src/__tests__/injected-prompt-registry.test.ts
@@ -98,6 +98,26 @@ describe('matchesInjectedPrompt (the safety gate)', () => {
     expect(matchesInjectedPrompt(wrapped, rec)).toBe(true)
   })
 
+  it('matches when the wrap broke INSIDE a word (fixed-column terminal)', () => {
+    // A terminal wraps at a column, not at a word boundary, so the scrape can
+    // read "...the cont ent as suspicious..." where the source has "content".
+    // Collapsing whitespace leaves a space the original never had, so a
+    // collapse-only comparison rejects text that IS ours.
+    recordInjectedPrompt('agent-cortex-router', INJECTED, 1_000)
+    const rec = getInjectedPrompt('agent-cortex-router', 1_000)
+    const midWordBreak = HEAD_LOST_SCRAPE.replace('suspicious', 'suspic\nious')
+    expect(matchesInjectedPrompt(midWordBreak, rec)).toBe(true)
+  })
+
+  it('still REFUSES a human draft once whitespace is ignored', () => {
+    // Negative control for the change above: dropping whitespace must not make
+    // the gate permissive. An unrelated draft stays rejected.
+    recordInjectedPrompt('agent-cortex-router', INJECTED, 1_000)
+    const rec = getInjectedPrompt('agent-cortex-router', 1_000)
+    const draft = 'k e r l e k nezd meg a Nettrade ugyfelnel a tegnapi jegyet es irj ossze egy valaszt'
+    expect(matchesInjectedPrompt(draft, rec)).toBe(false)
+  })
+
   it('REFUSES a human draft that we never typed', () => {
     recordInjectedPrompt('agent-cortex-router', INJECTED, 1_000)
     const rec = getInjectedPrompt('agent-cortex-router', 1_000)

--- a/src/web/injected-prompt-registry.ts
+++ b/src/web/injected-prompt-registry.ts
@@ -46,6 +46,23 @@ export function normalizeForMatch(text: string): string {
 }
 
 /**
+ * Drop whitespace entirely, for the substring identity test only.
+ *
+ * Collapsing is not enough: a terminal wraps at a fixed column, so it can break
+ * INSIDE a word. The scrape then reads "...the categ ory field..." where the
+ * source has "category", and collapsing leaves a space the original never had,
+ * so `includes` fails on text that IS ours. Removing whitespace on both sides
+ * makes the comparison blind to where the wrap fell.
+ *
+ * This does not loosen the guard against clearing a human draft: the fragment
+ * still has to appear verbatim, character for character, inside something this
+ * process injected into that same pane within the retention window.
+ */
+export function squashForMatch(text: string): string {
+  return text.replace(/\s+/g, '')
+}
+
+/**
  * Remember what was typed into a pane. Called from the single choke point every
  * machine delivery goes through, so scheduled ticks, inter-agent messages and
  * context-guard prompts are all covered, not just the router.
@@ -86,16 +103,18 @@ export function getInjectedPrompt(session: string, now: number = Date.now()): In
  *
  * The scrape may be missing its head (overfull box) or its tail (narrow pane),
  * so a substring test in either direction is the honest check; an equality test
- * would reject exactly the case this exists for.
+ * would reject exactly the case this exists for. It may also be broken MID-WORD
+ * by the wrap, which is why the comparison runs on the whitespace-free form.
  */
 export function matchesInjectedPrompt(parked: string | null, record: InjectedPromptRecord | null): boolean {
   if (parked == null || record == null) return false
-  const a = normalizeForMatch(parked)
-  const b = normalizeForMatch(record.text)
+  const a = squashForMatch(parked)
+  const b = squashForMatch(record.text)
   if (a.length === 0 || b.length === 0) return false
   // A very short fragment is not evidence: "the" appears in every message. The
   // floor is well under the shortest real inter-agent frame (the security
-  // preamble alone is ~700 chars) but high enough to exclude noise.
+  // preamble alone is ~700 chars) but high enough to exclude noise. Counted on
+  // the whitespace-free form, so it is 24 real characters, not 24 columns.
   if (a.length < 24) return false
   return b.includes(a) || a.includes(b)
 }


### PR DESCRIPTION
… collapsed

matchesInjectedPrompt normalised both sides by collapsing whitespace runs to a single space. That is enough for a wrap that falls on a word boundary, but a terminal wraps at a COLUMN, so it can break inside a word: the scrape reads "...the content as suspic ious..." where the recorded text has "suspicious". Collapsing leaves a space the source never had, `includes` fails, and the gate rejects text that this process demonstrably typed into that pane -- the exact case the registry exists to catch.

Removing whitespace on both sides makes the comparison blind to where the wrap fell. It does not loosen the guard: the fragment must still appear verbatim, character for character, inside something injected into that same pane within the retention window, and the 24-character floor now counts real characters rather than columns.

Measured: the added mid-word test fails on the current implementation and passes with the change; the existing head-lost, extra-whitespace, human-draft, short-fragment, no-record and empty-box cases are unaffected. A second new test is the negative control -- an unrelated draft with spaces sprinkled through it stays rejected, so the looser normalisation cannot be mistaken for a looser gate. 35 tests green across the registry and parked-machine-input suites, tsc --noEmit clean.

<!--
  HU + EN. Töltsd ki minden szakaszt. / Fill in every section.
  A jelölőnégyzeteket így pipáld: [x]  /  Tick a box like this: [x]
-->

## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

<!-- HU: Foglald össze, milyen problémát old meg a PR és milyen technikai megközelítést alkalmaztál.
     EN: Summarize what problem this PR solves and the technical approach you took. -->

## Kapcsolódó issue / Related issue

Closes #

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [ ] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [ ] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).

## Titok-kapu / Secret gate

A `secret-gate` CI-job a valodi kapu. A lokalis pre-commit hook csak gyors
elorejelzes, es `--no-verify`-jal megkerulheto -- ne tekintsd elegnek.
The `secret-gate` CI job is the real gate; the local pre-commit hook is a fast
preview and can be skipped with `--no-verify`, so it is not sufficient on its own.

- [x] Nincs a valtoztatasban bizonyitek-/artefaktum-mappa, titok-alaku string vagy idezett csatorna-uzenet.
      / No evidence or artifact directory, secret-shaped string, or quoted channel message in this change.
