### PR TITLE
feat(email-gate): email_send level as a real switch on the main agent (EMAILKAPU901 PR2)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,7 +17,10 @@
     "PreToolUse": [
       { "matcher": "Bash", "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/outgoing-copy-gate.py\"", "timeout": 15 } ] },
       { "matcher": ".*send_email.*", "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/outgoing-copy-gate.py\"", "timeout": 15 } ] },
-      { "matcher": "mcp__plugin_telegram_telegram__reply", "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/outgoing-copy-gate.py\"", "timeout": 15 } ] }
+      { "matcher": "mcp__plugin_telegram_telegram__reply", "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/outgoing-copy-gate.py\"", "timeout": 15 } ] },
+      { "matcher": "Bash", "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/email-approval-gate.py\"", "timeout": 10 } ] },
+      { "matcher": ".*send_email.*", "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/email-approval-gate.py\"", "timeout": 10 } ] },
+      { "matcher": ".*manage_email.*", "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/email-approval-gate.py\"", "timeout": 10 } ] }
     ],
     "Stop": [
       { "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/telegram-reply-guard.py\"", "timeout": 10 } ] }

--- a/scripts/__tests__/email-approval-gate.test.py
+++ b/scripts/__tests__/email-approval-gate.test.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""EMAILKAPU901 PR2: the email_send level becomes a real switch on the main agent.
+
+Branches proven (Marveen msgs 17900/17936):
+  - level 1: the send is DENIED outright.
+  - level 2: denied without approval; ALLOWED against an approved, matching,
+    in-window approval; the SAME send a SECOND time is denied again (one-shot
+    consumption -- the feature's built-in mutation control); an expired window
+    denies; a pending approval denies with its id.
+  - level 3: allowed.
+  - four-field anchor: an approval for the SAME subject+body but a DIFFERENT
+    recipient does NOT authorize the send.
+  - FAIL-CLOSED, proven separately from the happy path: missing approvals DB,
+    missing/corrupt autonomy-config, unreadable letter ($VAR body), and a
+    recipient that cannot be extracted all DENY (exit 2, never 1).
+
+Run: python3 <thisfile>   Exit 0 = all pass.
+"""
+import json
+import os
+import re
+import sqlite3
+import subprocess
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+GATE = os.path.join(os.path.dirname(HERE), "hooks", "email-approval-gate.py")
+WINDOW = 1800
+
+failed = []
+
+
+def check(name, ok, detail=""):
+    print(f"  [{'PASS' if ok else 'FAIL'}] {name}" + (f" -- {detail}" if not ok and detail else ""))
+    if not ok:
+        failed.append(name)
+
+
+def make_store(td, level=2, max_level=None, config="ok"):
+    store = os.path.join(td, "store")
+    os.makedirs(store, exist_ok=True)
+    cfg_path = os.path.join(store, "autonomy-config.json")
+    if config == "ok":
+        cat = {"key": "email_send", "label": "Email", "level": level, "locked": False}
+        if max_level is not None:
+            cat["maxLevel"] = max_level
+        with open(cfg_path, "w", encoding="utf-8") as fh:
+            json.dump({"version": 1, "categories": [cat]}, fh)
+    elif config == "corrupt":
+        with open(cfg_path, "w", encoding="utf-8") as fh:
+            fh.write("{not json")
+    # config == "missing": write nothing
+    db_path = os.path.join(store, "claudeclaw.db")
+    con = sqlite3.connect(db_path)
+    con.execute("""
+      CREATE TABLE approvals (
+        id TEXT PRIMARY KEY, agent_id TEXT NOT NULL, category TEXT NOT NULL,
+        action_description TEXT NOT NULL, action_payload TEXT,
+        status TEXT NOT NULL DEFAULT 'pending',
+        timeout_at INTEGER, telegram_message_id INTEGER,
+        requested_at INTEGER NOT NULL DEFAULT (unixepoch()),
+        resolved_at INTEGER, resolved_by TEXT,
+        content_hash TEXT, consumed_at INTEGER)""")
+    con.commit()
+    con.close()
+    return store
+
+
+def run_gate(store, payload):
+    env = dict(os.environ,
+               EMAIL_APPROVAL_GATE_STORE=store,
+               EMAIL_APPROVAL_WINDOW_S=str(WINDOW),
+               OUTGOING_COPY_GATE_RULES=os.path.join(store, "no-rules.json"))
+    proc = subprocess.run([sys.executable, GATE], input=json.dumps(payload).encode(),
+                          capture_output=True, env=env)
+    return proc.returncode, proc.stdout.decode(), proc.stderr.decode()
+
+
+def mcp_send(to="a@b.hu", cc=None, subject="Teszt tárgy", body="Kedves Ügyfelünk! Törzs."):
+    ti = {"to": [to], "subject": subject, "body": body}
+    if cc:
+        ti["cc"] = [cc]
+    return {"tool_name": "mcp__server-gmail-autoauth-mcp__send_email", "tool_input": ti}
+
+
+def approve(store, anchor, resolved_ago=0, status="approved", consumed=None):
+    con = sqlite3.connect(os.path.join(store, "claudeclaw.db"))
+    con.execute(
+        "INSERT INTO approvals (id, agent_id, category, action_description, status,"
+        " requested_at, resolved_at, resolved_by, content_hash, consumed_at)"
+        " VALUES (hex(randomblob(6)), 'marveen', 'email_send', 'Email teszt', ?,"
+        " unixepoch()-?-60, CASE WHEN ?='pending' THEN NULL ELSE unixepoch()-? END,"
+        " 'szabi', ?, ?)",
+        (status, resolved_ago, status, resolved_ago, anchor, consumed))
+    con.commit()
+    con.close()
+
+
+def anchor_from_stderr(err):
+    m = re.search(r"\b([0-9a-f]{64})\b", err)
+    return m.group(1) if m else None
+
+
+with tempfile.TemporaryDirectory() as td:
+    # --- scope: what the gate must NOT touch --------------------------------
+    store = make_store(os.path.join(td, "s0"), level=1)
+    code, _, _ = run_gate(store, {"tool_name": "Bash", "tool_input": {"command": "ls -la"}})
+    check("non-send Bash passes untouched even at level 1", code == 0, f"exit={code}")
+    code, _, _ = run_gate(store, {"tool_name": "Read", "tool_input": {"file_path": "/x"}})
+    check("non-email tool passes untouched", code == 0, f"exit={code}")
+
+    # --- level 1: hard deny --------------------------------------------------
+    code, _, err = run_gate(store, mcp_send())
+    check("level 1: MCP send DENIED", code == 2 and "szint 1" in err, f"exit={code}")
+    code, _, err = run_gate(store, {"tool_name": "mcp__x__manage_email",
+                                    "tool_input": {"action": "send", "to": ["a@b.hu"], "body": "x"}})
+    check("level 1: manage_email DENIED too (2026-08-10 bypass class)", code == 2, f"exit={code}")
+
+    # --- level 3: allow ------------------------------------------------------
+    store = make_store(os.path.join(td, "s3"), level=3)
+    code, _, _ = run_gate(store, mcp_send())
+    check("level 3: MCP send allowed", code == 0, f"exit={code}")
+
+    # --- level 2: the approval loop -----------------------------------------
+    store = make_store(os.path.join(td, "s2"), level=2)
+    payload = mcp_send()
+    code, _, err = run_gate(store, payload)
+    anchor = anchor_from_stderr(err)
+    check("level 2 without approval: DENIED and the deny carries the sha256 anchor",
+          code == 2 and "NINCS jovahagyas" in err and anchor is not None, f"exit={code} err={err[:150]!r}")
+    check("deny message is actionable (POST /api/approvals + resend instructions)",
+          "api/approvals" in err and "content_hash" in err and "a@b.hu" in err)
+
+    approve(store, anchor)
+    code, out, _ = run_gate(store, payload)
+    check("level 2 with approved+matching+in-window approval: ALLOWED",
+          code == 0 and "felhasznalva" in out, f"exit={code} out={out[:120]!r}")
+
+    con = sqlite3.connect(os.path.join(store, "claudeclaw.db"))
+    consumed = con.execute("SELECT consumed_at FROM approvals WHERE content_hash=?", (anchor,)).fetchone()[0]
+    con.close()
+    check("the allow CONSUMED the approval (consumed_at set in the DB)", consumed is not None)
+
+    code, _, err = run_gate(store, payload)
+    check("the SAME send a SECOND time: DENIED (one-shot)",
+          code == 2 and "FEL LETT HASZNALVA" in err, f"exit={code}")
+
+    # window expiry: a different letter, approved too long ago
+    payload_b = mcp_send(subject="Masik tárgy")
+    _, _, err = run_gate(store, payload_b)
+    anchor_b = anchor_from_stderr(err)
+    approve(store, anchor_b, resolved_ago=WINDOW + 60)
+    code, _, err = run_gate(store, payload_b)
+    check("approval outside the time window: DENIED as expired",
+          code == 2 and "IDOABLAKA lejart" in err, f"exit={code} err={err[:150]!r}")
+
+    # pending approval names itself
+    payload_c = mcp_send(subject="Harmadik tárgy")
+    _, _, err = run_gate(store, payload_c)
+    anchor_c = anchor_from_stderr(err)
+    approve(store, anchor_c, status="pending")
+    code, _, err = run_gate(store, payload_c)
+    check("pending approval: DENIED with 'meg fuggoben'",
+          code == 2 and "FUGGOBEN" in err, f"exit={code}")
+
+    # --- the four-field anchor: recipient is part of the identity ------------
+    payload_d = mcp_send(subject="Negyedik tárgy", body="Ugyanaz a törzs.")
+    _, _, err = run_gate(store, payload_d)
+    approve(store, anchor_from_stderr(err))
+    hijacked = mcp_send(to="evil@x.hu", subject="Negyedik tárgy", body="Ugyanaz a törzs.")
+    code, _, err = run_gate(store, hijacked)
+    check("approved subject+body to a DIFFERENT recipient: DENIED (anchor covers to)",
+          code == 2 and "NINCS jovahagyas" in err, f"exit={code}")
+    cc_flip = mcp_send(cc="cc@x.hu", subject="Negyedik tárgy", body="Ugyanaz a törzs.")
+    code, _, _ = run_gate(store, cc_flip)
+    check("same letter with an ADDED cc: DENIED (anchor covers cc)", code == 2)
+
+    # --- maxLevel clamps -----------------------------------------------------
+    store = make_store(os.path.join(td, "sclamp"), level=3, max_level=2)
+    code, _, err = run_gate(store, mcp_send())
+    check("level 3 clamped by maxLevel 2: behaves as level 2 (deny w/o approval)",
+          code == 2 and "level 2" in err, f"exit={code}")
+
+    # --- Bash path end-to-end at level 2 ------------------------------------
+    store = make_store(os.path.join(td, "sbash"), level=2)
+    bash_payload = {"tool_name": "Bash", "tool_input": {
+        "command": 'sendmail --to a@b.hu --subject "Bash tárgy" --body "Bash törzs."'}}
+    code, _, err = run_gate(store, bash_payload)
+    b_anchor = anchor_from_stderr(err)
+    check("level 2 Bash send without approval: DENIED with anchor",
+          code == 2 and b_anchor is not None, f"exit={code} err={err[:150]!r}")
+    approve(store, b_anchor)
+    code, _, _ = run_gate(store, bash_payload)
+    check("level 2 Bash send with approval: ALLOWED", code == 0, f"exit={code}")
+
+    # --- FAIL-CLOSED, each branch separately --------------------------------
+    store = make_store(os.path.join(td, "sf1"), level=2)
+    os.remove(os.path.join(store, "claudeclaw.db"))
+    code, _, err = run_gate(store, mcp_send())
+    check("fail-closed: approvals DB missing -> DENIED (undecidable != allowed)",
+          code == 2 and "nem-eldontheto" in err, f"exit={code}")
+
+    store = make_store(os.path.join(td, "sf2"), config="missing")
+    code, _, err = run_gate(store, mcp_send())
+    check("fail-closed: autonomy-config missing -> level 2 path, DENIED w/o approval",
+          code == 2 and "fail-closed" in err, f"exit={code}")
+
+    store = make_store(os.path.join(td, "sf3"), config="corrupt")
+    code, _, err = run_gate(store, mcp_send())
+    check("fail-closed: autonomy-config corrupt -> level 2 path, DENIED",
+          code == 2, f"exit={code}")
+
+    store = make_store(os.path.join(td, "sf4"), level=2)
+    code, _, err = run_gate(store, {"tool_name": "Bash", "tool_input": {
+        "command": 'sendmail --to a@b.hu --body "$LETTER"'}})
+    check("fail-closed: $VAR body at level 2 -> DENIED as unanchorable",
+          code == 2 and "horgonyozhato" in err, f"exit={code}")
+
+    code, _, err = run_gate(store, {"tool_name": "mcp__x__send_email",
+                                    "tool_input": {"subject": "t", "body": "b"}})
+    check("fail-closed: no extractable recipient -> DENIED",
+          code == 2 and "cimzett" in err, f"exit={code}")
+
+    code, _, err = run_gate(store, {"tool_name": "mcp__x__send_email", "tool_input": "not-a-dict"})
+    check("fail-closed: non-dict tool_input -> DENIED (exit 2, never 1)",
+          code == 2, f"exit={code}")
+
+print()
+if failed:
+    print(f"{len(failed)} FAILED: {failed}", file=sys.stderr)
+    sys.exit(1)
+print("All email-approval-gate tests passed.")

--- a/scripts/hooks/email-approval-gate.py
+++ b/scripts/hooks/email-approval-gate.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Level-aware email approval gate for the MAIN agent (EMAILKAPU901 PR2).
+
+Wired in the repo's .claude/settings.json (PreToolUse: Bash + *send_email* +
+*manage_email*), i.e. for sessions rooted at PROJECT_ROOT -- the main agent.
+Sub-agents keep their unconditional hard-deny (scripts/email-send-gate.mjs in
+their own settings); a sub-agent session that also loads this hook is still
+blocked by that one, so this gate can never widen sub-agent rights.
+
+The `email_send.level` in store/autonomy-config.json becomes a real switch:
+  level 1  -> hard deny (signal-only autonomy).
+  level 2  -> CHECK-BEFORE-SEND: the send is allowed only against an APPROVED,
+              UNCONSUMED, IN-WINDOW approval whose content_hash equals the
+              sha256 anchor of THIS letter's four fields (to + cc + subject +
+              body). A body+subject hash alone would let an approved letter be
+              re-sent to a different recipient -- hence all four (msg 17936).
+  level 3  -> allow (autonomous; the outgoing-copy-gate still audits copy).
+
+Anchor semantics (Marveen msg 17900, 5+1 conditions):
+  1. the hash is computed from the SAME extraction the copy gate audits
+     (email_extract.collect_email_envelope -- single implementation);
+  2. an approval is ONE-SHOT: consumed atomically on allow;
+  3. a TIME WINDOW (~30 min from approval) bounds the hash match;
+  4. FAIL-CLOSED: unreadable letter, unrecoverable recipient, missing config,
+     or unreachable approvals DB all DENY -- "cannot decide" never means
+     "allowed";
+  5. the deny message hands the agent the exact hash + a readable summary, so
+     the approval's action_description is human-readable and the resend can
+     only succeed with byte-identical content.
+
+Exit codes (PreToolUse contract): 0 = allow, 2 = block. A crash must never
+exit 1 (non-blocking) -- the __main__ net converts it to 2 on send paths.
+"""
+import hashlib
+import importlib.util
+import json
+import os
+import re
+import sqlite3
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(os.path.dirname(_HERE))
+STORE_DIR = os.environ.get("EMAIL_APPROVAL_GATE_STORE",
+                           os.path.join(_ROOT, "store"))
+DB_PATH = os.path.join(STORE_DIR, "claudeclaw.db")
+CONFIG_PATH = os.path.join(STORE_DIR, "autonomy-config.json")
+# ~30 minutes from approval (resolved_at) to send; env override is for tests.
+WINDOW_S = int(os.environ.get("EMAIL_APPROVAL_WINDOW_S", "1800"))
+
+sys.path.insert(0, _HERE)
+from email_extract import collect_email_envelope  # noqa: E402
+
+_SEND_TOOL = re.compile(r"send_email|manage_email", re.I)
+
+
+def _load_is_send_invocation():
+    """Import is_send_invocation from outgoing-copy-gate.py (dashed filename,
+    so importlib by path). Single implementation: the same classifier that
+    decides what the copy gate audits decides what this gate levels."""
+    spec = importlib.util.spec_from_file_location(
+        "outgoing_copy_gate", os.path.join(_HERE, "outgoing-copy-gate.py"))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.is_send_invocation
+
+
+def read_email_level():
+    """Return (level, note). Missing category / unreadable config -> level 2:
+    fail-closed but recoverable through an approval, instead of a hard lockout
+    on an install whose config never listed the category."""
+    try:
+        with open(CONFIG_PATH, encoding="utf-8") as fh:
+            cfg = json.load(fh)
+        for cat in cfg.get("categories") or []:
+            if cat.get("key") == "email_send":
+                level = int(cat.get("level"))
+                mx = cat.get("maxLevel")
+                if isinstance(mx, int):
+                    level = min(level, mx)
+                return max(1, min(3, level)), None
+        return 2, "az email_send kategoria hianyzik az autonomy-configbol -> level 2 (fail-closed)"
+    except Exception as exc:  # noqa: BLE001 -- unreadable config is a fail-closed input
+        return 2, f"az autonomy-config nem olvashato ({exc!r}) -> level 2 (fail-closed)"
+
+
+def content_anchor(env: dict) -> str:
+    """sha256 over the four-field envelope. Canonical JSON so the same letter
+    always yields the same anchor; `text` is subject+body exactly as the copy
+    gate audits it, from the shared extractor."""
+    canon = json.dumps({"to": env["to"], "cc": env["cc"], "text": env["text"]},
+                       ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canon.encode("utf-8")).hexdigest()
+
+
+def find_and_consume(anchor: str):
+    """Return (verdict, detail). verdict: 'allowed' (consumed approval id),
+    'pending', 'consumed', 'expired', 'none', 'race'. Raises on any DB problem
+    -- the caller turns that into a fail-closed deny."""
+    if not os.path.exists(DB_PATH):
+        raise OSError(f"approvals DB hianyzik ({DB_PATH})")
+    con = sqlite3.connect(DB_PATH, timeout=5)
+    try:
+        con.execute("PRAGMA busy_timeout=5000")
+        row = con.execute(
+            "SELECT id FROM approvals WHERE category='email_send' AND status='approved'"
+            " AND content_hash=? AND consumed_at IS NULL AND resolved_at >= unixepoch()-?"
+            " ORDER BY resolved_at DESC LIMIT 1", (anchor, WINDOW_S)).fetchone()
+        if row:
+            # Atomic one-shot: only the UPDATE that flips NULL->now wins.
+            cur = con.execute(
+                "UPDATE approvals SET consumed_at=unixepoch()"
+                " WHERE id=? AND consumed_at IS NULL", (row[0],))
+            con.commit()
+            return ("allowed", row[0]) if cur.rowcount > 0 else ("race", row[0])
+        for verdict, cond in (
+            ("pending", "status='pending'"),
+            ("consumed", "status='approved' AND consumed_at IS NOT NULL"),
+            ("expired", f"status='approved' AND consumed_at IS NULL AND resolved_at < unixepoch()-{int(WINDOW_S)}"),
+        ):
+            hit = con.execute(
+                f"SELECT id FROM approvals WHERE category='email_send' AND content_hash=? AND {cond} LIMIT 1",
+                (anchor,)).fetchone()
+            if hit:
+                return (verdict, hit[0])
+        return ("none", None)
+    finally:
+        con.close()
+
+
+def deny(msg: str):
+    sys.stderr.write(f"EMAIL JOVAHAGYASI KAPU: TILTVA.\n{msg}\n")
+    sys.exit(2)
+
+
+def summarize(env: dict) -> str:
+    to = ", ".join(env["to"]) or "(nincs)"
+    cc = ", ".join(env["cc"]) or "-"
+    head = env["text"].replace("\n", " ")[:120]
+    return f"Cimzett: {to} | CC: {cc} | Szoveg eleje: {head}"
+
+
+def main():
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)  # unparseable payload must not wedge the session (copy-gate parity)
+    tool = str(payload.get("tool_name") or "")
+    tool_input = payload.get("tool_input")
+    tool_input = tool_input if isinstance(tool_input, dict) else {}
+
+    if _SEND_TOOL.search(tool):
+        pass  # MCP email send: always in scope
+    elif tool == "Bash":
+        cmd = str(tool_input.get("command") or "")
+        if not _load_is_send_invocation()(cmd):
+            sys.exit(0)
+    else:
+        sys.exit(0)
+
+    level, note = read_email_level()
+    prefix = f"({note})\n" if note else ""
+    if level >= 3:
+        sys.exit(0)
+    if level <= 1:
+        deny(prefix +
+             "Az email_send autonomia-szint 1 (csak jelez): a kuldes tiltott.\n"
+             "Jelezd a gazdanak inter-agent uzenettel vagy a dashboardon; a szint "
+             "emelese a store/autonomy-config.json-ban a gazda dontese.")
+
+    # level 2: CHECK-BEFORE-SEND
+    env = collect_email_envelope(tool, tool_input)
+    if env["unreadable_reason"]:
+        deny(prefix +
+             f"A level nem horgonyozhato: {env['unreadable_reason']}.\n"
+             "Fail-closed: tedd a hivast determinisztikusan olvashatova (inline "
+             "--to/--cc/--subject/--body vagy MCP-mezok, shell-valtozo NELKUL), "
+             "aztan kuldd ujra.")
+    if not env["text"].strip():
+        deny(prefix + "A hivasbol nem nyerheto ki level-szoveg -- fail-closed.")
+    if not env["to"]:
+        deny(prefix +
+             "A hivasbol nem nyerheto ki cimzett (a horgony a cimzettet is fedi).\n"
+             "Hasznalj explicit --to flaget vagy MCP to-mezot, aztan kuldd ujra.")
+
+    anchor = content_anchor(env)
+    try:
+        verdict, detail = find_and_consume(anchor)
+    except Exception as exc:  # noqa: BLE001 -- DB unreachable is fail-closed, not no-right
+        deny(prefix +
+             f"A jovahagyasok nem elerheto(k) ({exc!r}) -- nem-eldontheto, ezert "
+             "fail-closed TILTVA. Ha a dashboard/DB helyreallt, kuldd ujra.")
+
+    if verdict == "allowed":
+        print(json.dumps({"systemMessage":
+            f"email-approval-gate: jovahagyas {detail} felhasznalva (egyszer-hasznalatos), a kuldes mehet."}))
+        sys.exit(0)
+
+    reasons = {
+        "pending": f"A(z) {detail} jovahagyas meg FUGGOBEN van -- varj a gazda donteseig, aztan kuldd ujra.",
+        "consumed": f"A(z) {detail} jovahagyas MAR FEL LETT HASZNALVA (egyszer-hasznalatos) -- uj jovahagyas kell.",
+        "expired": f"A(z) {detail} jovahagyas IDOABLAKA lejart ({WINDOW_S // 60} perc) -- uj jovahagyas kell.",
+        "race": "A jovahagyast egy parhuzamos kuldes hasznalta fel -- uj jovahagyas kell.",
+        "none": "Ehhez a levelhez NINCS jovahagyas.",
+    }
+    deny(prefix +
+         f"email_send level 2 (CHECK-BEFORE-SEND). {reasons[verdict]}\n"
+         f"Tartalom-horgony (sha256; to+cc+targy+torzs): {anchor}\n"
+         f"{summarize(env)}\n"
+         "Jovahagyas kerese: POST /api/approvals a sajat agent_id-ddal, "
+         'category="email_send", content_hash=a fenti horgony, action_description='
+         "az olvashato osszefoglalo (cimzett + targy + torzs eleje).\n"
+         "Jovahagyas UTAN PONTOSAN ugyanezt a hivast kuldd ujra -- a horgony csak "
+         "byte-azonos levelre egyezik, es a jovahagyas egyszer hasznalhato, "
+         f"{WINDOW_S // 60} percig ervenyes.")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except SystemExit:
+        raise
+    except Exception as exc:  # noqa: BLE001 -- deliberate fail-closed net
+        # Same contract as the copy gate: an unhandled crash would exit 1,
+        # which PreToolUse treats as NON-blocking -- the send would run
+        # unchecked. On this gate every matched path is a send path, so
+        # blocking is always the safe failure mode.
+        sys.stderr.write(
+            f"EMAIL JOVAHAGYASI KAPU: TILTVA, belso hiba a vizsgalat kozben ({exc!r}).\n"
+            "Fail-closed: tedd vizsgalhatova a hivast, aztan kuldd ujra.\n")
+        sys.exit(2)

