### PR TITLE
fix(first-run): answer the folder-trust dialog from the pane, not by number (TRUSTGATE901)

### DIFF
--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -679,7 +679,16 @@ $TMUX new-session -d -s "$SESSION" -c "$INSTALL_DIR" \
 # soha nem toltodne be. Tobb fajta dialog elofordulhat:
 #  - "Bypass Permissions mode" (--dangerously-skip-permissions confirmation,
 #    valasz: 2 Enter = "Yes, I accept")
-#  - "Do you trust the files in this folder?" / "trust" prompts (Y Enter)
+#  - a folder-trust dialogus (valasz: 1 Enter). KET szoveget kell nezni, mert
+#    a Claude Code 2.1.246 atirta a panelt: a regi kerdes ("Do you trust the
+#    files in this folder?") ELTUNT, az uj panel a "Quick safety check: ..."
+#    mondattal kezdodik es az opcio szovege "Yes, I trust this folder".
+#    A HORGONY az OPCIO-SZOVEG, mert az a funkcionalis elem; a folotte levo
+#    mondat az, amit a szallito atir (epp most tette). A regi kerdes marad a
+#    regebbi CLI-verziok miatt -- a regi panel opcioja "Yes, proceed" volt,
+#    tehat egyik string sem fedi le onmagaban mindket verziot. (TRUSTGATE901)
+#    FIGYELEM: az uj panel NEM tartalmazza a "Welcome to Claude Code" bannert,
+#    tehat a lenti welcome-ag sem kapta el -- a session csendben parkolt.
 #  - "Welcome to Claude Code" / kezdo vezetes (Enter a folytatashoz)
 # 12 sec timeout ket retry-jal, mert WSL/tmux paint slow lehet first-run-on.
 #
@@ -723,7 +732,7 @@ for i in 1 2 3 4 5 6 7 8 9 10 11 12; do
       sleep 1
       continue
       ;;
-    *"Do you trust the files in this folder?"*)
+    *"Do you trust the files in this folder?"*|*"Yes, I trust this folder"*)
       $TMUX send-keys -t "$SESSION" "1" Enter
       sleep 1
       continue

--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -695,6 +695,30 @@ $TMUX new-session -d -s "$SESSION" -c "$INSTALL_DIR" \
 # EPERM fallback (Claude Code 2.1.183+ regression): launching --channels in a
 # trusted project directory throws EPERM before any dialog appears. Detected
 # below; one auto-restart from /tmp where the trust dialog fires instead.
+# TRUSTGATE901: NEM szamra es NEM alapertelmezesre. A 2.1.252 eldobta az
+# "1."/"2." szamozast (a "1" igy semmit nem valaszt) ES a "No, exit" lett
+# az elso, kijelolt opcio -- a regi "1" + Enter tehat AKTIVAN a kilepest
+# valasztotta egy friss telepitesen. A valaszt a pane-bol olvassuk ki:
+# ha a kurzor sora maga a "yes", eleg a megerosites; ha a KOZVETLENUL
+# alatta levo sor az, egyet lepunk le. Barmi mas alaknal NEM nyomunk
+# semmit -- se Entert, se Escape-et: ezen a panelen egyik sem semleges
+# (az Escape maga a "No, exit"), tehat a nem-cselekves a helyes.
+# Ugyanez a kockazat all a bypass-panelre: ott is a "No, exit" az elso opcio.
+_answer_accept_dialog() {
+  _cur=$(printf '%s\n' "$1" | grep -n "❯" | head -1 | cut -d: -f1)
+  _yes=$(printf '%s\n' "$1" | grep -n "Yes" | grep -v "No, exit" | head -1 | cut -d: -f1)
+  if [ -n "$_cur" ] && [ -n "$_yes" ] && [ "$_yes" = "$_cur" ]; then
+    $TMUX send-keys -t "$SESSION" Enter
+  elif [ -n "$_cur" ] && [ -n "$_yes" ] && [ "$_yes" = "$((_cur + 1))" ]; then
+    $TMUX send-keys -t "$SESSION" Down
+    sleep 1
+    $TMUX send-keys -t "$SESSION" Enter
+  else
+    echo "channels.sh: elfogado dialogus ismeretlen alakban -- nem kuldok billentyut (TRUSTGATE901)" >&2
+  fi
+  unset _cur _yes
+}
+
 _eperm_restarted=0
 for i in 1 2 3 4 5 6 7 8 9 10 11 12; do
   sleep 1
@@ -728,31 +752,12 @@ for i in 1 2 3 4 5 6 7 8 9 10 11 12; do
       continue
       ;;
     *"Bypass Permissions mode"*"Yes, I accept"*)
-      $TMUX send-keys -t "$SESSION" "2" Enter
+      _answer_accept_dialog "$pane"
       sleep 1
       continue
       ;;
     *"Do you trust the files in this folder?"*|*"Yes, I trust this folder"*)
