### PR TITLE
fix(limit-monitor): quota heredoc out of $() -- root-closure of the bash-3.2 apostrophe hazard (MIOHEREDOC902)

### DIFF
--- a/scripts/__tests__/limit-monitor-signals.test.sh
+++ b/scripts/__tests__/limit-monitor-signals.test.sh
@@ -25,6 +25,8 @@ new_case() {
   # is not a smaller install -- it is a BROKEN one, and the difference would
   # only show up as a silently missing send. Copy what a real install has.
   mkdir -p "$c/scripts/lib"; cp "$INSTALL_DIR/scripts/lib/send-telegram.sh" "$c/scripts/lib/"
+  # MIOHEREDOC902: the measured quota path now lives in its own file.
+  cp "$INSTALL_DIR/scripts/lib/quota-check.py" "$c/scripts/lib/"
   printf 'MAIN_AGENT_ID=probe\nALLOWED_CHAT_ID=1\n' > "$c/.env"
   echo "$c"
 }
@@ -184,6 +186,24 @@ if grep -q "quota:seven_day" "$C/store/limit-monitor.log" 2>/dev/null; then
   pass "the live weekly window still alerts beside a rolled-over one"
 else
   fail "a rolled-over window silenced the live one next to it"
+fi
+
+# MIOHEREDOC902: a missing quota-check.py must be LOUD, never a silent skip --
+# an empty quota reading and a healthy one look identical from the outside.
+C="$(new_case quota_missing_py)"
+rm -f "$C/scripts/lib/quota-check.py"
+printf '{"written_at":%d,"rate_limits":{"five_hour":{"used_percentage":95,"resets_at":%d}}}\n' "$now" "$reset" \
+  > "$C/store/.claude-rate-limits.json"
+run_case "$C"
+if grep -q "quota-check.py hianyzik" "$C/store/limit-monitor.log" 2>/dev/null; then
+  pass "missing quota-check.py is logged loudly (fail-open, not silent)"
+else
+  fail "missing quota-check.py skipped SILENTLY"
+fi
+if alerted "$C"; then
+  fail "missing quota-check.py must not raise a quota alert"
+else
+  pass "no phantom quota alert without the checker"
 fi
 
 C="$(new_case quota_stale)"

