### PR TITLE
fix(copy-gate): missing rules file = open + loud; broken file stays closed (CLCOPYGATEHIANY902)

### DIFF
--- a/scripts/__tests__/outgoing-copy-gate-rules-policy.test.py
+++ b/scripts/__tests__/outgoing-copy-gate-rules-policy.test.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""CLCOPYGATEHIANY902: a MISSING rules file is not the same as a BROKEN one.
+
+Owner decision (TG 14442): the rules file is deliberately not shipped (it
+names a private person), so on every fresh customer install it is ABSENT --
+and the old email path fail-closed on that, blocking a paying customer's
+outbound mail entirely. New policy, pinned here:
+
+  missing / valid-but-empty  -> email goes OUT (fail-open) with a LOUD,
+                                user-visible systemMessage -- the warning is
+                                asserted, not just the exit code, because a
+                                silent pass is indistinguishable from
+                                protection that does not exist;
+  present but INVALID        -> email stays BLOCKED (negative control: a fix
+                                that fail-opens both branches is WORSE than
+                                the bug and would look green without this);
+  valid with patterns        -> the name check still enforces (regression
+                                guard on the thing the gate is for).
+
+Run: python3 <thisfile>   Exit 0 = all pass.
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+GATE = os.path.join(os.path.dirname(HERE), "hooks", "outgoing-copy-gate.py")
+
+failed = []
+
+
+def check(name, ok, detail=""):
+    print(f"  [{'PASS' if ok else 'FAIL'}] {name}" + (f" -- {detail}" if not ok and detail else ""))
+    if not ok:
+        failed.append(name)
+
+
+def run_gate(rules_path, payload):
+    proc = subprocess.run(
+        [sys.executable, GATE], input=json.dumps(payload).encode(),
+        capture_output=True,
+        env=dict(os.environ, OUTGOING_COPY_GATE_RULES=rules_path),
+    )
+    return proc.returncode, proc.stdout.decode(), proc.stderr.decode()
+
+
+# A letter that passes every copy check: flawless accents, no em dash, no
+# double-hyphen prose, no mixed script.
+CLEAN_MAIL = {
+    "tool_name": "mcp__server-gmail-autoauth-mcp__send_email",
+    "tool_input": {"to": ["a@b.hu"], "subject": "Rendben",
+                   "body": "Kedves Ügyfelünk! Köszönjük a levelét, minden rendben van."},
+}
+
+with tempfile.TemporaryDirectory() as td:
+    missing = os.path.join(td, "nincs-ilyen.json")
+
+    # --- missing: OPEN + LOUD --------------------------------------------
+    code, out, err = run_gate(missing, CLEAN_MAIL)
+    check("missing rules: the email goes OUT (exit 0, not blocked)",
+          code == 0, f"exit={code} err={err[:150]!r}")
+    check("missing rules: the pass is LOUD (systemMessage names the absent check)",
+          "systemMessage" in out and "HIANYZIK" in out and "nev-ellenorzes NELKUL" in out,
+          f"out={out[:200]!r}")
+
+    # --- valid but empty: OPEN + LOUD ------------------------------------
+    empty = os.path.join(td, "empty.json")
+    with open(empty, "w") as fh:
+        json.dump({"bad_name_patterns": []}, fh)
+    code, out, _ = run_gate(empty, CLEAN_MAIL)
+    check("valid-empty rules: email goes OUT and the pass is loud",
+          code == 0 and "URES" in out, f"exit={code} out={out[:160]!r}")
+
+    # --- invalid variants: CLOSED (the negative control) ------------------
+    invalid_cases = [
+        ("not-json", "{ez nem json"),
+        ("wrong-schema (patterns not a list)", json.dumps({"bad_name_patterns": "Szota"})),
+        ("uncompilable regex", json.dumps({"bad_name_patterns": ["[unclosed"]})),
+        ("top-level not a dict", json.dumps(["Szota"])),
+    ]
+    for label, content in invalid_cases:
+        bad = os.path.join(td, "bad.json")
+        with open(bad, "w") as fh:
+            fh.write(content)
+        code, _, err = run_gate(bad, CLEAN_MAIL)
+        check(f"invalid rules ({label}): email stays BLOCKED (exit 2)",
+              code == 2 and "ervenytelen" in err, f"exit={code} err={err[:150]!r}")
+
+    # --- valid with patterns: the check still enforces --------------------
+    good = os.path.join(td, "good.json")
+    with open(good, "w") as fh:
+        json.dump({"bad_name_patterns": [r"Szóta"], "correction": "Helyesen: Szota."}, fh)
+    bad_name_mail = {
+        "tool_name": "mcp__server-gmail-autoauth-mcp__send_email",
+        "tool_input": {"to": ["a@b.hu"], "subject": "Rendben",
+                       "body": "Kedves Szóta Úr! Köszönjük a levelét, minden rendben van."},
+    }
+    code, _, err = run_gate(good, bad_name_mail)
+    check("valid rules: a bad name is still BLOCKED (the gate still gates)",
+          code == 2 and "HELYTELEN NEV" in err, f"exit={code} err={err[:150]!r}")
+    code, out, _ = run_gate(good, CLEAN_MAIL)
+    check("valid rules: a clean letter passes WITHOUT the missing-rules warning",
+          code == 0 and "systemMessage" not in out, f"exit={code} out={out[:120]!r}")
+
+    # --- telegram branch: unchanged fail-open on missing ------------------
+    tg = {"tool_name": "mcp__plugin_telegram_telegram__reply",
+          "tool_input": {"chat_id": 1, "text": "Rendben, köszönöm szépen."}}
+    code, out, _ = run_gate(missing, tg)
+    check("telegram + missing rules: still fail-open with its own warning",
+          code == 0 and "systemMessage" in out, f"exit={code}")
+
+print()
+if failed:
+    print(f"{len(failed)} FAILED: {failed}", file=sys.stderr)
+    sys.exit(1)
+print("All rules-policy tests passed.")

