### PR TITLE
fix(installer): detect the bridge the installer itself started, not just a systemd unit

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -1964,11 +1964,37 @@ if [ "$CHANNEL_PROVIDER" = "telegram" ] && [ -n "$BOT_TOKEN" ]; then
 
   ACCESS_FILE="$CHANNEL_DIR/access.json"
 
+  # Is the Telegram bridge actually running?
+  #
+  # `systemctl --user is-active` alone answers a NARROWER question than this
+  # step needs -- "does a systemd USER unit for it exist and run" -- and the two
+  # answers diverge on exactly the hosts the [7/7] step already handles. There,
+  # `pidof systemd` / `systemctl --user status` failing is not an error: the
+  # installer falls back to a direct nohup launch and prints
+  #   "Channels (Telegram bridge) fut (nohup, pid N)"
+  # ...and then this check called the very bridge it had just started "not
+  # started", skipped pairing, and left the install with ALLOWED_CHAT_ID=0 plus
+  # a red warning telling the operator to pair by hand. WSL is a documented
+  # supported platform and has no systemd user session by default, so this is
+  # not an exotic shape.
+  #
+  # Ask the same three ways start.sh/stop.sh already distinguish -- user unit,
+  # system unit, direct launch -- so pairing works wherever the launch worked.
+  _bridge_is_up() {
+    systemctl --user is-active --quiet "${CHAN_UNIT}" 2>/dev/null && return 0
+    systemctl is-active --quiet "${CHAN_UNIT}" 2>/dev/null && return 0
+    # The pidfile start.sh writes on its no-systemd branch. `kill -0` only
+    # probes for existence; it sends no signal.
+    local _pid
+    _pid="$(cat "$INSTALL_DIR/store/channels.pid" 2>/dev/null)" || return 1
+    [ -n "$_pid" ] && kill -0 "$_pid" 2>/dev/null
+  }
+
   # Megvarjuk amig a channels service tenyleg valaszol (max 15 mp)
   echo -e "  Varakozas a Telegram bridge elindulasara..."
   BRIDGE_OK=false
   for i in $(seq 1 15); do
-    if systemctl --user is-active --quiet "${CHAN_UNIT}" 2>/dev/null; then
+    if _bridge_is_up; then
       BRIDGE_OK=true
       break
     fi
@@ -1976,9 +2002,10 @@ if [ "$CHANNEL_PROVIDER" = "telegram" ] && [ -n "$BOT_TOKEN" ]; then
   done
 
   if [ "$BRIDGE_OK" = "false" ]; then
-    warn "A ${CHAN_UNIT} service nem indult el. Parositas kihagyva."
-    echo -e "  ${DIM}Ellenorizd: journalctl --user -u ${CHAN_UNIT} -n 30${NC}"
-    echo -e "  ${DIM}Kesobb: systemctl --user start ${CHAN_UNIT}, majd irj a botodnak${NC}"
+    warn "A Telegram bridge nem indult el. Parositas kihagyva."
+    echo -e "  ${DIM}systemd-vel:  journalctl --user -u ${CHAN_UNIT} -n 30${NC}"
+    echo -e "  ${DIM}anelkul:      tail -n 30 $INSTALL_DIR/store/channels.log${NC}"
+    echo -e "  ${DIM}Kesobb: ./scripts/start.sh, majd irj a botodnak${NC}"
   else
     ok "Telegram bridge fut"
     echo ""

