### PR TITLE
test(router): declare countNewerMessagesFromSameSender in the db mock (groundwork for #1104)

### DIFF
--- a/src/__tests__/feedback-modal-positive-router.test.ts
+++ b/src/__tests__/feedback-modal-positive-router.test.ts
@@ -50,6 +50,14 @@ vi.mock('../db.js', () => ({
   stampMessageTrace: (..._a: unknown[]) => false,
   upsertOtelSpan: (..._a: unknown[]) => undefined,
   closeOtelSpan: (..._a: unknown[]) => false,
+  // Forward-compatible: this mock declares an EXPLICIT export list, so any db
+  // helper a future router path calls has to appear here or the module resolves
+  // it as undefined and the tick dies silently -- the delivery simply never
+  // happens and the assertion reads as "spy called 0 times".
+  // Added ahead of #1104 (superseded-message marking), whose router path calls
+  // this helper. Nothing reads the value until that lands; until then it is an
+  // unused key, which is why this is safe to ship on its own.
+  countNewerMessagesFromSameSender: (..._a: unknown[]) => 0,
 }))
 
 vi.mock('../web/voice-directive.js', () => ({


### PR DESCRIPTION
Groundwork for #1104, deliberately landed **before** it so `develop` is never red for a minute.

## What breaks without this

`src/__tests__/feedback-modal-positive-router.test.ts` mocks `../db.js` with an **explicit export list**. #1104 adds a router path that calls `countNewerMessagesFromSameSender`, which the mock does not declare, so inside that test the helper resolves to `undefined`, the tick dies, the delivery never happens, and the assertion surfaces as the far less obvious `spy called 0 times`.

## Measured

| tree | result |
|---|---|
| develop alone | green |
| develop + #1104 | **1 test fails** (this one) |
| develop + #1104 + this line | green, 351 files / 4560 tests |
| develop + this line, **without** #1104 | green, 350 files / 4569 tests |

The last row is why this can ship on its own: the mock factory just returns an object, and nothing reads the key until the router path exists.

## Worth stating plainly

The contributor's green check on #1104 was **honest**. Their CI ran 2026-08-30; the test that now fails landed 2026-08-31 (#1127). A passing check certifies the tree it ran against, not today's. That is our timing, not their mistake, so the one-line fixup belongs here rather than in a change-request to them.