--- a/scripts/__tests__/outgoing-copy-gate-rules-policy.test.py
+++ b/scripts/__tests__/outgoing-copy-gate-rules-policy.test.py
@@ -105,8 +105,12 @@ with tempfile.TemporaryDirectory() as td:
           code == 0 and "systemMessage" not in out, f"exit={code} out={out[:120]!r}")
 
     # --- telegram branch: unchanged fail-open on missing ------------------
+    # No chat_id in the fixture: collect_telegram_body() reads only
+    # text/caption/message, and a numeric chat_id trips the secret-gate's
+    # "telegram update dump" detector (a false positive here, but the gate's
+    # pattern must not be loosened for one test file).
     tg = {"tool_name": "mcp__plugin_telegram_telegram__reply",
-          "tool_input": {"chat_id": 1, "text": "Rendben, köszönöm szépen."}}
+          "tool_input": {"text": "Rendben, köszönöm szépen."}}
     code, out, _ = run_gate(missing, tg)
     check("telegram + missing rules: still fail-open with its own warning",
           code == 0 and "systemMessage" in out, f"exit={code}")

--- a/scripts/hooks/outgoing-copy-gate.py
+++ b/scripts/hooks/outgoing-copy-gate.py
@@ -440,24 +440,48 @@ _LOCAL_RULES = os.environ.get(
 )
 
 
+# CLCOPYGATEHIANY902 (owner decision, TG 14442): a MISSING rules file is not
+# the same thing as a BROKEN one, and until now both produced the same
+# email-blocking outcome. The file is deliberately NOT shipped (it names a
+# private person), so on every fresh customer install it is absent -- and the
+# old fail-closed email path made a paying customer's agent unable to send
+# mail at all (reported by Nova, 2026-09-02). New policy:
+#   "missing"/"empty" -> the name check is OFF: fail-OPEN with a LOUD,
+#                        user-visible warning on every send (the customer
+#                        must know the check is not protecting them);
+#   "invalid"         -> the file EXISTS but cannot be used (bad JSON, wrong
+#                        schema, uncompilable regex): the operator tried to
+#                        configure it and something is wrong -- the email
+#                        path stays fail-CLOSED until it is fixed;
+#   "ok"              -> patterns loaded, the check enforces as before.
 def load_bad_name():
+    """Return (compiled_regex_or_None, state) -- state in ok/missing/empty/invalid."""
     try:
         with open(_LOCAL_RULES, encoding="utf-8") as fh:
-            pats = json.load(fh).get("bad_name_patterns") or []
-        if pats:
-            return re.compile("|".join(pats))
-    except OSError:
-        pass
+            data = json.load(fh)
+        if not isinstance(data, dict):
+            return (None, "invalid")
+        pats = data.get("bad_name_patterns") or []
+        if not isinstance(pats, list) or not all(isinstance(x, str) for x in pats):
+            return (None, "invalid")
+        if not pats:
+            return (None, "empty")
+        return (re.compile("|".join(pats)), "ok")
+    except FileNotFoundError:
+        state = "missing"
     except Exception:
-        pass
+        # Present but unusable: unreadable (permissions), unparseable JSON,
+        # or an uncompilable pattern. All of these mean someone TRIED to
+        # configure the rule and failed -- that must stay loud AND closed.
+        state = "invalid"
     try:
         log_path = os.path.join(os.path.dirname(_LOCAL_RULES), "outgoing-copy-gate.log")
         with open(log_path, "a", encoding="utf-8") as fh:
-            fh.write(f"outgoing-copy-gate: NEV-SZABALY FAJL HIANYZIK/URES ({_LOCAL_RULES}) -- "
-                     "a nev-ellenorzes NEM fut; potold a store/outgoing-copy-gate-rules.json-t.\n")
+            fh.write(f"outgoing-copy-gate: NEV-SZABALY {state.upper()} ({_LOCAL_RULES}) -- "
+                     "a nev-ellenorzes NEM fut.\n")
     except OSError:
         pass
-    return None
+    return (None, state)
 
 
 def _name_correction() -> str:
@@ -469,7 +493,7 @@ def _name_correction() -> str:
         return ""
 
 
-BAD_NAME = load_bad_name()
+BAD_NAME, RULES_STATE = load_bad_name()
 ACCENTED = set("áéíóöőúüűÁÉÍÓÖŐÚÜŰ")
 TAG = re.compile(r"<[^>]+>")
 
@@ -771,12 +795,16 @@ def main():
     # csendben lealit nev-ellenorzes mellett kuldeni rosszabb, mint megvarni a
     # szabaly-fajl potlasat. (A telegram-ag fail-open marad systemMessage
     # figyelmeztetessel: az a felugyeleti csatorna, ott a nemulas a dragabb.)
-    if BAD_NAME is None:
+    if RULES_STATE == "invalid":
+        # The file EXISTS but cannot be used: someone configured it and got it
+        # wrong. Silent enforcement-loss here would be invisible, so this stays
+        # fail-closed until the file is repaired (negative control in tests).
         sys.stderr.write(
-            "KIMENO-SZOVEG KAPU: TILTVA -- a NEV-SZABALY fajl hianyzik/ures "
-            f"({_LOCAL_RULES}), igy a nev-ellenorzes nem tud lefutni.\n"
-            "Email fail-closed: potold a store/outgoing-copy-gate-rules.json-t "
-            "(bad_name_patterns + correction), aztan kuldd ujra.\n"
+            "KIMENO-SZOVEG KAPU: TILTVA -- a NEV-SZABALY fajl LETEZIK, de "
+            f"ervenytelen ({_LOCAL_RULES}): nem parse-olhato JSON, rossz sema "
+            "vagy hibas regex.\n"
+            "Javitsd a fajlt (bad_name_patterns: [regex, ...] + correction), "
+            "aztan kuldd ujra.\n"
         )
         sys.exit(2)
 
@@ -790,6 +818,16 @@ def main():
         )
         sys.exit(2)
 
+    if RULES_STATE in ("missing", "empty"):
+        # Fail-OPEN, but never silent: the send goes out WITHOUT the name
+        # check, and the user must see that on the surface they are using --
+        # a log line nobody reads is the same as nothing (CLCOPYGATEHIANY902).
+        print(json.dumps({"systemMessage":
+            "outgoing-copy-gate: a NEV-SZABALY fajl "
+            + ("HIANYZIK" if RULES_STATE == "missing" else "URES (nincs minta)")
+            + f" ({_LOCAL_RULES}) -- ez a level a nev-ellenorzes NELKUL ment ki. "
+            "Ha kell a vedelem, hozd letre a fajlt: "
+            '{"bad_name_patterns": ["<python-regex>"], "correction": "<helyes alak>"}.'}))
     sys.exit(0)
 
 

--- a/scripts/hooks/outgoing-copy-gate.py
+++ b/scripts/hooks/outgoing-copy-gate.py
@@ -460,13 +460,15 @@ def load_bad_name():
         with open(_LOCAL_RULES, encoding="utf-8") as fh:
             data = json.load(fh)
         if not isinstance(data, dict):