-      # TRUSTGATE901: NEM szamra es NEM alapertelmezesre. A 2.1.252 eldobta az
-      # "1."/"2." szamozast (a "1" igy semmit nem valaszt) ES a "No, exit" lett
-      # az elso, kijelolt opcio -- a regi "1" + Enter tehat AKTIVAN a kilepest
-      # valasztotta egy friss telepitesen. A valaszt a pane-bol olvassuk ki:
-      # ha a kurzor sora maga a "yes", eleg a megerosites; ha a KOZVETLENUL
-      # alatta levo sor az, egyet lepunk le. Barmi mas alaknal NEM nyomunk
-      # semmit -- se Entert, se Escape-et: ezen a panelen egyik sem semleges
-      # (az Escape maga a "No, exit"), tehat a nem-cselekves a helyes.
-      _cur=$(printf '%s\n' "$pane" | grep -n "❯" | head -1 | cut -d: -f1)
-      _yes=$(printf '%s\n' "$pane" | grep -n "Yes" | grep -v "No, exit" | head -1 | cut -d: -f1)
-      if [ -n "$_cur" ] && [ -n "$_yes" ] && [ "$_yes" = "$_cur" ]; then
-        $TMUX send-keys -t "$SESSION" Enter
-      elif [ -n "$_cur" ] && [ -n "$_yes" ] && [ "$_yes" = "$((_cur + 1))" ]; then
-        $TMUX send-keys -t "$SESSION" Down
-        sleep 1
-        $TMUX send-keys -t "$SESSION" Enter
-      else
-        echo "channels.sh: a folder-trust dialogus alakja ismeretlen -- nem kuldok billentyut (TRUSTGATE901)" >&2
-      fi
-      unset _cur _yes
+      _answer_accept_dialog "$pane"
       sleep 1
       continue
       ;;

--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -733,7 +733,26 @@ for i in 1 2 3 4 5 6 7 8 9 10 11 12; do
       continue
       ;;
     *"Do you trust the files in this folder?"*|*"Yes, I trust this folder"*)
-      $TMUX send-keys -t "$SESSION" "1" Enter
+      # TRUSTGATE901: NEM szamra es NEM alapertelmezesre. A 2.1.252 eldobta az
+      # "1."/"2." szamozast (a "1" igy semmit nem valaszt) ES a "No, exit" lett
+      # az elso, kijelolt opcio -- a regi "1" + Enter tehat AKTIVAN a kilepest
+      # valasztotta egy friss telepitesen. A valaszt a pane-bol olvassuk ki:
+      # ha a kurzor sora maga a "yes", eleg a megerosites; ha a KOZVETLENUL
+      # alatta levo sor az, egyet lepunk le. Barmi mas alaknal NEM nyomunk
+      # semmit -- se Entert, se Escape-et: ezen a panelen egyik sem semleges
+      # (az Escape maga a "No, exit"), tehat a nem-cselekves a helyes.
+      _cur=$(printf '%s\n' "$pane" | grep -n "❯" | head -1 | cut -d: -f1)
+      _yes=$(printf '%s\n' "$pane" | grep -n "Yes" | grep -v "No, exit" | head -1 | cut -d: -f1)
+      if [ -n "$_cur" ] && [ -n "$_yes" ] && [ "$_yes" = "$_cur" ]; then
+        $TMUX send-keys -t "$SESSION" Enter
+      elif [ -n "$_cur" ] && [ -n "$_yes" ] && [ "$_yes" = "$((_cur + 1))" ]; then
+        $TMUX send-keys -t "$SESSION" Down
+        sleep 1
+        $TMUX send-keys -t "$SESSION" Enter
+      else
+        echo "channels.sh: a folder-trust dialogus alakja ismeretlen -- nem kuldok billentyut (TRUSTGATE901)" >&2
+      fi
+      unset _cur _yes
       sleep 1
       continue
       ;;

--- a/src/__tests__/pane-first-run-gate.test.ts
+++ b/src/__tests__/pane-first-run-gate.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
-import { detectsFirstRunGate, detectPaneState, detectsBlockingMenu, trustDialogAnswerKeys } from '../pane-state.js'
+import { detectsFirstRunGate, detectPaneState, detectsBlockingMenu, firstRunAcceptKeys } from '../pane-state.js'
 
 // Fresh-install first-run gate detection (card 5F37BB84, Oligo2000 VPS
 // 2026-07-22). A sub-agent session parked on a Claude Code first-run dialog
@@ -318,36 +318,61 @@ describe('first-run gate wiring contracts', () => {
   })
 })
 
