### PR TITLE
fix(email-gate): the approval gate ran SQL the live host's SQLite can…

### DIFF
--- a/scripts/__tests__/email-approval-gate.test.py
+++ b/scripts/__tests__/email-approval-gate.test.py
@@ -23,10 +23,15 @@ import sqlite3
 import subprocess
 import sys
 import tempfile
+import tokenize
 
 HERE = os.path.dirname(os.path.abspath(__file__))
-GATE = os.path.join(os.path.dirname(HERE), "hooks", "email-approval-gate.py")
+HOOKS = os.path.join(os.path.dirname(HERE), "hooks")
+GATE = os.path.join(HOOKS, "email-approval-gate.py")
 WINDOW = 1800
+# Same portability constraint as the gate: this file drives the gate through
+# the HOST's python3, so its own fixtures must not need SQLite 3.38 either.
+NOW_S = "CAST(strftime('%s','now') AS INTEGER)"
 
 failed = []
 
@@ -59,7 +64,7 @@ def make_store(td, level=2, max_level=None, config="ok"):
         action_description TEXT NOT NULL, action_payload TEXT,
         status TEXT NOT NULL DEFAULT 'pending',
         timeout_at INTEGER, telegram_message_id INTEGER,
-        requested_at INTEGER NOT NULL DEFAULT (unixepoch()),
+        requested_at INTEGER NOT NULL DEFAULT (CAST(strftime('%s','now') AS INTEGER)),
         resolved_at INTEGER, resolved_by TEXT,
         content_hash TEXT, consumed_at INTEGER)""")
     con.commit()
@@ -90,7 +95,7 @@ def approve(store, anchor, resolved_ago=0, status="approved", consumed=None):
         "INSERT INTO approvals (id, agent_id, category, action_description, status,"
         " requested_at, resolved_at, resolved_by, content_hash, consumed_at)"
         " VALUES (hex(randomblob(6)), 'marveen', 'email_send', 'Email teszt', ?,"
-        " unixepoch()-?-60, CASE WHEN ?='pending' THEN NULL ELSE unixepoch()-? END,"
+        f" {NOW_S}-?-60, CASE WHEN ?='pending' THEN NULL ELSE {NOW_S}-? END,"
         " 'szabi', ?, ?)",
         (status, resolved_ago, status, resolved_ago, anchor, consumed))
     con.commit()
@@ -235,6 +240,39 @@ with tempfile.TemporaryDirectory() as td:
                           capture_output=True, env=env)
     check("fail-closed: unparseable stdin -> DENIED (exit 2, never 0/1)",
           proc.returncode == 2, f"exit={proc.returncode}")
+
+    # SQLite-version portability, kept as a STATIC check on purpose. The
+    # behavioural cases above only catch the bad call on a host whose sqlite is
+    # older than 3.38 -- on CI (newer) they stay green while the live install
+    # denies every approved letter. So assert the function is absent from the
+    # source, which fails on every host once it is reintroduced. Measured
+    # 2026-09-02: host python sqlite3 3.37.2, gate raised OperationalError,
+    # and the fail-closed deny read as "no approval" rather than a version
+    # fault. The 'unixepoch' MODIFIER (date(x,'unixepoch')) is ancient and
+    # fine -- only the bare function call is banned.
+    #
+    # COMMENTS ARE STRIPPED before matching, and the pattern is assembled from
+    # fragments: otherwise this file's own prose (and the pattern itself) would
+    # register as a violation and the check would fail for a reason that has
+    # nothing to do with any SQL. Strings are KEPT -- that is where the SQL is.
+    banned = re.compile(r"(?<!')\b" + "unix" + r"epoch\s*\(")
+
+    def code_without_comments(path):
+        with open(path, "rb") as fh:
+            return "".join(t.string for t in tokenize.tokenize(fh.readline)
+                           if t.type != tokenize.COMMENT)
+
+    hook_srcs = [os.path.join(HOOKS, f) for f in sorted(os.listdir(HOOKS)) if f.endswith(".py")]
+    offenders = [os.path.basename(p) for p in hook_srcs + [os.path.abspath(__file__)]
+                 if banned.search(code_without_comments(p))]
+    check("portability: no bare SQLite unixepoch function call (needs 3.38+) in the hooks",
+          not offenders, f"offenders={offenders}")
+    # Control: the check can actually fail. Without this, a broken matcher
+    # would report a clean tree forever and read exactly like a passing gate.
+    check("control: the same matcher DOES flag the old expression",
+          bool(banned.search("SELECT unix" + "epoch()-60")))
+    check("control: the host's own sqlite3 really executes the replacement expression",
+          sqlite3.connect(":memory:").execute(f"SELECT {NOW_S}").fetchone()[0] > 1_700_000_000)
 
 print()
 if failed:

--- a/scripts/hooks/email-approval-gate.py
+++ b/scripts/hooks/email-approval-gate.py
@@ -96,6 +96,21 @@ def content_anchor(env: dict) -> str:
     return hashlib.sha256(canon.encode("utf-8")).hexdigest()
 
 
+# SQLite's unixepoch() only exists from 3.38 (2022-02). The hook runs under
+# the HOST's python3, whose bundled sqlite3 can be older than the one node's
+# better-sqlite3 carries -- measured 2026-09-02 on the live install: python
+# sqlite3 3.37.2, so every such call raised OperationalError. That is
+# not a crash the operator ever sees as a version problem: find_and_consume
+# raises, the caller turns any DB fault into a fail-closed deny, and the
+# message reads "approvals not available" -- i.e. at level 2 a genuinely
+# APPROVED letter is refused and the reason looks like a missing approval.
+# CI stayed green throughout because its SQLite is newer, so the suite tested
+# every host except the one the gate actually runs on.
+# strftime('%s') is present in every SQLite that ships a date function; the
+# CAST keeps the comparison integer-to-integer against resolved_at.
+NOW_S = "CAST(strftime('%s','now') AS INTEGER)"
+
+
 def find_and_consume(anchor: str):
     """Return (verdict, detail). verdict: 'allowed' (consumed approval id),
     'pending', 'consumed', 'expired', 'none', 'race'. Raises on any DB problem