-            return (None, "invalid")
-        pats = data.get("bad_name_patterns") or []
-        if not isinstance(pats, list) or not all(isinstance(x, str) for x in pats):
-            return (None, "invalid")
-        if not pats:
-            return (None, "empty")
-        return (re.compile("|".join(pats)), "ok")
+            state = "invalid"
+        else:
+            pats = data.get("bad_name_patterns") or []
+            if not isinstance(pats, list) or not all(isinstance(x, str) for x in pats):
+                state = "invalid"
+            elif not pats:
+                state = "empty"
+            else:
+                return (re.compile("|".join(pats)), "ok")
     except FileNotFoundError:
         state = "missing"
     except Exception:
@@ -474,6 +476,10 @@ def load_bad_name():
         # or an uncompilable pattern. All of these mean someone TRIED to
         # configure the rule and failed -- that must stay loud AND closed.
         state = "invalid"
+    # ONE logging tail for EVERY non-ok state (Marveen review on #1156: the
+    # first cut logged only the exception branches, so empty/schema-invalid
+    # left no log line while missing did -- same event class, inconsistent
+    # ledger).
     try:
         log_path = os.path.join(os.path.dirname(_LOCAL_RULES), "outgoing-copy-gate.log")
         with open(log_path, "a", encoding="utf-8") as fh:

--- a/src/__tests__/outgoing-copy-gate-rules-policy.test.ts
+++ b/src/__tests__/outgoing-copy-gate-rules-policy.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { spawnSync } from 'node:child_process'
+import { join } from 'node:path'
+
+// CLCOPYGATEHIANY902 (owner decision, TG 14442): a MISSING rules file is not
+// the same as a BROKEN one. The file is deliberately unshipped (it names a
+// private person), so every fresh customer install lacks it -- and the old
+// email path fail-closed on that, blocking a paying customer's outbound mail
+// (Nova, 2026-09-02). The python suite pins the new policy: missing/empty ->
+// fail-open with a LOUD user-visible warning (the warning itself asserted);
+// present-but-invalid -> stays fail-closed (negative control); valid rules
+// still enforce. This wrapper makes that suite a CI gate.
+const ROOT = join(__dirname, '..', '..')
+
+describe('outgoing-copy-gate rules-file policy (CLCOPYGATEHIANY902)', () => {
+  it('the python suite passes (missing=open+loud, invalid=closed, valid=enforces)', () => {
+    const res = spawnSync('python3', [join(ROOT, 'scripts', '__tests__', 'outgoing-copy-gate-rules-policy.test.py')], {
+      encoding: 'utf-8',
+      timeout: 120_000,
+    })
+    if (res.status !== 0) {
+      console.error(res.stdout)
+      console.error(res.stderr)
+    }
+    expect(res.status).toBe(0)
+  })
+})


### PR DESCRIPTION
## What (owner decision TG 14442, option b)

The unshipped rules file (deliberate -- it names a private person) made the email path fail-closed on EVERY fresh customer install: a paying customer's agent could not send mail at all (Nova, 2026-09-02). The missing file and the broken file were collapsing into the same outcome; now they are distinct states:

| state | email path | surface |
|---|---|---|
| `ok` (patterns loaded) | enforces as before | block on bad name |
| `missing` (never configured) | **fail-OPEN** | **LOUD** stdout `systemMessage` on every send, naming the absent check + the file shape to create |
| `empty` (valid, zero patterns) | fail-OPEN | same loud warning |
| `invalid` (exists but unusable: bad JSON / wrong schema / uncompilable regex / unreadable) | **stays fail-CLOSED** | error names *invalid*, not *missing* |

Telegram branch: unchanged (by-design fail-open). Built on Marveen's measurements (single repo reference; no shipper) -- not re-measured.

## Proof

- **Loudness asserted, not implied**: the missing/empty tests assert the `systemMessage` CONTENT, not just exit 0 -- a silent pass is indistinguishable from protection that does not exist.
- **Negative control** (the explicit ask): four invalid variants each stay blocked (exit 2). A fix that fail-opens both branches would be worse than the bug and would look green without these.
- **Regression guard**: valid rules still block a bad name; a clean letter passes with no warning.
- **Mutation control, all three RED**: (1) missing reverted to `exit(2)` -> open-test red; (2) invalid reclassified as missing -> blocked-tests red; (3) the warning silenced -> loud-test red. Reverted green.
- Existing suites green (failclosed / approval-gate / extract-parity), full vitest 4512, tsc clean.

## Not in this PR

The rules file itself is NOT added to the repo (per the standing decision: policy shipped, private content not).

🤖 Generated with [Claude Code](https://claude.com/claude-code)