--- a/src/__tests__/installer-pairing-bridge-detection.test.ts
+++ b/src/__tests__/installer-pairing-bridge-detection.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { readFileSync, writeFileSync, mkdtempSync, mkdirSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+// Measured on a Linux/Docker install 2026-09-01: [7/7] printed
+//   "systemd --user nem elerheto (WSL / konteneren / VPS user-session nelkul)"
+//   "Channels (Telegram bridge) fut (nohup, pid 782)"
+// and the pairing step that follows it printed
+//   "A marveen-channels service nem indult el. Parositas kihagyva."
+// about that same, running bridge -- then the install ended on the red
+// "FIGYELEM: Telegram parositas nem tortent meg!" banner with ALLOWED_CHAT_ID=0.
+//
+// Cause: the readiness probe asked `systemctl --user is-active`, which answers
+// "is there a systemd USER unit" -- a narrower question than "is the bridge
+// running". [7/7] itself already treats a missing user session as a normal
+// shape and launches directly instead, so the probe contradicted the launch it
+// was waiting on. WSL is a documented supported platform and ships no systemd
+// user session by default, so this is not an exotic host.
+//
+// These tests run the REAL probe + wait loop out of the shipped
+// install-linux.sh against the three launch shapes start.sh distinguishes.
+
+const ROOT = join(__dirname, '..', '..')
+const LINUX = readFileSync(join(ROOT, 'install-linux.sh'), 'utf-8')
+
+/**
+ * Pull the readiness probe + the wait loop that consumes it out of the script.
+ *
+ * Anchored on `BRIDGE_OK=false` -- which both the old (systemctl-only) and the
+ * fixed shape contain -- and widened backwards over the `_bridge_is_up` helper
+ * when one is present. That is deliberate: it lets these tests run unchanged
+ * against the PRE-fix install-linux.sh, where they fail on the ANSWER
+ * (BRIDGE_OK=false for a running bridge) rather than on a missing symbol. A
+ * test that only failed because a function had not been written yet would
+ * prove nothing about the bug.
+ */
+function bridgeProbeBlock(src: string): string {
+  const flag = src.indexOf('  BRIDGE_OK=false')
+  if (flag < 0) throw new Error('BRIDGE_OK not found')
+  const probeDef = src.indexOf('  _bridge_is_up() {')
+  const start = probeDef >= 0 && probeDef < flag ? probeDef : flag
+  // The first `done` after the flag closes the readiness wait loop.
+  const end = src.indexOf('\n  done\n', flag)
+  if (end < 0) throw new Error('wait loop not found')
+  return src.slice(start, end + '\n  done\n'.length)
+}
+
+/**
+ * Run the REAL probe with a chosen host shape.
+ *  - systemdUser/systemdSystem: what `systemctl` reports
+ *  - pid: written to store/channels.pid ('' writes no file at all)
+ * `sleep` is stubbed so the 15s wait costs nothing.
+ */
+function runProbe(opts: { systemdUser?: boolean; systemdSystem?: boolean; pid?: number | '' }): string {
+  const dir = mkdtempSync(join(tmpdir(), 'marveen-pairprobe-'))
+  mkdirSync(join(dir, 'store'), { recursive: true })
+  if (opts.pid !== undefined && opts.pid !== '') {
+    writeFileSync(join(dir, 'store', 'channels.pid'), String(opts.pid))
+  }
+
+  // `systemctl --user is-active` vs `systemctl is-active`: the stub tells them
+  // apart the same way the probe calls them.
+  const systemctlStub = [
+    'systemctl() {',
+    '  if [ "$1" = "--user" ]; then',
+    `    return ${opts.systemdUser ? 0 : 1}`,
+    '  fi',
+    `  return ${opts.systemdSystem ? 0 : 1}`,
+    '}',
+  ]
+
+  const script = [
+    'set -e',
+    `INSTALL_DIR=${JSON.stringify(dir)}`,
+    'CHAN_UNIT=marveen-channels',
+    ...systemctlStub,
+    'sleep() { :; }',
+    bridgeProbeBlock(LINUX),
+    'echo "BRIDGE_OK=$BRIDGE_OK"',
+  ].join('\n')
+
+  return execFileSync('bash', ['-c', script], { encoding: 'utf-8' }).trim()
+}
+
+describe('installer: Telegram pairing bridge readiness', () => {
+  it('sees a bridge started directly (no systemd) -- the regression', () => {
+    // process.pid is this test runner: alive by construction.
+    expect(runProbe({ pid: process.pid })).toContain('BRIDGE_OK=true')
+  })
+
+  it('still sees a bridge run by a systemd USER unit', () => {
+    expect(runProbe({ systemdUser: true })).toContain('BRIDGE_OK=true')
+  })
+
+  it('sees a bridge run by a SYSTEM-scope unit (root-style install)', () => {
+    expect(runProbe({ systemdSystem: true })).toContain('BRIDGE_OK=true')
+  })
+
+  it('reports down when the pidfile is stale', () => {
+    // Above Linux's default pid_max, so it cannot name a live process.
+    expect(runProbe({ pid: 2147483646 })).toContain('BRIDGE_OK=false')
+  })
+
+  it('reports down when there is no unit and no pidfile', () => {
+    expect(runProbe({})).toContain('BRIDGE_OK=false')
+  })
+})


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)