--- a/scripts/lib/quota-check.py
+++ b/scripts/lib/quota-check.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Quota-threshold check for limit-monitor.sh (MIOHEREDOC902).
+
+Reads QUOTA_FILE / QUOTA_WARN_PCT / QUOTA_MAX_AGE_SEC from the environment
+and prints STALE / EXPIRED / HIT lines exactly as the old in-script heredoc
+did (byte-parity measured against the pre-move body). Moved OUT of the
+shell command substitution because bash 3.2's $() scanner dies on any
+unpaired apostrophe inside a $()-embedded heredoc -- the whole monitor
+exits 2 at parse time and Linux CI (bash >= 4) is structurally blind to it
+(measured on the PR #1080 verify). With the body in its own file the
+hazard class is gone and comments may use normal punctuation.
+"""
+import json, os, time
+
+path = os.environ["QUOTA_FILE"]
+warn = float(os.environ["QUOTA_WARN_PCT"])
+max_age = int(os.environ["QUOTA_MAX_AGE_SEC"])
+try:
+    d = json.load(open(path))
+except Exception:
+    raise SystemExit(0)
+
+age = int(time.time()) - int(d.get("written_at") or 0)
+if age > max_age:
+    print("STALE\t%d" % age)
+    raise SystemExit(0)
+
+# Alert on crossed LEVELS, not on the raw percentage: keying the dedupe on the
+# exact number would send a fresh alert for every single point from 90 to 100.
+# Two levels are enough -- the heads-up, and the moment it is actually gone.
+levels = sorted({100.0, warn}, reverse=True)
+
+labels = {"five_hour": "5 oras keret", "seven_day": "heti keret"}
+labels_short = {"five_hour": "five_hour", "seven_day": "seven_day"}
+hits = []
+expired = []
+for key in ("five_hour", "seven_day"):
+    w = (d.get("rate_limits") or {}).get(key) or {}
+    pct = w.get("used_percentage")
+    if not isinstance(pct, (int, float)) or pct < warn:
+        continue
+    resets = w.get("resets_at")
+    # A window whose reset time has already passed describes a window that no
+    # longer exists. The numbers only move when an API response brings new ones,
+    # so after a rollover the block sits there unchanged with resets_at in the
+    # past (measured at the 22:00 rollover on 2026-08-18: 25% / "resets 22:00"
+    # still standing at 22:00:29). Alerting on it would report a spent quota
+    # that has since been handed back. Nothing real is lost by skipping: while
+    # the quota was actually spent, resets_at was in the future and the alert
+    # already went out.
+    if isinstance(resets, (int, float)) and resets <= time.time():
+        expired.append(labels_short[key])
+        continue
+    level = next((L for L in levels if pct >= L), warn)
+    when = ""
+    if isinstance(resets, (int, float)):
+        when = time.strftime("%m-%d %H:%M", time.localtime(resets))
+    hits.append((key, round(float(pct)), when, int(resets or 0), int(level)))
+
+if not hits:
+    if expired:
+        print("EXPIRED\t%s" % ",".join(expired))
+    raise SystemExit(0)
+
+# Dedupe key: window + crossed level + the reset timestamp of that window. One
+# alert per level per window; the next window (new resets_at) starts clean.
+key = "|".join("%s:%s:%s" % (k, lv, rs) for k, _p, _w, rs, lv in hits)
+lines = []
+for k, p, w, _rs, _lv in hits:
+    line = "%s: %d%% elhasznalva" % (labels[k], p)
+    if w:
+        line += " (nullazodik: %s)" % w
+    lines.append(line)
+print("HIT\t%s\t%s" % (key, " / ".join(lines)))

--- a/scripts/limit-monitor.sh
+++ b/scripts/limit-monitor.sh
@@ -93,71 +93,16 @@ QUOTA_WARN_PCT="${QUOTA_WARN_PCT:-90}"
 QUOTA_MAX_AGE_SEC="${QUOTA_MAX_AGE_SEC:-21600}"
 
 if [ -s "$QUOTA_FILE" ] && command -v python3 >/dev/null 2>&1; then
-  QUOTA_OUT="$(QUOTA_FILE="$QUOTA_FILE" QUOTA_WARN_PCT="$QUOTA_WARN_PCT" QUOTA_MAX_AGE_SEC="$QUOTA_MAX_AGE_SEC" python3 - <<\PYQ 2>/dev/null
-import json, os, time
-
-path = os.environ["QUOTA_FILE"]
-warn = float(os.environ["QUOTA_WARN_PCT"])
-max_age = int(os.environ["QUOTA_MAX_AGE_SEC"])
-try:
-    d = json.load(open(path))
-except Exception:
-    raise SystemExit(0)
-
-age = int(time.time()) - int(d.get("written_at") or 0)
-if age > max_age:
-    print("STALE\t%d" % age)
-    raise SystemExit(0)
-
-# Alert on crossed LEVELS, not on the raw percentage: keying the dedupe on the
-# exact number would send a fresh alert for every single point from 90 to 100.
-# Two levels are enough -- the heads-up, and the moment it is actually gone.
-levels = sorted({100.0, warn}, reverse=True)
-
-labels = {"five_hour": "5 oras keret", "seven_day": "heti keret"}
-labels_short = {"five_hour": "five_hour", "seven_day": "seven_day"}
-hits = []
-expired = []
-for key in ("five_hour", "seven_day"):
-    w = (d.get("rate_limits") or {}).get(key) or {}
-    pct = w.get("used_percentage")
-    if not isinstance(pct, (int, float)) or pct < warn:
-        continue
-    resets = w.get("resets_at")
-    # A window whose reset time has already passed describes a window that no
-    # longer exists. The numbers only move when an API response brings new ones,
-    # so after a rollover the block sits there unchanged with resets_at in the
-    # past (measured at the 22:00 rollover on 2026-08-18: 25% / "resets 22:00"
-    # still standing at 22:00:29). Alerting on it would report a spent quota
-    # that has since been handed back. Nothing real is lost by skipping: while
-    # the quota was actually spent, resets_at was in the future and the alert
-    # already went out.
-    if isinstance(resets, (int, float)) and resets <= time.time():
-        expired.append(labels_short[key])
-        continue
-    level = next((L for L in levels if pct >= L), warn)
-    when = ""
-    if isinstance(resets, (int, float)):
-        when = time.strftime("%m-%d %H:%M", time.localtime(resets))
-    hits.append((key, round(float(pct)), when, int(resets or 0), int(level)))
-
-if not hits:
-    if expired:
-        print("EXPIRED\t%s" % ",".join(expired))
-    raise SystemExit(0)
-
-# Dedupe key: window + crossed level + the reset timestamp of that window. One
-# alert per level per window; the next window (new resets_at) starts clean.
-key = "|".join("%s:%s:%s" % (k, lv, rs) for k, _p, _w, rs, lv in hits)
-lines = []
-for k, p, w, _rs, _lv in hits:
-    line = "%s: %d%% elhasznalva" % (labels[k], p)
-    if w:
-        line += " (nullazodik: %s)" % w
-    lines.append(line)
-print("HIT\t%s\t%s" % (key, " / ".join(lines)))
-PYQ
-)"
+  QUOTA_CHECK="$INSTALL_DIR/scripts/lib/quota-check.py"
+  if [ ! -f "$QUOTA_CHECK" ]; then
+    # Fail-open on purpose (the text-scan fallback below still runs), but NEVER
+    # silent: an empty quota reading and a healthy one are byte-identical from
+    # the outside, and a wordless skip would read as "nothing to alert about".
+    log "quota-check.py hianyzik ($QUOTA_CHECK), a mert quota-ut EZEN A KORON KIMARAD -- a text-fallback fut tovabb"
+    QUOTA_OUT=""
+  else
+    QUOTA_OUT="$(QUOTA_FILE="$QUOTA_FILE" QUOTA_WARN_PCT="$QUOTA_WARN_PCT" QUOTA_MAX_AGE_SEC="$QUOTA_MAX_AGE_SEC" python3 "$QUOTA_CHECK" 2>/dev/null)"
+  fi
   case "$QUOTA_OUT" in
     STALE*)
       log "quota file stale ($(printf '%s' "$QUOTA_OUT" | cut -f2)s), skipping the measured path"


### PR DESCRIPTION
## What

Option (a) from the MIOHEREDOC902 measurement, per Marveen's decision (msg 18003): the quota-check python body moves **verbatim** (62 lines) out of the `$()`-embedded heredoc into `scripts/lib/quota-check.py`. This closes the CLASS: bash 3.2's `$()` scanner dies at parse time on any unpaired apostrophe inside such a heredoc -- with **both** delimiter forms (measured on the #1080 verify) -- and Linux CI (bash >= 4) cannot see it.

**Condition baked in**: a missing `quota-check.py` stays fail-open (text-scan fallback runs) but is **never silent** -- the skip is logged, because an empty quota reading and a healthy one are byte-identical from the outside.

## Proof

- **Byte-parity**: the moved body is verbatim (diff against the pre-move heredoc body: identical); old-body vs new-file outputs byte-equal on the same quota input; isolated live run produces the same HIT key + honest-alert path.
- **No behavior change**: direct `python3 <file>` call -- no tmp-file lifecycle, no parallelism or error-branch difference; env contract and stdout protocol unchanged.
- **Loudness mutation-checked**: deleting the log line turns exactly the new test case red (`missing quota-check.py skipped SILENTLY`); reverted green.
- `bash -n` clean (bash 3.2.57), `limit-monitor-signals.test.sh` ALL PASS (sandbox now ships the lib file; two new asserts: loud skip + no phantom alert), full vitest 4511 green, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)