-describe('trustDialogAnswerKeys (TRUSTGATE901)', () => {
+describe('firstRunAcceptKeys (TRUSTGATE901)', () => {
   // Numbered, "Yes" first and already highlighted -> confirm where we are.
   it('2.1.246 layout: the cursor already sits on yes, so just confirm', () => {
-    expect(trustDialogAnswerKeys(TRUST_PANE_2_1_246)).toEqual(['Enter'])
+    expect(firstRunAcceptKeys(TRUST_PANE_2_1_246)).toEqual(['Enter'])
   })
 
   // Unnumbered, "No, exit" first AND highlighted -> move down, then confirm.
   // This is the regression that quit a fresh install.
   it('2.1.252 layout: moves the selection onto yes before confirming', () => {
-    expect(trustDialogAnswerKeys(TRUST_PANE_2_1_252)).toEqual(['Down', 'Enter'])
+    expect(firstRunAcceptKeys(TRUST_PANE_2_1_252)).toEqual(['Down', 'Enter'])
   })
 
   // The discriminating assertion: a naive "always Enter" answer -- which is
   // what the old code effectively did after typing a number that no longer
   // selects anything -- is WRONG here, and this fixture is what proves it.
   it('2.1.252 layout: a bare Enter would confirm "No, exit"', () => {
-    expect(trustDialogAnswerKeys(TRUST_PANE_2_1_252)).not.toEqual(['Enter'])
+    expect(firstRunAcceptKeys(TRUST_PANE_2_1_252)).not.toEqual(['Enter'])
   })
 
   it('the older boxed dialog still resolves to a plain confirm', () => {
-    expect(trustDialogAnswerKeys(TRUST_PANE)).toEqual(['Enter'])
+    expect(firstRunAcceptKeys(TRUST_PANE)).toEqual(['Enter'])
   })
 
   // Not-acting is the correct answer on an unmodelled layout: Escape is
   // "No, exit" by the dialog's own footer and Enter confirms the highlight.
   it('returns null when no unambiguous yes option exists (park, send nothing)', () => {
-    expect(trustDialogAnswerKeys(TRUST_PANE_UNKNOWN_SHAPE)).toBeNull()
+    expect(firstRunAcceptKeys(TRUST_PANE_UNKNOWN_SHAPE)).toBeNull()
   })
 
   it('returns null on a pane with no selection cursor at all', () => {
-    expect(trustDialogAnswerKeys(ORDINARY_PANE.replace('❯', ' '))).toBeNull()
+    expect(firstRunAcceptKeys(ORDINARY_PANE.replace('❯', ' '))).toBeNull()
+  })
+
+  // The bypass-permissions dialog answered by the SAME rule. Its accept row is
+  // second, behind a first and highlighted "No, exit" -- the identical shape
+  // that made the trust dialog dangerous once the numbering disappeared.
+  it('bypass dialog: moves onto the accept row instead of typing its number', () => {
+    expect(firstRunAcceptKeys(BYPASS_PANE)).toEqual(['Down', 'Enter'])
+  })
+
+  // HYPOTHETICAL, and labelled as such: this layout was NOT captured from any
+  // release. It exists to prove the rule does not depend on the numbering,
+  // which is precisely what vanished from the trust dialog in 2.1.252. If the
+  // bypass panel ever loses its prefixes the same way, this is the behaviour
+  // we want -- and the old "type 2" answer would have selected nothing and
+  // then confirmed the refusal.
+  it('bypass dialog without numbering (hypothetical) still resolves correctly', () => {
+    const unnumbered = [
+      ' Bypass Permissions mode',
+      '',
+      ' ❯ No, exit',
+      '   Yes, I accept',
+      '',
+      ' Enter to confirm · Esc to cancel',
+    ].join('\n')
+    expect(firstRunAcceptKeys(unnumbered)).toEqual(['Down', 'Enter'])
   })
 })

--- a/src/__tests__/pane-first-run-gate.test.ts
+++ b/src/__tests__/pane-first-run-gate.test.ts
@@ -97,9 +97,86 @@ const BUSY_WITH_QUOTE_PANE = [
   ' Thinking… (12s · ↓ 1.2k tokens · esc to interrupt)',
 ].join('\n')
 
+// The SAME dialog as TRUST_PANE, as Claude Code 2.1.246 actually renders it --
+// captured live on 2026-09-01 from a `claude` started in a throwaway directory
+// (tmux capture-pane), not written from memory. Only the workspace path is
+// swapped for a generic one; every other line is verbatim, including the
+// unboxed layout, the marketing lead-in and the changed option text.
+//
+// Two things changed at once, which is why one string cannot cover both
+// versions: the question "Do you trust the files in this folder?" is GONE
+// (zero occurrences in the 2.1.246 binary), and the option is no longer
+// "Yes, proceed" but "Yes, I trust this folder".
+const TRUST_PANE_2_1_246 = [
+  '────────────────────────────────────────────────────────────────',
+  ' Accessing workspace:',
+  '',
+  ' /home/gabor/marveen/agents/nova',
+  '',
+  " Quick safety check: Is this a project you created or one you trust? (Like your own code, a well-known open source project, or work from your team). If not, take a moment to review what's in this",
+  ' folder first.',
+  '',
+  " Claude Code'll be able to read, edit, and execute files here.",
+  '',
+  ' Security guide',
+  '',
+  ' ❯ 1. Yes, I trust this folder',
+  '   2. No, exit',
+  '',
+  ' Enter to confirm · Esc to cancel',
+].join('\n')
+
+// Negative control for the NEW anchor. The option text is short and eminently
+// quotable -- an agent explaining this very incident types it into a live
+// session. A visible idle footer means the real prompt is up, so this must
+// never read as a gate (same discipline as IDLE_WITH_QUOTE_PANE above).
+const IDLE_WITH_NEW_QUOTE_PANE = [
+  ' A telepitesnel az elso opcio: "Yes, I trust this folder" -- ezt kell valaszolni.',
+  '',
+  '──────────────────────────────────────────────────',
+  ' ❯ ',
+  '──────────────────────────────────────────────────',
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+].join('\n')
+
+// Negative control Marveen asked for: an ordinary working pane, no dialog of
+// any kind. If this ever classifies as a gate, the detector is matching noise.
+const ORDINARY_PANE = [
+  ' $ npm test',
+  ' Test Files  325 passed (325)',
+  '',
+  '──────────────────────────────────────────────────',
+  ' ❯ ',
+  '──────────────────────────────────────────────────',
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+].join('\n')
+
 describe('detectsFirstRunGate', () => {
   it('classifies the folder-trust dialog', () => {
     expect(detectsFirstRunGate(TRUST_PANE)).toBe('trust')
+  })
+
+  // TRUSTGATE901: the 2.1.246 rewrite. This is the regression that shipped --
+  // the old pattern returns null here, the pane falls through to the generic
+  // blocking-menu recovery, and that sends Escape, which on this dialog is
+  // "No, exit". A fresh install quit at startup.
+  it('classifies the REWRITTEN folder-trust dialog (Claude Code 2.1.246)', () => {
+    expect(detectsFirstRunGate(TRUST_PANE_2_1_246)).toBe('trust')
+  })
+
+  // Both versions at once, so a later edit cannot "simplify" the alternation
+  // down to whichever string it happens to see first.
+  it('covers BOTH dialog versions, not one of them', () => {
+    expect([detectsFirstRunGate(TRUST_PANE), detectsFirstRunGate(TRUST_PANE_2_1_246)])
+      .toEqual(['trust', 'trust'])
+  })
+
+  it('does NOT flag an idle pane quoting the NEW option text', () => {
+    expect(detectsFirstRunGate(IDLE_WITH_NEW_QUOTE_PANE)).toBeNull()
+  })
+
+  it('does NOT flag an ordinary working pane', () => {
+    expect(detectsFirstRunGate(ORDINARY_PANE)).toBeNull()
   })
 
   it('classifies the bypass-permissions acceptance dialog', () => {

--- a/src/__tests__/pane-first-run-gate.test.ts
+++ b/src/__tests__/pane-first-run-gate.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
-import { detectsFirstRunGate, detectPaneState, detectsBlockingMenu } from '../pane-state.js'
+import { detectsFirstRunGate, detectPaneState, detectsBlockingMenu, trustDialogAnswerKeys } from '../pane-state.js'
 
 // Fresh-install first-run gate detection (card 5F37BB84, Oligo2000 VPS
 // 2026-07-22). A sub-agent session parked on a Claude Code first-run dialog
@@ -151,6 +151,46 @@ const ORDINARY_PANE = [
   '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
 ].join('\n')
 
+// The SAME dialog again, as Claude Code 2.1.252 renders it -- captured live on
+// 2026-09-01 from an ISOLATED install (npm install --prefix into a throwaway
+// directory; the global 2.1.246 was left alone and re-checked afterwards).
+// Only the workspace path is genericised.
+//
+// TWO further breaks on top of the reworded text, six patch releases later:
+//   * the "1." / "2." numbering is GONE, so typing "1" selects nothing;
+//   * "No, exit" is FIRST and is the highlighted option, so the Enter that
+//     followed the useless "1" CONFIRMED the exit.
+// A fresh install therefore did not park -- it quit, and our own code chose it.
+const TRUST_PANE_2_1_252 = [
+  '────────────────────────────────────────────────────────────────',
+  ' Accessing workspace:',
+  '',
+  ' /home/gabor/marveen/agents/nova',
+  '',
+  " Quick safety check: Is this a project you created or one you trust? (Like your own code, a well-known open source project, or work from your team). If not, take a moment to review what's in this",
+  ' folder first.',
+  '',
+  " Claude Code'll be able to read, edit, and execute files here.",
+  '',
+  ' Security guide',
+  '',
+  ' ❯ No, exit',
+  '   Yes, I trust this folder',
+  '',
+  ' Enter to confirm · Esc to cancel',
+].join('\n')
+
+// A trust-shaped panel whose accept option is missing entirely: the layout is
+// not one we model, so the answer must be "send nothing".
+const TRUST_PANE_UNKNOWN_SHAPE = [
+  ' Quick safety check: Is this a project you created or one you trust?',
+  '',
+  ' ❯ Maybe later',
+  '   No, exit',
+  '',
+  ' Enter to confirm · Esc to cancel',
+].join('\n')
+
 describe('detectsFirstRunGate', () => {
   it('classifies the folder-trust dialog', () => {
     expect(detectsFirstRunGate(TRUST_PANE)).toBe('trust')
@@ -275,5 +315,39 @@ describe('first-run gate wiring contracts', () => {
     expect(stampIdx).toBeGreaterThan(0)
     // The stamp must happen BEFORE the tmux session is spawned.
     expect(launchIdx).toBeGreaterThan(stampIdx)
+  })
+})
+
+describe('trustDialogAnswerKeys (TRUSTGATE901)', () => {
+  // Numbered, "Yes" first and already highlighted -> confirm where we are.
+  it('2.1.246 layout: the cursor already sits on yes, so just confirm', () => {
+    expect(trustDialogAnswerKeys(TRUST_PANE_2_1_246)).toEqual(['Enter'])
+  })
+
+  // Unnumbered, "No, exit" first AND highlighted -> move down, then confirm.
+  // This is the regression that quit a fresh install.
+  it('2.1.252 layout: moves the selection onto yes before confirming', () => {
+    expect(trustDialogAnswerKeys(TRUST_PANE_2_1_252)).toEqual(['Down', 'Enter'])
+  })
+
+  // The discriminating assertion: a naive "always Enter" answer -- which is
+  // what the old code effectively did after typing a number that no longer
+  // selects anything -- is WRONG here, and this fixture is what proves it.
+  it('2.1.252 layout: a bare Enter would confirm "No, exit"', () => {
+    expect(trustDialogAnswerKeys(TRUST_PANE_2_1_252)).not.toEqual(['Enter'])
+  })
+
+  it('the older boxed dialog still resolves to a plain confirm', () => {
+    expect(trustDialogAnswerKeys(TRUST_PANE)).toEqual(['Enter'])
+  })
+
+  // Not-acting is the correct answer on an unmodelled layout: Escape is
+  // "No, exit" by the dialog's own footer and Enter confirms the highlight.
+  it('returns null when no unambiguous yes option exists (park, send nothing)', () => {
+    expect(trustDialogAnswerKeys(TRUST_PANE_UNKNOWN_SHAPE)).toBeNull()
+  })
+
+  it('returns null on a pane with no selection cursor at all', () => {
+    expect(trustDialogAnswerKeys(ORDINARY_PANE.replace('❯', ' '))).toBeNull()
   })
 })

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -566,8 +566,9 @@ const FIRST_RUN_GATES: Array<{ kind: FirstRunGateKind; rx: RegExp }> = [
 ]
 
 /**
- * Which keys select "yes" on the folder-trust dialog, from wherever the cursor
- * currently sits -- or null when the pane does not say clearly enough to act.
+ * Which keys select the ACCEPTING option on a first-run consent dialog
+ * (folder-trust, bypass-permissions), from wherever the cursor currently
+ * sits -- or null when the pane does not say clearly enough to act.
  *
  * TRUSTGATE901. Answering this dialog by NUMBER or by DEFAULT is not safe, and
  * both assumptions broke inside six patch releases:
@@ -579,14 +580,22 @@ const FIRST_RUN_GATES: Array<{ kind: FirstRunGateKind; rx: RegExp }> = [
  * and thereby chose "No, exit" on a fresh install.
  *
  * So the answer is derived from the pane instead of assumed: find the cursor,
- * find the "yes" option, and move the selection onto it.
+ * find the accepting option, and move the selection onto it.
+ *
+ * The bypass-permissions dialog is answered the same way and for the same
+ * reason. Its own accept row ("Yes, I accept") sits SECOND behind a first,
+ * highlighted "No, exit" -- so the previously used number ("2") was one
+ * dropped prefix away from the identical failure. Measured 2026-09-01: on
+ * an existing HOME the bypass panel does not appear at all, but that says
+ * nothing about a brand-new machine, which is exactly the fresh-install
+ * path this whole card is about.
  *
  * Returns null -- meaning PARK AND ALERT, send nothing -- when the layout is
  * not understood. Neither Enter nor Escape is a safe default here: Escape is
  * "No, exit" by the dialog's own footer, and Enter confirms whatever happens
  * to be highlighted. On an unrecognised shape, not acting is the correct move.
  */
-export function trustDialogAnswerKeys(pane: string): string[] | null {
+export function firstRunAcceptKeys(pane: string): string[] | null {
   if (!pane || !pane.trim()) return null
   const lines = pane.split('\n')
   const cursorIdx = lines.findIndex(l => l.includes(CURSOR_GLYPH))

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -532,6 +532,9 @@ export function detectsBlockingMenu(pane: string): boolean {
 // detectsBlockingMenu's discipline: a busy pane is never a gate, and a visible
 // idle footer means the real prompt is live (capture-pane -p sees only the
 // visible screen, so a quoted phrase always coexists with the live footer).
+// The tmux-visible selection marker Claude Code draws on the active option.
+const CURSOR_GLYPH = '\u276f'
+
 export type FirstRunGateKind = 'trust' | 'bypass-permissions' | 'login' | 'theme' | 'welcome'
 
 // Ordered: the login picker and theme screen render UNDER the "Welcome to
@@ -561,6 +564,56 @@ const FIRST_RUN_GATES: Array<{ kind: FirstRunGateKind; rx: RegExp }> = [
   { kind: 'theme', rx: /Choose the text style/ },
   { kind: 'welcome', rx: /Welcome to Claude Code/ },
 ]
+
+/**
+ * Which keys select "yes" on the folder-trust dialog, from wherever the cursor
+ * currently sits -- or null when the pane does not say clearly enough to act.
+ *
+ * TRUSTGATE901. Answering this dialog by NUMBER or by DEFAULT is not safe, and
+ * both assumptions broke inside six patch releases:
+ *   2.1.246: "❯ 1. Yes, I trust this folder" / "  2. No, exit"
+ *   2.1.252: "❯ No, exit"                    / "  Yes, I trust this folder"
+ * In 2.1.252 the numbering is GONE (so typing "1" selects nothing) and "No,
+ * exit" is both first AND the highlighted default (so the Enter that follows
+ * CONFIRMS the exit). The old code did exactly that: it typed 1, then Enter,
+ * and thereby chose "No, exit" on a fresh install.
+ *
+ * So the answer is derived from the pane instead of assumed: find the cursor,
+ * find the "yes" option, and move the selection onto it.
+ *
+ * Returns null -- meaning PARK AND ALERT, send nothing -- when the layout is
+ * not understood. Neither Enter nor Escape is a safe default here: Escape is
+ * "No, exit" by the dialog's own footer, and Enter confirms whatever happens
+ * to be highlighted. On an unrecognised shape, not acting is the correct move.
+ */
+export function trustDialogAnswerKeys(pane: string): string[] | null {
+  if (!pane || !pane.trim()) return null
+  const lines = pane.split('\n')
+  const cursorIdx = lines.findIndex(l => l.includes(CURSOR_GLYPH))
+  if (cursorIdx < 0) return null
+
+  // The options are the contiguous run of non-blank lines around the cursor.
+  // Anchoring on the run (rather than on line numbers or on a fixed distance)
+  // is what survives a layout change: boxed or unboxed, numbered or not.
+  let first = cursorIdx
+  while (first > 0 && lines[first - 1].trim() !== '') first--
+  let last = cursorIdx
+  while (last < lines.length - 1 && lines[last + 1].trim() !== '') last++
+  const block = lines.slice(first, last + 1)
+
+  // The target is the option that accepts. Match on "yes" and exclude the
+  // refusal explicitly, so a future "Yes, exit"-shaped wording cannot be
+  // mistaken for consent.
+  const yesIdx = block.findIndex(l => /\byes\b/i.test(l) && !/\bno,\s*exit\b/i.test(l))
+  if (yesIdx < 0) return null
+  // Ambiguity is a reason to stop, not to guess: two "yes"-looking rows mean
+  // the layout is not what this function models.
+  if (block.filter(l => /\byes\b/i.test(l) && !/\bno,\s*exit\b/i.test(l)).length !== 1) return null
+
+  const delta = yesIdx - (cursorIdx - first)
+  const move = delta === 0 ? [] : Array.from({ length: Math.abs(delta) }, () => (delta > 0 ? 'Down' : 'Up'))
+  return [...move, 'Enter']
+}
 
 /**
  * Classify the pane as a Claude Code first-run gate, or null when it is a

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -538,7 +538,24 @@ export type FirstRunGateKind = 'trust' | 'bypass-permissions' | 'login' | 'theme
 // Claude Code" banner, so the more specific matches must win before the
 // generic welcome fallback.
 const FIRST_RUN_GATES: Array<{ kind: FirstRunGateKind; rx: RegExp }> = [
-  { kind: 'trust', rx: /Do you trust the files in this folder\?/ },
+  // TRUSTGATE901 (2026-09-01): ALTERNATION, not a replacement. Claude Code
+  // 2.1.246 rewrote this dialog -- the old question is GONE and the panel now
+  // opens with a marketing line ("Quick safety check: Is this a project you
+  // created or one you trust? ..."). Measured on the installed binary with a
+  // known-positive/known-negative control: "Do you trust the files in this
+  // folder" occurs ZERO times in 2.1.246, "Yes, I trust this folder" twice.
+  //
+  // The anchor is the OPTION TEXT, not the prose: the option is the functional
+  // element the dialog cannot drop, while the sentence above it is exactly the
+  // kind of copy a vendor rewrites (it just did). The old question stays for
+  // installs still on an older CLI -- note the old panel's option read
+  // "Yes, proceed", so neither string alone covers both versions.
+  //
+  // Why this mattered more than a missed classification: a null here does not
+  // merely skip the answer (answerFirstRunGates reports 'unchanged'), it hands
+  // the pane to the GENERIC blocking-menu recovery, which sends Escape -- and
+  // on this dialog Escape IS "No, exit". A fresh install quit on startup.
+  { kind: 'trust', rx: /Do you trust the files in this folder\?|Yes, I trust this folder/ },
   { kind: 'bypass-permissions', rx: /Bypass Permissions mode/ },
   { kind: 'login', rx: /Select login method/ },
   { kind: 'theme', rx: /Choose the text style/ },

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -23,7 +23,7 @@ import {
   detectsModelConsentDialog,
   detectsFeedbackDraftModal,
   detectsFeedbackOptOutPrompt,
-  trustDialogAnswerKeys,
+  firstRunAcceptKeys,
   type FirstRunGateKind,
 } from '../pane-state.js'
 import { agentDir, listAgentNames, readAgentModel, readAgentClaudeConfigDir, readAgentClaudePlan, readAgentChannelProvider, readAgentAuthMode, readAgentDisplayName, readAgentRemoteConfig, readAgentRemoteHost, readAgentMemoryIsolation } from './agent-config.js'
@@ -1640,7 +1640,7 @@ export async function answerFirstRunGates(
         // `pane` is non-null here (gate came from it), but the narrowing does
         // not survive the intervening checks -- and a null capture is itself a
         // reason to park rather than guess.
-        const keys = pane != null ? trustDialogAnswerKeys(pane) : null
+        const keys = pane != null ? firstRunAcceptKeys(pane) : null
         if (keys == null) {
           // Unrecognised layout. Enter confirms whatever is highlighted and
           // Escape is "No, exit" by the dialog's own footer, so there is no
@@ -1654,9 +1654,19 @@ export async function answerFirstRunGates(
           await delay(150)
         }
       } else if (gate === 'bypass-permissions') {
-        runTmux(host, ['send-keys', '-t', session, '2'], { timeout: 5000 })
-        await delay(150)
-        runTmux(host, ['send-keys', '-t', session, 'Enter'], { timeout: 5000 })
+        // Same rule, same reason as 'trust' above: the accept row sits behind a
+        // first, highlighted "No, exit", so answering by number is one dropped
+        // prefix away from confirming the refusal.
+        const keys = pane != null ? firstRunAcceptKeys(pane) : null
+        if (keys == null) {
+          logger.warn({ session, gate },
+            'first-run bypass dialog: no unambiguous accept option found -- parking, NO keystrokes sent')
+          return 'blocked'
+        }
+        for (const k of keys) {
+          runTmux(host, ['send-keys', '-t', session, k], { timeout: 5000 })
+          await delay(150)
+        }
       } else {
         // theme / welcome: Enter accepts the highlighted default and moves on.
         runTmux(host, ['send-keys', '-t', session, 'Enter'], { timeout: 5000 })

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -23,6 +23,7 @@ import {
   detectsModelConsentDialog,
   detectsFeedbackDraftModal,
   detectsFeedbackOptOutPrompt,
+  trustDialogAnswerKeys,
   type FirstRunGateKind,
 } from '../pane-state.js'
 import { agentDir, listAgentNames, readAgentModel, readAgentClaudeConfigDir, readAgentClaudePlan, readAgentChannelProvider, readAgentAuthMode, readAgentDisplayName, readAgentRemoteConfig, readAgentRemoteHost, readAgentMemoryIsolation } from './agent-config.js'
@@ -1623,7 +1624,7 @@ const FIRST_RUN_ANSWER_SETTLE_MS = 1500
 export async function answerFirstRunGates(
   session: string,
   host: string | null = null,
-): Promise<'cleared' | 'login' | 'unchanged'> {
+): Promise<'cleared' | 'login' | 'unchanged' | 'blocked'> {
   let acted = false
   for (let i = 0; i < FIRST_RUN_ANSWER_MAX_STEPS; i++) {
     const pane = capturePane(session, host)
@@ -1632,9 +1633,26 @@ export async function answerFirstRunGates(
     if (gate === 'login') return 'login'
     try {
       if (gate === 'trust') {
-        runTmux(host, ['send-keys', '-t', session, '1'], { timeout: 5000 })
-        await delay(150)
-        runTmux(host, ['send-keys', '-t', session, 'Enter'], { timeout: 5000 })
+        // TRUSTGATE901: never by number, never by default. 2.1.252 dropped the
+        // "1."/"2." prefixes AND put "No, exit" first as the highlighted
+        // option, so the old `1` + Enter typed nothing and then CONFIRMED the
+        // exit. The keys come from the pane instead.
+        // `pane` is non-null here (gate came from it), but the narrowing does
+        // not survive the intervening checks -- and a null capture is itself a
+        // reason to park rather than guess.
+        const keys = pane != null ? trustDialogAnswerKeys(pane) : null
+        if (keys == null) {
+          // Unrecognised layout. Enter confirms whatever is highlighted and
+          // Escape is "No, exit" by the dialog's own footer, so there is no
+          // safe key to send: park and let the caller alert a human.
+          logger.warn({ session, gate },
+            'first-run trust dialog: no unambiguous "yes" option found -- parking, NO keystrokes sent')
+          return 'blocked'
+        }
+        for (const k of keys) {
+          runTmux(host, ['send-keys', '-t', session, k], { timeout: 5000 })
+          await delay(150)
+        }
       } else if (gate === 'bypass-permissions') {
         runTmux(host, ['send-keys', '-t', session, '2'], { timeout: 5000 })
         await delay(150)

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -1703,6 +1703,14 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
           const res = await answerFirstRunGates(t.session)
           if (res === 'login') {
             sendAlert(`🔑 A(z) ${label} agent első-indítási dialogjait továbbléptettem, de Claude-belépés kell ("Select login method"). Lépj be: tmux attach -t ${t.session}. Utána minden várakozó feladat magától kézbesítődik.`)
+          } else if (res === 'blocked') {
+            // TRUSTGATE901: the trust dialog rendered in a shape we do not
+            // model, so NO keystroke was sent -- deliberately. Neither Enter
+            // nor Escape is neutral on that panel (Escape is "No, exit", and
+            // Enter confirms whatever is highlighted, which in 2.1.252 is the
+            // exit). A human picks; we only say so, loudly.
+            logger.warn({ session: t.session, agent: label }, 'first-run trust dialog in an unrecognised shape -- parked, NO keystrokes sent')
+            sendAlert(`🛑 A(z) ${label} session a mappa-megbízhatósági dialóguson parkol, de a panel alakját nem ismerem fel, ezért NEM nyomtam meg semmit. Se az Enter, se az Escape nem semleges rajta (az Escape a "No, exit"). Válassz kézzel: tmux attach -t ${t.session}, majd a "Yes, I trust this folder" sort jelöld ki és Enter.`)
           } else {
             sendAlert(`🧭 A(z) ${label} session a Claude Code első-indítási képernyőjén parkolt (${firstRunGate}); automatikusan továbbléptettem. A várakozó ütemezett feladatok a következő körben kézbesítődnek.`)
           }


### PR DESCRIPTION
## What broke

A fresh Marveen install **quit** at the folder-trust dialog. Not parked: quit, and our own code chose it.

Claude Code broke this dialog in **three independent ways**, and only the first was visible from this host.

| # | break | 2.1.246 (this host) | 2.1.252 (what a fresh install pulls) |
|---|---|---|---|
| 1 | the question text | gone | gone |
| 2 | the `1.` / `2.` numbering | present | **gone** |
| 3 | option order | `Yes` first, highlighted | **`No, exit` first, highlighted** |

Reproduced on both. 2.1.252 was installed in isolation (`npm install --prefix` into a throwaway directory); the global 2.1.246 was left alone and re-checked afterwards.

```
2.1.246                              2.1.252
 ❯ 1. Yes, I trust this folder        ❯ No, exit
   2. No, exit                          Yes, I trust this folder
```

So on 2.1.252 the old code typed `1`, which selects nothing because there are no numbers any more, and then pressed Enter, which **confirmed the highlighted option: `No, exit`**.

## The fix

**Detection**: the pattern is an alternation, not a replacement. The anchor is the option text (`Yes, I trust this folder`), because the option is the functional element the dialog cannot drop, while the sentence above it is exactly the copy a vendor rewrites. The old question stays for older CLIs, whose option read `Yes, proceed` -- neither string alone covers both.

**Answering**: never by number, never by default. `trustDialogAnswerKeys()` finds the selection cursor and the single unambiguous "yes" option inside the contiguous option block, and returns the keys that move the selection onto it. Numbered or unnumbered, either order, same code path.

**When the layout is not understood**: send nothing. Neither key is neutral here -- Escape is `No, exit` by the dialog's own footer, and Enter confirms whatever is highlighted. `answerFirstRunGates` returns a new `blocked` outcome and the channel-monitor alerts a human. On an unrecognised dialog, not acting is the correct move.

## Two guards, not one

`scripts/channels.sh` carried its own copy of the dead string **and** the same number assumption. Fixing only the TypeScript detector would have left the startup path broken -- and that is the path a fresh install takes.

Measured on the real 2.1.252 capture: with the old shell pattern, **no `case` branch matched at all**, not even the `Welcome to Claude Code` fallback, because the new panel does not carry that banner.

## Measurement

Both binaries, with a known-positive and a known-negative control so a zero is a measurement rather than an absence:

| string | 2.1.246 | 2.1.252 |
|---|---|---|
| `Do you trust the files in this folder` | 0 | 0 |
| `Yes, I trust this folder` | 2 | 2 |
| `Bypass Permissions mode` | 6 | 6 |
| `Select login method` | 2 | 2 |
| `Choose the text style` | 2 | 2 |
| `Welcome to Claude Code` | 7 | 7 |
| `No, exit` (known positive) | 5 | 5 |
| a string that cannot exist (known negative) | 0 | 0 |

## Tests

Real captures of all three layouts, not invented fixtures: 2.1.246 (numbered, yes first), 2.1.252 (unnumbered, no first), and the older boxed dialog. Plus an unmodelled shape and a pane with no cursor, both of which must answer `null`.

The discriminating assertion is explicit: **on the 2.1.252 layout, a bare Enter is not the answer**. Without it, a fixture set can pass while modelling nothing.

The earlier detection-only change is covered by a mutation control: with the old pattern restored, exactly the two new detection assertions fail and the negative controls still pass.

## Verification on current develop

- `tsc --noEmit`: clean
- `vitest run`: 4364 tests pass, 1 skipped
- secret-gate job command: 26/26
- shell branch decision exercised against all four shapes (2.1.246, 2.1.252, old boxed, unmodelled)

## Open risk this PR does NOT fix

The **bypass-permissions** dialog is answered the same discredited way: by number (`2`), and its known layout has `No, exit` as the first option. If 2.1.252 dropped the numbering there too, the same three-step failure applies. Its anchor string still exists in both binaries, but the trust case just proved that **string presence says nothing about layout**. It was not reproduced here (reaching it requires advancing past the theme picker), so this is a stated risk, not a finding. The same pane-derived treatment would remove the assumption.
