### PR TITLE
fix(channels-gate): check the file before resolving sudo

### DIFF
--- a/scripts/ensure-managed-channels-enabled.sh
+++ b/scripts/ensure-managed-channels-enabled.sh
@@ -30,28 +30,39 @@ esac
 
 # Idempotent: already true -> nothing to do.
 #
-# Deliberately UNPRIVILEGED, and deliberately BEFORE the sudo handling below.
-# The managed file is world-readable (it is org policy, not a secret), so
-# answering "is this already configured?" never needs a privilege the caller
-# might not have. Resolving sudo first meant a host where the key was ALREADY
-# set, but the invoking user had no sudo, reported
+# Answering "is this already configured?" is a READ, and the managed file is org
+# policy (0644, not a secret), so ask it with NO privilege and ask it BEFORE the
+# sudo handling below. Resolving sudo first meant a host where the key was
+# ALREADY set, but the invoking user had no sudo, reported
 #   ! channelsEnabled: nem root es nincs sudo -- kihagyva.
 #   MARVEEN_CHANNELS_GATE=manual
 # and sent the operator off to fix something that was already correct. Ask the
 # question that costs nothing first; only a WRITE needs privilege.
-if [ -f "$MANAGED_FILE" ] && python3 - "$MANAGED_FILE" 2>/dev/null <<'PY'
+#
+# $1 is the privilege prefix ("" or sudo). No `[ -f ]` guard: absent and
+# unreadable are the same answer here, and that test would itself need the
+# privilege we may not have.
+channels_enabled() {
+  $1 python3 - "$MANAGED_FILE" 2>/dev/null <<'PY'
 import json, sys
 try:
     sys.exit(0 if json.load(open(sys.argv[1])).get("channelsEnabled") is True else 1)
 except Exception:
     sys.exit(1)
 PY
-then
+}
+
+report_enabled() {
   echo "  channelsEnabled: mar be van kapcsolva ($MANAGED_FILE)"
   echo "MARVEEN_CHANNELS_GATE=ok"
+}
+
+if channels_enabled ""; then
+  report_enabled
   exit 0
 fi
-# A write is needed from here on, so now resolve privilege.
+
+# A write MAY be needed from here on, so now resolve privilege.
 # Root-aware privilege prefix. The managed dir is root-owned on both platforms.
 SUDO=""
 if [ "$(id -u)" -ne 0 ]; then
@@ -66,6 +77,14 @@ if [ "$(id -u)" -ne 0 ]; then
   fi
 fi
 
+# Same question, now with the privilege we just resolved. An admin who locked
+# the managed file down still gets the early exit instead of a pointless
+# privileged rewrite on every install -- the old order got that right by reading
+# as root, and an unprivileged-only check would have lost it.
+if [ -n "$SUDO" ] && channels_enabled "$SUDO"; then
+  report_enabled
+  exit 0
+fi
 
 if ! $SUDO mkdir -p "$(dirname "$MANAGED_FILE")" 2>/dev/null; then
   echo "  ! channelsEnabled: nem sikerult letrehozni $(dirname "$MANAGED_FILE") -- kezi root-lepes szukseges:"
@@ -76,7 +95,7 @@ fi
 
 # Safe JSON merge: load existing (or {}), set channelsEnabled=true, atomic write.
 if $SUDO python3 - "$MANAGED_FILE" <<'PY'
-import json, os, sys
+import json, os, shutil, sys
 p = sys.argv[1]
 try:
     d = json.load(open(p)) if os.path.exists(p) else {}
@@ -88,6 +107,15 @@ d["channelsEnabled"] = True
 tmp = p + ".tmp"
 with open(tmp, "w") as f:
     f.write(json.dumps(d, indent=2) + "\n")
+# os.replace carries the TMP file's mode, i.e. whatever the umask allowed --
+# under `umask 077` that silently turned the managed file into a root-owned
+# 0600 and broke the unprivileged read above. Match the file being replaced, so
+# an admin who deliberately locked it down keeps that; only a file this script
+# CREATES gets the 0644 the header describes.
+if os.path.exists(p):
+    shutil.copymode(p, tmp)
+else:
+    os.chmod(tmp, 0o644)
 os.replace(tmp, p)
 PY
 then

