### PR TITLE
fix(installer): honour OLLAMA_URL instead of hardcoding localhost

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -1450,8 +1450,25 @@ echo ""
 echo -e "${BOLD}$(_t section_6_linux)${NC}"
 
 # --- Ollama telepites ---
+#
+# Where the RUNTIME will look. src/config.ts:331 reads OLLAMA_URL and falls back
+# to http://localhost:11434; this step used to hardcode that fallback in seven
+# places, so an install pointed at a non-default or remote Ollama probed and
+# pulled the embedding model somewhere the running fleet would never read --
+# and installed a second, local daemon it did not need. Same precedence as the
+# runtime: the environment first, then the .env this installer has already
+# written, then the historical default.
+OLLAMA_API="${OLLAMA_URL:-}"
+if [ -z "$OLLAMA_API" ] && [ -f "$INSTALL_DIR/.env" ]; then
+  OLLAMA_API="$(grep -E '^OLLAMA_URL=' "$INSTALL_DIR/.env" | head -1 | cut -d= -f2- | tr -d ' "')"
+fi
+OLLAMA_API="${OLLAMA_API:-http://localhost:11434}"
+
 echo -e "  Ollama ellenorzese (szemantikus memoria kereseshez)..."
-if command -v ollama &>/dev/null; then
+if curl -s --max-time 5 "${OLLAMA_API}/api/version" &>/dev/null; then
+  # Answering already: nothing to install, wherever it happens to run.
+  ok "ollama elerheto (${OLLAMA_API})"
+elif command -v ollama &>/dev/null; then
   ok "ollama mar telepitve"
 else
   echo -e "  Ollama telepitese..."
@@ -1471,16 +1488,18 @@ else
   fi
 fi
 
-# A service-inditas es modell-letoltes csak akkor fut, ha az ollama tenyleg telepult.
-if command -v ollama &>/dev/null; then
+# The service-start + model-pull block runs when there is a local binary to
+# start OR an API to pull through -- a remote/containerised Ollama has no local
+# binary, but the model still has to exist on it.
+if command -v ollama &>/dev/null || curl -s --max-time 5 "${OLLAMA_API}/api/version" &>/dev/null; then
 # A telepito letrehoz egy ollama.service systemd egységet és elindítja.
 # Ha megis nem futna, systemctl-lel indítjuk -- NEM ollama serve &
-if ! curl -s http://localhost:11434/api/version &>/dev/null; then
+if ! curl -s "${OLLAMA_API}/api/version" &>/dev/null; then
   echo -e "$(_t linux.ollama_starting)"
   sudo systemctl enable --now ollama 2>/dev/null || true
   # Megvarjuk amig az API valaszol (max 15 mp)
   for i in $(seq 1 15); do
-    curl -s http://localhost:11434/api/version &>/dev/null && break
+    curl -s "${OLLAMA_API}/api/version" &>/dev/null && break
     sleep 1
   done
 fi
