### PR TITLE
feat(heartbeat): calendar becomes an instrument measurement, not an agent fetch (5E0A32B0)

### DIFF
--- a/scripts/heartbeat-metrics.sh
+++ b/scripts/heartbeat-metrics.sh
@@ -19,9 +19,19 @@
 #   COUNTS urgent=N in_progress=N waiting=N planned=N new_hot_memories_1h=N db_size_mb=N waiting_shown=N
 #   URGENT <id> <title>            (0..n lines)
 #   WAITING <id> <title>           (0..n lines)
+#   CALENDAR_EVENTS n=N window=2h  (measured; n=0 is a MEASURED empty calendar)
+#   CAL_EVENT <HH:MM|all-day> <summary> [attendees=N]   (0..n lines)
 #   SCHEDULES enabled=N
 #   TASK_RUNS_1H total=N [<status>=N ...]
 #   ERROR <section>: <reason>      (any failed measurement)
+#
+# 5E0A32B0: the calendar is measured HERE (server-side /api/heartbeat/calendar,
+# which reaches Google through the dashboard's own OAuth path), never by the
+# agent. The two calendar end-states are deliberately distinct lines:
+# CALENDAR_EVENTS n=0 means "queried, calendar free"; ERROR calendar: means
+# "could not query". A month of migrating agent-side symptoms ended in a
+# fossil (one 404 on a nonexistent endpoint copy-forwarded round after round),
+# and collapsing these two states is exactly how it stayed invisible.
 #
 # Fail-closed (the load-bearing property): a missing or null field NEVER
 # prints as 0 -- it prints an ERROR line and the exit code is non-zero.
@@ -52,7 +62,7 @@ echo "HB_METRICS_V1 ts=$(TZ="$TZNAME" date +'%Y-%m-%d %H:%M')"
 # piped data is silently lost; here the heredoc IS the program and nothing
 # is piped). python3's sqlite3 module replaces the sqlite3 CLI, which does
 # not exist on a stock Linux install (exit 127).
-STORE_DIR="$STORE_DIR" ORIGIN="$ORIGIN" python3 - <<'PY'
+STORE_DIR="$STORE_DIR" ORIGIN="$ORIGIN" TZNAME="$TZNAME" python3 - <<'PY'
 import json, os, sqlite3, sys, urllib.request
 
 store = os.environ['STORE_DIR']
@@ -105,6 +115,45 @@ if tok is not None:
                 print('WAITING', x.get('id'), x.get('title'))
     except Exception as e:
         err('summary', repr(e))
+
+    # Calendar (next 2h) -- measured server-side on /api/heartbeat/calendar
+    # (5E0A32B0). The endpoint answers 200 with {ok:true, events} OR
+    # {ok:false, error}: a failed query is a RESULT to relay, not an empty
+    # list. n=0 therefore always means "queried, calendar free".
+    try:
+        d = get('/api/heartbeat/calendar')
+        if d.get('ok') is True and isinstance(d.get('events'), list):
+            evs = d['events']
+            print('CALENDAR_EVENTS n=%d window=2h' % len(evs))
+            def hhmm(part):
+                # dateTime carries its own offset; render in CLAW_TZ. An
+                # all-day event has only `date`. On any parse trouble print
+                # the raw value -- wrong-looking beats silently dropped.
+                if not isinstance(part, dict):
+                    return '?'
+                if part.get('dateTime'):
+                    try:
+                        from datetime import datetime
+                        from zoneinfo import ZoneInfo
+                        dt = datetime.fromisoformat(part['dateTime'])
+                        return dt.astimezone(ZoneInfo(os.environ.get('TZNAME', 'Europe/Budapest'))).strftime('%H:%M')
+                    except Exception:
+                        return str(part['dateTime'])
+                if part.get('date'):
+                    return 'all-day'
+                return '?'
+            for e in evs:
+                att = e.get('attendees') or 0
+                print('CAL_EVENT %s %s%s' % (
+                    hhmm(e.get('start')),
+                    e.get('summary') or '(nincs cim)',
+                    (' attendees=%d' % att) if att else ''))
+        elif d.get('ok') is False:
+            err('calendar', str(d.get('error') or 'unknown'))
+        else:
+            err('calendar', 'unrecognized response shape: %s' % json.dumps(d)[:120])
+    except Exception as e:
+        err('calendar', repr(e))
 
     # The live schedule registry -- NOT the scheduled_tasks table, which is
     # empty on this deployment and would report 0 forever.

--- a/src/__tests__/heartbeat-agent-scaffold.test.ts
+++ b/src/__tests__/heartbeat-agent-scaffold.test.ts
@@ -58,9 +58,9 @@ describe('renderHeartbeatClaudeMd', () => {
     expect(out).toContain('against `nina@example.com`')
   })
 