## Rövid leírás / Summary

**HU.** A Telegram-párosítás lépése `systemctl --user is-active`-tal kérdezi, fut-e a bridge. Ez szűkebb kérdés, mint amire szüksége van: azt méri, van-e systemd **user unit** — nem azt, hogy fut-e a bridge. A kettő pont azokon a gépeken tér el, amiket a `[7/7]` lépés maga is normálisnak kezel.

Ugyanabban a futásban, másodpercek különbséggel (Linux/Docker telepítés, 2026-09-01):

```
[7/7]    systemd --user nem elerheto (WSL / konteneren / VPS user-session nelkul)
         Channels (Telegram bridge) fut (nohup, pid 782)
pairing  A marveen-channels service nem indult el. Parositas kihagyva.
```

A telepítő arról a bridge-ről mondta, hogy „nem indult el", amit öt sorral korábban ő maga indított el. A párosítás kimaradt, és a telepítés a piros `FIGYELEM: Telegram parositas nem tortent meg!` táblával zárult, `ALLOWED_CHAT_ID=0`-val.

Ez nem konténer-specifikus: a **WSL** dokumentáltan támogatott platform, és alapból nincs benne systemd user-session — ezt az `install-linux.sh` maga is leírja a `[7/7]` fallback kommentjében.

**EN.** The pairing step probed readiness with `systemctl --user is-active`, which answers "does a systemd USER unit exist and run" rather than "is the bridge running". The installer had just started that bridge itself via nohup. WSL ships no systemd user session by default and is a supported platform.

A javítás ugyanazt a három indítási formát kérdezi, amit a `start.sh` / `stop.sh` már megkülönböztet: user unit, system unit, majd a pidfile, amit a `start.sh` a közvetlen indítás ágán ír.

**Mellékesen kiderült:** a root-stílusú (system-scope unit) telepítés is érintett volt, nem csak a systemd nélküli. A tesztek ezt is lefedik.

## Kapcsolódó issue / Related issue

Nincs / none.

## Tesztek

Az új tesztek a leszállított `install-linux.sh`-ból vágják ki a **valódi** probe-ot és várakozó ciklust, az `installer-ollama-nonfatal.test.ts` mintájára. A horgony szándékosan olyan, hogy a **javítás előtti** scripten is lefutnak — ott a **válaszon** buknak (`BRIDGE_OK=false` egy futó bridge-re), nem hiányzó szimbólumon:

```
javítás nélkül:  2 failed | 3 passed
javítással:      5 passed
```

A telepítőt érintő 10 meglévő teszt-fájl (112 teszt) változatlanul zöld ezen az ágon.

## Ellenőrzőlista / Checklist

- [ ] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard) — **lásd lentebb.**
- [x] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. *(Nem érinti: a viselkedés a dokumentált szándékhoz tér vissza, a felület nem változik.)*
- [x] A kód nem tartalmaz beleégetett szenzitív adatot.
- [x] Saját, beszédes nevű branch-ről nyitom.

**Az első pontról őszintén:** a hibát élesben megfigyeltem (a fenti kimenet valódi), és a javítást unit-teszttel fedtem le, de a teljes varázslót a javítással **nem futtattam újra** végig — ahhoz új bot- és Claude-tokenre lett volna szükség. A párosítást a dashboardon fejeztem be, az működik. Ha szeretnéd, hogy előbb végigfussak egy tiszta telepítést, szólj.

## Titok-kapu / Secret gate

- [x] Nincs a változtatásban bizonyíték-/artefaktum-mappa, titok-alakú string vagy idézett csatorna-üzenet.

---

*Docker/Linux üzembe helyezés kidolgozása közben jött elő. macOS-en valószínűleg nem jelentkezik: ott az `install.sh` launchd-t használ, és a probe-nak van mit olvasnia.*
