### PR TITLE
fix(email-gate): unparseable payload fails closed on the approval gate

### DIFF
--- a/scripts/__tests__/email-approval-gate.test.py
+++ b/scripts/__tests__/email-approval-gate.test.py
@@ -226,6 +226,16 @@ with tempfile.TemporaryDirectory() as td:
     check("fail-closed: non-dict tool_input -> DENIED (exit 2, never 1)",
           code == 2, f"exit={code}")
 
+    # Marveen's #1149 review: this gate AUTHORIZES, so unlike the copy gate it
+    # must fail closed on an unparseable payload too -- the docstring and the
+    # code now state the same contract.
+    env = dict(os.environ, EMAIL_APPROVAL_GATE_STORE=store,
+               OUTGOING_COPY_GATE_RULES=os.path.join(store, "no-rules.json"))
+    proc = subprocess.run([sys.executable, GATE], input=b"this is not json",
+                          capture_output=True, env=env)
+    check("fail-closed: unparseable stdin -> DENIED (exit 2, never 0/1)",
+          proc.returncode == 2, f"exit={proc.returncode}")
+
 print()
 if failed:
     print(f"{len(failed)} FAILED: {failed}", file=sys.stderr)

--- a/scripts/hooks/email-approval-gate.py
+++ b/scripts/hooks/email-approval-gate.py
@@ -30,6 +30,9 @@ Anchor semantics (Marveen msg 17900, 5+1 conditions):
 
 Exit codes (PreToolUse contract): 0 = allow, 2 = block. A crash must never
 exit 1 (non-blocking) -- the __main__ net converts it to 2 on send paths.
+EVERY malformed input (unparseable stdin included) blocks: unlike the copy
+gate, which audits and stays alive on harness faults, this gate authorizes,
+so "cannot decide" is always a deny.
 """
 import hashlib
 import importlib.util
@@ -144,7 +147,15 @@ def main():
     try:
         payload = json.load(sys.stdin)
     except Exception:
-        sys.exit(0)  # unparseable payload must not wedge the session (copy-gate parity)
+        # FAIL-CLOSED, deliberately DIVERGING from the copy gate (Marveen's
+        # #1149 review): the copy gate AUDITS and chooses session-liveness on
+        # a broken harness payload; this gate AUTHORIZES, and an unreadable
+        # payload on a send-matched call must not authorize anything. Loud
+        # deny beats a silent fail-open on the one hook whose whole job is
+        # the deny. (Costs: a systematically broken harness blocks Bash on
+        # the main agent -- visible immediately, which is the point.)
+        deny("A hook-payload nem ertelmezheto (nem-JSON stdin) -- fail-closed, "
+             "mert ez a kapu ENGEDELYEZ: ertelmezhetetlen hivas nem kaphat engedelyt.")
     tool = str(payload.get("tool_name") or "")
     tool_input = payload.get("tool_input")
     tool_input = tool_input if isinstance(tool_input, dict) else {}

--- a/src/__tests__/hook-exit-code-invariant.test.ts
+++ b/src/__tests__/hook-exit-code-invariant.test.ts
@@ -41,6 +41,7 @@ interface HookCase {
 const HOOKS: HookCase[] = [
   // PreToolUse gates
   { script: 'scripts/hooks/outgoing-copy-gate.py', runner: 'python3', cls: 'gate', tool: 'mcp__x__send_email' },
+  { script: 'scripts/hooks/email-approval-gate.py', runner: 'python3', cls: 'gate', tool: 'mcp__x__send_email' },
   { script: 'scripts/hooks/egress-gate.mjs', runner: 'node', cls: 'gate', tool: 'WebFetch' },
   { script: 'scripts/email-send-gate.mjs', runner: 'node', cls: 'gate', tool: 'mcp__x__send_email' },
   { script: 'scripts/self-pace-gate.mjs', runner: 'node', cls: 'gate', tool: 'Bash' },


### PR DESCRIPTION
## What

Closes the inconsistency from Marveen's #1149 review: the unparseable-stdin branch exited 0 (copy-gate parity) while the crash net a few lines down declared blocking the safe failure mode -- both could not be true. Resolved toward strictness, with the divergence from the copy gate stated in the code: the copy gate audits and keeps the session alive on a harness fault; this gate authorizes, so an unreadable payload on a send-matched call must not authorize anything. The docstring now states exactly the contract the code enforces.

Also: the gate joins the `hook-exit-code-invariant` corpus (gate class -- exit 1 forbidden on both malformed shapes), which it was missing from.

## Verify

- New suite case: unparseable stdin -> exit 2 (never 0/1). Mutation-checked: restoring the old `sys.exit(0)` turns exactly that check red; reverted green.
- Invariant suite green with the new corpus entry (34 targeted tests), full `npm test` 4465 green, tsc clean.
- Trade-off stated in-code: a systematically broken harness now blocks main-agent Bash loudly instead of letting possible sends through silently -- visible immediately, which is the point of a governance gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)