-  it('falls back to the MCP primary calendar when no account is set', () => {
+  it('falls back to the dashboard-configured calendar when no account is set', () => {
     const out = renderHeartbeatClaudeMd({ ...ID, calendarAccount: '' })
-    expect(out).toContain('your primary calendar')
+    expect(out).toContain('the calendar the dashboard is configured for')
     // No dangling "against `<empty>`" -- the empty case must not emit a
     // backtick-quoted account at all.
     expect(out).not.toContain('against `')
@@ -163,19 +163,33 @@ describe('renderHeartbeatClaudeMd', () => {
     expect(out).not.toContain('## Heartbeat YYYY-MM-DD HH:MM')
   })
 
-  it('requires the calendar MCP to be called as a tool, never from a subprocess', () => {
-    // Same round: the agent tried to reach the MCP server from a python
-    // subprocess and reported "not accessible in subprocess context" while the
-    // server was a live child of its own session.
+  it('forbids ANY agent-side calendar fetch -- the instrument is the only source (5E0A32B0)', () => {
+    // A month of agent-side fetch variants ended in a fossil: one probe
+    // against a nonexistent endpoint, copy-forwarded round after round as
+    // "calendar fetch failed: API error" with zero real attempts.
     const out = renderHeartbeatClaudeMd(ID)
-    expect(out).toContain('Call it as a TOOL, directly.')
-    expect(out).toMatch(/Do not try to reach an MCP server\s+from Bash, python, curl or any other subprocess/)
+    expect(out).toContain('You never fetch the calendar yourself')
+    expect(out).toContain('/api/heartbeat/calendar')
+    // The old MCP-tool instructions must be gone -- prose telling the agent
+    // to fetch is exactly the surface the fossil grew on.
+    expect(out).not.toContain('mcp__server-google-calendar-mcp__list-events')
   })
 
-  it('separates "tool absent" from "call failed" so the two are not reported alike', () => {
+  it('separates "measured empty" from "failed query" so the two are not reported alike', () => {
     const out = renderHeartbeatClaudeMd(ID)
-    expect(out).toContain('calendar tool not available in this session')
+    // no-events may only come from a measured n=0 line...
+    expect(out).toMatch(/no upcoming events[\s\S]{0,40}CALENDAR_EVENTS n=0/)
+    // ...and the failure line only from THIS round's ERROR calendar: line.
     expect(out).toContain('calendar fetch failed: <reason>')
+    expect(out).toMatch(/calendar fetch failed: <reason>"\s*--\s*ONLY from ERROR calendar: of THIS round/)
+  })
+
+  it('pins the mechanical freshness check on the instrument ts= stamp', () => {
+    // The anti-fossil prose existed before 5E0A32B0 and was ignored; the
+    // ts=-vs-step-0-clock comparison is the mechanical form of it.
+    const out = renderHeartbeatClaudeMd(ID)
+    expect(out).toMatch(/ts=.*stamp[\s\S]{0,120}same\s+hour as the step-0 clock/)
+    expect(out).toContain('stale instrument')
   })
 
   // Same investigation: the Tasks section read the `scheduled_tasks` table,
@@ -297,16 +311,16 @@ describe('no unfalsifiable warnings metric (HBWARN807)', () => {
   })
 })
 
-describe('deferred MCP tools (HBCALMCP808)', () => {
-  it('the calendar step teaches the ToolSearch select protocol', () => {
+describe('instrument-fed calendar (5E0A32B0, supersedes HBCALMCP808)', () => {
+  it('the calendar section names the instrument lines it may be built from', () => {
     const md = renderHeartbeatClaudeMd(ID)
-    // The load-bearing line: without it, a deferred calendar tool reads as
-    // absent and the section silently goes empty (measured 2026-08-08/09:
-    // 13 not-available reports, zero ToolSearch calls, all 13 tools present
-    // in the session's own deferred list).
-    expect(md).toContain('select:mcp__server-google-calendar-mcp__list-events')
-    // "not available" may only be claimed after ToolSearch also failed.
-    expect(md).toMatch(/ONLY[\s\S]{0,80}ToolSearch itself cannot surface/)
+    // With the fetch moved server-side, the ToolSearch/deferred-MCP protocol
+    // (HBCALMCP808) has no remaining subject; what replaces it is the line
+    // vocabulary of the instrument, which is the ONLY sanctioned source.
+    expect(md).toContain('CALENDAR_EVENTS')
+    expect(md).toContain('CAL_EVENT')
+    expect(md).toContain('ERROR calendar:')
+    expect(md).not.toContain('ToolSearch')
   })
 })
 

--- a/src/__tests__/heartbeat-calendar-fail-open.test.ts
+++ b/src/__tests__/heartbeat-calendar-fail-open.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { shouldNotify, buildAgentPrompt } from '../heartbeat.js'
+import type { HeartbeatCalendarResult } from '../heartbeat.js'
+
+// 5E0A32B0 #1159 review (Marveen): the code-side heartbeat prompt was the
+// SECOND calendar source in the same round, and the one that lied -- a failed
+// fetch collapsed to [] and rendered as "Nincs kozelgo esemeny.", while
+// shouldNotify saw an empty list and, on a quiet weekday, skipped the round
+// entirely: an expired token presented as SILENCE. These are the negative
+// controls the review demanded: (a) a failed fetch must never wear the
+// free-calendar sentence, (b) it must make an otherwise-quiet round notify.
+
+function data(calendar: HeartbeatCalendarResult, ts: Date) {
+  return {
+    timestamp: ts,
+    calendar,
+    kanban: { urgent: 0, in_progress: 0, waiting: 0, urgentLabels: [], waitingLabels: [] },
+    system: { dbSizeMB: 50, dbWarning: false },
+    tasks: { count: 0, nextRun: null },
+  }
+}
+
+// Wednesday 10:00 local -- daytime, weekday, nothing else notify-worthy.
+const QUIET_WEEKDAY = new Date(2026, 8, 2, 10, 0)
+
+describe('buildAgentPrompt: a failed calendar fetch never reads as a free calendar', () => {
+  it('failed fetch: names the failure verbatim, no "Nincs kozelgo esemeny."', () => {
+    const prompt = buildAgentPrompt(data({ ok: false, error: 'Token refresh failed: 400' }, QUIET_WEEKDAY))
+    expect(prompt).not.toContain('Nincs kozelgo esemeny.')
+    expect(prompt).toContain('NAPTAR-LEKERDEZES HIBARA FUTOTT: Token refresh failed: 400')
+  })
+
+  it('control: a MEASURED empty calendar still says so', () => {
+    const prompt = buildAgentPrompt(data({ ok: true, events: [] }, QUIET_WEEKDAY))
+    expect(prompt).toContain('Nincs kozelgo esemeny.')
+    expect(prompt).not.toContain('NAPTAR-LEKERDEZES HIBARA FUTOTT')
+  })
+})
+
+describe('shouldNotify: fail-open on a failed calendar query', () => {
+  it('control: the quiet weekday round does NOT notify with a measured-empty calendar', () => {
+    expect(shouldNotify(data({ ok: true, events: [] }, QUIET_WEEKDAY))).toBe(false)
+  })
+
+  it('the SAME round notifies when the calendar query failed', () => {
+    expect(shouldNotify(data({ ok: false, error: 'Token refresh failed: 400' }, QUIET_WEEKDAY))).toBe(true)
+  })
+
+  it('the 22:00 curfew still holds: a broken token waits until morning (dbWarning-only window)', () => {
+    const night = new Date(2026, 8, 2, 22, 30)
+    expect(shouldNotify(data({ ok: false, error: 'Token refresh failed: 400' }, night))).toBe(false)
+  })
+})

--- a/src/__tests__/heartbeat-calendar-route.test.ts
+++ b/src/__tests__/heartbeat-calendar-route.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// 5E0A32B0: the route the metrics instrument reads the calendar from. The
+// load-bearing contract: BOTH end-states are HTTP 200 with a distinguishing
+// payload -- {ok:true, events} vs {ok:false, error} -- so "no events" and
+// "could not query" can never collapse into the same look. (The agent-side
+// era collapsed them, and one failure line fossilized for a day.)
+
+const getCalendarEvents = vi.fn()
+
+vi.mock('../google-api.js', () => ({
+  getCalendarEvents: (...a: unknown[]) => getCalendarEvents(...a),
+}))
+vi.mock('../config.js', async (orig) => {
+  const actual = await orig<typeof import('../config.js')>()
+  return { ...actual, HEARTBEAT_CALENDAR_ID: 'owner@example.com' }
+})
+vi.mock('../logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+}))
+
+const { tryHandleHeartbeat } = await import('../web/routes/heartbeat.js')
+
+async function get(): Promise<{ status: number; json: any }> {
+  let status = 200
+  let body = ''
+  const res = {
+    setHeader() {},
+    writeHead(s: number) { status = s },
+    end(b?: string) { body = b ?? '' },
+  } as any
+  const handled = await tryHandleHeartbeat({
+    req: {} as any, res, path: '/api/heartbeat/calendar', method: 'GET',
+    url: new URL('http://localhost/api/heartbeat/calendar'),
+  } as any)
+  expect(handled).toBe(true)
+  return { status, json: body ? JSON.parse(body) : null }
+}
+
+beforeEach(() => { getCalendarEvents.mockReset() })
+
+describe('GET /api/heartbeat/calendar', () => {
+  it('returns ok:true with slimmed events, cancelled ones filtered', async () => {
+    getCalendarEvents.mockResolvedValue([
+      { id: '1', summary: 'Meeting', start: { dateTime: '2026-09-03T14:30:00+02:00' }, end: { dateTime: '2026-09-03T15:00:00+02:00' }, attendees: [{ email: 'a@b.c' }, { email: 'd@e.f' }] },
+      { id: '2', summary: 'Cancelled thing', status: 'cancelled', start: { dateTime: '2026-09-03T15:00:00+02:00' } },
+    ])
+    const { status, json } = await get()
+    expect(status).toBe(200)
+    expect(json.ok).toBe(true)
+    expect(json.events).toHaveLength(1)
+    expect(json.events[0]).toEqual({
+      start: { dateTime: '2026-09-03T14:30:00+02:00' },
+      end: { dateTime: '2026-09-03T15:00:00+02:00' },
+      summary: 'Meeting',
+      attendees: 2,
+    })
+  })
+
+  it('returns ok:true with an EMPTY list for a measured free calendar', async () => {
+    getCalendarEvents.mockResolvedValue([])
+    const { status, json } = await get()
+    expect(status).toBe(200)
+    expect(json).toEqual({ ok: true, events: [] })
+  })
+
+  it('a thrown fetch (e.g. token refresh 400) is HTTP 200 ok:false with the reason', async () => {
+    getCalendarEvents.mockRejectedValue(new Error('Token refresh failed: 400'))
+    const { status, json } = await get()
+    expect(status).toBe(200)
+    expect(json.ok).toBe(false)
+    expect(json.error).toContain('Token refresh failed: 400')
+  })
+
+  it('asks for a 2h window starting now', async () => {
+    getCalendarEvents.mockResolvedValue([])
+    const before = Date.now()
+    await get()
+    const [id, timeMin, timeMax] = getCalendarEvents.mock.calls[0] as [string, Date, Date]
+    expect(id).toBe('owner@example.com')
+    expect(timeMin.getTime()).toBeGreaterThanOrEqual(before - 1000)
+    expect(timeMax.getTime() - timeMin.getTime()).toBe(2 * 60 * 60 * 1000)
+  })
+})

--- a/src/__tests__/heartbeat-metrics-script.test.ts
+++ b/src/__tests__/heartbeat-metrics-script.test.ts
@@ -11,7 +11,7 @@
 //      (The prose side is fail-safe too -- sentinel rule -- but that only
 //      makes the breakage visible, not impossible.)
 
-import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest'
 import { execFile, spawnSync } from 'node:child_process'
 import { createServer, type Server } from 'node:http'
 import { accessSync, constants, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
@@ -26,6 +26,10 @@ const TOKEN = 'test-token-abc'
 // Mutable fixtures the server serves; individual tests reshape them.
 let summaryBody: unknown
 let schedulesBody: unknown
+// Calendar default: measured-empty. Tests that probe the calendar reshape it;
+// the beforeEach below restores the default so pollution cannot leak forward.
+let calendarBody: unknown = { ok: true, events: [] }
+beforeEach(() => { calendarBody = { ok: true, events: [] } })
 let server: Server
 let origin: string
 let storeDir: string
@@ -100,6 +104,7 @@ con.commit()
     const body =
       req.url === '/api/kanban/heartbeat-summary' ? summaryBody
       : req.url === '/api/schedules' ? schedulesBody
+      : req.url === '/api/heartbeat/calendar' ? calendarBody
       : undefined
     if (body === undefined) {
       res.writeHead(404).end('{}')
@@ -152,6 +157,7 @@ describe('positive control: full fixture', () => {
     )
     expect(r.stdout).toContain('URGENT CARD1 first urgent')
     expect(r.stdout).toContain('WAITING CARD2 a waiting card')
+    expect(r.stdout).toContain('CALENDAR_EVENTS n=0 window=2h')
     expect(r.stdout).toContain('SCHEDULES enabled=2')
     expect(r.stdout).not.toContain('ERROR')
   })
@@ -163,6 +169,49 @@ describe('positive control: full fixture', () => {
     // 2 recent ms rows in; the 2h-old ms row and the seconds-unit row out.
     // A seconds-cutoff regression reports total=4 here.
     expect(r.stdout).toContain('TASK_RUNS_1H total=2 fired=2')
+  })
+})
+
+// 5E0A32B0: the calendar's two end-states must stay two DIFFERENT lines --
+// collapsing "queried, calendar free" and "could not query" into one look is
+// exactly what let a fossil failure line pass as a fresh measurement.
+describe('calendar section: measured empty vs failed query vs events', () => {
+  it('renders timed and all-day events with a count line', async () => {
+    summaryBody = FULL_SUMMARY()
+    schedulesBody = []
+    calendarBody = {
+      ok: true,
+      events: [
+        { start: { dateTime: '2026-09-03T14:30:00+02:00' }, end: { dateTime: '2026-09-03T15:00:00+02:00' }, summary: 'Ruszkovszki telepites', attendees: 2 },
+        { start: { date: '2026-09-03' }, end: { date: '2026-09-04' }, summary: 'Nevnap', attendees: 0 },
+      ],
+    }
+    const r = await runScript()
+    expect(r.status).toBe(0)
+    expect(r.stdout).toContain('CALENDAR_EVENTS n=2 window=2h')
+    expect(r.stdout).toContain('CAL_EVENT 14:30 Ruszkovszki telepites attendees=2')
+    expect(r.stdout).toContain('CAL_EVENT all-day Nevnap')
+  })
+
+  it('a failed query is an ERROR calendar: line + non-zero exit, never an empty list', async () => {
+    summaryBody = FULL_SUMMARY()
+    schedulesBody = [{ enabled: true }]
+    calendarBody = { ok: false, error: 'Token refresh failed: 400' }
+    const r = await runScript()
+    expect(r.status).not.toBe(0)
+    expect(r.stdout).toContain('ERROR calendar: Token refresh failed: 400')
+    expect(r.stdout).not.toContain('CALENDAR_EVENTS')
+    // Partial output stays usable: the unaffected sections still print.
+    expect(r.stdout).toContain('SCHEDULES enabled=1')
+  })
+
+  it('an unrecognized response shape is an instrument failure, not a quiet skip', async () => {
+    summaryBody = FULL_SUMMARY()
+    schedulesBody = []
+    calendarBody = { something: 'else' }
+    const r = await runScript()
+    expect(r.status).not.toBe(0)
+    expect(r.stdout).toContain('ERROR calendar: unrecognized response shape')
   })
 })
 

--- a/src/google-api.ts
+++ b/src/google-api.ts
@@ -186,7 +186,10 @@ export async function getCalendarEvents(
     })
     if (retry.status !== 200) {
       logger.error({ status: retry.status, body: retry.data }, 'Google Calendar API error after refresh')
-      return []
+      // 5E0A32B0: throw, never return []. An API failure that returns an
+      // empty list is indistinguishable from a genuinely free calendar --
+      // the caller must be able to say "couldn't query" vs "no events".
+      throw new Error(`Google Calendar API error after refresh: ${retry.status}`)
     }
     const parsed: CalendarListResponse = JSON.parse(retry.data)
     return parsed.items ?? []
@@ -194,7 +197,7 @@ export async function getCalendarEvents(
 
   if (status !== 200) {
     logger.error({ status, body: data }, 'Google Calendar API error')
-    return []
+    throw new Error(`Google Calendar API error: ${status}`)
   }
 
   const parsed: CalendarListResponse = JSON.parse(data)

--- a/src/heartbeat.ts
+++ b/src/heartbeat.ts
@@ -310,9 +310,18 @@ interface SystemInfo {
   dbWarning: boolean
 }
 
+// 5E0A32B0 #1159 review: a discriminated result, not a bare array. The old
+// contract collapsed "queried, calendar free" and "could not query" into the
+// same empty list, so a failed fetch rendered as "Nincs kozelgo esemeny." in
+// the prompt and read as a quiet morning -- the same lie the metrics
+// instrument was just cured of, one file over, in the same process.
+export type HeartbeatCalendarResult =
+  | { ok: true; events: CalendarEvent[] }
+  | { ok: false; error: string }
+
 interface HeartbeatData {
   timestamp: Date
-  calendar: CalendarEvent[]
+  calendar: HeartbeatCalendarResult
   kanban: { urgent: number; in_progress: number; waiting: number; urgentLabels: string[]; waitingLabels: string[] }
   system: SystemInfo
   tasks: { count: number; nextRun: number | null }
@@ -320,14 +329,14 @@ interface HeartbeatData {
 
 // --- Data collection ---
 
-async function collectCalendar(): Promise<CalendarEvent[]> {
+async function collectCalendar(): Promise<HeartbeatCalendarResult> {
   try {
     const now = new Date()
     const twoHoursLater = new Date(now.getTime() + 2 * 60 * 60 * 1000)
-    return await getCalendarEvents(HEARTBEAT_CALENDAR_ID, now, twoHoursLater)
+    return { ok: true, events: await getCalendarEvents(HEARTBEAT_CALENDAR_ID, now, twoHoursLater) }
   } catch (err) {
     logger.error({ err }, 'Heartbeat: calendar fetch failed')
-    return []
+    return { ok: false, error: String((err as Error)?.message ?? err).slice(0, 200) }
   }
 }
 
@@ -394,6 +403,16 @@ function shouldNotify(data: HeartbeatData): boolean {
   // a felhasznalot.
   if (hour >= 22) return false
 
+  // 5E0A32B0 fail-open on the NOTIFICATION side: a failed calendar QUERY is
+  // itself notify-worthy. Before this, an expired token emptied the list,
+  // shouldNotify saw nothing calendar-shaped, and on a quiet weekday the
+  // heartbeat simply did not fire -- the failure presented as SILENCE, which
+  // is the one presentation nobody investigates. Placed after the 22:00
+  // curfew (that window stays dbWarning-only by design: a broken token can
+  // wait until morning) but before the evening/weekend urgent-only filters,
+  // so a broken calendar surfaces on the next non-curfew round.
+  if (!data.calendar.ok) return true
+
   if (hour >= 21) {
     return data.kanban.urgent > 0
   }
@@ -402,7 +421,7 @@ function shouldNotify(data: HeartbeatData): boolean {
     return data.kanban.urgent > 0
   }
 
-  if (data.calendar.length > 0) return true
+  if (data.calendar.events.length > 0) return true
   if (data.kanban.urgent > 0) return true
   if (data.kanban.waiting > 2) return true
 
@@ -448,10 +467,16 @@ function buildAgentPrompt(data: HeartbeatData): string {
   // Calendar -- event summaries and attendee names come from whoever sent the
   // invite, so every one is wrapped individually as untrusted data.
   prompt += `## Naptar (kovetkezo 2 ora)\n`
-  if (data.calendar.length === 0) {
+  if (!data.calendar.ok) {
+    // 5E0A32B0: a failed query must never wear the free-calendar sentence.
+    // The error text is our own thrown message (google-api.ts), not remote
+    // content, but it stays inside this labelled line either way.
+    prompt += `NAPTAR-LEKERDEZES HIBARA FUTOTT: ${data.calendar.error}\n` +
+      `Ez NEM ures naptar -- a lekerdezes bukott. Jelezd a gazdanak, hogy a naptar-forras hibas (pl. lejart token), es hogy a naptari kep emiatt ISMERETLEN.\n\n`
+  } else if (data.calendar.events.length === 0) {
     prompt += `Nincs kozelgo esemeny.\n\n`
   } else {
-    for (const ev of data.calendar) {
+    for (const ev of data.calendar.events) {
       const start = ev.start?.dateTime
         ? new Date(ev.start.dateTime).toLocaleTimeString('hu-HU', { hour: '2-digit', minute: '2-digit', timeZone: APP_TZ })
         : 'egesz napos'

--- a/src/web.ts
+++ b/src/web.ts
@@ -49,6 +49,7 @@ import { tryHandleDailyLog } from './web/routes/daily-log.js'
 import { tryHandleMemories } from './web/routes/memories.js'
 import { tryHandleMigrate } from './web/routes/migrate.js'
 import { tryHandleKanban } from './web/routes/kanban.js'
+import { tryHandleHeartbeat } from './web/routes/heartbeat.js'
 import { tryHandleSchedules } from './web/routes/schedules.js'
 import { tryHandleConnectors } from './web/routes/connectors.js'
 import { tryHandleDocs } from './web/routes/docs.js'
@@ -183,6 +184,7 @@ export function startWebServer(port = 3420): http.Server {
       if (await tryHandleMemories(routeCtx)) return
       if (await tryHandleMigrate(routeCtx)) return
       if (await tryHandleKanban(routeCtx)) return
+      if (await tryHandleHeartbeat(routeCtx)) return
       if (await tryHandleSchedules(routeCtx)) return
       if (await tryHandleConnectorsHu(routeCtx)) return
       if (await tryHandleConnectors(routeCtx)) return

--- a/src/web/heartbeat-agent-scaffold.ts
+++ b/src/web/heartbeat-agent-scaffold.ts
@@ -96,7 +96,7 @@ export interface HeartbeatIdentity {
   // Dashboard origin for the inter-agent message POST, e.g.
   // http://localhost:3420.
   dashboardOrigin: string
-  // Google Calendar account to summarise, or '' to let the calendar MCP
+  // Google Calendar account to summarise (display only), or '' to let the
   // server use whatever account it is authenticated as.
   calendarAccount: string
   // Absolute path to scripts/heartbeat-metrics.sh -- the round's single
@@ -143,7 +143,7 @@ export function shouldBootHeartbeatAgent(opts: { respawnEnabled: boolean; agentE
 export function renderHeartbeatClaudeMd(id: HeartbeatIdentity): string {
   const calendarTarget = id.calendarAccount
     ? `against \`${id.calendarAccount}\``
-    : 'against your primary calendar (whatever account the calendar MCP server is authenticated as)'
+    : 'against the calendar the dashboard is configured for (HEARTBEAT_CALENDAR_ID)'
   return `# Heartbeat agent
 
 You are the **heartbeat agent** -- a dedicated, headless worker that
@@ -181,37 +181,26 @@ When you receive the heartbeat prompt:
    1h") is read against it, so an hour of drift silently moves the
    window as well as the label.
 
-1. **Collect** the four data sources:
-   - **Calendar (next 2 hours)** -- use the
-     \`mcp__server-google-calendar-mcp__list-events\` tool
-     ${calendarTarget}, timeMin=now, timeMax=now+2h.
-     Call it as a TOOL, directly. Do not try to reach an MCP server
-     from Bash, python, curl or any other subprocess: MCP tools exist
-     only in your own tool list, so a subprocess will always come back
-     empty and that emptiness says nothing about the server.
+1. **Collect** the data -- everything, calendar included, comes from
+   the ONE instrument below:
+   - **Calendar (next 2 hours)** -- comes from the SAME instrument as
+     every other number: the \`CALENDAR_EVENTS\` / \`CAL_EVENT\` /
+     \`ERROR calendar:\` lines of its output (measured server-side on
+     \`${id.dashboardOrigin}/api/heartbeat/calendar\`
+     ${calendarTarget}). You never fetch the calendar yourself: no MCP
+     tool, no curl, no python -- the history of every agent-side fetch
+     variant is a month of migrating symptoms (HBCALMCP808 "tool not
+     available"; then 5E0A32B0: one probe against a NONEXISTENT
+     endpoint on 2026-09-02 15:00 whose failure line was copy-forwarded
+     for a day as "calendar fetch failed: API error" with ZERO real
+     attempts -- the digest lied about the fact of measurement itself).
 
-     DEFERRED LOADING (2026-08-09, HBCALMCP808): MCP tools may arrive
-     DEFERRED -- their names appear in a system-reminder listing but
-     the schema is not loaded, and a direct call fails as if the tool
-     did not exist. That failure is NOT absence. Before concluding
-     anything, run:
-
-     ToolSearch with query "select:mcp__server-google-calendar-mcp__list-events"
-
-     and then call the tool normally. Between 2026-08-08 20:00 and
-     2026-08-09 every hourly round reported "calendar tool not
-     available" while all 13 calendar tools sat in the deferred list
-     of the very same session -- the section went empty for a day
-     because this step was missing.
-
-     You may say "calendar tool not available in this session" ONLY
-     when ToolSearch itself cannot surface the tool either -- that is
-     a different fact from a failed direct call on a deferred tool,
-     and a different fact again from a failed call (token revoked /
-     401), which only the loaded tool can produce.
-     If the call fails (token revoked / 401), record the failure
-     reason rather than the events; the main agent can act on the
-     failure.
+     The two calendar end-states are DIFFERENT lines, keep them apart:
+     \`CALENDAR_EVENTS n=0\` is a MEASURED empty calendar -> report
+     "no upcoming events"; \`ERROR calendar: <reason>\` is a failed
+     query -> report "calendar fetch failed: <reason>" with the reason
+     verbatim, so the main agent can act on it (an expired token must
+     surface as an expired token, not as a quiet free morning).
    - **Metrics (kanban + tasks + memory + DB size)** -- ONE fixed,
      on-disk instrument. Run it EXACTLY as written and copy its output
      lines VERBATIM into the report sections below; never recompose any
@@ -290,9 +279,9 @@ When you receive the heartbeat prompt:
    ## Heartbeat <the string step 0 measured> (${APP_TZ})
 
    ### Calendar (next 2h)
-   - HH:MM -- <summary> (<attendees>)
-   - <or: "no upcoming events">
-   - <or: "calendar fetch failed: <reason>">
+   - HH:MM -- <summary> (attendees=N)   <one line per CAL_EVENT, verbatim>
+   - <or: "no upcoming events"          -- ONLY from CALENDAR_EVENTS n=0>
+   - <or: "calendar fetch failed: <reason>" -- ONLY from ERROR calendar: of THIS round>
 
    ### Kanban
    - urgent: <N from COUNTS> (<short titles from the URGENT lines>)
@@ -315,6 +304,16 @@ When you receive the heartbeat prompt:
    A value carried over from an earlier round makes its line constant,
    and a line that always says the same thing stops being read -- at
    which point a real change looks exactly like the noise around it.
+   This is not hypothetical: between 2026-09-02 15:00 and 2026-09-03
+   09:00 every round re-sent "calendar fetch failed: API error" from
+   the previous round's text while making no calendar attempt at all
+   (5E0A32B0) -- the reader believed a query had failed THAT morning
+   when no query had happened. FRESHNESS CHECK, mechanical: the
+   instrument's own \`ts=\` stamp (sentinel line) must fall in the same
+   hour as the step-0 clock string. If it does not, the output in your
+   context is a PREVIOUS round's -- run the instrument again; if the
+   re-run still mismatches, report \`muszer-hiba: stale instrument
+   output (ts=<value>)\` in every section instead of any number.
 
 3. **Send** that string to the main agent via the dashboard API:
 

--- a/src/web/routes/heartbeat.ts
+++ b/src/web/routes/heartbeat.ts
@@ -1,0 +1,60 @@
+// 5E0A32B0: the heartbeat round's CODE-SIDE calendar source.
+//
+// The calendar was the last heartbeat data source the agent fetched itself
+// (MCP tool), and it produced a month of migrating symptoms -- "MCP tool
+// validation error", "tool not available", and finally a FOSSIL: one failed
+// probe against a NONEXISTENT endpoint (/api/calendar/list-events, 404) on
+// 2026-09-02 15:00 was copy-forwarded as "calendar fetch failed: API error"
+// for every subsequent round with zero real attempts. Moving the fetch here
+// -- next to the token cache and refresh logic that already work for the
+// dashboard process -- puts the calendar on the same instrument path as
+// every other digest number: the agent copies verbatim, composes nothing.
+//
+// Contract (consumed by scripts/heartbeat-metrics.sh):
+//   200 { ok: true,  events: [{ start, end, summary, attendees }] }
+//   200 { ok: false, error: "<reason>" }
+// Both states are HTTP 200 on purpose: "the query failed" is a MEASURED
+// result the instrument must relay ("calendar fetch failed: <reason>"),
+// distinct from "no events" (ok:true, empty list) -- exactly the difference
+// the fossil erased. A non-200 therefore always means the route itself is
+// absent/broken, never a calendar-side failure.
+import { getCalendarEvents } from '../../google-api.js'
+import { HEARTBEAT_CALENDAR_ID } from '../../config.js'
+import { json } from '../http-helpers.js'
+import { logger } from '../../logger.js'
+import type { RouteContext } from './types.js'
+
+export const HEARTBEAT_CALENDAR_WINDOW_MS = 2 * 60 * 60 * 1000
+
+export async function tryHandleHeartbeat(ctx: RouteContext): Promise<boolean> {
+  const { res, path, method } = ctx
+
+  if (path === '/api/heartbeat/calendar' && method === 'GET') {
+    if (!HEARTBEAT_CALENDAR_ID) {
+      json(res, { ok: false, error: 'HEARTBEAT_CALENDAR_ID is not configured' })
+      return true
+    }
+    const now = new Date()
+    const end = new Date(now.getTime() + HEARTBEAT_CALENDAR_WINDOW_MS)
+    try {
+      const events = await getCalendarEvents(HEARTBEAT_CALENDAR_ID, now, end)
+      json(res, {
+        ok: true,
+        events: events
+          .filter((e) => e.status !== 'cancelled')
+          .map((e) => ({
+            start: e.start ?? null,
+            end: e.end ?? null,
+            summary: e.summary ?? '(nincs cim)',
+            attendees: e.attendees?.length ?? 0,
+          })),
+      })
+    } catch (err) {
+      logger.warn({ err }, 'heartbeat calendar endpoint: fetch failed')
+      json(res, { ok: false, error: String((err as Error)?.message ?? err).slice(0, 200) })
+    }
+    return true
+  }
+
+  return false
+}


### PR DESCRIPTION
## Mit old meg

A naptár volt az utolsó digest-adatforrás, amit a heartbeat-agens maga hozott (MCP tool), és ez egy hónapnyi tünetvándorlást termelt, aminek a vége egy FOSSZÍLIA lett: egy 2026-09-02 15:00-ás, nem létező endpointra (`/api/calendar/list-events`, 404) adott bukás sorát az agens 2026-09-03 09:00-ig minden körben mérés nélkül továbbmásolta -- a digest a MÉRÉS TÉNYÉRŐL hazudott.

## Mechanizmus (Marveen GO msg 18139, végállapot = kód-oldali műszer)

- **`GET /api/heartbeat/calendar`** (új route): a dashboard saját OAuth-útján (google-api.ts, ami bizonyítottan egészséges) méri a következő 2 órát. MINDKÉT végállapot HTTP 200, megkülönböztető payloaddal: `{ok:true, events}` vs `{ok:false, error}` -- egy nem-200 mindig a route hiányát jelenti, sosem naptár-hibát.
- **`getCalendarEvents` mostantól THROW-ol nem-200-ra** üres lista helyett: egy API-hiba soha többé nem nézhet ki szabad naptárnak. (A heartbeat.ts collectCalendar catch-e változatlan szemantikájú.)
- **`heartbeat-metrics.sh`**: új `CALENDAR_EVENTS n=N` / `CAL_EVENT` / `ERROR calendar:` sorok, fail-closed. `n=0` = MÉRT üres naptár; `ERROR calendar:` = nem tudtam lekérdezni -- a kettő szerkezetileg különbözik.
- **Scaffold**: az MCP-fetch utasítások törölve, az agens csak a műszer sorait formázza verbatim, saját fetch tilos (a fosszília-incidens beleírva). 

## Negatív kontroll (1. kikötés)

A "nincs esemény" vs "nem tudtam lekérdezni" szétválasztása három rétegben pinelve: route-teszt (`ok:false` a thrown Token refresh 400-ra, `ok:true+üres` a szabad naptárra), műszer-teszt (`ERROR calendar: Token refresh failed: 400` + nem-nulla exit vs `CALENDAR_EVENTS n=0` + exit 0), scaffold-teszt (a "no upcoming events" CSAK `CALENDAR_EVENTS n=0`-ból, a "calendar fetch failed" CSAK az ADOTT kör `ERROR calendar:` sorából írható).

## Fosszília-osztály audit (2. kikötés)

Mérve a fosszília-körökön: a kanban-számok körről körre VÁLTOZTAK (waiting 431→432, planned 410→404→407), tehát a műszer minden körben lefutott -- pontosan és kizárólag az egyetlen agens-fetchelt sor (naptár) kövült meg. E PR után MINDEN szekció műszer-etetett. A megmaradó fosszília-felület: egy teljes korábbi műszer-output újrafelhasználása -- erre megy a mechanikus frissesség-ellenőrzés: a műszer `ts=` bélyege és a 0. lépés órája azonos órába kell essen, különben újrafuttatás, tartós eltérésnél `muszer-hiba: stale instrument output` minden szekcióban.

## Megjegyzések

- A HBCALMCP808 ToolSearch-protokoll prózája tárgytalanná vált és kikerült (a teszt is ezt pinnli: `not.toContain('ToolSearch')` a scaffoldban).
- Konfigurálatlan `HEARTBEAT_CALENDAR_ID` esetén az endpoint `ok:false, "not configured"` -- őszinte hibasor, nem néma üresség.
- Élesedés: a scaffoldot a dashboard respawnkor újrarendereli, route+műszer+szabály együtt mozog (ugyanaz az egyben-szállítás elv, mint a #1158-nál).

Tesztek: 348 fájl / 4534 zöld (10 új/átírt a három rétegre). Kártya: 5E0A32B0, merge Marveennél.

🤖 Generated with [Claude Code](https://claude.com/claude-code)