--- a/src/__tests__/approvals-delivery.test.ts
+++ b/src/__tests__/approvals-delivery.test.ts
@@ -40,6 +40,8 @@ function approval(over: Partial<Approval> = {}): Approval {
     requested_at: Math.floor(NOW_MS / 1000),
     resolved_at: null,
     resolved_by: null,
+    content_hash: null,
+    consumed_at: null,
     ...over,
   }
 }

--- a/src/__tests__/approvals.test.ts
+++ b/src/__tests__/approvals.test.ts
@@ -34,6 +34,36 @@ describe('createApproval', () => {
     expect(a.telegram_message_id).toBeNull()
   })
 
+  // EMAILKAPU901 PR2: the content-hash anchor must survive the DB roundtrip
+  // exactly -- the python gate matches it byte-for-byte, so a truncated or
+  // re-cased value would silently authorize nothing.
+  it('persists content_hash verbatim and readable back (EMAILKAPU901 PR2)', () => {
+    const hash = 'a'.repeat(40) + '0123456789abcdef01234567'
+    const a = createApproval({
+      id: 'ap-hash-1',
+      agent_id: 'marveen',
+      category: 'email_send',
+      action_description: 'Email: to=a@b.hu, targy=Teszt',
+      content_hash: hash,
+    })
+    expect(a.content_hash).toBe(hash)
+    expect(a.consumed_at).toBeNull()
+    const back = getApproval('ap-hash-1')
+    expect(back?.content_hash).toBe(hash)
+    expect(back?.consumed_at).toBeNull()
+  })
+
+  it('content_hash defaults to null when not provided', () => {
+    const a = createApproval({
+      id: 'ap-hash-2',
+      agent_id: 'agent-a',
+      category: 'email_send',
+      action_description: 'x',
+    })
+    expect(a.content_hash).toBeNull()
+    expect(getApproval('ap-hash-2')?.content_hash).toBeNull()
+  })
+
   it('stores timeout_at when provided', () => {
     const timeout_at = Math.floor(Date.now() / 1000) + 1800
     const a = createApproval({

--- a/src/__tests__/email-approval-gate.test.ts
+++ b/src/__tests__/email-approval-gate.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { spawnSync } from 'node:child_process'
+import { join } from 'node:path'
+
+// EMAILKAPU901 PR2: the email_send autonomy level becomes a real switch on the
+// main agent (scripts/hooks/email-approval-gate.py, wired in the repo's
+// .claude/settings.json). The python suite proves all three level branches,
+// the one-shot + time-window approval semantics against a real SQLite store,
+// the four-field anchor (an approved letter re-addressed to a different
+// recipient or cc is denied), and each fail-closed branch separately (missing
+// DB, missing/corrupt config, unreadable letter, missing recipient, non-dict
+// input). This wrapper makes that suite a CI gate.
+const ROOT = join(__dirname, '..', '..')
+
+describe('email approval gate levels (EMAILKAPU901 PR2)', () => {
+  it('the python suite passes (levels + one-shot + window + anchor + fail-closed)', () => {
+    const res = spawnSync('python3', [join(ROOT, 'scripts', '__tests__', 'email-approval-gate.test.py')], {
+      encoding: 'utf-8',
+      timeout: 120_000,
+    })
+    if (res.status !== 0) {
+      console.error(res.stdout)
+      console.error(res.stderr)
+    }
+    expect(res.status).toBe(0)
+  })
+})

--- a/src/db.ts
+++ b/src/db.ts
@@ -956,6 +956,14 @@ export function initDatabase(dbPathOverride?: string): void {
   `)
   db.exec(`CREATE INDEX IF NOT EXISTS idx_approvals_status ON approvals(status, requested_at)`)
   db.exec(`CREATE INDEX IF NOT EXISTS idx_approvals_agent ON approvals(agent_id, requested_at)`)
+  // EMAILKAPU901 PR2: content-hash anchor + one-shot consumption. content_hash
+  // pins an approval to the EXACT letter (sha256 over to+cc+subject+body,
+  // computed by scripts/hooks/email-approval-gate.py); consumed_at is flipped
+  // atomically by the gate on the first allowed send, so an approval can never
+  // authorize two sends.
+  try { db.exec('ALTER TABLE approvals ADD COLUMN content_hash TEXT') } catch { /* already exists */ }
+  try { db.exec('ALTER TABLE approvals ADD COLUMN consumed_at INTEGER') } catch { /* already exists */ }
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_approvals_hash ON approvals(content_hash)`)
 
   // --- Dashboard browser login (OPTIONAL; the bearer token stays primary) ---
   // Zero rows here = exactly the token-only behavior. A row is created only when
@@ -3463,6 +3471,8 @@ export interface Approval {
   requested_at: number
   resolved_at: number | null
   resolved_by: string | null
+  content_hash: string | null
+  consumed_at: number | null
 }
 
 export function createApproval(params: {
@@ -3472,11 +3482,12 @@ export function createApproval(params: {
   action_description: string
   action_payload?: string | null
   timeout_at?: number | null
+  content_hash?: string | null
 }): Approval {
   const now = Math.floor(Date.now() / 1000)
   db.prepare(`
-    INSERT INTO approvals (id, agent_id, category, action_description, action_payload, timeout_at, requested_at)
-    VALUES (?, ?, ?, ?, ?, ?, ?)
+    INSERT INTO approvals (id, agent_id, category, action_description, action_payload, timeout_at, requested_at, content_hash)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
   `).run(
     params.id,
     params.agent_id,
@@ -3485,6 +3496,7 @@ export function createApproval(params: {
     params.action_payload ?? null,
     params.timeout_at ?? null,
     now,
+    params.content_hash ?? null,
   )
   return {
     id: params.id,
@@ -3498,6 +3510,8 @@ export function createApproval(params: {
     requested_at: now,
     resolved_at: null,
     resolved_by: null,
+    content_hash: params.content_hash ?? null,
+    consumed_at: null,
   }
 }
 

--- a/src/web/routes/approvals.ts
+++ b/src/web/routes/approvals.ts
@@ -162,7 +162,7 @@ export async function tryHandleApprovals(ctx: RouteContext): Promise<boolean> {
 
   // POST /api/approvals -- create new approval request
   if (path === '/api/approvals' && method === 'POST') {
-    let body: { agent_id?: unknown; category?: unknown; action_description?: unknown; action_payload?: unknown; timeout_seconds?: unknown }
+    let body: { agent_id?: unknown; category?: unknown; action_description?: unknown; action_payload?: unknown; timeout_seconds?: unknown; content_hash?: unknown }
     try {
       body = JSON.parse((await readBody(req)).toString())
     } catch {
@@ -170,7 +170,7 @@ export async function tryHandleApprovals(ctx: RouteContext): Promise<boolean> {
       return true
     }
 
-    const { agent_id, category, action_description, action_payload, timeout_seconds } = body
+    const { agent_id, category, action_description, action_payload, timeout_seconds, content_hash } = body
     if (typeof agent_id !== 'string' || !agent_id.trim()) {
       json(res, { error: 'agent_id is required' }, 400)
       return true
@@ -187,6 +187,14 @@ export async function tryHandleApprovals(ctx: RouteContext): Promise<boolean> {
       json(res, { error: 'action_payload must be a string (JSON) if provided' }, 400)
       return true
     }
+    // EMAILKAPU901 PR2: the email-approval-gate hook hands the requesting
+    // agent this exact sha256 anchor (to+cc+subject+body); a malformed value
+    // could never match the gate's recomputation, so reject it loudly here
+    // instead of storing a row that silently authorizes nothing.
+    if (content_hash !== undefined && (typeof content_hash !== 'string' || !/^[0-9a-f]{64}$/.test(content_hash))) {
+      json(res, { error: 'content_hash must be a 64-char lowercase sha256 hex string if provided' }, 400)
+      return true
+    }
 
     const id = randomUUID()
     const timeout_at = computeTimeoutAt(category, timeout_seconds)
@@ -197,6 +205,7 @@ export async function tryHandleApprovals(ctx: RouteContext): Promise<boolean> {
       action_description: action_description.trim(),
       action_payload: typeof action_payload === 'string' ? action_payload : null,
       timeout_at,
+      content_hash: typeof content_hash === 'string' ? content_hash : null,
     })
 
     notifyOwner(approval)


### PR DESCRIPTION
## What

PR2 of the EMAILKAPU901 split, built on the PR1 module (#1148). The main agent's outbound email goes through the new `scripts/hooks/email-approval-gate.py` (wired in the tracked `.claude/settings.json`, same mechanism as the copy gate -- this is where main-agent hooks live, so the intent of "the gate reaches the main agent" is satisfied without touching agent-scaffold; sub-agents keep the unconditional `email-send-gate.mjs` hard-deny, which this hook can never loosen).

- **level 1** -> hard deny. **level 3** -> allow. **level 2** -> CHECK-BEFORE-SEND against the approvals store: allowed only with an APPROVED, UNCONSUMED, IN-WINDOW (30 min from `resolved_at`) approval whose `content_hash` equals the sha256 anchor over **to + cc + subject + body** (the four-field anchor from msg 17936 -- an approved letter re-addressed to a different recipient or cc does NOT pass).
- The anchor is computed from `email_extract.collect_email_envelope` -- the SAME single extraction the copy gate audits (condition 5). The deny message hands the agent the exact anchor + readable summary (readable `action_description`, condition +1); only a byte-identical resend can match.
- One-shot: consumption is an atomic `UPDATE ... WHERE consumed_at IS NULL`; the second identical send is denied.
- Fail-closed everywhere: unreachable approvals DB = undecidable = deny; missing/corrupt autonomy-config degrades to level 2 (recoverable through approval, not silent allow and not permanent lockout); unreadable letter or unextractable recipient = deny; crash exits 2, never 1.
- Store: `approvals` + `content_hash`, `consumed_at` (ALTER-if-missing); `POST /api/approvals` accepts validated `content_hash`.

## Verify

`scripts/__tests__/email-approval-gate.test.py` (23 checks, CI-gated via vitest wrapper): all three level branches; the full approval loop against a real SQLite store (deny-without -> allow-with -> **second identical send denied**, the spec's built-in mutation control); window expiry; pending-approval named; **recipient-flip and cc-flip denied** (four-field anchor proven on the colliding fields); maxLevel clamp; Bash path end-to-end; and each **fail-closed branch separately** -- missing DB, missing config, corrupt config, `$VAR` body, missing recipient, non-dict input (the happy path never certifies the failure path).

External mutation control (run + reverted, all three RED as required): one-shot SELECT filter removed; time window neutralized; missing DB swallowed as "no approval".

Full `npm test`: 4460 passed. `tsc --noEmit` clean. hook-registration-completeness green (the hook registers via `.claude/settings.json`).

## Deploy consequence (owner decision surface, flagged per canary-deploy rule)

Our live config has `email_send: level 2, maxLevel 2`. Once this deploys, the main agent's email sends (including scheduled flows like the weekly newsletter) require an approval round. That is exactly the GO'd CHECK-BEFORE-SEND, but the timing/level for specific flows is the owner's call -- flag at deploy, not after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)