### PR TITLE
feat(config): AGENT_API_ORIGIN -- the agent-side API address is its o…

### DIFF
--- a/src/__tests__/agent-scaffold-dashboard-origin.test.ts
+++ b/src/__tests__/agent-scaffold-dashboard-origin.test.ts
@@ -61,6 +61,45 @@ describe('resolveDashboardOrigin', () => {
   it('accepts a non-default port in the public URL', () => {
     expect(resolveDashboardOrigin('https://example.com:8443', 3420)).toBe('https://example.com:8443')
   })
+
+  // --- AGENT_API_ORIGIN precedence -------------------------------------------
+  // The agent-side origin answers a different question than the public URL:
+  // "where does an AGENT reach the API from where it runs" vs "where does the
+  // BROWSER reach the dashboard". On a single-host install behind NAT these
+  // differ -- measured 2026-09-03: the public name was reachable from a phone
+  // but not from the host itself (hairpin), so every generated curl example
+  // pointed at a dead address.
+
+  it('REGRESSION GUARD: an empty agent origin changes nothing (old behaviour)', () => {
+    // This is the test that protects existing k3s/distributed installs: with
+    // the key unset, the resolver must behave exactly as before the key existed.
+    expect(resolveDashboardOrigin('https://marveen.example.com', 3420, '')).toBe('https://marveen.example.com')
+    expect(resolveDashboardOrigin('', 3420, '')).toBe('http://localhost:3420')
+  })
+
+  it('the agent origin wins over the public URL when both are set', () => {
+    expect(resolveDashboardOrigin('https://marveen.example.com', 3420, 'http://localhost:3420'))
+      .toBe('http://localhost:3420')
+  })
+
+  it('the agent origin wins even with no public URL', () => {
+    expect(resolveDashboardOrigin('', 3420, 'http://dashboard.internal:3420'))
+      .toBe('http://dashboard.internal:3420')
+  })
+
+  it('strips a trailing slash from the agent origin too', () => {
+    expect(resolveDashboardOrigin('', 3420, 'http://localhost:3420/')).toBe('http://localhost:3420')
+  })
+
+  it('supports an internal service name (k8s-style) as the agent origin', () => {
+    expect(resolveDashboardOrigin('https://marveen.example.com', 3420, 'http://marveen-dashboard.default.svc:3420'))
+      .toBe('http://marveen-dashboard.default.svc:3420')
+  })
+
+  it('defaults the third argument, so two-argument callers keep working', () => {
+    // Existing call sites and tests pass two arguments; that must stay valid.
+    expect(resolveDashboardOrigin('https://marveen.example.com', 3420)).toBe('https://marveen.example.com')
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -103,11 +142,16 @@ describe('generateClaudeMd prompt: no hardcoded localhost:3420', () => {
     expect(fnBody).toContain('${dashboardOrigin}/api/messages')
   })
 
-  it('defines dashboardOrigin using resolveDashboardOrigin', () => {
+  it('defines dashboardOrigin using resolveDashboardOrigin, passing AGENT_API_ORIGIN', () => {
     // Ensures the fallback logic lives in one place (resolveDashboardOrigin),
     // not as an ad-hoc inline expression that could diverge from the heartbeat
-    // scaffold.
-    expect(src).toContain('resolveDashboardOrigin(DASHBOARD_PUBLIC_URL, WEB_PORT)')
+    // scaffold. The third argument is what lets an operator state the
+    // agent-side answer when it differs from the browser-side public URL.
+    expect(src).toContain('resolveDashboardOrigin(DASHBOARD_PUBLIC_URL, WEB_PORT, AGENT_API_ORIGIN)')
+  })
+
+  it('imports AGENT_API_ORIGIN from config', () => {
+    expect(src).toMatch(/import\s*{[^}]*\bAGENT_API_ORIGIN\b[^}]*}\s*from\s*'\.\.\/config\.js'/)
   })
 })
 
@@ -166,7 +210,7 @@ describe('currentHeartbeatIdentity: delegates to resolveDashboardOrigin', () => 
     expect(fnStart).toBeGreaterThan(0)
     const fnEnd = src.indexOf('\n}', fnStart)
     const fnBody = src.slice(fnStart, fnEnd)
-    expect(fnBody).toContain('resolveDashboardOrigin(DASHBOARD_PUBLIC_URL, WEB_PORT)')
+    expect(fnBody).toContain('resolveDashboardOrigin(DASHBOARD_PUBLIC_URL, WEB_PORT, AGENT_API_ORIGIN)')
   })
 
   it('does not hardcode localhost:PORT as a string literal in currentHeartbeatIdentity', () => {

--- a/src/__tests__/autonomy-section.test.ts
+++ b/src/__tests__/autonomy-section.test.ts
@@ -18,6 +18,10 @@ vi.mock('../config.js', () => ({
   WEB_PORT: 3420,
   OWNER_DRIVE_FOLDER: '',
   DASHBOARD_PUBLIC_URL: '',
+  // Empty = the resolver falls through to the public URL, then to
+  // localhost -- i.e. exactly the behaviour these tests asserted
+  // before AGENT_API_ORIGIN existed.
+  AGENT_API_ORIGIN: '',
   APP_TZ: 'Europe/Budapest',
 }))
 

--- a/src/__tests__/fleet-roster-section.test.ts
+++ b/src/__tests__/fleet-roster-section.test.ts
@@ -15,6 +15,10 @@ vi.mock('../config.js', () => ({
   WEB_PORT: 3420,
   OWNER_DRIVE_FOLDER: '',
   DASHBOARD_PUBLIC_URL: '',
+  // Empty = the resolver falls through to the public URL, then to
+  // localhost -- i.e. exactly the behaviour these tests asserted
+  // before AGENT_API_ORIGIN existed.
+  AGENT_API_ORIGIN: '',
 }))
 
 vi.mock('../web/agent-config.js', () => ({

--- a/src/__tests__/skills-path-trap-section.test.ts
+++ b/src/__tests__/skills-path-trap-section.test.ts
@@ -19,6 +19,10 @@ vi.mock('../config.js', () => ({
   WEB_PORT: 3420,
   OWNER_DRIVE_FOLDER: '',
   DASHBOARD_PUBLIC_URL: '',
+  // Empty = the resolver falls through to the public URL, then to
+  // localhost -- i.e. exactly the behaviour these tests asserted
+  // before AGENT_API_ORIGIN existed.
+  AGENT_API_ORIGIN: '',
   APP_TZ: 'Europe/Budapest',
 }))
 

--- a/src/config-registry.ts
+++ b/src/config-registry.ts
@@ -267,6 +267,15 @@ export const SETTINGS_REGISTRY: SettingDefinition[] = [
     requiresRestart: true,
   },
   {
+    key: 'AGENT_API_ORIGIN',
+    type: 'string',
+    default: '',
+    description: 'Az a cím, amin az ÜGYNÖKÖK érik el a dashboard API-ját onnan, ahol futnak (pl. http://localhost:3420 egy gépes telepítésnél, vagy egy belső szolgáltatás-név k8s-en). Üres = a régi viselkedés: DASHBOARD_PUBLIC_URL, annak hiányában localhost. Ez NEM a böngészőnek szóló publikus cím.',
+    module: 'system',
+    secret: false,
+    requiresRestart: true,
+  },
+  {
     key: 'OLLAMA_URL',
     type: 'string',
     default: 'http://localhost:11434',

--- a/src/config.ts
+++ b/src/config.ts
@@ -322,6 +322,16 @@ export const KANBAN_WIP_OVER_COLOR = env['KANBAN_WIP_OVER_COLOR'] ?? '#c53030'
 // requiresRestart registry keys: read through the override layer so a value
 // saved on the Settings page takes effect on the next restart.
 export const DASHBOARD_PUBLIC_URL = cfg('DASHBOARD_PUBLIC_URL') ?? ''
+// Where the AGENTS reach the dashboard API from wherever they run. This is a
+// DIFFERENT question from DASHBOARD_PUBLIC_URL, which answers "where does the
+// BROWSER reach the dashboard" and feeds the CORS allowlist. On a single-host
+// install the two answers differ: measured 2026-09-03, the public name resolves
+// but its 443 is unreachable from the host itself (hairpin NAT), so every
+// generated curl example pointed at a dead address -- `curl exit 7`, i.e. the
+// agent gets nothing, not an error it could report. Deriving one answer from
+// the other cannot be correct for both deployment shapes, so it is its own key.
+// Empty preserves the previous behaviour exactly (public URL, else localhost).
+export const AGENT_API_ORIGIN = cfg('AGENT_API_ORIGIN') ?? ''
 // Extra browser origins allowed to make state-changing dashboard requests
 // (CORS + CSRF allowlist), comma-separated, e.g. for VPN/LAN addresses that
 // aren't covered by WEB_HOST or DASHBOARD_PUBLIC_URL. Empty by default so

--- a/src/web/agent-scaffold.ts
+++ b/src/web/agent-scaffold.ts
@@ -1,7 +1,7 @@
 import { readFileSync, writeFileSync, existsSync, mkdirSync, copyFileSync, readdirSync, statSync, rmSync, watchFile, unwatchFile } from 'node:fs'
 import { join } from 'node:path'
 import { homedir } from 'node:os'
-import { PROJECT_ROOT, OWNER_NAME, MAIN_AGENT_ID, HEARTBEAT_AGENT_ID, BOT_NAME, CHANNEL_PROVIDER, WEB_PORT, OWNER_DRIVE_FOLDER, APP_TZ, DASHBOARD_PUBLIC_URL, STORE_DIR } from '../config.js'
+import { PROJECT_ROOT, OWNER_NAME, MAIN_AGENT_ID, HEARTBEAT_AGENT_ID, BOT_NAME, CHANNEL_PROVIDER, WEB_PORT, OWNER_DRIVE_FOLDER, APP_TZ, DASHBOARD_PUBLIC_URL, AGENT_API_ORIGIN, STORE_DIR } from '../config.js'
 import { channelStateDir } from '../channel-provider.js'
 import { runAgent } from '../agent.js'
 import { atomicWriteFileSync } from './atomic-write.js'
@@ -12,16 +12,31 @@ import { resolveProfilePlaceholders, type ProfileTemplate } from './profiles.js'
 import { sanitizeCapabilityTag, CAPABILITY_TAG_MAX_PER_AGENT } from '../prompt-safety.js'
 
 // Resolve the base URL agents should use to reach the dashboard API.
-// DASHBOARD_PUBLIC_URL wins when set (distributed / k3s deployment); falls
-// back to localhost for single-host installs. Exported so heartbeat-agent-
-// scaffold and tests can import the same logic without duplicating it.
-export function resolveDashboardOrigin(publicUrl: string, port: number | string): string {
-  return (publicUrl || `http://localhost:${port}`).replace(/\/$/, '')
+//
+// Precedence: AGENT_API_ORIGIN > DASHBOARD_PUBLIC_URL > localhost:port.
+//
+// AGENT_API_ORIGIN exists because the previous two-step fallback answered the
+// wrong question. DASHBOARD_PUBLIC_URL means "where does the BROWSER reach the
+// dashboard" (it also feeds the CORS allowlist in web.ts); "where does an AGENT
+// reach the API from where it runs" is a separate question, and on a
+// single-host install behind NAT the answers differ. Measured 2026-09-03 on a
+// live install: the public name resolved, but its 443 was unreachable FROM THE
+// HOST (hairpin NAT), so all 73 generated curl examples across 18 agent
+// CLAUDE.md files pointed at a dead address -- `curl exit 7`, meaning the agent
+// receives nothing at all, not an error it could surface. Meanwhile the same
+// URL was perfectly reachable from a phone.
+//
+// Empty AGENT_API_ORIGIN keeps the old behaviour byte-for-byte, so k3s and
+// other distributed installs that rely on the public URL are unaffected: this
+// only gives the operator a way to say the agent-side answer out loud when it
+// differs. Exported so heartbeat-agent-scaffold and tests share one resolver.
+export function resolveDashboardOrigin(publicUrl: string, port: number | string, agentApiOrigin = ''): string {
+  return (agentApiOrigin || publicUrl || `http://localhost:${port}`).replace(/\/$/, '')
 }
 
-// Resolved once at module load; DASHBOARD_PUBLIC_URL requires a restart
-// (see config-registry.ts `requiresRestart` flag), so a const is safe.
-const dashboardOrigin = resolveDashboardOrigin(DASHBOARD_PUBLIC_URL, WEB_PORT)
+// Resolved once at module load; both keys are `requiresRestart` in
+// config-registry.ts, so a const is safe.
+const dashboardOrigin = resolveDashboardOrigin(DASHBOARD_PUBLIC_URL, WEB_PORT, AGENT_API_ORIGIN)
 // Dashboard token path emitted into generated CLAUDE.md curl examples.
 // MUST be absolute: sub-agents run from agents/<name>/, where a relative
 // `store/.dashboard-token` does not exist -- curl then sends an empty Bearer

--- a/src/web/heartbeat-agent-scaffold.ts
+++ b/src/web/heartbeat-agent-scaffold.ts
@@ -46,6 +46,7 @@ import {
   HEARTBEAT_CALENDAR_ACCOUNT,
   APP_TZ,
   DASHBOARD_PUBLIC_URL,
+  AGENT_API_ORIGIN,
 } from '../config.js'
 import { resolveDashboardOrigin } from './agent-scaffold.js'
 import { logger } from '../logger.js'
@@ -115,7 +116,7 @@ export function currentHeartbeatIdentity(): HeartbeatIdentity {
     botName: BOT_NAME,
     mainAgentId: MAIN_AGENT_ID,
     storeDir: STORE_DIR,
-    dashboardOrigin: resolveDashboardOrigin(DASHBOARD_PUBLIC_URL, WEB_PORT),
+    dashboardOrigin: resolveDashboardOrigin(DASHBOARD_PUBLIC_URL, WEB_PORT, AGENT_API_ORIGIN),
     calendarAccount: HEARTBEAT_CALENDAR_ACCOUNT,
     metricsScript: join(PROJECT_ROOT, 'scripts', 'heartbeat-metrics.sh'),
   }


### PR DESCRIPTION
…wn question (AGENTAPIORIG903)

The scaffold derived the URL it writes into every agent's curl examples from DASHBOARD_PUBLIC_URL. Those are two different questions:

  DASHBOARD_PUBLIC_URL -> where does the BROWSER reach the dashboard
                          (it also feeds the CORS allowlist in web.ts)
  agent-side origin    -> where does an AGENT reach the API from where it runs

On a single-host install behind NAT the answers differ, and deriving one from the other cannot be right for both. Measured 2026-09-03 on a live install: the public name resolved, but its 443 was unreachable FROM THE HOST (hairpin NAT), while the same URL loaded fine from a phone. Result: all 73 generated curl examples across 18 agent CLAUDE.md files pointed at a dead address. The failure is silent -- `curl exit 7` gives the agent nothing at all, not an error it could report. Five agents had no other documented path, and one of them hit it on its first live run.

Hardcoding localhost would have been wrong the other way: the existing comment says the public URL is what k3s/distributed deployments need, because there the agent really does run on another host.

So the operator gets to say the agent-side answer out loud:

  AGENT_API_ORIGIN > DASHBOARD_PUBLIC_URL > http://localhost:<WEB_PORT>

Empty (the default) reproduces the old behaviour byte-for-byte, so existing installs are untouched. A regression test pins exactly that, next to tests for the new precedence, trailing-slash handling and a k8s-style service name.

Also adds AGENT_API_ORIGIN to the three test config mocks that load agent-scaffold: a mocked module must export it or the module-load fails. That gap is invisible to tsc, since a vi.mock object literal is not type-checked against the real module.

<!--
  HU + EN. Töltsd ki minden szakaszt. / Fill in every section.
  A jelölőnégyzeteket így pipáld: [x]  /  Tick a box like this: [x]
-->

## A változtatás típusa / Type of change

- [ ] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

<!-- HU: Foglald össze, milyen problémát old meg a PR és milyen technikai megközelítést alkalmaztál.
     EN: Summarize what problem this PR solves and the technical approach you took. -->

## Kapcsolódó issue / Related issue

Closes #

## Ellenőrzőlista / Checklist

- [ ] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [ ] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
- [ ] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [ ] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).

## Titok-kapu / Secret gate

A `secret-gate` CI-job a valodi kapu. A lokalis pre-commit hook csak gyors
elorejelzes, es `--no-verify`-jal megkerulheto -- ne tekintsd elegnek.
The `secret-gate` CI job is the real gate; the local pre-commit hook is a fast
preview and can be skipped with `--no-verify`, so it is not sufficient on its own.

- [ ] Nincs a valtoztatasban bizonyitek-/artefaktum-mappa, titok-alaku string vagy idezett csatorna-uzenet.
      / No evidence or artifact directory, secret-shaped string, or quoted channel message in this change.