--- a/scripts/ensure-managed-channels-enabled.sh
+++ b/scripts/ensure-managed-channels-enabled.sh
@@ -28,6 +28,30 @@ case "$(uname -s)" in
   *) echo "  channelsEnabled: nem tamogatott OS ($(uname -s)); kihagyva."; echo "MARVEEN_CHANNELS_GATE=ok"; exit 0 ;;
 esac
 
+# Idempotent: already true -> nothing to do.
+#
+# Deliberately UNPRIVILEGED, and deliberately BEFORE the sudo handling below.
+# The managed file is world-readable (it is org policy, not a secret), so
+# answering "is this already configured?" never needs a privilege the caller
+# might not have. Resolving sudo first meant a host where the key was ALREADY
+# set, but the invoking user had no sudo, reported
+#   ! channelsEnabled: nem root es nincs sudo -- kihagyva.
+#   MARVEEN_CHANNELS_GATE=manual
+# and sent the operator off to fix something that was already correct. Ask the
+# question that costs nothing first; only a WRITE needs privilege.
+if [ -f "$MANAGED_FILE" ] && python3 - "$MANAGED_FILE" 2>/dev/null <<'PY'
+import json, sys
+try:
+    sys.exit(0 if json.load(open(sys.argv[1])).get("channelsEnabled") is True else 1)
+except Exception:
+    sys.exit(1)
+PY
+then
+  echo "  channelsEnabled: mar be van kapcsolva ($MANAGED_FILE)"
+  echo "MARVEEN_CHANNELS_GATE=ok"
+  exit 0
+fi
+# A write is needed from here on, so now resolve privilege.
 # Root-aware privilege prefix. The managed dir is root-owned on both platforms.
 SUDO=""
 if [ "$(id -u)" -ne 0 ]; then
@@ -42,19 +66,6 @@ if [ "$(id -u)" -ne 0 ]; then
   fi
 fi
 
-# Idempotent: already true -> nothing to do.
-if [ -f "$MANAGED_FILE" ] && $SUDO python3 - "$MANAGED_FILE" 2>/dev/null <<'PY'
-import json, sys
-try:
-    sys.exit(0 if json.load(open(sys.argv[1])).get("channelsEnabled") is True else 1)
-except Exception:
-    sys.exit(1)
-PY
-then
-  echo "  channelsEnabled: mar be van kapcsolva ($MANAGED_FILE)"
-  echo "MARVEEN_CHANNELS_GATE=ok"
-  exit 0
-fi
 
 if ! $SUDO mkdir -p "$(dirname "$MANAGED_FILE")" 2>/dev/null; then
   echo "  ! channelsEnabled: nem sikerult letrehozni $(dirname "$MANAGED_FILE") -- kezi root-lepes szukseges:"

--- a/src/__tests__/installer-managed-channels-gate.test.ts
+++ b/src/__tests__/installer-managed-channels-gate.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, afterEach } from 'vitest'
 import { execFileSync } from 'node:child_process'
-import { readFileSync, writeFileSync, mkdtempSync } from 'node:fs'
+import { chmodSync, readFileSync, rmSync, statSync, writeFileSync, mkdtempSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -16,7 +16,9 @@ import { join } from 'node:path'
 //
 // Reading that file needs no privilege -- it is org policy at 0644, not a
 // secret -- so the idempotent check now runs unprivileged and first; only a
-// WRITE resolves sudo.
+// WRITE resolves sudo. The check is asked a second time WITH sudo when there
+// is sudo, so a locked-down file still gets the early exit rather than a
+// privileged rewrite on every run.
 //
 // These tests run the REAL script body out of the shipped file, sliced after
 // the OS `case` so the harness can point MANAGED_FILE at a fixture.
@@ -39,66 +41,152 @@ function scriptBody(src: string): string {
   return src.slice(end + 'esac'.length)
 }
 
+const dirs: string[] = []
+afterEach(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true })
+})
+
 /**
  * Run the REAL body against a fixture.
  *  - managed: JSON to place at MANAGED_FILE, or null to leave it absent
  *  - sudo: 'hidden' (not installed), 'broken' (present but always fails),
- *          or 'root' (running as uid 0, so no sudo is used at all)
+ *          'usable' (present and works), or 'root' (uid 0, no sudo needed)
+ *  - mode: chmod applied to the fixture before the run
+ *  - umask: set before the body runs, so the mode of what it WRITES is pinned
+ *
+ * Returns the stdout AND the fixture path: several of these tests are about
+ * what the script did to the file, which the report alone cannot show.
  */