@@ -107,19 +122,19 @@ def find_and_consume(anchor: str):
         con.execute("PRAGMA busy_timeout=5000")
         row = con.execute(
             "SELECT id FROM approvals WHERE category='email_send' AND status='approved'"
-            " AND content_hash=? AND consumed_at IS NULL AND resolved_at >= unixepoch()-?"
+            f" AND content_hash=? AND consumed_at IS NULL AND resolved_at >= {NOW_S}-?"
             " ORDER BY resolved_at DESC LIMIT 1", (anchor, WINDOW_S)).fetchone()
         if row:
             # Atomic one-shot: only the UPDATE that flips NULL->now wins.
             cur = con.execute(
-                "UPDATE approvals SET consumed_at=unixepoch()"
+                f"UPDATE approvals SET consumed_at={NOW_S}"
                 " WHERE id=? AND consumed_at IS NULL", (row[0],))
             con.commit()
             return ("allowed", row[0]) if cur.rowcount > 0 else ("race", row[0])
         for verdict, cond in (
             ("pending", "status='pending'"),
             ("consumed", "status='approved' AND consumed_at IS NOT NULL"),
-            ("expired", f"status='approved' AND consumed_at IS NULL AND resolved_at < unixepoch()-{int(WINDOW_S)}"),
+            ("expired", f"status='approved' AND consumed_at IS NULL AND resolved_at < {NOW_S}-{int(WINDOW_S)}"),
         ):
             hit = con.execute(
                 f"SELECT id FROM approvals WHERE category='email_send' AND content_hash=? AND {cond} LIMIT 1",


### PR DESCRIPTION
…not parse (EMAILKAPU902)

`unixepoch()` arrived in SQLite 3.38 (2022-02). The gate runs under the HOST's python3, and on the live install that is sqlite3 3.37.2 -- so all three call sites raised OperationalError. find_and_consume() raises, the caller turns any DB fault into a fail-closed deny, and the operator reads "the approvals are not available": at level 2 a genuinely APPROVED letter is refused, and the message looks like a missing approval rather than a version fault.

CI never saw it. Its SQLite is newer, so the suite covered every host except the one the gate actually runs on -- measured 2026-09-02: the python suite was already red on the live host (2 of 24 cases) while green on GitHub.

Replaces the three calls with CAST(strftime('%s','now') AS INTEGER), present in every SQLite that ships a date function, and fixes the same call in the test's own fixtures so the suite can run on the host it is meant to protect.

The behavioural cases cannot guard this on their own -- on a new-enough SQLite they pass either way -- so the regression guard is STATIC: no bare unixepoch function call in scripts/hooks/*.py. It strips comments before matching (else the prose explaining the ban would trip it) and carries its own control case proving the matcher still flags the old expression.

<!--
  HU + EN. Töltsd ki minden szakaszt. / Fill in every section.
  A jelölőnégyzeteket így pipáld: [x]  /  Tick a box like this: [x]
-->

## A változtatás típusa / Type of change

- [ ] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

<!-- HU: Foglald össze, milyen problémát old meg a PR és milyen technikai megközelítést alkalmaztál.
     EN: Summarize what problem this PR solves and the technical approach you took. -->

## Kapcsolódó issue / Related issue

Closes #

## Ellenőrzőlista / Checklist

- [ ] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [ ] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
- [ ] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [ ] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).

## Titok-kapu / Secret gate

A `secret-gate` CI-job a valodi kapu. A lokalis pre-commit hook csak gyors
elorejelzes, es `--no-verify`-jal megkerulheto -- ne tekintsd elegnek.
The `secret-gate` CI job is the real gate; the local pre-commit hook is a fast
preview and can be skipped with `--no-verify`, so it is not sufficient on its own.

- [ ] Nincs a valtoztatasban bizonyitek-/artefaktum-mappa, titok-alaku string vagy idezett csatorna-uzenet.
      / No evidence or artifact directory, secret-shaped string, or quoted channel message in this change.
