### PR TITLE
fix(scheduler): suppress downtime-only alerts, keep self-healing intact

### DIFF
--- a/src/__tests__/schedule-catchup.test.ts
+++ b/src/__tests__/schedule-catchup.test.ts
@@ -172,10 +172,27 @@ describe('the runner wires the policy in', () => {
   })
 
   it('reports both halves of the gap in one line', () => {
-    expect(SRC).toMatch(/sendCatchUpSummary\(caughtUpThisTick, staleThisTick/)
+    expect(SRC).toMatch(/logCatchUpSummary\(caughtUpThisTick, staleThisTick/)
   })
 
   it('stays silent on a tick that caught nothing up', () => {
     expect(SRC).toMatch(/if \(caughtUpThisTick\.length \|\| staleThisTick\.length\) \{/)
+  })
+
+  // 2026-09-02 (kanban 83b8c4c3): the catch-up summary fires exactly when the
+  // scheduler slept through a gap, which on this install always means the
+  // machine was asleep or off -- operator-caused downtime, not an incident.
+  // The summary is therefore LOG-ONLY: the catch-up mechanism (re-running /
+  // stale-declaring) is untouched, but no channel message ever goes out.
+  it('the catch-up summary is log-only -- no channel send on downtime recovery (fix-revert guard)', () => {
+    const fnStart = SRC.indexOf('function logCatchUpSummary')
+    expect(fnStart, 'logCatchUpSummary not found').toBeGreaterThan(0)
+    const fnEnd = SRC.indexOf('\nfunction ', fnStart + 1)
+    const fnBody = SRC.slice(fnStart, fnEnd > fnStart ? fnEnd : undefined)
+    expect(fnBody).not.toMatch(/sendSchedulerAlertMessage/)
+    expect(fnBody).not.toMatch(/resolveSchedulerAlertToken/)
+    expect(fnBody).toMatch(/logger\.info/)
+    // And no renamed send helper sneaks back in at the call site either.
+    expect(SRC).not.toMatch(/sendCatchUpSummary/)
   })
 })

--- a/src/__tests__/sleep-wake-detector.test.ts
+++ b/src/__tests__/sleep-wake-detector.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  detectClockJump,
+  sleptInWindow,
+  recordClockSample,
+  systemSleptBetween,
+  resetSleepWakeDetectorForTest,
+  SLEEP_GAP_THRESHOLD_MS,
+  SLEEP_SAMPLE_INTERVAL_MS,
+  type WakeEvent,
+} from '../web/sleep-wake-detector.js'
+
+// Tests for the machine sleep/wake detector (2026-09-02, kanban 83b8c4c3).
+//
+// The detector's job: turn "our setInterval could not fire for a long
+// stretch" into a queryable fact, so wall-clock-based alert paths (stuck-task
+// timeout, keepalive staleness) can tell operator-caused downtime (lid close,
+// power off) apart from a genuine hang while running. Suppressed: the
+// Telegram ping. Untouched: respawn / retry / kanban / log visibility.
+
+afterEach(() => resetSleepWakeDetectorForTest())
+
+describe('detectClockJump', () => {
+  it('null previous sample (first ever sample) is never a jump', () => {
+    expect(detectClockJump(null, 1_000_000)).toBeNull()
+  })
+
+  it('a normal sample cadence is not a jump', () => {
+    expect(detectClockJump(0, SLEEP_SAMPLE_INTERVAL_MS)).toBeNull()
+  })
+
+  it('event-loop jitter below the threshold is not a jump', () => {
+    expect(detectClockJump(0, SLEEP_GAP_THRESHOLD_MS - 1)).toBeNull()
+  })
+
+  it('a gap at the threshold is a jump spanning [prev, now]', () => {
+    const jump = detectClockJump(1000, 1000 + SLEEP_GAP_THRESHOLD_MS)
+    expect(jump).toEqual({ sleepStartMs: 1000, wakeMs: 1000 + SLEEP_GAP_THRESHOLD_MS })
+  })
+
+  it('a BACKWARD clock step (NTP correction) is not sleep', () => {
+    expect(detectClockJump(1_000_000, 500_000)).toBeNull()
+  })
+})
+
+describe('sleptInWindow', () => {
+  const HOUR = 3_600_000
+  const nap: WakeEvent = { sleepStartMs: 10 * HOUR, wakeMs: 12 * HOUR }
+
+  it('no recorded events -> never slept (fail-safe: alerts behave as before)', () => {
+    expect(sleptInWindow([], 0, 100 * HOUR)).toBe(false)
+  })
+
+  it('a window fully containing the sleep gap overlaps', () => {
+    expect(sleptInWindow([nap], 9 * HOUR, 13 * HOUR)).toBe(true)
+  })
+
+  it('a window that merely BRUSHES the gap on either side overlaps', () => {
+    // Stuck-check opened before the sleep, closed mid-sleep... (cannot really
+    // happen mid-sleep, but the boundary math must not care)
+    expect(sleptInWindow([nap], 9 * HOUR, 10 * HOUR)).toBe(true)
+    // ...or opened during the gap's tail and closed after the wake.
+    expect(sleptInWindow([nap], 12 * HOUR, 13 * HOUR)).toBe(true)
+  })
+
+  it('a window entirely before or entirely after the gap does not overlap', () => {
+    expect(sleptInWindow([nap], 0, 10 * HOUR - 1)).toBe(false)
+    expect(sleptInWindow([nap], 12 * HOUR + 1, 14 * HOUR)).toBe(false)
+  })
+})
+
+describe('recordClockSample + systemSleptBetween (module state)', () => {
+  it('regular sampling records nothing; systemSleptBetween stays false', () => {
+    let t = 1_000_000
+    for (let i = 0; i < 10; i++) {
+      expect(recordClockSample(t)).toBeNull()
+      t += SLEEP_SAMPLE_INTERVAL_MS
+    }
+    expect(systemSleptBetween(1_000_000, t)).toBe(false)
+  })
+
+  it('a sleep gap between samples is recorded and queryable', () => {
+    const HOUR = 3_600_000
+    recordClockSample(1_000_000)
+    recordClockSample(1_000_000 + SLEEP_SAMPLE_INTERVAL_MS)
+    // Lid closed for two hours.
+    const wakeAt = 1_000_000 + SLEEP_SAMPLE_INTERVAL_MS + 2 * HOUR
+    const jump = recordClockSample(wakeAt)
+    expect(jump).not.toBeNull()
+    // The exact stuck-check shape: injectedAt just before the sleep, checked
+    // just after the wake -- the window overlaps the gap.
+    expect(systemSleptBetween(1_000_000, wakeAt + 1000)).toBe(true)
+    // A window opened AFTER the wake has no gap in it -- a genuine hang there
+    // must still alert.
+    expect(systemSleptBetween(wakeAt + 1000, wakeAt + 10 * 60_000)).toBe(false)
+  })
+
+  it('with the detector never fed (webOnly / tests), every query is false', () => {
+    expect(systemSleptBetween(0, Date.now())).toBe(false)
+  })
+})
+
+// --- Fix-revert guard: the consumers actually consult the detector ---
+//
+// If either sleep guard were removed, the greps below turn RED. Verified by
+// inspection: deleting the systemSleptBetween call in sendTaskTimeoutAlert or
+// checkMainKeepaliveStaleness fails the corresponding assertion.
+
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+describe('fix-revert guard: alert paths are sleep-aware', () => {
+  it('sendTaskTimeoutAlert consults systemSleptBetween before the channel send', () => {
+    const src = readFileSync(join(__dirname, '../web/schedule-runner.ts'), 'utf-8')
+    const fnStart = src.indexOf('function sendTaskTimeoutAlert')
+    expect(fnStart).toBeGreaterThan(0)
+    const fnEnd = src.indexOf('\nexport const SCHEDULE_TICK_MS', fnStart)
+    const fnBody = src.slice(fnStart, fnEnd > fnStart ? fnEnd : undefined)
+    const sleptIdx = fnBody.indexOf('systemSleptBetween(entry.injectedAt')
+    const sendIdx = fnBody.indexOf('await sendSchedulerAlertMessage(')
+    expect(sleptIdx, 'sleep guard missing from sendTaskTimeoutAlert').toBeGreaterThan(0)
+    expect(sendIdx).toBeGreaterThan(sleptIdx)
+    // The kanban 'waiting' move must NOT be short-circuited by the guard: the
+    // board keeps reflecting the stuck state even when Telegram stays quiet.
+    const kanbanIdx = fnBody.indexOf('markScheduledTaskKanbanWaiting(')
+    const suppressReturnIdx = fnBody.indexOf('if (sleptDuringWindow)')
+    expect(kanbanIdx).toBeGreaterThan(0)
+    expect(suppressReturnIdx).toBeGreaterThan(kanbanIdx)
+  })
+
+  it('checkMainKeepaliveStaleness suppresses sendAlert on sleep but keeps the respawn', () => {
+    const src = readFileSync(join(__dirname, '../web/channel-monitor.ts'), 'utf-8')
+    const fnStart = src.indexOf('function checkMainKeepaliveStaleness')
+    expect(fnStart).toBeGreaterThan(0)
+    const fnEnd = src.indexOf('\nexport function sendAlert', fnStart)
+    const fnBody = src.slice(fnStart, fnEnd > fnStart ? fnEnd : undefined)
+    const sleptIdx = fnBody.indexOf('systemSleptBetween(now - ageMs, now)')
+    expect(sleptIdx, 'sleep guard missing from checkMainKeepaliveStaleness').toBeGreaterThan(0)
+    // sendAlert is inside the !staleDueToSleep branch...
+    expect(fnBody).toMatch(/if \(!staleDueToSleep\) \{\s*\n\s*sendAlert\(/)
+    // ...while the respawn stays UNCONDITIONAL on sleep (self-healing keeps going).
+    const respawnIdx = fnBody.indexOf('respawnMarveenSessionFresh()')
+    expect(respawnIdx).toBeGreaterThan(sleptIdx)
+    const betweenGuardAndRespawn = fnBody.slice(fnBody.indexOf('if (!staleDueToSleep)'), respawnIdx)
+    expect(betweenGuardAndRespawn).not.toMatch(/return/)
+  })
+})

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -53,6 +53,7 @@ import { decideDownAgentAction, AGENT_MAX_RESTART_ATTEMPTS, parseEtimeToSeconds 
 // module so the standalone channel-coordinator reuses the exact same probe.
 import { getClaudePidForSession, hasChannelPluginAlive, probeChannelPluginLiveness, classifyRespawnStampAdvance } from '../channel-coordinator/liveness.js'
 import { getDesiredAgents } from './agent-desired-state.js'
+import { startSleepWakeDetector, systemSleptBetween } from './sleep-wake-detector.js'
 
 // Lazily resolved (see makeLazyBinResolver): a module-level `resolveFromPath`
 // const throws at IMPORT time, so any environment where the binary is not
@@ -1509,8 +1510,20 @@ function checkMainKeepaliveStaleness(): void {
     return
   }
   const ageMin = Math.round((ageMs ?? 0) / 60000)
-  logger.warn({ ageMs, paneState }, 'Channel keep-alive stale -- main session likely wedged/deaf, respawning via respawn-pane')
-  sendAlert(`⚠️ A fő channel keep-alive ${ageMin} perce nem frissült -- respawn-pane a ${MAIN_CHANNELS_SESSION} session-on (a beszelgetes elveszik, memoria marad).`)
+  // SLEEP GUARD (2026-09-02, kanban 83b8c4c3): a keepalive that went stale
+  // because the machine was asleep is not deafness -- every writer of that
+  // file was suspended right along with the poller. The respawn below still
+  // runs (harmless self-healing, it re-establishes the keepalive), but the
+  // Telegram alert is suppressed: waking the laptop should not ping the owner
+  // about an "outage" they caused by closing the lid. The staleness window is
+  // exactly [mtime, now], so a sleep gap overlapping it explains the age.
+  // Genuine wedge-while-running has no sleep gap in that window and alerts
+  // as before.
+  const staleDueToSleep = ageMs != null && systemSleptBetween(now - ageMs, now)
+  logger.warn({ ageMs, paneState, staleDueToSleep }, 'Channel keep-alive stale -- main session likely wedged/deaf, respawning via respawn-pane')
+  if (!staleDueToSleep) {
+    sendAlert(`⚠️ A fő channel keep-alive ${ageMin} perce nem frissült -- respawn-pane a ${MAIN_CHANNELS_SESSION} session-on (a beszelgetes elveszik, memoria marad).`)
+  }
   if (respawnMarveenSessionFresh()) {
     marveenLastKeepaliveRespawn = now
     // Suppress the process-down handler during the respawn window (reuses the
@@ -1671,6 +1684,10 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
   // per-agent spawn path never reaches, so an already-running unstamped install
   // heals on the next dashboard boot instead of never.
   try { stampFableOverageConsentSharedRoots() } catch { /* backstop handlers remain */ }
+
+  // Sleep/wake detection for the keepalive-staleness alert suppression
+  // (idempotent; the schedule runner starts it too, whichever runs first wins).
+  startSleepWakeDetector()
 
   const mainProvider = getMainAgentProvider()
 

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -58,6 +58,7 @@ import { decideQuotaAction, type QuotaWorkClass } from '../quota-gate.js'
 import { readQuotaSnapshot } from '../quota-snapshot.js'
 import { paneShowsContextSaturation, detectsFirstRunGate, detectPaneState, type PaneState } from '../pane-state.js'
 import { withSessionSendLock } from './session-send-lock.js'
+import { startSleepWakeDetector, systemSleptBetween } from './sleep-wake-detector.js'
 
 // How many bare-Enter attempts the post-send resubmit tries before escalating
 // to a clear + re-inject, and the hard cap after which it gives up.
@@ -1111,46 +1112,40 @@ function sendSchedulerAlertMessage(token: string, chatId: string, text: string):
 }
 
 // One line about what the scheduler missed while it was down: which tasks it
-// caught up, and which were too stale to be worth running. Sent once per tick
-// that produced any such entry -- in normal operation that is never, so the
-// channel stays quiet. This is the reporting half of the catch-up policy: a
-// missed occurrence either runs or gets named, never both and never neither.
-function sendCatchUpSummary(
+// caught up, and which were too stale to be worth running. Logged once per
+// tick that produced any such entry -- in normal operation that is never.
+// This is the reporting half of the catch-up policy: a missed occurrence
+// either runs or gets named, never both and never neither.
+//
+// LOG-ONLY, deliberately (2026-09-02, kanban 83b8c4c3). This summary fires
+// exactly when the scheduler noticed a gap it slept through, which on this
+// install means one thing: the machine was asleep or powered off. That is
+// downtime the operator caused on purpose, not a fault -- pinging Telegram
+// with "Kimaradt ütemezés (X perc kiesés)" on every lid-open was pure noise.
+// The catch-up MECHANISM (re-running / stale-declaring the missed
+// occurrences) is untouched; only the channel notification is gone. The
+// per-run records (appendTaskRun) and the dashboard /Ütemezések page still
+// show what was caught up or declared stale.
+function logCatchUpSummary(
   caughtUp: Array<{ task: string; ageMs: number }>,
   stale: Array<{ task: string; ageMs: number }>,
   gapMs: number,
 ): void {
-  const token = resolveSchedulerAlertToken()
-  if (!token) {
-    logger.warn({ provider: CHANNEL_PROVIDER }, 'catch-up summary suppressed: no channel bot token (config error)')
-    return
-  }
-  const ownerChat = resolveSchedulerOwnerChat()
-  if (!ownerChat) {
-    logger.warn({ provider: CHANNEL_PROVIDER }, 'catch-up summary suppressed: no owner chat (ALLOWED_CHAT_ID unset/placeholder and no paired channel)')
-    return
-  }
   const mins = (ms: number) => `${Math.round(ms / 60000)} perc`
-  const lines = [`[${BOT_NAME} scheduler] Kimaradt ütemezés (${mins(gapMs)} kiesés).`]
+  const lines = [`Kimaradt ütemezés (${mins(gapMs)} kiesés).`]
   if (caughtUp.length) {
     // "elindítva", not "lefutott": a catch-up injection can still land in the
     // pending-retry queue if the target session is busy. It will run; it may
-    // not have run yet at the moment this line is sent.
+    // not have run yet at the moment this line is logged.
     lines.push(`Pótlás elindítva: ${caughtUp.map(e => `${e.task} (${mins(e.ageMs)} késés)`).join(', ')}`)
   }
   if (stale.length) {
     lines.push(`Nem pótolva, mert elavult: ${stale.map(e => `${e.task} (${mins(e.ageMs)})`).join(', ')}`)
-    lines.push('Ezek a dashboard /Ütemezések oldalán kézzel indíthatók.')
   }
-  const text = lines.join('\n')
-  ;(async () => {
-    try {
-      await sendSchedulerAlertMessage(token, ownerChat, text)
-      logger.info({ caughtUp: caughtUp.length, stale: stale.length, provider: CHANNEL_PROVIDER }, 'catch-up summary alert sent')
-    } catch (err) {
-      logger.warn({ err }, 'catch-up summary delivery failed')
-    }
-  })()
+  logger.info(
+    { caughtUp: caughtUp.length, stale: stale.length, gapMinutes: Math.round(gapMs / 60000) },
+    `catch-up summary (log-only, downtime is not an incident): ${lines.join(' ')}`,
+  )
 }
 
 // Build the pending-retry alert body shared by stage 1 (main agent,
@@ -1312,6 +1307,18 @@ function sendTaskInflightMainAgentNotice(entry: TaskInflightEntry, elapsedMs: nu
 // alert, not a per-agent channel notification.
 function sendTaskTimeoutAlert(entry: TaskInflightEntry, elapsedMs: number): void {
   const ageMinutes = Math.floor(elapsedMs / 60000)
+  // SLEEP GUARD (2026-09-02, kanban 83b8c4c3): elapsedMs is wall-clock time
+  // since injection. If the machine slept anywhere inside that window, the
+  // number lies -- a 2-minute task injected just before lid-close reads as
+  // "stuck for hours" on wake (observed with ledger-live-drain). A window
+  // that contains a sleep gap proves nothing about the task, so no Telegram
+  // ping; the log line, the kanban 'waiting' move below, and the rest of the
+  // stuck handling (one-shot flag, eviction, retries) run unchanged. Genuine
+  // hangs are unaffected: their window contains no sleep gap. Trade-off,
+  // accepted: the alert is one-shot per injection, so a task that ALSO hangs
+  // for real after the wake stays Telegram-silent for that injection -- it is
+  // still visible in the log/dashboard and ages into the normal eviction path.
+  const sleptDuringWindow = systemSleptBetween(entry.injectedAt, Date.now())
   const token = resolveSchedulerAlertToken()
   if (!token) {
     logger.warn({ task: entry.taskName, agent: entry.agentName, provider: CHANNEL_PROVIDER }, 'task-timeout alert suppressed: no channel bot token (config error)')
@@ -1320,6 +1327,14 @@ function sendTaskTimeoutAlert(entry: TaskInflightEntry, elapsedMs: number): void
   const ownerChat = resolveSchedulerOwnerChat()
   if (!ownerChat) {
     logger.warn({ task: entry.taskName, agent: entry.agentName, provider: CHANNEL_PROVIDER }, 'task-timeout alert suppressed: no owner chat (ALLOWED_CHAT_ID unset/placeholder and no paired channel)')
+    return
+  }
+
+  if (sleptDuringWindow) {
+    logger.info(
+      { task: entry.taskName, agent: entry.agentName, ageMinutes, injectedAt: entry.injectedAt },
+      'task-timeout: machine slept inside the stuck-check window -- wall-clock elapsed is unreliable, Telegram alert suppressed (stuck handling continues)',
+    )
     return
   }
 
@@ -1348,6 +1363,9 @@ function sendTaskTimeoutAlert(entry: TaskInflightEntry, elapsedMs: number): void
 export const SCHEDULE_TICK_MS = 15_000
 
 export function startScheduleRunner(): NodeJS.Timeout {
+  // Sleep/wake detection for the downtime-aware alert suppression above
+  // (idempotent; the channel monitor starts it too, whichever runs first wins).
+  startSleepWakeDetector()
   // Reload the persisted last-run times so a restart inside a task's catch-up
   // window does not re-fire an already-run task.
   loadScheduleLastRun()
@@ -1727,11 +1745,12 @@ export function startScheduleRunner(): NodeJS.Timeout {
       }
     }
 
-    // Tell the operator, in one line, what the gap cost. Only fires when this
-    // tick actually caught something up or declared something too stale, which
-    // in steady state is never.
+    // Record, in one line, what the gap cost (log + dashboard only -- see
+    // logCatchUpSummary for why this never goes to the channel). Only fires
+    // when this tick actually caught something up or declared something too
+    // stale, which in steady state is never.
     if (caughtUpThisTick.length || staleThisTick.length) {
-      sendCatchUpSummary(caughtUpThisTick, staleThisTick, pendingStartupGapMs || (now - fromMs))
+      logCatchUpSummary(caughtUpThisTick, staleThisTick, pendingStartupGapMs || (now - fromMs))
     }
     pendingStartupGapMs = 0
 

--- a/src/web/sleep-wake-detector.ts
+++ b/src/web/sleep-wake-detector.ts
@@ -1,0 +1,110 @@
+import { logger } from '../logger.js'
+
+// Machine sleep/wake detection for downtime-aware alerting (2026-09-02, kanban
+// 83b8c4c3): the scheduler and channel-monitor alert paths must be able to
+// tell "something broke WHILE the machine was running" apart from "the machine
+// was asleep / powered off, and every wall-clock timer aged past its threshold
+// while nothing was actually wrong". The first is worth a Telegram ping; the
+// second is pure noise (the operator closed the lid, they know).
+//
+// Implementation choice: a CLOCK-JUMP detector, not `pmset -g log` parsing.
+// A setInterval cannot fire while the host (or this process) is suspended, so
+// a sample gap far beyond the sample interval is positive evidence the process
+// was not running across that gap. Compared to pmset this is
+//   - cross-platform (the installer targets plain Linux hosts too; pmset is
+//     macOS-only and its log format is not a stable API),
+//   - free of a subprocess spawn on every check (`pmset -g log` reads the
+//     whole power log, routinely megabytes), and
+//   - a superset signal: it also catches SIGSTOP / App Nap / VM pauses, which
+//     age wall-clock timers exactly the way real sleep does and deserve the
+//     same alert suppression.
+// The trade-off: no history from before this process started. That is fine
+// for every consumer here -- each one measures a window that opened while
+// this process was alive (an injection it performed, a keepalive mtime it
+// tracks), so a sleep inside that window necessarily stalled our own timer.
+//
+// Window sizing: 15 s samples (aligned with the scheduler tick, negligible
+// cost) and a 60 s gap threshold = four consecutive missed samples. Event-loop
+// jitter or a slow tick can eat one sample interval, not four; real lid-close
+// sleep is minutes to hours. Events are kept 24 h (covers any overnight gap a
+// morning stuck-check could span) and capped so a pathological clock cannot
+// grow the buffer unbounded.
+
+export interface WakeEvent {
+  // Last sample before the gap: the machine was provably awake here...
+  sleepStartMs: number
+  // ...and provably awake again here. The gap between them is downtime.
+  wakeMs: number
+}
+
+export const SLEEP_SAMPLE_INTERVAL_MS = 15_000
+export const SLEEP_GAP_THRESHOLD_MS = 60_000
+export const WAKE_EVENT_RETENTION_MS = 24 * 60 * 60_000
+const WAKE_EVENT_MAX = 200
+
+// Pure: does a sample pair prove a sleep/suspend gap? prevSampleMs is null on
+// the very first sample (nothing to compare against). A BACKWARD jump (NTP
+// step, manual clock set) is not sleep; only a forward gap counts.
+export function detectClockJump(
+  prevSampleMs: number | null,
+  nowMs: number,
+  gapThresholdMs: number = SLEEP_GAP_THRESHOLD_MS,
+): WakeEvent | null {
+  if (prevSampleMs == null) return null
+  if (nowMs - prevSampleMs < gapThresholdMs) return null
+  return { sleepStartMs: prevSampleMs, wakeMs: nowMs }
+}
+
+// Pure: did any recorded sleep gap overlap [fromMs, toMs]? Overlap, not
+// containment: a stuck-check window that merely BRUSHES a sleep gap already
+// means the wall-clock elapsed time overstates the awake time.
+export function sleptInWindow(events: readonly WakeEvent[], fromMs: number, toMs: number): boolean {
+  return events.some(e => e.wakeMs >= fromMs && e.sleepStartMs <= toMs)
+}
+
+let wakeEvents: WakeEvent[] = []
+let lastSampleMs: number | null = null
+let detectorTimer: NodeJS.Timeout | null = null
+
+// Feed one wall-clock sample. Exposed (with an explicit `nowMs`) so callers
+// that already tick on their own cadence could piggyback, and for tests.
+export function recordClockSample(nowMs: number = Date.now()): WakeEvent | null {
+  const jump = detectClockJump(lastSampleMs, nowMs)
+  lastSampleMs = nowMs
+  if (jump) {
+    wakeEvents.push(jump)
+    const cutoff = nowMs - WAKE_EVENT_RETENTION_MS
+    wakeEvents = wakeEvents.filter(e => e.wakeMs >= cutoff)
+    if (wakeEvents.length > WAKE_EVENT_MAX) wakeEvents = wakeEvents.slice(-WAKE_EVENT_MAX)
+    logger.info(
+      { sleepStartMs: jump.sleepStartMs, wakeMs: jump.wakeMs, gapMinutes: Math.round((jump.wakeMs - jump.sleepStartMs) / 60000) },
+      'sleep-wake: clock gap detected -- machine (or process) was suspended; downtime-caused alerts in this window will be suppressed',
+    )
+  }
+  return jump
+}
+
+// Did the machine sleep at any point inside [fromMs, toMs]? Fail-safe: with
+// the detector never started (webOnly mode, unit tests) there are no events
+// and this is false, so every alert path behaves exactly as before.
+export function systemSleptBetween(fromMs: number, toMs: number = Date.now()): boolean {
+  return sleptInWindow(wakeEvents, fromMs, toMs)
+}
+
+// Idempotent: both the schedule runner and the channel-plugin monitor call
+// this from their start functions; whichever runs first owns the timer.
+// unref() so a lingering detector never keeps a test process alive.
+export function startSleepWakeDetector(): NodeJS.Timeout {
+  if (detectorTimer) return detectorTimer
+  lastSampleMs = Date.now()
+  detectorTimer = setInterval(() => { recordClockSample() }, SLEEP_SAMPLE_INTERVAL_MS)
+  detectorTimer.unref?.()
+  return detectorTimer
+}
+
+export function resetSleepWakeDetectorForTest(): void {
+  if (detectorTimer) clearInterval(detectorTimer)
+  detectorTimer = null
+  wakeEvents = []
+  lastSampleMs = null
+}


### PR DESCRIPTION
On a part-time-uptime install (machine off outside work hours), the missed-schedule catch-up summary, the keep-alive respawn alert, and the scheduled-task stuck alarm all fire routinely just because the machine was asleep, not because anything actually broke.

This keeps every self-healing action unchanged (catch-up run still fires, pane still respawns, stuck-task handling still proceeds) but suppresses the owner-facing notification when the gap/staleness window is explained by the machine having been asleep. Adds a small clock-jump based sleep/wake detector (samples the clock every 15s, 60s+ gap = missed samples = sleep) so it works without a platform-specific dependency like pmset.

Tests: new src/__tests__/sleep-wake-detector.test.ts, updated src/__tests__/schedule-catchup.test.ts. Full suite green (4393 passed, 1 skipped) at the time this was written.