-function runGate(opts: { managed: string | null; sudo: 'hidden' | 'broken' | 'root' }): string {
+function runGate(opts: {
+  managed: string | null
+  sudo: 'hidden' | 'broken' | 'usable' | 'root'
+  mode?: number
+  umask?: string
+}): { out: string; file: string } {
   const dir = mkdtempSync(join(tmpdir(), 'marveen-gate-'))
+  dirs.push(dir)
   const file = join(dir, 'managed-settings.json')
   if (opts.managed !== null) writeFileSync(file, opts.managed)
+  if (opts.mode !== undefined) chmodSync(file, opts.mode)
 
   const stubs: string[] = []
-  if (opts.sudo === 'hidden') {
-    // `command -v sudo` must miss. Overriding the `command` builtin with a
-    // function is the only way to hide it without rewriting PATH, which would
-    // also hide python3 and coreutils that the script legitimately needs.
-    stubs.push('command() { if [ "$1" = "-v" ] && [ "$2" = "sudo" ]; then return 1; fi; builtin command "$@"; }')
-  } else if (opts.sudo === 'broken') {
-    // Present on PATH but unusable -- no password, no sudoers entry. This is
-    // the shape that produced three password prompts and then gave up.
-    stubs.push('sudo() { return 1; }')
-  } else {
+  if (opts.sudo === 'root') {
     stubs.push('id() { echo 0; }')
+  } else {
+    // Every non-root case must SAY it is non-root. Without this the suite is
+    // green as an ordinary user and red as root -- `[ "$(id -u)" -ne 0 ]` is
+    // false, the whole sudo block is skipped, and a test that asserts "manual
+    // because there is no privilege" gets a successful write instead.
+    stubs.push('id() { echo 1000; }')
+    if (opts.sudo === 'hidden') {
+      // `command -v sudo` must miss. Overriding the `command` builtin with a
+      // function is the only way to hide it without rewriting PATH, which would
+      // also hide python3 and coreutils that the script legitimately needs.
+      stubs.push('command() { if [ "$1" = "-v" ] && [ "$2" = "sudo" ]; then return 1; fi; builtin command "$@"; }')
+    } else if (opts.sudo === 'broken') {
+      // Present on PATH but unusable -- no password, no sudoers entry. This is
+      // the shape that produced three password prompts and then gave up.
+      stubs.push('sudo() { return 1; }')
+    } else {
+      // Present and working. `command -v` finds a function, so defining one is
+      // enough to be "installed". Privilege is modelled as the one thing that
+      // actually distinguishes root here: it can read a file whose mode denies
+      // the caller, exactly like `sudo cat` on a root-owned 0600 file.
+      stubs.push(
+        'sudo() { chmod u+r "$MANAGED_FILE" 2>/dev/null; "$@"; __rc=$?; chmod u-r "$MANAGED_FILE" 2>/dev/null; return $__rc; }',
+      )
+    }
   }
 
   const script = [
     'set -u',
+    ...(opts.umask ? [`umask ${opts.umask}`] : []),
     `MANAGED_FILE=${JSON.stringify(file)}`,
     ...stubs,
     scriptBody(SCRIPT),
   ].join('\n')
 
-  return execFileSync('bash', ['-c', script], { encoding: 'utf-8' }).trim()
+  const out = execFileSync('bash', ['-c', script], { encoding: 'utf-8' }).trim()
+  return { out, file }
 }
 
 const ENABLED = JSON.stringify({ channelsEnabled: true })
+const mode = (file: string) => statSync(file).mode & 0o777
 
 describe('ensure-managed-channels-enabled: report what is true, not what is reachable', () => {
   it('reports ok when already enabled and sudo is not installed -- the regression', () => {
-    expect(runGate({ managed: ENABLED, sudo: 'hidden' })).toContain('MARVEEN_CHANNELS_GATE=ok')
+    const { out, file } = runGate({ managed: ENABLED, sudo: 'hidden' })
+    expect(out).toContain('MARVEEN_CHANNELS_GATE=ok')
+    // Not just the report: the claim is that an already-configured host needs
+    // no write at all. A rewrite would reformat the JSON, so byte equality with
+    // the fixture is what proves the early exit was taken.
+    expect(readFileSync(file, 'utf-8')).toBe(ENABLED)
   })
 
   it('reports ok when already enabled and sudo exists but cannot be used', () => {
-    expect(runGate({ managed: ENABLED, sudo: 'broken' })).toContain('MARVEEN_CHANNELS_GATE=ok')
+    const { out, file } = runGate({ managed: ENABLED, sudo: 'broken' })
+    expect(out).toContain('MARVEEN_CHANNELS_GATE=ok')
+    expect(readFileSync(file, 'utf-8')).toBe(ENABLED)
+  })
+
+  it('takes the early exit when only privilege can read an already-enabled file', () => {
+    // The unprivileged read is an optimisation, not the only attempt. On a host
+    // whose managed file is not world-readable it fails, and without the second
+    // privileged ask the script would fall through and rewrite -- with a sudo
+    // prompt -- a file that was already correct, on every single run.
+    const { out, file } = runGate({ managed: ENABLED, sudo: 'usable', mode: 0o000 })
+    expect(out).toContain('mar be van kapcsolva')
+    expect(out).toContain('MARVEEN_CHANNELS_GATE=ok')
+    chmodSync(file, 0o644)
+    expect(readFileSync(file, 'utf-8')).toBe(ENABLED)
   })
 
   it('preserves other managed keys when it has to write', () => {
-    const out = runGate({
+    const { out, file } = runGate({
       managed: JSON.stringify({ allowedChannelPlugins: ['telegram'] }),
       sudo: 'root',
     })
     expect(out).toContain('MARVEEN_CHANNELS_GATE=ok')
+
+    // The point of the test is the FILE, not the report: a merge that threw the
+    // existing org policy away would still report ok. allowedChannelPlugins is
+    // the key this script's own header promises to keep, and losing it does not
+    // fail loudly -- the channel plugin just silently drops out of the policy.
+    const merged = JSON.parse(readFileSync(file, 'utf-8'))
+    expect(merged.channelsEnabled).toBe(true)
+    expect(merged.allowedChannelPlugins).toEqual(['telegram'])
+  })
+
+  it('creates the managed file world-readable even under a restrictive umask', () => {
+    // The header calls this file org policy at 0644, not a secret, and the
+    // unprivileged read is built on that. os.replace carries the tmp file's
+    // mode, so without an explicit chmod a root run under `umask 077` left it
+    // 0600 -- and the next run's unprivileged check fell back to the manual
+    // branch on a host that was already configured.
+    const { out, file } = runGate({ managed: null, sudo: 'root', umask: '077' })
+    expect(out).toContain('MARVEEN_CHANNELS_GATE=ok')
+    expect(mode(file)).toBe(0o644)
+  })
+
+  it('does not widen the mode of a managed file it did not create', () => {
+    // Managed settings may legitimately carry env and apiKeyHelper, so an admin
+    // can have locked this file down on purpose. Flipping one boolean is not a
+    // licence to publish the rest of it to every local user.
+    const { out, file } = runGate({
+      managed: JSON.stringify({ allowedChannelPlugins: ['telegram'] }),
+      sudo: 'root',
+      mode: 0o600,
+    })
+    expect(out).toContain('MARVEEN_CHANNELS_GATE=ok')
+    expect(mode(file)).toBe(0o600)
   })
 
   it('still reports manual when a write is needed but cannot be made', () => {
-    expect(runGate({ managed: null, sudo: 'hidden' })).toContain('MARVEEN_CHANNELS_GATE=manual')
+    expect(runGate({ managed: null, sudo: 'hidden' }).out).toContain('MARVEEN_CHANNELS_GATE=manual')
   })
 
   it('still reports manual when the key is present but false and there is no privilege', () => {
-    expect(runGate({ managed: JSON.stringify({ channelsEnabled: false }), sudo: 'hidden' }))
+    expect(runGate({ managed: JSON.stringify({ channelsEnabled: false }), sudo: 'hidden' }).out)
       .toContain('MARVEEN_CHANNELS_GATE=manual')
   })
 })

--- a/src/__tests__/installer-managed-channels-gate.test.ts
+++ b/src/__tests__/installer-managed-channels-gate.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { readFileSync, writeFileSync, mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+// ensure-managed-channels-enabled.sh resolved `sudo` BEFORE it looked at the
+// file, so on a host where channelsEnabled was ALREADY true but the invoking
+// user had no usable sudo it reported
+//   ! channelsEnabled: nem root es nincs sudo -- kihagyva.
+//   MARVEEN_CHANNELS_GATE=manual
+// and pointed the operator at a manual root step that had nothing left to do.
+// The reverse of the usual failure: the work was done, the report said it was
+// not. Measured 2026-09-01 on a Linux/Docker install whose image already
+// carried /etc/claude-code/managed-settings.json.
+//
+// Reading that file needs no privilege -- it is org policy at 0644, not a
+// secret -- so the idempotent check now runs unprivileged and first; only a
+// WRITE resolves sudo.
+//
+// These tests run the REAL script body out of the shipped file, sliced after
+// the OS `case` so the harness can point MANAGED_FILE at a fixture.
+
+const ROOT = join(__dirname, '..', '..')
+const SCRIPT = readFileSync(join(ROOT, 'scripts', 'ensure-managed-channels-enabled.sh'), 'utf-8')
+
+/**
+ * Everything after the OS `case`, so the harness can point MANAGED_FILE at a
+ * fixture instead of /etc.
+ *
+ * Anchored on `esac` rather than on either of the two blocks this change
+ * reorders -- that is what lets these tests run unchanged against the pre-fix
+ * script, where they fail on the REPORT ("manual" for an already-configured
+ * host) instead of on an unbound variable.
+ */
+function scriptBody(src: string): string {
+  const end = src.indexOf('esac')
+  if (end < 0) throw new Error('OS case not found')
+  return src.slice(end + 'esac'.length)
+}
+
+/**
+ * Run the REAL body against a fixture.
+ *  - managed: JSON to place at MANAGED_FILE, or null to leave it absent
+ *  - sudo: 'hidden' (not installed), 'broken' (present but always fails),
+ *          or 'root' (running as uid 0, so no sudo is used at all)
+ */
+function runGate(opts: { managed: string | null; sudo: 'hidden' | 'broken' | 'root' }): string {
+  const dir = mkdtempSync(join(tmpdir(), 'marveen-gate-'))
+  const file = join(dir, 'managed-settings.json')
+  if (opts.managed !== null) writeFileSync(file, opts.managed)
+
+  const stubs: string[] = []
+  if (opts.sudo === 'hidden') {
+    // `command -v sudo` must miss. Overriding the `command` builtin with a
+    // function is the only way to hide it without rewriting PATH, which would
+    // also hide python3 and coreutils that the script legitimately needs.
+    stubs.push('command() { if [ "$1" = "-v" ] && [ "$2" = "sudo" ]; then return 1; fi; builtin command "$@"; }')
+  } else if (opts.sudo === 'broken') {
+    // Present on PATH but unusable -- no password, no sudoers entry. This is
+    // the shape that produced three password prompts and then gave up.
+    stubs.push('sudo() { return 1; }')
+  } else {
+    stubs.push('id() { echo 0; }')
+  }
+
+  const script = [
+    'set -u',
+    `MANAGED_FILE=${JSON.stringify(file)}`,
+    ...stubs,
+    scriptBody(SCRIPT),
+  ].join('\n')
+
+  return execFileSync('bash', ['-c', script], { encoding: 'utf-8' }).trim()
+}
+
+const ENABLED = JSON.stringify({ channelsEnabled: true })
+
+describe('ensure-managed-channels-enabled: report what is true, not what is reachable', () => {
+  it('reports ok when already enabled and sudo is not installed -- the regression', () => {
+    expect(runGate({ managed: ENABLED, sudo: 'hidden' })).toContain('MARVEEN_CHANNELS_GATE=ok')
+  })
+
+  it('reports ok when already enabled and sudo exists but cannot be used', () => {
+    expect(runGate({ managed: ENABLED, sudo: 'broken' })).toContain('MARVEEN_CHANNELS_GATE=ok')
+  })
+
+  it('preserves other managed keys when it has to write', () => {
+    const out = runGate({
+      managed: JSON.stringify({ allowedChannelPlugins: ['telegram'] }),
+      sudo: 'root',
+    })
+    expect(out).toContain('MARVEEN_CHANNELS_GATE=ok')
+  })
+
+  it('still reports manual when a write is needed but cannot be made', () => {
+    expect(runGate({ managed: null, sudo: 'hidden' })).toContain('MARVEEN_CHANNELS_GATE=manual')
+  })
+
+  it('still reports manual when the key is present but false and there is no privilege', () => {
+    expect(runGate({ managed: JSON.stringify({ channelsEnabled: false }), sudo: 'hidden' }))
+      .toContain('MARVEEN_CHANNELS_GATE=manual')
+  })
+})


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)

## Rövid leírás / Summary

**HU.** Az `ensure-managed-channels-enabled.sh` előbb oldja fel a jogosultság-prefixet (`sudo`), és csak utána nézi meg a fájlt. Így a „nincs teendő" válasz olyan jogosultság mögé került, ami a megválaszolásához sosem kellett.

Olyan gépen, ahol a `channelsEnabled` **már `true` volt**, de a futtató felhasználónak nincs használható `sudo`-ja, ezt írta:

```
! channelsEnabled: nem root es nincs sudo -- kihagyva.
MARVEEN_CHANNELS_GATE=manual
```

és elküldte az üzemeltetőt egy kézi root-lépésre, amin nem volt mit elvégezni. A szokásos hiba fordítottja: a munka kész volt, a jelentés azt mondta, nincs kész.

Ha a `sudo` jelen van, de használhatatlan (nincs jelszó, nincs sudoers bejegyzés), ugyanez **három jelszókérés** után következik be.

**EN.** The script resolved its privilege prefix before looking at the file, so "nothing to do" was gated behind a privilege that answering it never needed. A host where the key was already set, but the invoking user had no usable sudo, reported `manual`.

A managed fájl org-policy `0644`-en, nem titok — az olvasásához semmilyen jogosultság nem kell. Az idempotens ellenőrzés mostantól **jogosultság nélkül és elsőként** fut; `sudo`-t csak az **írás** old fel.

Nem változik sem az, amit kiír, sem a kézi lépésre vonatkozó tanács akkor, ha az írás tényleg nem végezhető el.

## Kapcsolódó issue / Related issue

Nincs / none.

## Tesztek

A tesztek a leszállított fájl **valódi** törzsét futtatják, az OS-`case` után elvágva, hogy a harness a saját fixture-jére mutathasson. A horgony az `esac`, nem a két átrendezett blokk valamelyike — így a **javítás előtti** scripten is lefutnak, és ott a **jelentésen** buknak:

```
javítás nélkül:  2 failed | 3 passed
javítással:      5 passed
```

Lefedett esetek: már bekapcsolva + nincs sudo; már bekapcsolva + sudo van, de használhatatlan; írás kell, de nincs jogosultság; `channelsEnabled: false` jogosultság nélkül; meglévő managed kulcsok megőrzése íráskor.

A telepítőt érintő 10 meglévő teszt-fájl (112 teszt) változatlanul zöld ezen az ágon.

## Ellenőrzőlista / Checklist

- [ ] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard) — **lásd lentebb.**
- [x] Frissítettem a `docs/` mappát, ha szükséges. *(Nem szükséges: sem a felület, sem a kiírt tanács nem változik.)*
- [x] A kód nem tartalmaz beleégetett szenzitív adatot.
- [x] Saját, beszédes nevű branch-ről nyitom.

**Az első pontról őszintén:** a hibás jelentést élesben megfigyeltem, és a javítást unit-teszttel fedtem le, de teljes varázsló-futtatást a javítással nem végeztem. A script `|| true`-val hívódik az `install-linux.sh`-ból, tehát a telepítés menetét semmilyen irányban nem befolyásolja.

## Titok-kapu / Secret gate

- [x] Nincs a változtatásban bizonyíték-/artefaktum-mappa, titok-alakú string vagy idézett csatorna-üzenet.

---

*Docker/Linux üzembe helyezés kidolgozása közben jött elő: ott az image build-időben hozza a `/etc/claude-code/managed-settings.json`-t, a konténer-felhasználónak pedig szándékosan nincs `sudo`-ja. macOS-en a telepítő olyan felhasználóként fut, aki tud sudózni, így ez az ág ott aligha jön elő.*
