### PR TITLE
test(scaffold): forward-compat AGENT_API_ORIGIN in the system-directive-auth config mock (#1157 prep)

### DIFF
--- a/src/__tests__/system-directive-auth-section.test.ts
+++ b/src/__tests__/system-directive-auth-section.test.ts
@@ -18,6 +18,10 @@ vi.mock('../config.js', () => ({
   WEB_PORT: 3420,
   OWNER_DRIVE_FOLDER: '',
   DASHBOARD_PUBLIC_URL: '',
+  // Forward-compat for #1157 (AGENT_API_ORIGIN): the strict config mock
+  // must carry the key BEFORE that PR lands -- unread until then, and the
+  // merge stays green the minute agent-scaffold starts importing it.
+  AGENT_API_ORIGIN: '',
 }))
 
 vi.mock('../web/agent-config.js', () => ({


### PR DESCRIPTION
Egysoros előkészítő a #1157 elé (Marveen msg 18152 sorrend-kérése): a #1158-as szekció-teszt strict config-mockja megkapja az `AGENT_API_ORIGIN: ''` kulcsot MOST, amíg semmi nem olvassa -- így a develop a #1157 merge-ének mindkét oldalán zöld marad, nincs piros-develop ablak.

Mérve: a #1157 merge-preview-jén ezzel a sorral a teljes szuit zöld (4533). A #1157 EZUTÁN mergelendő.

Megjegyzés: direkt developra push-t próbáltam Marveen kérése szerint, de a branch-protection (2 required check) elutasította -- ezért PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)