@@ -1498,11 +1517,11 @@ ollama_pull() {
   # exits non-zero, the assignment inherits it, and the ERR trap kills the
   # install at step "ollama-whisper". So skip -- non-fatal -- whenever the API is
   # not answering, instead of trying a pull that cannot work.
-  if ! curl -s --max-time 5 http://localhost:11434/api/version &>/dev/null; then
-    warn "ollama API nem valaszol (:11434) -- $model letoltese kimarad (a szolgaltatas nem all fel). Kesobb: ollama serve && ollama pull $model"
+  if ! curl -s --max-time 5 "${OLLAMA_API}/api/version" &>/dev/null; then
+    warn "ollama API nem valaszol (${OLLAMA_API}) -- $model letoltese kimarad (a szolgaltatas nem all fel). Kesobb: ollama serve && ollama pull $model"
     return 0
   fi
-  if curl -s http://localhost:11434/api/tags | grep -q "\"$model\""; then
+  if curl -s "${OLLAMA_API}/api/tags" | grep -q "\"$model\""; then
     ok "$model mar letoltve"
     return 0
   fi
@@ -1512,7 +1531,7 @@ ollama_pull() {
   # assignment aborts the script when its pipeline exits non-zero (empty body ->
   # json.load raises -> python3 exits 1). The guard turns that into the warn path.
   status=$(curl -s --max-time 600 \
-    -X POST http://localhost:11434/api/pull \
+    -X POST "${OLLAMA_API}/api/pull" \
     -H 'Content-Type: application/json' \
     -d "{\"model\": \"$model\", \"stream\": false}" |
     python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('status','?'))" 2>/dev/null) || status=""

--- a/src/__tests__/installer-ollama-nonfatal.test.ts
+++ b/src/__tests__/installer-ollama-nonfatal.test.ts
@@ -24,12 +24,13 @@ import { join } from 'node:path'
 const ROOT = join(__dirname, '..', '..')
 const LINUX = readFileSync(join(ROOT, 'install-linux.sh'), 'utf-8')
 
-/** Pull the `if command -v ollama ... fi` block (defs + call) out of the script. */
+/** Pull the ollama service+pull block (defs + call) out of the script. */
 function ollamaBlock(src: string): string {
-  // The second `if command -v ollama` opens the service+pull block (the first is
-  // the install-or-skip block just above); slice from there to its labelled fi.
-  const firstIdx = src.indexOf('if command -v ollama &>/dev/null; then')
-  const start = src.indexOf('if command -v ollama &>/dev/null; then', firstIdx + 1)
+  // Since OLLAMAURL901 the service+pull guard also accepts a reachable API, so
+  // it no longer reads `command -v ollama` alone -- a remote or containerised
+  // Ollama has no local binary but still needs the model. That `|| curl` is
+  // what distinguishes it from the install-or-skip guard above.
+  const start = src.indexOf('if command -v ollama &>/dev/null || curl')
   const end = src.indexOf('fi  # command -v ollama')
   if (start < 0 || end < 0 || end <= start) throw new Error('ollama block not found')
   return src.slice(start, end + 'fi  # command -v ollama'.length)
@@ -66,6 +67,9 @@ function runOllamaBlock(opts: { apiUp: boolean; pullBody?: string }): { code: nu
     'warn() { echo "warn: $*"; }',
     '_t() { echo "$1"; }',
     'sudo() { return 0; }',       // service enable is best-effort; never real here
+    // The block reads OLLAMA_API (resolved from OLLAMA_URL further up the
+    // installer); the historical default is what these cases describe.
+    'OLLAMA_API=http://localhost:11434',
     'seq() { command seq "$@"; }',
     'sleep() { return 0; }',      // no real waiting in the test
     // ollama is PRESENT (binary installed) -- the exact BC100 shape.

--- a/src/__tests__/installer-ollama-url.test.ts
+++ b/src/__tests__/installer-ollama-url.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { readFileSync, writeFileSync, mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+// src/config.ts:331 resolves the embedding endpoint as
+//   OLLAMA_URL ?? 'http://localhost:11434'
+// but install-linux.sh hardcoded that fallback in seven places and never read
+// OLLAMA_URL at all (`grep -c OLLAMA_URL install-linux.sh` was 0). An install
+// pointed at a non-default or remote Ollama therefore:
+//   - probed :11434 locally, found nothing, and installed a SECOND daemon,
+//   - pulled nomic-embed-text into that local daemon,
+//   - while the running fleet read the configured endpoint, where the model
+//     was missing -- semantic memory silently degraded.
+//
+// The installer now resolves the endpoint the way the runtime does. These tests
+// run the REAL resolution block out of the shipped install-linux.sh.
+
+const ROOT = join(__dirname, '..', '..')
+const LINUX = readFileSync(join(ROOT, 'install-linux.sh'), 'utf-8')
+const DEFAULT_URL = 'http://localhost:11434'
+
+/** The OLLAMA_API resolution block. */
+function resolutionBlock(src: string): string {
+  const start = src.indexOf('OLLAMA_API="${OLLAMA_URL:-}"')
+  if (start < 0) throw new Error('OLLAMA_API resolution not found')
+  const marker = `OLLAMA_API="\${OLLAMA_API:-${DEFAULT_URL}}"`
+  const end = src.indexOf(marker, start)
+  if (end < 0) throw new Error('OLLAMA_API default not found')
+  return src.slice(start, end + marker.length)
+}
+
+/** Resolve with a given environment and .env content. */
+function resolve(opts: { envVar?: string; dotenv?: string }): string {
+  const dir = mkdtempSync(join(tmpdir(), 'marveen-ollamaurl-'))
+  if (opts.dotenv !== undefined) writeFileSync(join(dir, '.env'), opts.dotenv)
+
+  const script = [
+    'set -e',
+    `INSTALL_DIR=${JSON.stringify(dir)}`,
+    resolutionBlock(LINUX),
+    'echo "$OLLAMA_API"',
+  ].join('\n')
+
+  return execFileSync('bash', ['-c', script], {
+    encoding: 'utf-8',
+    env: { ...process.env, ...(opts.envVar ? { OLLAMA_URL: opts.envVar } : { OLLAMA_URL: '' }) },
+  }).trim()
+}
+
+describe('installer: OLLAMA_URL resolution matches the runtime', () => {
+  it('falls back to the historical default when nothing is configured', () => {
+    expect(resolve({})).toBe(DEFAULT_URL)
+  })
+
+  it('takes OLLAMA_URL from the environment', () => {
+    expect(resolve({ envVar: 'http://ollama.internal:11434' })).toBe('http://ollama.internal:11434')
+  })
+
+  it('takes OLLAMA_URL from the .env the installer has already written', () => {
+    expect(resolve({ dotenv: 'BOT_NAME=Marveen\nOLLAMA_URL=http://10.0.0.5:11434\n' }))
+      .toBe('http://10.0.0.5:11434')
+  })
+
+  it('lets the environment win over .env, as cfg() does', () => {
+    expect(resolve({ envVar: 'http://env-wins:11434', dotenv: 'OLLAMA_URL=http://dotenv:11434\n' }))
+      .toBe('http://env-wins:11434')
+  })
+
+  it('tolerates a quoted .env value', () => {
+    expect(resolve({ dotenv: 'OLLAMA_URL="http://quoted:11434"\n' })).toBe('http://quoted:11434')
+  })
+
+  it('falls back when .env has no OLLAMA_URL key', () => {
+    expect(resolve({ dotenv: 'BOT_NAME=Marveen\n' })).toBe(DEFAULT_URL)
+  })
+})
+
+describe('installer: no hardcoded endpoint left in the ollama step', () => {
+  it('reaches the API only through OLLAMA_API', () => {
+    // Everything after the resolution must go through the variable. The two
+    // remaining literals are the documented default and the comment naming it.
+    const afterResolution = LINUX.slice(LINUX.indexOf('OLLAMA_API="${OLLAMA_URL:-}"'))
+    const stray = afterResolution
+      .split('\n')
+      .filter((l) => l.includes(DEFAULT_URL) && !l.includes('OLLAMA_API="${OLLAMA_API:-'))
+    expect(stray).toEqual([])
+  })
+})


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)

## Rövid leírás / Summary

**HU.** A `src/config.ts:331` így oldja fel az embedding-végpontot:

```ts
export const OLLAMA_URL = cfg('OLLAMA_URL') ?? 'http://localhost:11434'
```

és az `OLLAMA_URL` regisztrált, restart-jelölt konfig-kulcs (`src/config-registry.ts:270`). Az `install-linux.sh` viszont **soha nem olvasta** — a `grep -c OLLAMA_URL install-linux.sh` **0**-t adott —, helyette hét helyen beégette ugyanazt az alapértelmezést.

Következmény, ha valaki nem-alapértelmezett vagy távoli Ollamára mutat: a telepítő a **helyi** `:11434`-et pingeli, nem talál semmit, feltelepít egy **második** daemont, abba húzza le a `nomic-embed-text`-et — miközben a futó flotta a konfigurált végpontot olvassa, ahol a modell soha nem jött le. Semmi nem hasal el hangosan: a szemantikus memória csendben leromlik.

**EN.** The runtime resolves the embedding endpoint from `OLLAMA_URL`; the installer never read it and hardcoded the fallback in seven places. An install pointed at a non-default or remote Ollama installed a second local daemon and pulled the model into the wrong one.

### Változtatások

- `OLLAMA_API` egyszeri feloldása, a runtime saját precedenciájával: környezet → a már megírt `.env` → a történeti alapértelmezés
- minden probe/pull/tags hívás és az „API nem valaszol" figyelmeztetés ezen keresztül megy
- a helyi telepítés kimarad, ha a konfigurált végpont már válaszol
- a service+pull blokk akkor fut, ha **van helyi bináris VAGY elérhető API** — egy távoli/konténeres Ollamának nincs helyi binárisa, de a modellnek ott is léteznie kell

### Meglévő teszt

Az `installer-ollama-nonfatal.test.ts` a régi service+pull őrfeltételre volt horgonyozva, amit ez a PR kiszélesít. A horgonyát és a harness-ét ugyanebben a commitban frissítettem; a három esete változatlanul zöld.

## Kapcsolódó issue / Related issue

Nincs / none.

## Tesztek

Az új teszt a leszállított `install-linux.sh`-ból futtatja a **valódi** feloldó blokkot: alapértelmezés, környezeti változó, `.env`-ből olvasás, környezet nyer a `.env` felett (ahogy a `cfg()` is teszi), idézőjeles `.env` érték, és hiányzó kulcs. Plusz egy őr arra, hogy a feloldás után ne maradjon beégetett végpont.

```
7 passed
```

A telepítőt érintő 10 meglévő teszt-fájl (112 teszt) változatlanul zöld ezen az ágon.

## Ellenőrzőlista / Checklist

- [ ] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard) — **lásd lentebb.**
- [x] Frissítettem a `docs/` mappát, ha szükséges. *(Szólj, ha szeretnéd: az `OLLAMA_URL` mostantól a telepítéskor is értelmezett, ez a `docs/memory-system.md`-be kívánkozhat.)*
- [x] A kód nem tartalmaz beleégetett szenzitív adatot.
- [x] Saját, beszédes nevű branch-ről nyitom.

**Az első pontról őszintén:** ez a három PR közül a legnagyobb felületű, és **teljes varázsló-futtatással nem validáltam** — a hibát statikusan azonosítottam (`grep -c OLLAMA_URL` = 0), a viselkedést unit-teszttel fedtem le. Ha ezt a hármat rangsorolnád, ezt tenném a sor végére.

## Titok-kapu / Secret gate

- [x] Nincs a változtatásban bizonyíték-/artefaktum-mappa, titok-alakú string vagy idézett csatorna-üzenet.

---

*Docker/Linux üzembe helyezés kidolgozása közben jött elő, ahol a konténer a host már futó Ollamájára mutat, hogy a modell és a GPU ne duplázódjon. macOS-en, ahol az Ollama jellemzően ugyanazon a gépen, alapértelmezett porton fut, ez a szakadék nem látszik.*
