### PR TITLE
fix(gmail-mcp): vendor a patched gmail-mcp-server with real multi-user routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,12 @@
 # Dependencies & build
 node_modules
 dist/
+# Vendored gmail-mcp-server ships its patched build under its own dist/ --
+# carve it out of the blanket dist/ ignore above (same directory-vs-contents
+# gotcha as .claude/ further down: needs the directory itself un-ignored
+# before the negation can reach its contents).
+!vendor/gmail-mcp-server/dist/
+!vendor/gmail-mcp-server/dist/**
 
 # Python bytecode cache (e.g. scripts/hooks/__pycache__/*.pyc)
 __pycache__/

--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -19,6 +19,13 @@ A Marveen saját licensze: [LICENSE](./LICENSE) (MIT).
 - **Hol a Marveen-ben**: `seed-skills/handoff/`, `seed-skills/retrospective/`, `seed-skills/skill-management/`
 - **Mit csinál nálunk**: a skill-csontváz a Marveen flotta-architektúrájára adaptálva. Az 5-szekciós handoff struktúra (Goal, Current Progress, What Worked, What Didn't Work, Next Steps), a sub-agent retrospective minta, és a skill-rot életciklus-kezelés koncepció mind Zhutov csomagjából származik. A megvalósítás TypeScript-ben újraírva, integrálva a Marveen checkpoint, DREAM, memória és inter-agent message rendszereivel.
 
+### gmail-mcp-server (Gmail MCP szerver, több-fiókos javítással)
+- **Forrás**: https://www.npmjs.com/package/gmail-mcp-server (npm, nincs publikus GitHub repo a csomaghoz)
+- **Szerző**: uhbarp-ayis / SIYA (prabhu@siya.com)
+- **Licensz**: MIT
+- **Hol a Marveen-ben**: `vendor/gmail-mcp-server/` (v1.0.30-ból vendorolva 2026-08-23-án)
+- **Mit csinál nálunk**: a Gmail integráció (email keresés/olvasás/küldés/draftok) MCP szervere. A csomag `--multi-user` módja a publikált verzióban félkész volt: a tool-sémák `userId` paramétert hirdettek, de a search/read/send/draft/attachment/label kezelők ezt sosem használták ténylegesen, mindig az egyetlen legacy fiókra mentek, `userId`-tól függetlenül (a `send_email` még a user-specifikus klienst is lekérte, aztán eldobta). Helyben javítottuk: az `overrideClient` paraméter végigvezetve mind a ~18 `GmailOperations` metóduson és mind a 9 érintett tool-handleren, a `getGmailClientForUser` pedig mostantól emailcímmel is kereshető (nem csak a generált userId hash-sel). `userId` hiányában a hívás a korábbi, alapértelmezett fiókra esik vissza (nem dob hibát), így a flottában meglévő, `userId`-t nem ismerő hívók (pl. a könyvelő ágens) törés nélkül tovább működnek.
+
 ### printing-press (agent-CLI generátor)
 - **Forrás**: https://github.com/mvanhorn/cli-printing-press
 - **Szerző**: Mike Van Horn

--- a/mcp-catalog.json
+++ b/mcp-catalog.json
@@ -25,7 +25,9 @@
     "env": {},
     "authType": "oauth",
     "authNote": "Google Cloud OAuth kliens kell hozzá (client ID + secret), ugyanaz az OAuth-app használható a Naptár összekötőhöz is. Első használatkor böngészőben kell bejelentkezni. A publikált npm csomag --multi-user módja hibás volt (userId figyelmen kívül hagyva minden olvasás/keresés/küldés hívásnál), ezért a vendor/gmail-mcp-server alatti, javított másolatot használjuk helyette, lásd ATTRIBUTIONS.md és vendor/gmail-mcp-server/MARVEEN_PATCH.md.",
-    "infoUrl": "https://github.com/ArtyMcLabin/Gmail-MCP-Server"
+    "infoUrl": "https://www.npmjs.com/package/gmail-mcp-server",
+    "verifiedAt": "2026-09-03",
+    "verifiedNote": "Vendorolt másolat ellenőrizve: gmail-mcp-server@1.0.30 (npm) és a vendor/gmail-mcp-server alatti kód között 4 fájl tér el (dist/index.js, dist/utils/gmail-operations.js, dist/utils/multi-user-auth.js, dist/utils/gmail-auth.js), mindegyik a MARVEEN_PATCH.md-ben dokumentált userId-bugfix vagy OAuth-prompt módosítás. Titok-sweep tiszta, nem-Google végpont nincs benne."
   },
   {
     "id": "google-calendar",

--- a/mcp-catalog.json
+++ b/mcp-catalog.json
@@ -20,14 +20,12 @@
     "type": "local",
     "category": "productivity",
     "icon": "📧",
-    "command": "npx",
-    "args": ["-y", "gmail-mcp-server"],
+    "command": "node",
+    "args": ["vendor/gmail-mcp-server/dist/index.js", "--multi-user"],
     "env": {},
     "authType": "oauth",
-    "authNote": "Google Cloud OAuth kliens kell hozzá (client ID + secret). UGYANAZ az OAuth-app használható a Naptár összekötőhöz is.",
-    "infoUrl": "https://github.com/ArtyMcLabin/Gmail-MCP-Server",
-    "verifiedAt": "2026-08-27",
-    "verifiedNote": "npm-csomag ellenőrizve: gmail-mcp-server v1.0.30 létezik."
+    "authNote": "Google Cloud OAuth kliens kell hozzá (client ID + secret), ugyanaz az OAuth-app használható a Naptár összekötőhöz is. Első használatkor böngészőben kell bejelentkezni. A publikált npm csomag --multi-user módja hibás volt (userId figyelmen kívül hagyva minden olvasás/keresés/küldés hívásnál), ezért a vendor/gmail-mcp-server alatti, javított másolatot használjuk helyette, lásd ATTRIBUTIONS.md és vendor/gmail-mcp-server/MARVEEN_PATCH.md.",
+    "infoUrl": "https://github.com/ArtyMcLabin/Gmail-MCP-Server"
   },
   {
     "id": "google-calendar",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,12 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.116",
+        "@modelcontextprotocol/sdk": "^1.18.1",
         "better-sqlite3": "^11.7.0",
         "cron-parser": "^5.0.0",
+        "googleapis": "^140.0.1",
+        "mime-types": "^3.0.1",
+        "open": "^10.2.0",
         "pino": "^9.6.0",
         "pino-pretty": "^13.0.0"
       },
@@ -1212,6 +1216,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
@@ -1295,6 +1308,15 @@
         "prebuild-install": "^7.1.1"
       }
     },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/bindings": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
@@ -1361,6 +1383,27 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/bytes": {
@@ -1593,6 +1636,46 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/default-browser": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.1.tgz",
+      "integrity": "sha512-m1pAzaJgZ/gssEqlOhJkPJp8Xly7QyW6xcrkUa2KKcDeDSEMP7X8xipU3snUcfisTQx0w1AGae+9UtJSfVnXGw==",
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -1623,6 +1706,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -1854,6 +1946,12 @@
         "express": ">= 4.11"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
     "node_modules/fast-copy": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.2.tgz",
@@ -1963,6 +2061,36 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -2019,6 +2147,62 @@
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "license": "MIT"
     },
+    "node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/googleapis": {
+      "version": "140.0.1",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-140.0.1.tgz",
+      "integrity": "sha512-ZGvBX4mQcFXO9ACnVNg6Aqy3KtBPB5zTuue43YVLxwn8HSv8jB7w+uDKoIPSoWuxGROgnj2kbng6acXncOQRNA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^9.0.0",
+        "googleapis-common": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/googleapis-common": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-7.2.0.tgz",
+      "integrity": "sha512-/fhDZEJZvOV3X5jmD+fKxMqma5q2Q9nZNSF3kn1F18tpxmA86BcTxAGBQdM0N89Z3bEaIs+HVznSmFJEAmMTjA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "gaxios": "^6.0.3",
+        "google-auth-library": "^9.7.0",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -2029,6 +2213,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/has-symbols": {
@@ -2088,6 +2285,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/iconv-lite": {
@@ -2156,11 +2366,71 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -2184,6 +2454,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
       }
     },
     "node_modules/json-schema-to-ts": {
@@ -2210,6 +2489,27 @@
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/loupe": {
       "version": "3.2.1",
@@ -2371,6 +2671,26 @@
         "node": ">=10"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -2420,6 +2740,24 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/parseurl": {
@@ -2867,6 +3205,18 @@
         "node": ">= 18"
       }
     },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -3288,6 +3638,12 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/ts-algebra": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
@@ -3370,11 +3726,31 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+      "license": "BSD"
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -3964,6 +4340,22 @@
         }
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4001,6 +4393,21 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/zod": {
       "version": "4.3.6",

--- a/package.json
+++ b/package.json
@@ -22,8 +22,12 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.116",
+    "@modelcontextprotocol/sdk": "^1.18.1",
     "better-sqlite3": "^11.7.0",
     "cron-parser": "^5.0.0",
+    "googleapis": "^140.0.1",
+    "mime-types": "^3.0.1",
+    "open": "^10.2.0",
     "pino": "^9.6.0",
     "pino-pretty": "^13.0.0"
   },

--- a/src/web/routes/connectors.ts
+++ b/src/web/routes/connectors.ts
@@ -664,7 +664,15 @@ export async function tryHandleConnectors(ctx: RouteContext): Promise<boolean> {
           .map(([k, v]) => `-e ${shellEscape(k)}=${shellEscape(v as string)}`)
           .join(' ')
 
-        const argsStr = (item.args || []).map((a: string) => shellEscape(a)).join(' ')
+        // Catalog args pointing into the repo (e.g. our vendored gmail-mcp-server)
+        // are relative to PROJECT_ROOT, but `claude mcp add --scope user` writes
+        // them verbatim into ~/.claude.json, and the MCP server later spawns from
+        // its own session cwd (agents/<name>), not the repo root -- so a relative
+        // path resolves to nothing there. Absolutize before registering.
+        const resolvedArgs = (item.args || []).map((a: string) =>
+          a.startsWith('vendor/') ? join(PROJECT_ROOT, a) : a,
+        )
+        const argsStr = resolvedArgs.map((a: string) => shellEscape(a)).join(' ')
         const cmd = `claude mcp add --scope user ${shellEscape(cliName)} ${envFlags} -- ${shellEscape(item.command)} ${argsStr} 2>&1`
         execSync(cmd, { timeout: 30000, encoding: 'utf-8' })
         if (Object.keys(userSecrets).length) {

--- a/vendor/gmail-mcp-server/LICENSE
+++ b/vendor/gmail-mcp-server/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Gmail MCP Server
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE. 

--- a/vendor/gmail-mcp-server/MARVEEN_PATCH.md
+++ b/vendor/gmail-mcp-server/MARVEEN_PATCH.md
@@ -58,6 +58,14 @@ sends through whichever account was authenticated first, via `gmail_authenticate
   `~/.gmail-mcp` (its actual per-user tokens live in `user-sessions.json`
   there anyway, written by `multi-user-auth.js`, which was NOT changed).
 
+- `dist/utils/gmail-auth.js`: the OAuth consent-screen prompt changed from
+  `prompt: 'consent'` to `prompt: 'select_account consent'` in all three auth
+  URL builders. In `--multi-user` mode, each new `gmail_authenticate_user`
+  call needs to let the person pick which Google account to sign in with;
+  plain `'consent'` skips the account chooser and reuses whatever Google
+  session is already active in the browser, which defeats the point of
+  authenticating a second/third account.
+
 ## If you ever refresh this vendor copy from a newer npm release
 
 Re-check whether `dist/index.js` and `dist/utils/gmail-operations.js` /

--- a/vendor/gmail-mcp-server/MARVEEN_PATCH.md
+++ b/vendor/gmail-mcp-server/MARVEEN_PATCH.md
@@ -1,0 +1,66 @@
+# Marveen patch notes
+
+Vendored from `gmail-mcp-server@1.0.30` (npm, MIT, https://www.npmjs.com/package/gmail-mcp-server)
+on 2026-08-23. See `../../ATTRIBUTIONS.md` for the full attribution entry.
+
+## Why this exists
+
+The published `--multi-user` mode advertises a `userId` parameter on every tool
+(`gmail_search_emails`, `gmail_read_email`, `gmail_send_email`, `gmail_draft`,
+`gmail_mark_email`, `gmail_move_email`, `gmail_delete_email`,
+`gmail_list_attachments`, `gmail_get_attachment`), but the shipped handlers never
+actually used it: they always called the single legacy `gmailOperations` singleton,
+regardless of `userId`. `gmail_send_email` even fetched the per-user client via
+`multiUserAuth.getGmailClientForUser(userId)` and then discarded it. Net effect:
+every account you authenticate through `gmail_authenticate_user` silently reads and
+sends through whichever account was authenticated first, via `gmail_authenticate`.
+
+## What changed
+
+- `dist/utils/gmail-operations.js`: every method that reaches Gmail
+  (`sendEmail`, `getEmail`, `getAttachment`, `getAttachmentToLocal`,
+  `listAttachments`, `searchEmails` + its two internal search strategies,
+  `markEmail`, `moveToLabel`, `deleteEmail`, the draft CRUD methods, `listEmails`)
+  now takes an optional trailing `overrideClient` param. When present, it's used
+  instead of the legacy singleton client; when absent, behavior is unchanged
+  (falls back to the legacy default account). Internal cross-calls
+  (`performEnhancedSearch`/`performTraditionalSearch` calling `getEmail`,
+  `listDrafts` calling `getDraft`) now thread the same override through.
+- `dist/utils/multi-user-auth.js`: `getGmailClientForUser(userId)` now also
+  accepts a plain email address (matched against `session.userEmail`), not just
+  the generated `user_<hash>_...` id, so callers don't need to remember the
+  opaque id.
+- `dist/index.js`: each of the 9 affected tool handlers now resolves
+  `overrideClient` from `userId` (via `multiUserAuth.getGmailClientForUser`)
+  *when userId is given*, and passes it through. The old
+  `"'userId' is required in multi-user mode"` throws were removed — omitting
+  `userId` now means "use the primary/default account" instead of erroring, so
+  existing callers that don't know about multi-user mode keep working
+  unchanged. The duplicated multi-user/single-user branches in the
+  `gmail_draft` handler were collapsed into one (they did the same discard-the-
+  client thing in both branches anyway).
+
+- `dist/utils/gmail-auth.js`: `CONFIG_DIR` (and therefore `CREDENTIALS_FILE`/
+  `TOKEN_FILE`) is now overridable via `GMAIL_CONFIG_DIR`, falling back to the
+  original hardcoded `~/.gmail-mcp` when unset. Needed because we run two
+  instances of this same package as separate MCP servers (`gmail` for
+  info@webkit.hu in `--multi-user` mode, `gmail-private` for a personal Gmail
+  account in single-user mode) with their own `GMAIL_CLIENT_ID`/`SECRET`, but
+  the single-user auth path (used by `gmail-private`) hardcoded the SAME
+  `~/.gmail-mcp/token.json` regardless of which client credentials were
+  configured. In practice this meant `gmail-private` read a stale, expired
+  token that actually belonged to the `gmail` server's account (left over from
+  before that server switched to `--multi-user` mode), causing every real
+  `gmail-private` API call to silently fail/timeout while `gmail_authenticate`
+  falsely reported "already authenticated". `gmail-private`'s MCP config now
+  sets `GMAIL_CONFIG_DIR=~/.gmail-mcp-private` so it gets its own, isolated
+  token store; `gmail` (multi-user) is untouched and keeps using the default
+  `~/.gmail-mcp` (its actual per-user tokens live in `user-sessions.json`
+  there anyway, written by `multi-user-auth.js`, which was NOT changed).
+
+## If you ever refresh this vendor copy from a newer npm release
+
+Re-check whether `dist/index.js` and `dist/utils/gmail-operations.js` /
+`multi-user-auth.js` still have this exact bug before assuming the patch still
+applies cleanly — search for `gmailOperations.searchEmails(searchCriteria)`
+(no second arg) and `is not authenticated` in `multi-user-auth.js` as anchors.

--- a/vendor/gmail-mcp-server/README.md
+++ b/vendor/gmail-mcp-server/README.md
@@ -1,0 +1,544 @@
+# Gmail MCP Server
+
+A comprehensive **Model Context Protocol (MCP) server** for Gmail integration with SIYA/Claude Desktop and other MCP-compatible clients. Features **on-demand authentication**, **multi-user support**, and **complete Gmail API access**.
+
+## 📋 Table of Contents
+
+- [✨ Features](#-features)
+- [📦 Quick Start](#-quick-start)
+- [🔧 Gmail API Setup](#-gmail-api-setup)
+- [🎯 Authentication Methods](#-authentication-methods)
+- [🚀 How It Works](#-how-it-works)
+- [📧 Available Tools](#-available-tools)
+- [💡 Usage Examples](#-usage-examples)
+- [🎯 Common Use Cases](#-common-use-cases)
+- [👥 Multi-User Mode](#-multi-user-mode)
+- [🛠️ NPX Troubleshooting](#️-npx-troubleshooting-macos--nvm)
+- [🔍 Debug & Troubleshooting](#-debug--troubleshooting)
+- [📋 Command Line Options](#-command-line-options)
+- [🔒 Security & Privacy](#-security--privacy)
+- [🏗️ Advanced Configuration](#️-advanced-configuration)
+- [📚 API Reference](#-api-reference)
+
+## ✨ Features
+
+- 🔐 **On-Demand Authentication** - Only authenticates when you use Gmail tools
+- 📧 **Complete Gmail Operations** - Send, read, search, organize emails  
+- 📝 **Draft Management** - Create, edit, and manage email drafts
+- 👥 **Multi-User Support** - Handle multiple Gmail accounts simultaneously
+- 🛡️ **Secure OAuth2** - Industry-standard Google authentication
+- 🔧 **Flexible Configuration** - Multiple credential methods
+- 🚀 **Zero-Config Startup** - Server starts immediately, authenticates when needed
+- 📎 **Attachment Support** - Handle email attachments with full MIME support
+- 🌍 **International Support** - Full UTF-8 and international character support
+
+## 📦 Quick Start
+
+### For SIYA/Claude Desktop
+
+Add to your `siya_desktop_config.json` or `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "gmail": {
+      "command": "npx",
+      "args": [
+        "gmail-mcp-server@latest",
+        "--client-id", "your-google-oauth2-client-id",
+        "--client-secret", "your-google-oauth2-client-secret"
+      ]
+    }
+  }
+}
+```
+
+**Optional**: Add custom redirect URI if needed:
+```json
+{
+  "mcpServers": {
+    "gmail": {
+      "command": "npx",
+      "args": [
+        "gmail-mcp-server@latest",
+        "--client-id", "your-google-oauth2-client-id",
+        "--client-secret", "your-google-oauth2-client-secret",
+        "--redirect-uri", "http://localhost:8080/oauth2callback"
+      ]
+    }
+  }
+}
+```
+
+**⚠️ macOS with NVM Users**: If you get "spawn npx ENOENT" error, see [NPX Troubleshooting](#-npx-troubleshooting-macos--nvm).
+
+### Test Installation
+
+```bash
+npx gmail-mcp-server@latest --help
+```
+
+## 🔧 Gmail API Setup
+
+### 1. Enable Gmail API
+1. Go to [Google Cloud Console](https://console.cloud.google.com/)
+2. Create or select a project
+3. Enable the **Gmail API**
+4. Go to **Credentials** → **Create Credentials** → **OAuth 2.0 Client ID**
+5. Choose **Desktop Application**
+6. Note your **Client ID** and **Client Secret**
+
+### 2. Configure OAuth2 Redirect
+- **Default**: Add `http://localhost:44000/oauth2callback` to authorized redirect URIs
+- **Custom**: If using `--redirect-uri` or `GMAIL_REDIRECT_URI`, add your custom URI
+- **Multi-user**: Add `http://localhost:44000/oauth2callback` through `http://localhost:44010/oauth2callback`
+
+**Examples of redirect URIs to add:**
+```
+http://localhost:44000/oauth2callback  (default)
+http://localhost:8080/oauth2callback  (custom port)
+https://yourdomain.com/oauth2callback (production)
+```
+
+## 🎯 Authentication Methods
+
+The server supports **three ways** to provide credentials:
+
+### Method 1: Command Line Arguments (Recommended)
+```json
+{
+  "mcpServers": {
+    "gmail": {
+      "command": "npx",
+      "args": [
+        "gmail-mcp-server@latest",
+        "--client-id", "676239218521-example.apps.googleusercontent.com",
+        "--client-secret", "GOCSPX-example-secret",
+        "--redirect-uri", "http://localhost:8080/oauth2callback"
+      ]
+    }
+  }
+}
+```
+
+**Note**: The `--redirect-uri` is optional and defaults to `http://localhost:44000/oauth2callback`.
+
+### Method 2: Environment Variables
+```bash
+export GMAIL_CLIENT_ID="your-client-id"
+export GMAIL_CLIENT_SECRET="your-client-secret"
+export GMAIL_REDIRECT_URI="http://localhost:8080/oauth2callback"  # Optional, defaults to http://localhost:44000/oauth2callback
+npx gmail-mcp-server@latest
+```
+
+### Method 3: Credentials File
+```bash
+# Download OAuth2 JSON from Google Cloud Console
+mkdir -p ~/.gmail-mcp
+cp /path/to/credentials.json ~/.gmail-mcp/credentials.json
+npx gmail-mcp-server@latest
+```
+
+### 🔄 Automatic Token Refresh
+**Once authenticated, you stay signed in for months!** The server automatically:
+- Refreshes expired access tokens using stored refresh tokens
+- Maintains long-term authentication without requiring re-authentication
+- Only prompts for new authentication if refresh tokens become invalid
+
+This means you authenticate once and use Gmail tools seamlessly for months without interruption.
+
+## 🚀 How It Works
+
+### On-Demand Authentication
+The server starts **immediately** without requiring authentication upfront:
+
+```
+📧 Gmail MCP Server starting...
+🔐 Authentication will be handled when you use Gmail tools or call "quick_authenticate"
+```
+
+### When You Use Gmail Tools
+First time you try any Gmail operation, you'll see:
+
+```
+🔐 **Authentication Required**
+
+To use Gmail tools, please authenticate first:
+
+**Option 1:** Use the `gmail_authenticate` tool with mode='auto' for automatic authentication
+**Option 2:** Use the `gmail_authenticate` tool with mode='manual' to get a clickable authentication link
+
+After authentication, you can use all Gmail tools!
+```
+
+## 📧 Available Tools
+
+Once authenticated, you have access to:
+
+### Email Operations
+- **gmail_send_email** - Send emails with attachments and HTML
+- **gmail_read_email** - Read email content and metadata  
+- **gmail_search_emails** - Advanced Gmail search with filters
+- **gmail_mark_email** - Mark as read/unread
+- **gmail_move_email** - Move between folders/labels
+- **gmail_delete_email** - Permanently delete emails
+- **gmail_get_attachment** - Download email attachments
+
+### Draft Management
+- **gmail_draft** - Comprehensive draft management with actions: create, list, get, update, delete, send
+
+### Authentication & Session
+- **gmail_authenticate** - Authentication with auto/manual modes
+- **gmail_logout** - Sign out and clear credentials
+
+### Multi-User Tools (when using `--multi-user`)
+- **gmail_authenticate_user** - Add new user accounts
+- **gmail_manage_session** - Manage user sessions (info/remove)
+
+## 💡 Usage Examples
+
+### Send an Email
+```json
+{
+  "tool": "gmail_send_email",
+  "arguments": {
+    "to": ["recipient@example.com"],
+    "subject": "Hello from SIYA!",
+    "text": "This is a plain text email.",
+    "html": "<h1>Hello!</h1><p>This is an <strong>HTML</strong> email.</p>"
+  }
+}
+```
+
+### Create a Draft
+```json
+{
+  "tool": "gmail_draft",
+  "arguments": {
+    "action": "create",
+    "to": ["recipient@example.com"],
+    "subject": "Draft Email",
+    "text": "This will be saved as a draft.",
+    "attachments": [
+      {
+        "filename": "document.pdf",
+        "content": "base64-encoded-content",
+        "contentType": "application/pdf"
+      }
+    ]
+  }
+}
+```
+
+### Search Emails
+```json
+{
+  "tool": "gmail_search_emails",
+  "arguments": {
+    "query": "is:unread has:attachment",
+    "maxResults": 10
+  }
+}
+```
+
+### List Drafts
+```json
+{
+  "tool": "gmail_draft",
+  "arguments": {
+    "action": "list",
+    "maxResults": 20
+  }
+}
+```
+
+### Update Draft
+```json
+{
+  "tool": "gmail_draft",
+  "arguments": {
+    "action": "update",
+    "draftId": "draft_id_here",
+    "to": ["updated@example.com"],
+    "subject": "Updated Draft Subject",
+    "text": "Updated draft content"
+  }
+}
+```
+
+### Send Draft
+```json
+{
+  "tool": "gmail_draft",
+  "arguments": {
+    "action": "send",
+    "draftId": "draft_id_here"
+  }
+}
+```
+
+## 🎯 Common Use Cases
+
+### Email Automation
+- **Newsletter Management** - Send bulk emails with personalized content
+- **Notification Systems** - Automated alerts and status updates
+- **Customer Communication** - Automated responses and follow-ups
+
+### Content Management
+- **Draft Workflows** - Create, review, and collaborate on email content
+- **Template Management** - Save and reuse email templates as drafts
+- **Content Scheduling** - Prepare emails in advance for later sending
+
+### Email Analysis
+- **Inbox Monitoring** - Track unread emails and important messages
+- **Attachment Processing** - Extract and process email attachments
+- **Search & Filter** - Find specific emails based on complex criteria
+
+### Multi-Account Management
+- **Team Collaboration** - Manage multiple team member accounts
+- **Client Communication** - Handle emails from different business accounts
+- **Personal/Business Separation** - Organize multiple Gmail accounts
+
+## 👥 Multi-User Mode
+
+Enable multiple Gmail accounts with the `--multi-user` flag:
+
+```bash
+npx gmail-mcp-server@latest --multi-user --client-id "your-id" --client-secret "your-secret"
+```
+
+### Multi-User Workflow
+1. **Start server** with `--multi-user` flag
+2. **Add users** with `gmail_authenticate_user` 
+3. **Use tools** with `userId` parameter for each operation
+4. **Manage sessions** with `gmail_manage_session`
+
+### Multi-User Example
+```json
+{
+  "tool": "gmail_authenticate_user",
+  "arguments": {
+    "userEmail": "user1@gmail.com"
+  }
+}
+```
+
+After authentication, use the returned `userId` for operations:
+```json
+{
+  "tool": "gmail_send_email",
+  "arguments": {
+    "userId": "user_12345",
+    "to": ["recipient@example.com"],
+    "subject": "Email from User 1",
+    "text": "This email is sent from user1@gmail.com account"
+  }
+}
+```
+
+## 🛠️ NPX Troubleshooting (macOS + NVM)
+
+If you get "spawn npx ENOENT" error on macOS with NVM:
+
+### Solution: Create NPX Wrapper
+
+```bash
+# Create wrapper directory
+mkdir -p ~/bin
+
+# Create NPX wrapper script
+echo '#!/bin/bash' > ~/bin/npx
+echo 'exec ~/.nvm/versions/node/v22.14.0/bin/npx "$@"' >> ~/bin/npx
+chmod +x ~/bin/npx
+
+# Update SIYA/Claude Desktop config
+```
+
+**Updated SIYA/Claude Desktop Config:**
+```json
+{
+  "mcpServers": {
+    "gmail": {
+      "command": "/Users/yourusername/bin/npx",
+      "args": [
+        "gmail-mcp-server@latest",
+        "--client-id", "your-client-id",
+        "--client-secret", "your-client-secret"
+      ]
+    }
+  }
+}
+```
+
+**Replace `/Users/yourusername/` with your actual home directory path.**
+
+### Find Your Node Version
+```bash
+node --version  # e.g., v22.14.0
+ls ~/.nvm/versions/node/  # List available versions
+```
+
+## 🔍 Debug & Troubleshooting  
+
+### Enable Debug Mode
+```bash
+npx gmail-mcp-server@latest --debug --client-id "your-id" --client-secret "your-secret"
+```
+
+### Common Issues
+
+**"Gmail credentials not configured"**
+- Use `npm uninstall -g gmail-mcp-server` to clear cache
+- Use `npx gmail-mcp-server@latest` to force latest version
+
+**"spawn npx ENOENT"**  
+- Follow [NPX Troubleshooting](#-npx-troubleshooting-macos--nvm) above
+- Ensure NPX wrapper has correct Node.js path
+
+**"Duplicate tools showing up"**
+- Update to version 1.0.17+ which fixes duplicate tool issues
+- Use `npx gmail-mcp-server@latest` to get latest version
+
+**Authentication popup on startup**
+- Update to version 1.0.11+ for on-demand authentication
+- Use `npx gmail-mcp-server@latest` to get latest version
+
+### Version Check
+```bash
+npx gmail-mcp-server@latest --help  # Shows current version info
+```
+
+## 📋 Command Line Options
+
+```bash
+npx gmail-mcp-server@latest [options]
+
+Options:
+  --client-id <id>           OAuth2 client ID
+  --client-secret <secret>   OAuth2 client secret
+  --redirect-uri <uri>       OAuth2 redirect URI (default: http://localhost:44000/oauth2callback)
+  --multi-user              Enable multi-user mode
+  --setup-auth              Interactive credential setup
+  --reset-auth              Clear stored authentication
+  --debug                   Enable debug logging
+  --non-interactive         Run without prompts
+  --help                    Show help information
+```
+
+### Examples with Custom Redirect URI
+```bash
+# Custom port
+npx gmail-mcp-server@latest --client-id "your-id" --client-secret "your-secret" --redirect-uri "http://localhost:8080/oauth2callback"
+
+# Production domain
+npx gmail-mcp-server@latest --client-id "your-id" --client-secret "your-secret" --redirect-uri "https://myapp.com/gmail/callback"
+
+# Environment variable (alternative)
+export GMAIL_REDIRECT_URI="http://localhost:3000/auth/callback"
+npx gmail-mcp-server@latest --client-id "your-id" --client-secret "your-secret"
+```
+
+## 🔒 Security & Privacy
+
+- **OAuth2 Standard** - Uses Google's official authentication
+- **Local Storage** - Tokens stored locally in `~/.gmail-mcp/`
+- **No Data Collection** - Your emails stay on Google's servers
+- **Secure Scopes** - Only requests necessary Gmail permissions
+
+## 🏗️ Advanced Configuration
+
+### Custom Redirect URI Configuration
+
+The server supports flexible redirect URI configuration for different deployment scenarios:
+
+**Default Configuration:**
+- Uses `http://localhost:44000/oauth2callback`
+- Automatically starts callback server on port 44000
+
+**Custom Port Example:**
+```bash
+# Command line
+npx gmail-mcp-server@latest --redirect-uri "http://localhost:8080/oauth2callback"
+
+# Environment variable
+export GMAIL_REDIRECT_URI="http://localhost:8080/oauth2callback"
+npx gmail-mcp-server@latest
+```
+
+**Production Deployment:**
+```bash
+# For production with custom domain
+npx gmail-mcp-server@latest --redirect-uri "https://myapp.com/gmail/callback"
+```
+
+**Key Features:**
+- **Auto Port Detection**: Server automatically uses the port from your redirect URI
+- **Custom Paths**: Use any callback path (not just `/oauth2callback`)
+- **HTTPS Support**: Works with production HTTPS domains
+- **Flexible Configuration**: Command line args override environment variables
+
+### Custom Token Storage
+```bash
+export GMAIL_TOKEN_DIR="/custom/path/to/tokens"
+npx gmail-mcp-server@latest
+```
+
+### Non-Interactive Mode
+```bash
+npx gmail-mcp-server@latest --non-interactive --client-id "id" --client-secret "secret"
+```
+
+### Reset Authentication
+```bash
+npx gmail-mcp-server@latest --reset-auth
+```
+
+## 📚 API Reference
+
+### Email Operations
+- **All operations support both single-user and multi-user modes**
+- **Multi-user operations require `userId` parameter**
+- **Comprehensive error handling and validation**
+- **Support for international characters and attachments**
+
+### Draft Operations
+- **Complete draft lifecycle management**
+- **Create, read, update, delete, and send drafts**
+- **Full content preservation including attachments**
+- **Seamless integration with email workflow**
+
+### Search Capabilities  
+- **Gmail search syntax support** (`is:unread`, `has:attachment`, etc.)
+- **Date range filtering** (`after:2024/01/01`, `before:2024/12/31`)
+- **Advanced filters** (sender, recipient, subject, labels)
+- **Pagination support** for large result sets
+- **Label-based organization** (INBOX, SENT, DRAFT, TRASH, SPAM)
+
+### Authentication Features
+- **On-demand authentication** - No upfront auth required
+- **Automatic token refresh** - Seamless credential management  
+- **Multi-account support** - Handle multiple Gmail accounts
+- **Secure token storage** - Local encrypted credential storage
+- **Manual/automatic modes** - Flexible authentication options
+
+## 🤝 Contributing
+
+1. Fork the repository
+2. Create a feature branch
+3. Make your changes
+4. Test thoroughly
+5. Submit a pull request
+
+## 📄 License
+
+MIT License - see LICENSE file for details.
+
+## 🆘 Support
+
+- **Issues**: [GitHub Issues](https://github.com/yourusername/gmail-mcp-server/issues)
+- **Documentation**: Check README.md and setup guides
+- **Latest Version**: Always use `@latest` tag for newest features
+
+---
+
+**📧 Happy emailing with SIYA/Claude Desktop!** 🚀 

--- a/vendor/gmail-mcp-server/bin/cli.js
+++ b/vendor/gmail-mcp-server/bin/cli.js
@@ -1,0 +1,283 @@
+#!/usr/bin/env node
+
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { spawn } from 'child_process';
+import fs from 'fs';
+import readline from 'readline';
+import os from 'os';
+
+// Debug info - write to a debug file
+const debugFile = path.join(os.tmpdir(), 'gmail-mcp-debug.log');
+const writeDebug = (message) => {
+  try {
+    fs.appendFileSync(debugFile, `${new Date().toISOString()} - ${message}\n`);
+  } catch (err) {
+    // Silently fail if we can't write to the debug file
+  }
+};
+
+// Start debugging
+writeDebug('Gmail MCP CLI script started');
+writeDebug(`Node version: ${process.version}`);
+writeDebug(`Platform: ${process.platform}`);
+writeDebug(`CLI Arguments: ${process.argv.join(' ')}`);
+writeDebug(`Is stdin a TTY: ${process.stdin.isTTY}`);
+writeDebug(`Is stdout a TTY: ${process.stdout.isTTY}`);
+writeDebug(`Process PID: ${process.pid}`);
+writeDebug(`Executable path: ${process.execPath}`);
+writeDebug(`Current directory: ${process.cwd()}`);
+
+// Print debug file location to stderr (not stdout)
+console.error(`Debug log: ${debugFile}`);
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const packageRoot = path.resolve(__dirname, '..');
+
+writeDebug(`__filename: ${__filename}`);
+writeDebug(`__dirname: ${__dirname}`);
+writeDebug(`packageRoot: ${packageRoot}`);
+
+// Check if bin/cli.js is executable
+try {
+  const stats = fs.statSync(__filename);
+  const isExecutable = !!(stats.mode & fs.constants.S_IXUSR);
+  writeDebug(`Is CLI executable: ${isExecutable}`);
+  
+  // Make it executable if it's not
+  if (!isExecutable) {
+    fs.chmodSync(__filename, '755');
+    writeDebug('Made CLI executable');
+  }
+} catch (err) {
+  writeDebug(`Error checking/setting executable: ${err.message}`);
+}
+
+// Parse command line arguments
+const args = process.argv.slice(2);
+let debug = false;
+let nonInteractive = false;
+let setupAuth = false;
+let resetAuth = false;
+
+// Detect if we're running under an MCP context (SIYA/Claude/ChatGPT/etc.)
+const isMcpContext = 
+  !process.stdin.isTTY || 
+  process.env.npm_execpath?.includes('npx') ||
+  process.env.CLAUDE_API_KEY ||
+  args.includes('--non-interactive') || args.includes('-n');
+
+writeDebug(`Detected MCP context: ${isMcpContext}`);
+if (isMcpContext) {
+  nonInteractive = true;
+  writeDebug('Setting non-interactive mode due to MCP context detection');
+}
+
+// Process command line arguments
+for (let i = 0; i < args.length; i++) {
+  const arg = args[i];
+  if (arg === '--debug') {
+    debug = true;
+    writeDebug('Debug mode enabled');
+  } else if (arg === '--non-interactive' || arg === '-n') {
+    nonInteractive = true;
+    writeDebug('Non-interactive mode enabled via flag');
+  } else if (arg === '--setup-auth') {
+    setupAuth = true;
+    writeDebug('Setup auth mode enabled');
+  } else if (arg === '--reset-auth') {
+    resetAuth = true;
+    writeDebug('Reset auth mode enabled');
+  } else if (arg === '--client-id') {
+    // Handle --client-id argument
+    if (i + 1 < args.length) {
+      // Ensure the next argument is not an option
+      if (args[i + 1].startsWith('--') || args[i + 1] === '-n') {
+        console.error('--client-id must be followed by a client ID');
+        process.exit(1);
+      }
+      // Store the client ID
+      process.env.GMAIL_CLIENT_ID = args[i + 1];
+      writeDebug(`Client ID set to: ${args[i + 1]}`);
+      i++; // Skip the next argument as it's already processed
+    } else {
+      console.error('--client-id requires a client ID');
+      process.exit(1);
+    }
+  } else if (arg === '--client-secret') {
+    // Handle --client-secret argument
+    if (i + 1 < args.length) {
+      // Ensure the next argument is not an option
+      if (args[i + 1].startsWith('--') || args[i + 1] === '-n') {
+        console.error('--client-secret must be followed by a client secret');
+        process.exit(1);
+      }
+      // Store the client secret
+      process.env.GMAIL_CLIENT_SECRET = args[i + 1];
+      writeDebug(`Client secret set to: ${args[i + 1]}`);
+      i++; // Skip the next argument as it's already processed
+    } else {
+      console.error('--client-secret requires a client secret');
+      process.exit(1);
+    }
+  } else if (arg === '--redirect-uri') {
+    // Handle --redirect-uri argument
+    if (i + 1 < args.length) {
+      // Ensure the next argument is not an option
+      if (args[i + 1].startsWith('--') || args[i + 1] === '-n') {
+        console.error('--redirect-uri must be followed by a redirect URI');
+        process.exit(1);
+      }
+      // Store the redirect URI
+      process.env.GMAIL_REDIRECT_URI = args[i + 1];
+      writeDebug(`Redirect URI set to: ${args[i + 1]}`);
+      i++; // Skip the next argument as it's already processed
+    } else {
+      console.error('--redirect-uri requires a redirect URI');
+      process.exit(1);
+    }
+  } else if (arg === '--help' || arg === '-h') {
+    console.log(`
+Gmail MCP Server - Gmail Integration for SIYA/Claude Desktop
+
+Usage: npx gmail-mcp-server [options]
+
+Options:
+  --setup-auth               Set up Gmail API credentials
+  --reset-auth               Clear stored authentication tokens
+  --debug                    Enable debug output
+  --non-interactive, -n      Run in non-interactive mode (no prompt)
+  --client-id <id>           Gmail OAuth2 client ID
+  --client-secret <secret>   Gmail OAuth2 client secret
+  --redirect-uri <uri>       Gmail OAuth2 redirect URI
+  --force-manual-auth        (Legacy option - manual auth is now default)
+  --help, -h                 Show this help message
+
+Setup:
+  1. Run: npx gmail-mcp-server --setup-auth
+  2. Follow the instructions to set up Google API credentials
+  3. Run: npx gmail-mcp-server to start the server
+
+Authentication Setup:
+  The server supports three methods for providing Gmail API credentials:
+
+  1. Command Line Arguments:
+     - --client-id <your_client_id>
+     - --client-secret <your_client_secret>
+     - --redirect-uri <your_redirect_uri>
+
+  2. Environment Variables:
+     - GMAIL_CLIENT_ID: Your OAuth2 client ID
+     - GMAIL_CLIENT_SECRET: Your OAuth2 client secret
+     - GMAIL_REDIRECT_URI: Your OAuth2 redirect URI (defaults to http://localhost:44000/oauth2callback)
+     - GMAIL_FORCE_MANUAL_AUTH: (Legacy - manual authentication is now default for all users)
+
+  3. Credentials File:
+     - Download credentials JSON from Google Cloud Console
+     - Save as ~/.gmail-mcp/credentials.json
+
+For detailed setup instructions, visit:
+https://developers.google.com/gmail/api/quickstart/nodejs
+
+Examples:
+  npx gmail-mcp-server --setup-auth    # Set up authentication
+  npx gmail-mcp-server                 # Start the server
+  npx gmail-mcp-server --reset-auth    # Clear auth tokens
+  npx gmail-mcp-server --client-id "your_id" --client-secret "your_secret"
+  npx gmail-mcp-server --client-id "your_id" --client-secret "your_secret" --redirect-uri "http://localhost:8080/oauth2callback"
+`);
+    process.exit(0);
+  }
+}
+
+function startServer() {
+  const serverPath = path.join(packageRoot, 'dist', 'index.js');
+  
+  // Check if the compiled server exists
+  if (!fs.existsSync(serverPath)) {
+    console.error('Server not found. Building...');
+    
+    // Try to build the project
+    const buildProcess = spawn('npm', ['run', 'build'], {
+      cwd: packageRoot,
+      stdio: 'inherit'
+    });
+    
+    buildProcess.on('close', (code) => {
+      if (code === 0) {
+        startServerWithPath(serverPath);
+      } else {
+        console.error('Build failed. Please run "npm run build" manually.');
+        process.exit(1);
+      }
+    });
+  } else {
+    startServerWithPath(serverPath);
+  }
+}
+
+function startServerWithPath(serverPath) {
+  writeDebug(`Starting server with path: ${serverPath}`);
+  
+  // Prepare arguments for the server
+  const serverArgs = [];
+  
+  if (setupAuth) serverArgs.push('--setup-auth');
+  if (resetAuth) serverArgs.push('--reset-auth');
+  if (debug) serverArgs.push('--debug');
+  if (nonInteractive) serverArgs.push('--non-interactive');
+  
+  writeDebug(`Server arguments: ${serverArgs.join(' ')}`);
+  
+  // Log environment variables for debugging
+  writeDebug(`GMAIL_CLIENT_ID in process.env: ${process.env.GMAIL_CLIENT_ID || 'not set'}`);
+  writeDebug(`GMAIL_CLIENT_SECRET in process.env: ${process.env.GMAIL_CLIENT_SECRET || 'not set'}`);
+  writeDebug(`GMAIL_REDIRECT_URI in process.env: ${process.env.GMAIL_REDIRECT_URI || 'not set'}`);
+  
+  // Start the server process
+  const serverProcess = spawn(process.execPath, [serverPath, ...serverArgs], {
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      // Ensure environment variables are passed through
+      NODE_PATH: process.env.NODE_PATH || '',
+    }
+  });
+  
+  // Handle server process events
+  serverProcess.on('error', (err) => {
+    writeDebug(`Server process error: ${err.message}`);
+    console.error('Failed to start Gmail MCP server:', err.message);
+    process.exit(1);
+  });
+  
+  serverProcess.on('close', (code, signal) => {
+    writeDebug(`Server process closed with code ${code} and signal ${signal}`);
+    if (code !== 0) {
+      console.error(`Gmail MCP server exited with code ${code}`);
+    }
+    process.exit(code || 0);
+  });
+  
+  // Handle SIGINT and SIGTERM
+  process.on('SIGINT', () => {
+    writeDebug('Received SIGINT, terminating server process');
+    serverProcess.kill('SIGINT');
+  });
+  
+  process.on('SIGTERM', () => {
+    writeDebug('Received SIGTERM, terminating server process');
+    serverProcess.kill('SIGTERM');
+  });
+}
+
+// Special handling for setup and reset modes
+if (setupAuth || resetAuth) {
+  writeDebug('Running in special mode (setup or reset)');
+  startServer();
+} else {
+  // Normal server startup
+  writeDebug('Starting normal server mode');
+  startServer();
+} 

--- a/vendor/gmail-mcp-server/dist/index.js
+++ b/vendor/gmail-mcp-server/dist/index.js
@@ -1,0 +1,1702 @@
+/**
+ * Gmail MCP Server
+ * A comprehensive server implementation using Model Context Protocol for Gmail API
+ */
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { CallToolRequestSchema, ListResourcesRequestSchema, ListToolsRequestSchema, ReadResourceRequestSchema, GetPromptRequestSchema, ListPromptsRequestSchema, ListResourceTemplatesRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import { gmailAuth } from "./utils/gmail-auth.js";
+import { gmailOperations } from "./utils/gmail-operations.js";
+import { multiUserAuth } from "./utils/multi-user-auth.js";
+import { logger } from './utils/api.js';
+import { ThreadReconstructor, ConversationManager, EmailIntelligence, ProactiveReminderSystem } from './utils/threading-intelligence.js';
+let gmailConfig;
+function parseArgs() {
+    const args = process.argv.slice(2);
+    const config = {
+        setupAuth: false,
+        resetAuth: false,
+        debug: false,
+        nonInteractive: false,
+        multiUser: false,
+        forceManualAuth: false
+    };
+    // Check environment variable for forcing manual auth
+    if (process.env.GMAIL_FORCE_MANUAL_AUTH === 'true' || process.env.GMAIL_FORCE_MANUAL_AUTH === '1') {
+        config.forceManualAuth = true;
+    }
+    for (let i = 0; i < args.length; i++) {
+        const arg = args[i];
+        if (arg === '--setup-auth') {
+            config.setupAuth = true;
+        }
+        else if (arg === '--reset-auth') {
+            config.resetAuth = true;
+        }
+        else if (arg === '--debug' || arg === '-d') {
+            config.debug = true;
+        }
+        else if (arg === '--non-interactive' || arg === '-n') {
+            config.nonInteractive = true;
+        }
+        else if (arg === '--multi-user') {
+            config.multiUser = true;
+        }
+        else if (arg === '--force-manual-auth') {
+            config.forceManualAuth = true;
+        }
+    }
+    return config;
+}
+const server = new Server({
+    name: "gmail-mcp-server",
+    version: "1.0.24"
+}, {
+    capabilities: {
+        resources: {
+            read: true,
+            list: true,
+            templates: true
+        },
+        tools: {
+            list: true,
+            call: true
+        },
+        prompts: {
+            list: true,
+            get: true
+        },
+        resourceTemplates: {
+            list: true
+        }
+    }
+});
+// Set up the resource listing request handler
+server.setRequestHandler(ListResourcesRequestSchema, async () => {
+    logger.log('Received list resources request');
+    return { resources: [] };
+});
+/**
+ * Handler for reading resource information.
+ */
+server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
+    logger.log('Received read resource request: ' + JSON.stringify(request));
+    throw new Error("Resource reading not implemented");
+});
+/**
+ * Handler for getting a prompt.
+ */
+server.setRequestHandler(GetPromptRequestSchema, async (request) => {
+    logger.log('Received get prompt request: ' + JSON.stringify(request));
+    throw new Error("Prompt reading not implemented");
+});
+/**
+ * Handler for listing prompts.
+ */
+server.setRequestHandler(ListPromptsRequestSchema, async (request) => {
+    logger.log('Received list prompts request: ' + JSON.stringify(request));
+    throw new Error("Prompt listing not implemented");
+});
+/**
+ * Handler for listing resource templates.
+ */
+server.setRequestHandler(ListResourceTemplatesRequestSchema, async (request) => {
+    logger.log('Received list resource templates request: ' + JSON.stringify(request));
+    throw new Error("Resource template listing not implemented");
+});
+/**
+ * Helper function to check if user is authenticated and provide guidance if not
+ */
+async function checkAuthenticationWithGuidance() {
+    if (!await gmailAuth.isConfigured()) {
+        return {
+            isAuthenticated: false,
+            errorResponse: {
+                content: [
+                    {
+                        type: "text",
+                        text: "❌ Gmail credentials not configured.\n\nPlease set up your OAuth2 credentials first:\n1. Set environment variables GMAIL_CLIENT_ID and GMAIL_CLIENT_SECRET\n2. Or run: gmail-mcp-server --setup-auth"
+                    }
+                ],
+                isError: true
+            }
+        };
+    }
+    if (!await gmailAuth.isAuthenticated()) {
+        return {
+            isAuthenticated: false,
+            errorResponse: {
+                content: [
+                    {
+                        type: "text",
+                        text: "🔐 **Authentication Required**\n\nTo use Gmail tools, please authenticate first:\n\n**Use the `authenticate` tool to get a clickable authentication link**\n\n🔗 Manual authentication is used for security and compatibility with all environments (servers, containers, etc.)\n\nAfter authentication, you can use all Gmail tools!"
+                    }
+                ],
+                isError: true
+            }
+        };
+    }
+    return { isAuthenticated: true };
+}
+/**
+ * List available tools for interacting with Gmail.
+ */
+server.setRequestHandler(ListToolsRequestSchema, async () => {
+    const baseTools = [
+        {
+            name: "gmail_send_email",
+            description: "Send an email message with support for HTML content, attachments, and international characters. Supports both plain text and HTML emails with proper multipart structure. For attachments: use base64 encoded content OR provide ABSOLUTE file paths (e.g., '/full/path/to/file.pdf'). Relative paths will fail.",
+            inputSchema: {
+                type: "object",
+                properties: {
+                    userId: {
+                        type: "string",
+                        description: "User ID or email of an account authenticated via gmail_authenticate_user (multi-user mode). Optional: omit to use the primary/default account."
+                    },
+                    to: {
+                        type: "array",
+                        items: { type: "string" },
+                        description: "List of recipient email addresses"
+                    },
+                    cc: {
+                        type: "array",
+                        items: { type: "string" },
+                        description: "List of CC recipient email addresses (optional)"
+                    },
+                    bcc: {
+                        type: "array",
+                        items: { type: "string" },
+                        description: "List of BCC recipient email addresses (optional)"
+                    },
+                    subject: {
+                        type: "string",
+                        description: "Email subject line with full support for international characters"
+                    },
+                    text: {
+                        type: "string",
+                        description: "Plain text content of the email (optional if html is provided)"
+                    },
+                    html: {
+                        type: "string",
+                        description: "HTML content of the email (optional if text is provided)"
+                    },
+                    replyTo: {
+                        type: "string",
+                        description: "Reply-to email address (optional)"
+                    },
+                    attachments: {
+                        type: "array",
+                        items: {
+                            type: "object",
+                            properties: {
+                                filename: {
+                                    type: "string",
+                                    description: "Name of the attachment file"
+                                },
+                                content: {
+                                    type: "string",
+                                    description: "Base64 encoded content of the attachment OR ABSOLUTE file path to read from disk. For base64: encode your file content first. For file path: provide FULL ABSOLUTE path like '/Users/username/Documents/file.pdf' or 'C:\\Users\\username\\Documents\\file.pdf'. Relative paths like 'uploads/file.pdf' will fail - always use complete paths."
+                                },
+                                contentType: {
+                                    type: "string",
+                                    description: "MIME type of the attachment (optional, auto-detected if not provided)"
+                                }
+                            },
+                            required: ["filename", "content"]
+                        },
+                        description: "List of email attachments (optional)"
+                    }
+                },
+                required: ["to", "subject"],
+                additionalProperties: false
+            }
+        },
+        {
+            name: "gmail_read_email",
+            description: "Read email message by ID with advanced MIME structure handling. Returns full email content including headers, body, and attachment information.",
+            inputSchema: {
+                type: "object",
+                properties: {
+                    userId: {
+                        type: "string",
+                        description: "User ID or email of an account authenticated via gmail_authenticate_user (multi-user mode). Optional: omit to use the primary/default account."
+                    },
+                    messageId: {
+                        type: "string",
+                        description: "Gmail message ID to retrieve"
+                    },
+                    format: {
+                        type: "string",
+                        enum: ["minimal", "full", "raw", "metadata"],
+                        description: "Level of detail to retrieve (default: full)",
+                        default: "full"
+                    },
+                    includeContent: {
+                        type: "boolean",
+                        description: "Whether to extract and include email content (text/html)",
+                        default: true
+                    }
+                },
+                required: ["messageId"],
+                additionalProperties: false
+            }
+        },
+        {
+            name: "gmail_search_emails",
+            description: "Enhanced email search with natural language processing, fuzzy matching, and cross-reference detection. Supports queries like 'Find income tax notice from May' or 'Show me emails about PAN ANYPS1039E'. Automatically detects natural language and applies intelligent matching.",
+            inputSchema: {
+                type: "object",
+                properties: {
+                    userId: {
+                        type: "string",
+                        description: "User ID or email of an account authenticated via gmail_authenticate_user (multi-user mode). Optional: omit to use the primary/default account."
+                    },
+                    query: {
+                        type: "string",
+                        description: "Search query - supports both natural language (e.g., 'Find income tax notice from May') and Gmail syntax (e.g., 'is:unread has:attachment'). Enhanced search automatically activates for natural language queries."
+                    },
+                    from: {
+                        type: "string",
+                        description: "Search for emails from specific sender"
+                    },
+                    to: {
+                        type: "string",
+                        description: "Search for emails to specific recipient"
+                    },
+                    subject: {
+                        type: "string",
+                        description: "Search for emails with specific subject"
+                    },
+                    after: {
+                        type: "string",
+                        description: "Search for emails after date (format: YYYY/MM/DD)"
+                    },
+                    before: {
+                        type: "string",
+                        description: "Search for emails before date (format: YYYY/MM/DD)"
+                    },
+                    hasAttachment: {
+                        type: "boolean",
+                        description: "Filter emails that have attachments"
+                    },
+                    label: {
+                        type: "string",
+                        description: "Search within specific label/folder (default: INBOX). Common values: INBOX, SENT, DRAFT, TRASH, SPAM",
+                        default: "INBOX"
+                    },
+                    isUnread: {
+                        type: "boolean",
+                        description: "Filter for unread emails only"
+                    },
+                    maxResults: {
+                        type: "number",
+                        description: "Maximum number of results to return (default: 50, max: 500)",
+                        minimum: 1,
+                        maximum: 500,
+                        default: 50
+                    },
+                    useEnhancedSearch: {
+                        type: "boolean",
+                        description: "Force enhanced search with natural language processing and fuzzy matching (default: auto-detected)",
+                        default: false
+                    },
+                    fuzzyThreshold: {
+                        type: "number",
+                        description: "Fuzzy matching threshold (0-100, default: 80). Higher values require more exact matches.",
+                        minimum: 0,
+                        maximum: 100,
+                        default: 80
+                    },
+                    includeCrossReferences: {
+                        type: "boolean",
+                        description: "Include cross-reference information for related emails (default: true)",
+                        default: true
+                    }
+                },
+                additionalProperties: false
+            }
+        },
+        {
+            name: "analyze_conversation",
+            description: "Analyze a conversation thread for a given email. Reconstructs the full thread (including forwards/replies), extracts participants, timeline, topics, references, and classifies each email for importance, urgency, deadlines, and suggests proactive reminders.",
+            inputSchema: {
+                type: "object",
+                properties: {
+                    emailId: { type: "string", description: "Starting email ID for the analysis" },
+                    includeReminders: { type: "boolean", description: "Include proactive reminder suggestions", default: true },
+                    maxThreadSize: { type: "number", description: "Maximum number of emails to analyze in the thread", default: 20 }
+                },
+                required: ["emailId"],
+                additionalProperties: false
+            }
+        },
+        {
+            name: "gmail_mark_email",
+            description: "Mark email as read or unread. Useful for managing email status and organizing your inbox.",
+            inputSchema: {
+                type: "object",
+                properties: {
+                    userId: {
+                        type: "string",
+                        description: "User ID or email of an account authenticated via gmail_authenticate_user (multi-user mode). Optional: omit to use the primary/default account."
+                    },
+                    messageId: {
+                        type: "string",
+                        description: "Gmail message ID to mark"
+                    },
+                    read: {
+                        type: "boolean",
+                        description: "True to mark as read, false to mark as unread"
+                    }
+                },
+                required: ["messageId", "read"],
+                additionalProperties: false
+            }
+        },
+        {
+            name: "gmail_move_email",
+            description: "Move email to different label/folder. Can add labels and remove existing ones in a single operation.",
+            inputSchema: {
+                type: "object",
+                properties: {
+                    userId: {
+                        type: "string",
+                        description: "User ID or email of an account authenticated via gmail_authenticate_user (multi-user mode). Optional: omit to use the primary/default account."
+                    },
+                    messageId: {
+                        type: "string",
+                        description: "Gmail message ID to move"
+                    },
+                    labelId: {
+                        type: "string",
+                        description: "Label ID to add to the email"
+                    },
+                    removeLabelIds: {
+                        type: "array",
+                        items: { type: "string" },
+                        description: "List of label IDs to remove from the email (optional)"
+                    }
+                },
+                required: ["messageId", "labelId"],
+                additionalProperties: false
+            }
+        },
+        {
+            name: "gmail_delete_email",
+            description: "Permanently delete an email message. Use with caution as this action cannot be undone.",
+            inputSchema: {
+                type: "object",
+                properties: {
+                    userId: {
+                        type: "string",
+                        description: "User ID or email of an account authenticated via gmail_authenticate_user (multi-user mode). Optional: omit to use the primary/default account."
+                    },
+                    messageId: {
+                        type: "string",
+                        description: "Gmail message ID to delete"
+                    }
+                },
+                required: ["messageId"],
+                additionalProperties: false
+            }
+        },
+        {
+            name: "gmail_list_attachments",
+            description: "REQUIRED FIRST STEP: List all attachments in a Gmail message before downloading. Shows attachment index, ID, filename, content type, and size. Use the index (0, 1, 2, etc.) or copy the exact attachmentId for gmail_get_attachment.",
+            inputSchema: {
+                type: "object",
+                properties: {
+                    userId: {
+                        type: "string",
+                        description: "User ID or email of an account authenticated via gmail_authenticate_user (multi-user mode). Optional: omit to use the primary/default account."
+                    },
+                    messageId: {
+                        type: "string",
+                        description: "Gmail message ID to list attachments from"
+                    }
+                },
+                required: ["messageId"],
+                additionalProperties: false
+            }
+        },
+        {
+            name: "gmail_get_attachment",
+            description: "Download Gmail attachment and automatically save to local file system. Base64 content is decoded to binary file and saved with unique timestamped filename. Returns full file path and file:// URL for direct access. IMPORTANT: Use 'gmail_list_attachments' first to see available attachments, then use the index (0, 1, 2, etc.) or copy the exact attachmentId from the list.",
+            inputSchema: {
+                type: "object",
+                properties: {
+                    userId: {
+                        type: "string",
+                        description: "User ID or email of an account authenticated via gmail_authenticate_user (multi-user mode). Optional: omit to use the primary/default account."
+                    },
+                    messageId: {
+                        type: "string",
+                        description: "Gmail message ID containing the attachment"
+                    },
+                    attachmentId: {
+                        type: "string",
+                        description: "Attachment ID or index (0, 1, 2, etc.) to download. REQUIRED: First run 'gmail_list_attachments' with the same messageId to see available attachments and their indexes/IDs."
+                    },
+                    customPath: {
+                        type: "string",
+                        description: "Custom download directory path (optional, defaults to ./downloads)"
+                    }
+                },
+                required: ["messageId", "attachmentId"],
+                additionalProperties: false
+            }
+        },
+        {
+            name: "gmail_draft",
+            description: "Comprehensive draft email management. Create, list, get, update, delete, and send drafts through a single tool.",
+            inputSchema: {
+                type: "object",
+                properties: {
+                    userId: {
+                        type: "string",
+                        description: "User ID or email of an account authenticated via gmail_authenticate_user (multi-user mode). Optional: omit to use the primary/default account."
+                    },
+                    action: {
+                        type: "string",
+                        enum: ["create", "list", "get", "update", "delete", "send"],
+                        description: "Action to perform: create, list, get, update, delete, or send"
+                    },
+                    draftId: {
+                        type: "string",
+                        description: "Draft ID (required for get, update, delete, send actions)"
+                    },
+                    to: {
+                        type: "array",
+                        items: { type: "string" },
+                        description: "List of recipient email addresses (required for create/update)"
+                    },
+                    cc: {
+                        type: "array",
+                        items: { type: "string" },
+                        description: "List of CC recipient email addresses (optional for create/update)"
+                    },
+                    bcc: {
+                        type: "array",
+                        items: { type: "string" },
+                        description: "List of BCC recipient email addresses (optional for create/update)"
+                    },
+                    subject: {
+                        type: "string",
+                        description: "Email subject line (required for create/update)"
+                    },
+                    text: {
+                        type: "string",
+                        description: "Plain text content (optional if html provided for create/update)"
+                    },
+                    html: {
+                        type: "string",
+                        description: "HTML content (optional if text provided for create/update)"
+                    },
+                    replyTo: {
+                        type: "string",
+                        description: "Reply-to email address (optional for create/update)"
+                    },
+                    attachments: {
+                        type: "array",
+                        items: {
+                            type: "object",
+                            properties: {
+                                filename: {
+                                    type: "string",
+                                    description: "Name of the attachment file"
+                                },
+                                content: {
+                                    type: "string",
+                                    description: "Base64 encoded content of the attachment"
+                                },
+                                contentType: {
+                                    type: "string",
+                                    description: "MIME type of the attachment (optional)"
+                                }
+                            },
+                            required: ["filename", "content"]
+                        },
+                        description: "List of email attachments (optional for create/update)"
+                    },
+                    maxResults: {
+                        type: "number",
+                        description: "Maximum number of drafts to return for list action (default: 50)",
+                        minimum: 1,
+                        maximum: 500,
+                        default: 50
+                    }
+                },
+                required: ["action"],
+                additionalProperties: false
+            }
+        },
+        {
+            name: "gmail_logout",
+            description: "Sign out and clear Gmail authentication credentials. Useful for switching accounts or ending the session.",
+            inputSchema: {
+                type: "object",
+                properties: {},
+                additionalProperties: false
+            }
+        },
+        {
+            name: "gmail_system_status",
+            description: "Check the system status including feature availability, circuit breaker states, and resilience metrics.",
+            inputSchema: {
+                type: "object",
+                properties: {},
+                additionalProperties: false
+            }
+        },
+        {
+            name: "gmail_performance_metrics",
+            description: "Get comprehensive performance metrics including cache hit rates, memory usage, batch operation efficiency, and connection pool statistics.",
+            inputSchema: {
+                type: "object",
+                properties: {},
+                additionalProperties: false
+            }
+        }
+    ];
+    // Add multi-user specific tools
+    const multiUserTools = [
+        {
+            name: "gmail_authenticate_user",
+            description: "Start authentication flow for a new user. Returns authentication URL that user needs to visit.",
+            inputSchema: {
+                type: "object",
+                properties: {
+                    userEmail: {
+                        type: "string",
+                        description: "User's email address (optional, for identification)"
+                    }
+                },
+                additionalProperties: false
+            }
+        },
+        {
+            name: "gmail_manage_session",
+            description: "Manage your Gmail authentication session (view info or remove session). User-specific and secure.",
+            inputSchema: {
+                type: "object",
+                properties: {
+                    userId: {
+                        type: "string",
+                        description: "Your User ID to manage"
+                    },
+                    action: {
+                        type: "string",
+                        enum: ["info", "remove"],
+                        description: "Action to perform: 'info' (view session details) or 'remove' (delete session)",
+                        default: "info"
+                    }
+                },
+                required: ["userId"],
+                additionalProperties: false
+            }
+        }
+    ];
+    // Add one-time authentication tool for single-user mode
+    const oneTimeAuthTools = [
+        {
+            name: "gmail_authenticate",
+            description: "Authenticate with Gmail using manual authentication (provides clickable link). Secure and compatible with all environments.",
+            inputSchema: {
+                type: "object",
+                properties: {
+                    force: {
+                        type: "boolean",
+                        description: "Force re-authentication even if already authenticated (default: false)",
+                        default: false
+                    }
+                },
+                additionalProperties: false
+            }
+        }
+    ];
+    if (gmailConfig.multiUser) {
+        return { tools: [...baseTools, ...multiUserTools] };
+    }
+    // For single-user mode, always include authentication tool
+    return { tools: [...baseTools, ...oneTimeAuthTools] };
+});
+/**
+ * Handle tool calls to the Gmail API.
+ */
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    logger.log('Received call tool request: ' + JSON.stringify(request));
+    switch (request.params.name) {
+        case "gmail_authenticate":
+            try {
+                const args = request.params.arguments || {};
+                const { force = false } = args;
+                // Check if already authenticated and not forcing re-auth
+                if (!force && await gmailAuth.isAuthenticated()) {
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: "✅ You're already authenticated! Gmail access is ready.\n\nYou can now use all Gmail tools. If you want to re-authenticate, use the 'force' option."
+                            }
+                        ]
+                    };
+                }
+                // Check if credentials are configured
+                if (!await gmailAuth.isConfigured()) {
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: "❌ Gmail credentials not configured.\n\nPlease set up your OAuth2 credentials first:\n1. Set environment variables GMAIL_CLIENT_ID and GMAIL_CLIENT_SECRET\n2. Or run: gmail-mcp-server --setup-auth"
+                            }
+                        ],
+                        isError: true
+                    };
+                }
+                try {
+                    // Manual authentication - get authentication URL without opening browser
+                    const authUrl = await gmailAuth.getAuthUrl();
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: `🔗 **Click here to authenticate with Gmail:**
+
+${authUrl}
+
+📋 **Instructions:**
+1. Click the URL above to authenticate
+2. Sign in with your Gmail account  
+3. Grant permissions to the app
+4. You'll see "Authentication Successful!"
+5. Return here and use Gmail tools!
+
+⚡ **After authentication, you can use:**
+- gmail_send_email, gmail_read_email, gmail_search_emails
+- gmail_move_email, gmail_mark_email, gmail_delete_email
+- gmail_draft
+- And more!
+
+💡 The authentication will be stored securely for future use.`
+                            }
+                        ]
+                    };
+                }
+                catch (authError) {
+                    const errorMessage = authError instanceof Error ? authError.message : 'Unknown error';
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: `❌ Authentication failed: ${errorMessage}\n\nPlease try again or check your OAuth2 credentials.`
+                            }
+                        ],
+                        isError: true
+                    };
+                }
+            }
+            catch (error) {
+                const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+                return {
+                    content: [
+                        {
+                            type: "text",
+                            text: `Error during authentication: ${errorMessage}`
+                        }
+                    ],
+                    isError: true
+                };
+            }
+        case "gmail_logout":
+            try {
+                // Check if we're in multi-user mode
+                if (gmailConfig.multiUser) {
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: "❌ Logout not available in multi-user mode.\n\nUse 'manage_session' with action 'remove' and your userId to sign out."
+                            }
+                        ],
+                        isError: true
+                    };
+                }
+                // Check if user is authenticated
+                const isAuthenticated = await gmailAuth.isAuthenticated();
+                if (!isAuthenticated) {
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: "ℹ️ You're not currently signed in.\n\nUse the 'authenticate' tool to sign in to Gmail."
+                            }
+                        ]
+                    };
+                }
+                // Clear authentication by removing token file
+                try {
+                    gmailAuth.resetAuth();
+                    gmailOperations.resetClient(); // Reset cached Gmail client
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: "✅ Successfully signed out of Gmail!\n\n🔐 Your authentication has been cleared.\n\n💡 To access Gmail again, use the 'authenticate' tool to sign in."
+                            }
+                        ]
+                    };
+                }
+                catch (clearError) {
+                    const errorMessage = clearError instanceof Error ? clearError.message : 'Unknown error';
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: `❌ Error clearing authentication: ${errorMessage}\n\nYou may need to manually delete the token file.`
+                            }
+                        ],
+                        isError: true
+                    };
+                }
+            }
+            catch (error) {
+                const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+                return {
+                    content: [
+                        {
+                            type: "text",
+                            text: `Error during logout: ${errorMessage}`
+                        }
+                    ],
+                    isError: true
+                };
+            }
+        case "gmail_authenticate_user":
+            try {
+                if (!gmailConfig.multiUser) {
+                    throw new Error("Multi-user mode not enabled. Restart server with --multi-user flag.");
+                }
+                const args = request.params.arguments || {};
+                const { userEmail } = args;
+                const authResult = await multiUserAuth.authenticateNewUser(userEmail);
+                return {
+                    content: [
+                        {
+                            type: "text",
+                            text: `🔐 Authentication started for user!
+
+User ID: ${authResult.userId}
+Authentication URL: ${authResult.authUrl}
+Server Port: ${authResult.port}
+
+🚀 Please visit the authentication URL to complete the process.
+The authentication will timeout in 10 minutes.
+
+After successful authentication, use this User ID for all Gmail operations: ${authResult.userId}`
+                        }
+                    ]
+                };
+            }
+            catch (error) {
+                const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+                return {
+                    content: [
+                        {
+                            type: "text",
+                            text: `Error starting authentication: ${errorMessage}`
+                        }
+                    ],
+                    isError: true
+                };
+            }
+        case "gmail_manage_session":
+            try {
+                if (!gmailConfig.multiUser) {
+                    throw new Error("Multi-user mode not enabled. Restart server with --multi-user flag.");
+                }
+                const args = request.params.arguments || {};
+                const { userId, action = "info" } = args;
+                if (!userId) {
+                    throw new Error("'userId' is required");
+                }
+                const session = multiUserAuth.getUserSession(userId);
+                if (!session) {
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: `❌ User session ${userId} not found.`
+                            }
+                        ]
+                    };
+                }
+                if (action === "info") {
+                    const responseText = `📋 User Session Info:
+
+User ID: ${session.userId}
+Email: ${session.userEmail || 'Unknown'}
+Authenticated: ${session.authenticated ? '✅' : '❌'}
+Token Expires: ${new Date(session.expiryDate).toLocaleString()}
+Status: ${session.authenticated ? 'Active' : 'Inactive'}`;
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: responseText
+                            }
+                        ]
+                    };
+                }
+                else {
+                    // action === "remove"
+                    const removed = multiUserAuth.removeUser(userId);
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: removed
+                                    ? `✅ User session ${userId} removed successfully.`
+                                    : `❌ User session ${userId} not found.`
+                            }
+                        ]
+                    };
+                }
+            }
+            catch (error) {
+                const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+                return {
+                    content: [
+                        {
+                            type: "text",
+                            text: `Error managing user session: ${errorMessage}`
+                        }
+                    ],
+                    isError: true
+                };
+            }
+        case "gmail_send_email":
+            try {
+                // Check authentication first
+                const authCheck = await checkAuthenticationWithGuidance();
+                if (!authCheck.isAuthenticated) {
+                    return authCheck.errorResponse;
+                }
+                const args = request.params.arguments || {};
+                const { userId, to, cc, bcc, subject, text, html, replyTo, attachments } = args;
+                if (!to || !Array.isArray(to) || to.length === 0) {
+                    throw new Error("'to' field is required and must be a non-empty array");
+                }
+                if (!subject) {
+                    throw new Error("'subject' field is required");
+                }
+                if (!text && !html) {
+                    throw new Error("Either 'text' or 'html' content is required");
+                }
+                const emailMessage = {
+                    to,
+                    cc,
+                    bcc,
+                    subject,
+                    text,
+                    html,
+                    replyTo,
+                    attachments: attachments?.map((att) => ({
+                        filename: att.filename,
+                        content: att.content,
+                        contentType: att.contentType,
+                        encoding: 'base64'
+                    }))
+                };
+                const overrideClient = (gmailConfig.multiUser && userId) ? await multiUserAuth.getGmailClientForUser(userId) : undefined;
+                const result = await gmailOperations.sendEmail(emailMessage, overrideClient);
+                return {
+                    content: [
+                        {
+                            type: "text",
+                            text: `Email sent successfully!\nMessage ID: ${result.id}\nThread ID: ${result.threadId}\nRecipients: ${to.join(', ')}\nSubject: ${subject}`
+                        }
+                    ]
+                };
+            }
+            catch (error) {
+                const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+                return {
+                    content: [
+                        {
+                            type: "text",
+                            text: `Error sending email: ${errorMessage}`
+                        }
+                    ],
+                    isError: true
+                };
+            }
+        case "gmail_read_email":
+            try {
+                // Check authentication first
+                const authCheck = await checkAuthenticationWithGuidance();
+                if (!authCheck.isAuthenticated) {
+                    return authCheck.errorResponse;
+                }
+                const args = request.params.arguments || {};
+                const { userId, messageId, format = 'full', includeContent = true } = args;
+                if (!messageId) {
+                    throw new Error("'messageId' is required");
+                }
+                const overrideClient = (gmailConfig.multiUser && userId) ? await multiUserAuth.getGmailClientForUser(userId) : undefined;
+                const email = await gmailOperations.getEmail(messageId, format, overrideClient);
+                let responseText = `Email ID: ${email.id}\nThread ID: ${email.threadId}\nSnippet: ${email.snippet}\nLabels: ${email.labelIds?.join(', ') || 'None'}\n`;
+                if (email.payload && email.payload.headers) {
+                    const headers = email.payload.headers;
+                    const fromHeader = headers.find((h) => h.name === 'From');
+                    const toHeader = headers.find((h) => h.name === 'To');
+                    const subjectHeader = headers.find((h) => h.name === 'Subject');
+                    const dateHeader = headers.find((h) => h.name === 'Date');
+                    responseText += `From: ${fromHeader?.value || 'Unknown'}\n`;
+                    responseText += `To: ${toHeader?.value || 'Unknown'}\n`;
+                    responseText += `Subject: ${subjectHeader?.value || 'No Subject'}\n`;
+                    responseText += `Date: ${dateHeader?.value || 'Unknown'}\n`;
+                }
+                if (includeContent && email.payload) {
+                    const content = gmailOperations.extractEmailContent(email.payload);
+                    if (content.text) {
+                        responseText += `\n--- Text Content ---\n${content.text}\n`;
+                    }
+                    if (content.html) {
+                        responseText += `\n--- HTML Content ---\n${content.html}\n`;
+                    }
+                    if (content.attachments.length > 0) {
+                        responseText += `\n--- Attachments ---\n`;
+                        content.attachments.forEach((att, index) => {
+                            responseText += `${index + 1}. ${att.filename} (${att.mimeType}, ${att.size} bytes)\n`;
+                        });
+                    }
+                }
+                return {
+                    content: [
+                        {
+                            type: "text",
+                            text: responseText
+                        }
+                    ]
+                };
+            }
+            catch (error) {
+                const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+                return {
+                    content: [
+                        {
+                            type: "text",
+                            text: `Error reading email: ${errorMessage}`
+                        }
+                    ],
+                    isError: true
+                };
+            }
+        case "gmail_search_emails":
+            try {
+                // Check authentication first
+                const authCheck = await checkAuthenticationWithGuidance();
+                if (!authCheck.isAuthenticated) {
+                    return authCheck.errorResponse;
+                }
+                const args = request.params.arguments || {};
+                const { userId, ...searchArgs } = args;
+                const overrideClient = (gmailConfig.multiUser && userId) ? await multiUserAuth.getGmailClientForUser(userId) : undefined;
+                const searchCriteria = {
+                    query: searchArgs.query,
+                    from: searchArgs.from,
+                    to: searchArgs.to,
+                    subject: searchArgs.subject,
+                    after: searchArgs.after,
+                    before: searchArgs.before,
+                    hasAttachment: searchArgs.hasAttachment,
+                    label: searchArgs.label || 'INBOX',
+                    isUnread: searchArgs.isUnread,
+                    maxResults: searchArgs.maxResults || 50,
+                    useEnhancedSearch: searchArgs.useEnhancedSearch,
+                    fuzzyThreshold: searchArgs.fuzzyThreshold,
+                    includeCrossReferences: searchArgs.includeCrossReferences
+                };
+                const result = await gmailOperations.searchEmails(searchCriteria, overrideClient);
+                if (result.messages.length === 0) {
+                    const label = searchArgs.label || 'INBOX';
+                    const searchTerm = searchArgs.query ? 'matching the search criteria' : `in ${label}`;
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: `No emails found ${searchTerm}.`
+                            }
+                        ]
+                    };
+                }
+                const isListing = !searchArgs.query && !searchArgs.from && !searchArgs.to && !searchArgs.subject && !searchArgs.after && !searchArgs.before && !searchArgs.hasAttachment && !searchArgs.isUnread;
+                const label = searchArgs.label || 'INBOX';
+                let responseText = isListing ? `Found ${result.messages.length} emails in ${label}:\n\n` : `Found ${result.messages.length} emails:\n\n`;
+                // Check if enhanced search was used
+                if (result.enhancedResults) {
+                    responseText += `🔍 **Enhanced Search Results**\n`;
+                    responseText += `Query: "${searchArgs.query}"\n`;
+                    responseText += `Search Type: Natural Language Processing with Fuzzy Matching\n`;
+                    responseText += `Match Threshold: ${searchArgs.fuzzyThreshold || 80}%\n\n`;
+                }
+                result.messages.forEach((email, index) => {
+                    const fromHeader = email.payload?.headers?.find((h) => h.name === 'From');
+                    const subjectHeader = email.payload?.headers?.find((h) => h.name === 'Subject');
+                    const dateHeader = email.payload?.headers?.find((h) => h.name === 'Date');
+                    responseText += `${index + 1}. ID: ${email.id}\n`;
+                    responseText += `   From: ${fromHeader?.value || 'Unknown'}\n`;
+                    responseText += `   Subject: ${subjectHeader?.value || 'No Subject'}\n`;
+                    responseText += `   Date: ${dateHeader?.value || 'Unknown'}\n`;
+                    responseText += `   Snippet: ${email.snippet}\n`;
+                    responseText += `   Labels: ${email.labelIds?.join(', ') || 'None'}\n`;
+                    // Add enhanced search information if available
+                    if (result.enhancedResults) {
+                        const enhancedResult = result.enhancedResults.searchResults.find(r => r.email.id === email.id);
+                        if (enhancedResult) {
+                            responseText += `   Match Score: ${enhancedResult.matchScore.toFixed(1)}%\n`;
+                            responseText += `   Relevance: ${enhancedResult.relevance.toUpperCase()}\n`;
+                            if (enhancedResult.crossReferences && enhancedResult.crossReferences.length > 0) {
+                                responseText += `   Related Emails: ${enhancedResult.crossReferences.length} found\n`;
+                            }
+                        }
+                    }
+                    responseText += `\n`;
+                });
+                // Add cross-reference information if available
+                if (result.enhancedResults && result.enhancedResults.crossReferences.length > 0) {
+                    responseText += `\n🔗 **Cross-References Found:**\n`;
+                    result.enhancedResults.crossReferences.slice(0, 5).forEach((ref, index) => {
+                        responseText += `${index + 1}. Email ID: ${ref.emailId}\n`;
+                        responseText += `   Relationship: ${ref.relationship.replace('_', ' ')}\n`;
+                        responseText += `   Confidence: ${ref.confidence.toFixed(1)}%\n`;
+                        responseText += `   Reason: ${ref.reason}\n\n`;
+                    });
+                }
+                if (result.nextPageToken) {
+                    responseText += `Note: More results available. Use pagination to retrieve additional emails.`;
+                }
+                return {
+                    content: [
+                        {
+                            type: "text",
+                            text: responseText
+                        }
+                    ]
+                };
+            }
+            catch (error) {
+                const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+                return {
+                    content: [
+                        {
+                            type: "text",
+                            text: `Error searching emails: ${errorMessage}`
+                        }
+                    ],
+                    isError: true
+                };
+            }
+        case "gmail_mark_email":
+            try {
+                const args = request.params.arguments || {};
+                const { userId, messageId, read } = args;
+                if (!messageId) {
+                    throw new Error("'messageId' is required");
+                }
+                if (typeof read !== 'boolean') {
+                    throw new Error("'read' must be a boolean value");
+                }
+                const overrideClient = (gmailConfig.multiUser && userId) ? await multiUserAuth.getGmailClientForUser(userId) : undefined;
+                await gmailOperations.markEmail(messageId, read, overrideClient);
+                return {
+                    content: [
+                        {
+                            type: "text",
+                            text: `Email ${messageId} marked as ${read ? 'read' : 'unread'} successfully.`
+                        }
+                    ]
+                };
+            }
+            catch (error) {
+                const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+                return {
+                    content: [
+                        {
+                            type: "text",
+                            text: `Error marking email: ${errorMessage}`
+                        }
+                    ],
+                    isError: true
+                };
+            }
+        case "gmail_move_email":
+            try {
+                const args = request.params.arguments || {};
+                const { userId, messageId, labelId, removeLabelIds } = args;
+                if (!messageId) {
+                    throw new Error("'messageId' is required");
+                }
+                if (!labelId) {
+                    throw new Error("'labelId' is required");
+                }
+                const overrideClient = (gmailConfig.multiUser && userId) ? await multiUserAuth.getGmailClientForUser(userId) : undefined;
+                await gmailOperations.moveToLabel(messageId, labelId, removeLabelIds, overrideClient);
+                return {
+                    content: [
+                        {
+                            type: "text",
+                            text: `Email ${messageId} moved to label ${labelId} successfully.`
+                        }
+                    ]
+                };
+            }
+            catch (error) {
+                const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+                return {
+                    content: [
+                        {
+                            type: "text",
+                            text: `Error moving email: ${errorMessage}`
+                        }
+                    ],
+                    isError: true
+                };
+            }
+        case "gmail_delete_email":
+            try {
+                const args = request.params.arguments || {};
+                const { userId, messageId } = args;
+                if (!messageId) {
+                    throw new Error("'messageId' is required");
+                }
+                const overrideClient = (gmailConfig.multiUser && userId) ? await multiUserAuth.getGmailClientForUser(userId) : undefined;
+                await gmailOperations.deleteEmail(messageId, overrideClient);
+                return {
+                    content: [
+                        {
+                            type: "text",
+                            text: `Email ${messageId} deleted successfully.`
+                        }
+                    ]
+                };
+            }
+            catch (error) {
+                const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+                return {
+                    content: [
+                        {
+                            type: "text",
+                            text: `Error deleting email: ${errorMessage}`
+                        }
+                    ],
+                    isError: true
+                };
+            }
+        case "gmail_list_attachments":
+            try {
+                const args = request.params.arguments || {};
+                const { userId, messageId } = args;
+                if (!messageId) {
+                    throw new Error("'messageId' is required");
+                }
+                const overrideClient = (gmailConfig.multiUser && userId) ? await multiUserAuth.getGmailClientForUser(userId) : undefined;
+                const attachments = await gmailOperations.listAttachments(messageId, overrideClient);
+                if (attachments.length === 0) {
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: "No attachments found in this message."
+                            }
+                        ]
+                    };
+                }
+                return {
+                    content: [
+                        {
+                            type: "text",
+                            text: JSON.stringify({
+                                messageId,
+                                totalAttachments: attachments.length,
+                                attachments: attachments.map(att => ({
+                                    index: att.index,
+                                    attachmentId: att.attachmentId,
+                                    filename: att.filename,
+                                    contentType: att.contentType,
+                                    size: att.size,
+                                    sizeFormatted: `${(att.size / 1024).toFixed(1)} KB`
+                                }))
+                            }, null, 2)
+                        }
+                    ]
+                };
+            }
+            catch (error) {
+                const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+                return {
+                    content: [
+                        {
+                            type: "text",
+                            text: `Error listing attachments: ${errorMessage}`
+                        }
+                    ],
+                    isError: true
+                };
+            }
+        case "gmail_get_attachment":
+            try {
+                const args = request.params.arguments || {};
+                const { userId, messageId, attachmentId, customPath } = args;
+                if (!messageId) {
+                    throw new Error("'messageId' is required");
+                }
+                if (!attachmentId) {
+                    throw new Error("'attachmentId' is required");
+                }
+                const overrideClient = (gmailConfig.multiUser && userId) ? await multiUserAuth.getGmailClientForUser(userId) : undefined;
+                // Use the new method that saves to local file
+                const result = await gmailOperations.getAttachmentToLocal(messageId, attachmentId, customPath, overrideClient);
+                return {
+                    content: [
+                        {
+                            type: "text",
+                            text: JSON.stringify({
+                                success: true,
+                                message: "Attachment downloaded successfully",
+                                filePath: result.filePath,
+                                filename: result.filename,
+                                size: result.size,
+                                contentType: result.contentType,
+                                fileUrl: result.fileUrl
+                            }, null, 2)
+                        }
+                    ]
+                };
+            }
+            catch (error) {
+                const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+                return {
+                    content: [
+                        {
+                            type: "text",
+                            text: `Error downloading attachment: ${errorMessage}`
+                        }
+                    ],
+                    isError: true
+                };
+            }
+        case "gmail_draft":
+            try {
+                // Check authentication first
+                const authCheck = await checkAuthenticationWithGuidance();
+                if (!authCheck.isAuthenticated) {
+                    return authCheck.errorResponse;
+                }
+                const args = request.params.arguments || {};
+                const { userId, action, draftId, to, cc, bcc, subject, text, html, replyTo, attachments, maxResults } = args;
+                if (!action) {
+                    throw new Error("'action' is required");
+                }
+                if (action === "create" && (!to || !subject)) {
+                    throw new Error("'to' and 'subject' are required for creating a draft");
+                }
+                if (action === "update" && !draftId) {
+                    throw new Error("'draftId' is required for updating a draft");
+                }
+                if (action === "delete" && !draftId) {
+                    throw new Error("'draftId' is required for deleting a draft");
+                }
+                if (action === "send" && !draftId) {
+                    throw new Error("'draftId' is required for sending a draft");
+                }
+                const overrideClient = (gmailConfig.multiUser && userId) ? await multiUserAuth.getGmailClientForUser(userId) : undefined;
+                switch (action) {
+                    case "create": {
+                        const createResult = await gmailOperations.createDraft({ to, cc, bcc, subject, text, html, replyTo, attachments }, overrideClient);
+                        return {
+                            content: [
+                                {
+                                    type: "text",
+                                    text: `Draft created successfully!\nDraft ID: ${createResult.id}\nMessage ID: ${createResult.message.id}\nRecipients: ${to.join(', ')}\nSubject: ${subject}`
+                                }
+                            ]
+                        };
+                    }
+                    case "list": {
+                        const listResult = await gmailOperations.listDrafts(maxResults, overrideClient);
+                        if (listResult.drafts.length === 0) {
+                            return {
+                                content: [
+                                    {
+                                        type: "text",
+                                        text: "No drafts found."
+                                    }
+                                ]
+                            };
+                        }
+                        let listText = `Found ${listResult.drafts.length} drafts:\n\n`;
+                        listResult.drafts.forEach((draft, index) => {
+                            const subjectHeader = draft.message.payload?.headers?.find((h) => h.name === 'Subject');
+                            listText += `${index + 1}. Draft ID: ${draft.id}\n`;
+                            listText += `   Message ID: ${draft.message.id}\n`;
+                            listText += `   Subject: ${subjectHeader?.value || 'No Subject'}\n`;
+                            listText += `   Snippet: ${draft.message.snippet}\n\n`;
+                        });
+                        return {
+                            content: [
+                                {
+                                    type: "text",
+                                    text: listText
+                                }
+                            ]
+                        };
+                    }
+                    case "get": {
+                        const getResult = await gmailOperations.getDraft(draftId, overrideClient);
+                        const subjectHeader = getResult.message.payload?.headers?.find((h) => h.name === 'Subject');
+                        return {
+                            content: [
+                                {
+                                    type: "text",
+                                    text: `Draft retrieved successfully!\nDraft ID: ${getResult.id}\nMessage ID: ${getResult.message.id}\nSubject: ${subjectHeader?.value || 'No Subject'}\nSnippet: ${getResult.message.snippet}`
+                                }
+                            ]
+                        };
+                    }
+                    case "update": {
+                        const updateResult = await gmailOperations.updateDraft(draftId, { to, cc, bcc, subject, text, html, replyTo, attachments }, overrideClient);
+                        return {
+                            content: [
+                                {
+                                    type: "text",
+                                    text: `Draft updated successfully!\nDraft ID: ${updateResult.id}\nMessage ID: ${updateResult.message.id}\nRecipients: ${to.join(', ')}\nSubject: ${subject}`
+                                }
+                            ]
+                        };
+                    }
+                    case "delete": {
+                        await gmailOperations.deleteDraft(draftId, overrideClient);
+                        return {
+                            content: [
+                                {
+                                    type: "text",
+                                    text: `Draft deleted successfully! Draft ID: ${draftId}`
+                                }
+                            ]
+                        };
+                    }
+                    case "send": {
+                        const sendResult = await gmailOperations.sendDraft(draftId, overrideClient);
+                        return {
+                            content: [
+                                {
+                                    type: "text",
+                                    text: `Draft sent successfully!\nMessage ID: ${sendResult.id}\nThread ID: ${sendResult.threadId}`
+                                }
+                            ]
+                        };
+                    }
+                    default:
+                        throw new Error(`Unknown action: ${action}`);
+                }
+            }
+            catch (error) {
+                const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+                return {
+                    content: [
+                        {
+                            type: "text",
+                            text: `Error managing draft: ${errorMessage}`
+                        }
+                    ],
+                    isError: true
+                };
+            }
+        case "analyze_conversation":
+            try {
+                const args = request.params.arguments || {};
+                const { emailId, includeReminders = true, maxThreadSize = 20 } = args;
+                // Check authentication first
+                const authCheck = await checkAuthenticationWithGuidance();
+                if (!authCheck.isAuthenticated) {
+                    return authCheck.errorResponse;
+                }
+                // Fetch all emails (limit for performance)
+                const allResult = await gmailOperations.searchEmails({ maxResults: 200 });
+                const allEmails = allResult.messages;
+                if (!allEmails || allEmails.length === 0) {
+                    return { content: [{ type: "text", text: "No emails found in mailbox." }], isError: true };
+                }
+                // Map EmailInfo[] to ThreadedEmail[]
+                const allThreadedEmails = allEmails.map(e => ({
+                    id: e.id,
+                    threadId: e.threadId,
+                    subject: e.payload?.headers?.find((h) => h.name === 'Subject')?.value || '',
+                    snippet: e.snippet,
+                    payload: e.payload,
+                    labelIds: e.labelIds,
+                    internalDate: e.internalDate
+                }));
+                // Thread reconstruction
+                const threadReconstructor = new ThreadReconstructor();
+                const thread = threadReconstructor.reconstructConversation(emailId, allThreadedEmails);
+                if (!thread || thread.length === 0) {
+                    return { content: [{ type: "text", text: `No thread found for email ID: ${emailId}` }], isError: true };
+                }
+                const limitedThread = thread.slice(0, maxThreadSize);
+                // Conversation context
+                const conversationManager = new ConversationManager();
+                const context = await conversationManager.preserveContext(limitedThread);
+                // Intelligence analysis
+                const intelligence = new EmailIntelligence();
+                const classified = limitedThread.map(email => ({
+                    id: email.id,
+                    subject: email.subject,
+                    from: email.payload?.headers?.find((h) => h.name === 'From')?.value || '',
+                    classification: intelligence.classifyEmail(email)
+                }));
+                // Proactive reminders
+                let reminders = [];
+                if (includeReminders) {
+                    const reminderSystem = new ProactiveReminderSystem();
+                    for (const email of limitedThread) {
+                        const cls = intelligence.classifyEmail(email);
+                        reminders.push(...reminderSystem.createSmartReminders(email, cls).map(r => ({
+                            emailId: email.id,
+                            subject: email.subject,
+                            ...r
+                        })));
+                    }
+                }
+                // Build response
+                let responseText = `🧠 **Conversation Analysis for Email ID: ${emailId}**\n\n`;
+                responseText += `**Thread Participants:** ${context.participants.join(', ')}\n`;
+                responseText += `**Topics:** ${context.topics.join(', ')}\n`;
+                responseText += `**Total Messages:** ${context.metadata.totalMessages}\n`;
+                responseText += `**Duration:** ${context.metadata.duration}\n`;
+                responseText += `**Last Activity:** ${context.metadata.lastActivity.toLocaleString()}\n\n`;
+                responseText += `**Timeline:**\n`;
+                context.timeline.forEach((t, i) => {
+                    responseText += `  ${i + 1}. [${t.date.toLocaleDateString()}] ${t.subject}\n`;
+                });
+                responseText += `\n**References:**\n`;
+                responseText += `  Documents: ${context.references.documents.join(', ') || 'None'}\n`;
+                responseText += `  URLs: ${context.references.urls.join(', ') || 'None'}\n`;
+                responseText += `  Attachments: ${context.references.attachments.join(', ') || 'None'}\n\n`;
+                responseText += `**Email Intelligence:**\n`;
+                classified.forEach((c, i) => {
+                    responseText += `  ${i + 1}. [${c.id}] ${c.subject}\n`;
+                    responseText += `     From: ${c.from}\n`;
+                    responseText += `     Importance: ${c.classification.importance}\n`;
+                    responseText += `     Category: ${c.classification.category}\n`;
+                    responseText += `     Action Required: ${c.classification.actionRequired ? 'YES' : 'NO'}\n`;
+                    if (c.classification.deadline)
+                        responseText += `     Deadline: ${c.classification.deadline.toLocaleDateString()}\n`;
+                    if (c.classification.reason)
+                        responseText += `     Reason: ${c.classification.reason}\n`;
+                });
+                if (reminders.length > 0) {
+                    responseText += `\n⏰ **Proactive Reminders:**\n`;
+                    reminders.forEach((r, i) => {
+                        responseText += `  ${i + 1}. [${r.emailId}] ${r.subject}\n`;
+                        responseText += `     Reminder Date: ${r.reminderDate.toLocaleDateString()}\n`;
+                        responseText += `     Type: ${r.type}\n`;
+                        if (r.context?.originalDeadline)
+                            responseText += `     Original Deadline: ${r.context.originalDeadline.toLocaleDateString()}\n`;
+                    });
+                }
+                return {
+                    content: [
+                        {
+                            type: "text",
+                            text: responseText
+                        }
+                    ]
+                };
+            }
+            catch (error) {
+                const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+                return {
+                    content: [
+                        {
+                            type: "text",
+                            text: `Error analyzing conversation: ${errorMessage}`
+                        }
+                    ],
+                    isError: true
+                };
+            }
+        case "gmail_system_status":
+            try {
+                const systemStatus = gmailOperations.getSystemStatus();
+                let responseText = "🔧 **Gmail MCP Server System Status**\n\n";
+                responseText += "**Feature Status:**\n";
+                for (const [feature, status] of Object.entries(systemStatus.features)) {
+                    const statusStr = status;
+                    const statusIcon = statusStr === 'enabled' ? '✅' : statusStr === 'disabled' ? '❌' : '⚠️';
+                    responseText += `  ${statusIcon} ${feature.replace('_', ' ')}: ${statusStr.toUpperCase()}\n`;
+                }
+                responseText += "\n**Circuit Breakers:**\n";
+                if (Object.keys(systemStatus.circuitBreakers).length === 0) {
+                    responseText += "  No circuit breakers active\n";
+                }
+                else {
+                    for (const [operation, stats] of Object.entries(systemStatus.circuitBreakers)) {
+                        const circuitStats = stats;
+                        const stateIcon = circuitStats.state === 'CLOSED' ? '✅' : circuitStats.state === 'OPEN' ? '❌' : '⚠️';
+                        responseText += `  ${stateIcon} ${operation}: ${circuitStats.state} (Failures: ${circuitStats.failureCount}, Successes: ${circuitStats.successCount})\n`;
+                    }
+                }
+                responseText += "\n**Rate Limiting:**\n";
+                const rateLimitIcon = systemStatus.rateLimiting.active ? '⚠️' : '✅';
+                responseText += `  ${rateLimitIcon} Rate Limiting: ${systemStatus.rateLimiting.active ? 'ACTIVE' : 'NORMAL'}\n`;
+                responseText += "\n**Overall Health:** ";
+                const allFeaturesOk = Object.values(systemStatus.features).every(status => status === 'enabled');
+                const allCircuitsClosed = Object.values(systemStatus.circuitBreakers).every(stats => stats.state === 'CLOSED');
+                const noRateLimit = !systemStatus.rateLimiting.active;
+                if (allFeaturesOk && allCircuitsClosed && noRateLimit) {
+                    responseText += "🟢 HEALTHY";
+                }
+                else if (Object.values(systemStatus.features).some(status => status === 'enabled')) {
+                    responseText += "🟡 DEGRADED";
+                }
+                else {
+                    responseText += "🔴 CRITICAL";
+                }
+                return {
+                    content: [
+                        {
+                            type: "text",
+                            text: responseText
+                        }
+                    ]
+                };
+            }
+            catch (error) {
+                const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+                return {
+                    content: [
+                        {
+                            type: "text",
+                            text: `Error checking system status: ${errorMessage}`
+                        }
+                    ],
+                    isError: true
+                };
+            }
+        case "gmail_performance_metrics":
+            try {
+                const performanceMetrics = gmailOperations.getPerformanceMetrics();
+                let responseText = "📊 **Gmail MCP Server Performance Metrics**\n\n";
+                responseText += "**Cache Performance:**\n";
+                responseText += `  🎯 Cache Hit Rate: ${(performanceMetrics.cacheHitRate * 100).toFixed(1)}%\n`;
+                responseText += `  📈 API Calls Reduced: ${performanceMetrics.apiCallsReduced}%\n`;
+                responseText += "\n**Memory Usage:**\n";
+                const memoryMB = (performanceMetrics.memoryUsage / 1024 / 1024).toFixed(1);
+                responseText += `  💾 Current Memory: ${memoryMB} MB\n`;
+                responseText += "\n**Connection Pool:**\n";
+                responseText += `  🔗 Active Connections: ${performanceMetrics.activeConnections}\n`;
+                responseText += "\n**Batch Operations:**\n";
+                responseText += `  ⚡ Batch Success Rate: ${(performanceMetrics.batchSuccessRate * 100).toFixed(1)}%\n`;
+                responseText += "\n**Response Time:**\n";
+                responseText += `  ⏱️ Average Response: ${performanceMetrics.avgResponseTime}ms\n`;
+                // Performance rating
+                responseText += "\n**Performance Rating:** ";
+                const cacheEfficient = performanceMetrics.cacheHitRate > 0.7; // 70%+ cache hit rate
+                const memoryEfficient = performanceMetrics.memoryUsage < 200 * 1024 * 1024; // <200MB
+                const batchEfficient = performanceMetrics.batchSuccessRate > 0.9; // 90%+ batch success
+                if (cacheEfficient && memoryEfficient && batchEfficient) {
+                    responseText += "🟢 EXCELLENT";
+                }
+                else if (performanceMetrics.cacheHitRate > 0.5) {
+                    responseText += "🟡 GOOD";
+                }
+                else {
+                    responseText += "🔴 NEEDS OPTIMIZATION";
+                }
+                return {
+                    content: [
+                        {
+                            type: "text",
+                            text: responseText
+                        }
+                    ]
+                };
+            }
+            catch (error) {
+                const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+                return {
+                    content: [
+                        {
+                            type: "text",
+                            text: `Error checking performance metrics: ${errorMessage}`
+                        }
+                    ],
+                    isError: true
+                };
+            }
+        default:
+            throw new Error(`Unknown tool: ${request.params.name}`);
+    }
+});
+async function main() {
+    gmailConfig = parseArgs();
+    // Handle special commands
+    if (gmailConfig.setupAuth) {
+        await gmailAuth.setupCredentials();
+        return;
+    }
+    if (gmailConfig.resetAuth) {
+        gmailAuth.resetAuth();
+        gmailOperations.resetClient(); // Reset cached Gmail client
+        if (gmailConfig.multiUser) {
+            multiUserAuth.clearAllSessions();
+            console.log('All authentication tokens and user sessions cleared.');
+        }
+        else {
+            console.log('Authentication tokens cleared. Run the server again to re-authenticate.');
+        }
+        return;
+    }
+    logger.log('Starting Gmail MCP Server...');
+    if (gmailConfig.multiUser) {
+        logger.log('Multi-user mode enabled');
+        console.error('📧 Gmail MCP Server starting in multi-user mode...');
+        console.error('🔗 Use "authenticate_user" tool to add users');
+    }
+    else {
+        // Just show startup message - credentials will be checked when tools are used
+        console.error('📧 Gmail MCP Server starting...');
+        console.error('🔐 Authentication will be handled when you use Gmail tools or call "authenticate"');
+    }
+    try {
+        const transport = new StdioServerTransport();
+        await server.connect(transport);
+        logger.log('Gmail MCP Server started successfully');
+        if (gmailConfig.multiUser) {
+            console.error('🎉 Multi-user Gmail MCP Server ready!');
+        }
+    }
+    catch (error) {
+        logger.error('Failed to start Gmail MCP Server:', error);
+        console.error('Failed to start Gmail MCP Server:', error instanceof Error ? error.message : 'Unknown error');
+        process.exit(1);
+    }
+}
+// Handle graceful shutdown
+process.on('SIGINT', async () => {
+    logger.log('Received SIGINT, shutting down gracefully...');
+    process.exit(0);
+});
+process.on('SIGTERM', async () => {
+    logger.log('Received SIGTERM, shutting down gracefully...');
+    process.exit(0);
+});
+if (import.meta.url === `file://${process.argv[1]}`) {
+    main().catch((error) => {
+        logger.error('Unhandled error in main:', error);
+        console.error('Error:', error);
+        process.exit(1);
+    });
+}

--- a/vendor/gmail-mcp-server/dist/utils/api.js
+++ b/vendor/gmail-mcp-server/dist/utils/api.js
@@ -1,0 +1,17 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+// Set up logging to temp file
+const logFile = path.join(os.tmpdir(), 'gmail-mcp-server.log');
+// Logger utility functions
+export const logger = {
+    log: (message) => {
+        fs.appendFileSync(logFile, `[INFO] ${new Date().toISOString()} - ${message}\n`);
+    },
+    error: (message, error) => {
+        fs.appendFileSync(logFile, `[ERROR] ${new Date().toISOString()} - ${message}\n`);
+        if (error) {
+            fs.appendFileSync(logFile, `${error.stack || error}\n`);
+        }
+    }
+};

--- a/vendor/gmail-mcp-server/dist/utils/enhanced-search.js
+++ b/vendor/gmail-mcp-server/dist/utils/enhanced-search.js
@@ -1,0 +1,542 @@
+/**
+ * Enhanced Gmail Search Implementation
+ * Provides natural language query parsing, fuzzy matching, and cross-reference detection
+ */
+import { logger } from './api.js';
+/**
+ * Natural Language Query Parser
+ * Converts natural language queries into structured search criteria
+ */
+export class NLQueryParser {
+    constructor() {
+        this.timePatterns = {
+            relative: {
+                'few weeks ago': () => ({ start: new Date(Date.now() - 21 * 24 * 60 * 60 * 1000), end: new Date() }),
+                'last week': () => ({ start: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000), end: new Date() }),
+                'last month': () => ({ start: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000), end: new Date() }),
+                'yesterday': () => ({ start: new Date(Date.now() - 24 * 60 * 60 * 1000), end: new Date() }),
+                'today': () => ({ start: new Date(), end: new Date() }),
+                'this week': () => ({ start: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000), end: new Date() }),
+                'this month': () => ({ start: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000), end: new Date() })
+            },
+            absolute: /(?:from|since|after)\s+(\w+\s+\d{1,2}|\d{1,2}\/\d{1,2}\/\d{4})/gi
+        };
+        this.entityPatterns = {
+            pan: /PAN\s+([A-Z]{5}\d{4}[A-Z])/gi,
+            din: /DIN\s+([A-Z0-9]+)/gi,
+            amount: /(?:Rs\.?|₹|INR)\s*(\d+(?:,\d{3})*(?:\.\d{2})?)/gi,
+            email: /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b/gi,
+            government: /(?:gov\.in|government|ministry|department)/gi
+        };
+        this.intentKeywords = {
+            find_document: ['find', 'search', 'locate', 'get', 'retrieve'],
+            check_status: ['status', 'check', 'verify', 'confirm'],
+            find_related: ['related', 'similar', 'same', 'connected', 'thread'],
+            summarize: ['summarize', 'summary', 'overview', 'brief']
+        };
+    }
+    parseQuery(naturalQuery) {
+        const query = naturalQuery.toLowerCase();
+        const result = { text: naturalQuery };
+        // Extract time references
+        result.dateRange = this.extractTimeRange(query);
+        // Extract entities
+        result.entities = this.extractEntities(naturalQuery);
+        // Extract sender information
+        result.sender = this.extractSenders(naturalQuery);
+        // Extract subject keywords
+        result.subject = this.extractSubjectKeywords(naturalQuery);
+        // Detect intent
+        result.intent = this.detectIntent(query);
+        // Extract attachment requirements
+        result.hasAttachment = this.extractAttachmentRequirement(query);
+        // Extract label/folder requirements
+        result.labels = this.extractLabels(query);
+        return result;
+    }
+    extractTimeRange(query) {
+        // Check relative time patterns first
+        for (const [pattern, handler] of Object.entries(this.timePatterns.relative)) {
+            if (query.includes(pattern)) {
+                return handler();
+            }
+        }
+        // Check for month names with "from"
+        const monthPattern = /(?:from|in)\s+(\w+)/gi;
+        const monthMatch = monthPattern.exec(query);
+        if (monthMatch) {
+            const monthName = monthMatch[1].toLowerCase();
+            const monthNum = this.getMonthNumber(monthName);
+            if (monthNum >= 0) {
+                const year = new Date().getFullYear();
+                const start = new Date(year, monthNum, 1);
+                const end = new Date(year, monthNum + 1, 0); // Last day of month
+                return { start, end };
+            }
+        }
+        // Check absolute date patterns
+        const absoluteMatch = this.timePatterns.absolute.exec(query);
+        if (absoluteMatch) {
+            const dateStr = absoluteMatch[1];
+            const date = this.parseDate(dateStr);
+            if (date) {
+                return { start: date, end: new Date() };
+            }
+        }
+        return undefined;
+    }
+    extractEntities(text) {
+        const entities = {};
+        // Extract PAN numbers
+        const panMatches = text.match(this.entityPatterns.pan);
+        if (panMatches) {
+            entities.panNumbers = panMatches.map(match => match.replace('PAN ', ''));
+        }
+        // Extract DIN numbers
+        const dinMatches = text.match(this.entityPatterns.din);
+        if (dinMatches) {
+            entities.dinNumbers = dinMatches.map(match => match.replace('DIN ', ''));
+        }
+        // Extract amounts
+        const amountMatches = text.match(this.entityPatterns.amount);
+        if (amountMatches) {
+            entities.amounts = amountMatches.map(match => {
+                const amount = match.replace(/[^\d.,]/g, '').replace(',', '');
+                return parseFloat(amount);
+            });
+        }
+        // Extract email addresses
+        const emailMatches = text.match(this.entityPatterns.email);
+        if (emailMatches) {
+            entities.organizations = emailMatches.map(email => email.split('@')[1]);
+        }
+        // Extract government references
+        const govMatches = text.match(this.entityPatterns.government);
+        if (govMatches) {
+            entities.organizations = entities.organizations || [];
+            entities.organizations.push('government');
+        }
+        return entities;
+    }
+    extractSenders(query) {
+        const senderPatterns = [
+            /(?:from|by)\s+([^\s,]+@[^\s,]+)/gi,
+            /(?:from|by)\s+([^\s,]+\.gov\.in)/gi,
+            /(?:from|by)\s+([^\s,]+\.com)/gi
+        ];
+        const senders = [];
+        for (const pattern of senderPatterns) {
+            const matches = query.match(pattern);
+            if (matches) {
+                senders.push(...matches.map(match => match.replace(/(?:from|by)\s+/, '')));
+            }
+        }
+        return senders;
+    }
+    extractSubjectKeywords(query) {
+        const subjectPatterns = [
+            /(?:subject|about|regarding)\s+"([^"]+)"/gi,
+            /(?:subject|about|regarding)\s+([^\s]+)/gi
+        ];
+        for (const pattern of subjectPatterns) {
+            const match = pattern.exec(query);
+            if (match) {
+                return match[1];
+            }
+        }
+        return undefined;
+    }
+    detectIntent(query) {
+        for (const [intent, keywords] of Object.entries(this.intentKeywords)) {
+            if (keywords.some(keyword => query.includes(keyword))) {
+                return intent;
+            }
+        }
+        return 'general';
+    }
+    extractAttachmentRequirement(query) {
+        const attachmentKeywords = ['attachment', 'file', 'document', 'pdf', 'attached'];
+        return attachmentKeywords.some(keyword => query.includes(keyword));
+    }
+    extractLabels(query) {
+        const labelKeywords = {
+            'inbox': 'INBOX',
+            'sent': 'SENT',
+            'draft': 'DRAFT',
+            'trash': 'TRASH',
+            'spam': 'SPAM',
+            'archive': 'INBOX' // Archive is typically in INBOX
+        };
+        const labels = [];
+        for (const [keyword, label] of Object.entries(labelKeywords)) {
+            if (query.includes(keyword)) {
+                labels.push(label);
+            }
+        }
+        return labels;
+    }
+    parseDate(dateStr) {
+        try {
+            // Try various date formats
+            const formats = [
+                /(\w+)\s+(\d{1,2})/, // "May 15"
+                /(\d{1,2})\/(\d{1,2})\/(\d{4})/, // "15/05/2024"
+                /(\d{1,2})-(\d{1,2})-(\d{4})/ // "15-05-2024"
+            ];
+            for (const format of formats) {
+                const match = dateStr.match(format);
+                if (match) {
+                    if (match.length === 3) {
+                        // Month name + day
+                        const month = this.getMonthNumber(match[1]);
+                        const day = parseInt(match[2]);
+                        const year = new Date().getFullYear();
+                        return new Date(year, month, day);
+                    }
+                    else if (match.length === 4) {
+                        // DD/MM/YYYY or DD-MM-YYYY
+                        const day = parseInt(match[1]);
+                        const month = parseInt(match[2]) - 1;
+                        const year = parseInt(match[3]);
+                        return new Date(year, month, day);
+                    }
+                }
+            }
+        }
+        catch (error) {
+            logger.error('Error parsing date:', error);
+        }
+        return null;
+    }
+    getMonthNumber(monthName) {
+        const months = {
+            'january': 0, 'jan': 0,
+            'february': 1, 'feb': 1,
+            'march': 2, 'mar': 2,
+            'april': 3, 'apr': 3,
+            'may': 4,
+            'june': 5, 'jun': 5,
+            'july': 6, 'jul': 6,
+            'august': 7, 'aug': 7,
+            'september': 8, 'sep': 8, 'sept': 8,
+            'october': 9, 'oct': 9,
+            'november': 10, 'nov': 10,
+            'december': 11, 'dec': 11
+        };
+        const month = months[monthName.toLowerCase()];
+        return month !== undefined ? month : -1;
+    }
+}
+/**
+ * Fuzzy Matching Engine
+ * Provides intelligent matching with similarity scoring
+ */
+export class FuzzyMatcher {
+    constructor(threshold = 80) {
+        this.similarityThreshold = threshold;
+    }
+    calculateSimilarity(str1, str2) {
+        const s1 = str1.toLowerCase();
+        const s2 = str2.toLowerCase();
+        // Exact match
+        if (s1 === s2)
+            return 100;
+        // Substring match
+        if (s1.includes(s2) || s2.includes(s1))
+            return 95;
+        // Word-level matching
+        const words1 = s1.split(/\s+/);
+        const words2 = s2.split(/\s+/);
+        const commonWords = words1.filter(word => words2.includes(word));
+        const totalWords = Math.max(words1.length, words2.length);
+        if (totalWords === 0)
+            return 0;
+        const wordSimilarity = (commonWords.length / totalWords) * 100;
+        // Character-level similarity (simple implementation)
+        const charSimilarity = this.calculateCharacterSimilarity(s1, s2);
+        // Weighted combination
+        return (wordSimilarity * 0.7) + (charSimilarity * 0.3);
+    }
+    calculateCharacterSimilarity(str1, str2) {
+        const len1 = str1.length;
+        const len2 = str2.length;
+        if (len1 === 0 && len2 === 0)
+            return 100;
+        if (len1 === 0 || len2 === 0)
+            return 0;
+        const matrix = [];
+        // Initialize matrix
+        for (let i = 0; i <= len1; i++) {
+            matrix[i] = [i];
+        }
+        for (let j = 0; j <= len2; j++) {
+            matrix[0][j] = j;
+        }
+        // Fill matrix
+        for (let i = 1; i <= len1; i++) {
+            for (let j = 1; j <= len2; j++) {
+                const cost = str1[i - 1] === str2[j - 1] ? 0 : 1;
+                matrix[i][j] = Math.min(matrix[i - 1][j] + 1, // deletion
+                matrix[i][j - 1] + 1, // insertion
+                matrix[i - 1][j - 1] + cost // substitution
+                );
+            }
+        }
+        const distance = matrix[len1][len2];
+        const maxLen = Math.max(len1, len2);
+        return maxLen === 0 ? 100 : ((maxLen - distance) / maxLen) * 100;
+    }
+    findMatches(query, emails) {
+        const results = [];
+        for (const email of emails) {
+            const fieldsToSearch = [
+                email.subject || '',
+                email.snippet || '',
+                this.extractSender(email) || '',
+                this.extractContent(email) || ''
+            ];
+            let bestScore = 0;
+            let bestField = '';
+            for (const field of fieldsToSearch) {
+                const similarity = this.calculateSimilarity(query, field);
+                if (similarity > bestScore) {
+                    bestScore = similarity;
+                    bestField = field;
+                }
+            }
+            if (bestScore >= this.similarityThreshold) {
+                results.push({
+                    email,
+                    matchScore: bestScore,
+                    matchedField: bestField,
+                    relevance: this.getRelevanceLevel(bestScore),
+                    crossReferences: this.findCrossReferences(email, emails)
+                });
+            }
+        }
+        // Sort by relevance score
+        return results.sort((a, b) => b.matchScore - a.matchScore);
+    }
+    extractSender(email) {
+        if (email.payload?.headers) {
+            const fromHeader = email.payload.headers.find((h) => h.name === 'From');
+            return fromHeader?.value || '';
+        }
+        return '';
+    }
+    extractContent(email) {
+        if (email.payload?.body?.data) {
+            return this.decodeBase64Url(email.payload.body.data);
+        }
+        return '';
+    }
+    decodeBase64Url(str) {
+        try {
+            return Buffer.from(str.replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString('utf8');
+        }
+        catch {
+            return '';
+        }
+    }
+    getRelevanceLevel(score) {
+        if (score >= 95)
+            return 'exact';
+        if (score >= 85)
+            return 'high';
+        if (score >= 70)
+            return 'medium';
+        return 'low';
+    }
+    findCrossReferences(email, allEmails) {
+        const references = [];
+        // Same thread
+        const threadEmails = allEmails.filter(e => e.threadId === email.threadId);
+        if (threadEmails.length > 1) {
+            references.push(...threadEmails.map(e => e.id).filter(id => id !== email.id));
+        }
+        // Same sender
+        const sender = this.extractSender(email);
+        if (sender) {
+            const senderEmails = allEmails.filter(e => e.id !== email.id && this.extractSender(e) === sender);
+            references.push(...senderEmails.map(e => e.id));
+        }
+        return references.slice(0, 5); // Limit to 5 references
+    }
+}
+/**
+ * Cross-Reference Detection Engine
+ * Finds related emails based on various criteria
+ */
+export class CrossReferenceEngine {
+    async findRelatedEmails(email, allEmails) {
+        const related = [];
+        // Extract entities from the email
+        const entities = this.extractEntities(email);
+        // Find emails with same entities
+        for (const otherEmail of allEmails) {
+            if (otherEmail.id === email.id)
+                continue;
+            const otherEntities = this.extractEntities(otherEmail);
+            const relationship = this.findRelationship(email, otherEmail, entities, otherEntities);
+            if (relationship) {
+                related.push(relationship);
+            }
+        }
+        // Sort by confidence and limit results
+        return related
+            .sort((a, b) => b.confidence - a.confidence)
+            .slice(0, 10);
+    }
+    extractEntities(email) {
+        const content = `${email.subject || ''} ${email.snippet || ''}`;
+        return {
+            panNumbers: this.extractPANNumbers(content),
+            dinNumbers: this.extractDINNumbers(content),
+            amounts: this.extractAmounts(content),
+            organizations: this.extractOrganizations(content),
+            dates: this.extractDates(content)
+        };
+    }
+    extractPANNumbers(text) {
+        const panRegex = /[A-Z]{5}\d{4}[A-Z]/g;
+        return text.match(panRegex) || [];
+    }
+    extractDINNumbers(text) {
+        const dinRegex = /DIN\s*([A-Z0-9]+)/gi;
+        const matches = text.match(dinRegex) || [];
+        return matches.map(match => match.replace(/DIN\s*/i, ''));
+    }
+    extractAmounts(text) {
+        const amountRegex = /(?:Rs\.?|₹|INR)\s*(\d+(?:,\d{3})*(?:\.\d{2})?)/gi;
+        const matches = text.match(amountRegex) || [];
+        return matches.map(match => {
+            const amount = match.replace(/[^\d.,]/g, '').replace(',', '');
+            return parseFloat(amount);
+        });
+    }
+    extractOrganizations(text) {
+        const orgRegex = /(?:from|by)\s+([^\s,]+@[^\s,]+)/gi;
+        const matches = text.match(orgRegex) || [];
+        return matches.map(match => match.replace(/(?:from|by)\s+/, ''));
+    }
+    extractDates(text) {
+        const dateRegex = /(\d{1,2}\/\d{1,2}\/\d{4}|\d{1,2}-\d{1,2}-\d{4})/g;
+        const matches = text.match(dateRegex) || [];
+        return matches.map(match => new Date(match)).filter(date => !isNaN(date.getTime()));
+    }
+    findRelationship(email1, email2, entities1, entities2) {
+        let confidence = 0;
+        let relationship = 'same_topic';
+        let reason = '';
+        // Same thread relationship
+        if (email1.threadId === email2.threadId) {
+            return {
+                emailId: email2.id,
+                relationship: 'same_thread',
+                confidence: 100,
+                reason: 'Same conversation thread'
+            };
+        }
+        // Same sender relationship
+        const sender1 = this.extractSender(email1);
+        const sender2 = this.extractSender(email2);
+        if (sender1 && sender1 === sender2) {
+            confidence = 90;
+            relationship = 'same_sender';
+            reason = 'Same sender';
+        }
+        // Entity-based relationships
+        const entityMatches = this.findEntityMatches(entities1, entities2);
+        if (entityMatches.length > 0) {
+            confidence = Math.max(confidence, 80);
+            relationship = 'same_entity';
+            reason = `Shared entities: ${entityMatches.join(', ')}`;
+        }
+        // Topic similarity
+        const topicSimilarity = this.calculateTopicSimilarity(email1, email2);
+        if (topicSimilarity > 70) {
+            confidence = Math.max(confidence, topicSimilarity);
+            relationship = 'same_topic';
+            reason = `Similar topic (${topicSimilarity}% match)`;
+        }
+        return confidence > 50 ? {
+            emailId: email2.id,
+            relationship,
+            confidence,
+            reason
+        } : null;
+    }
+    extractSender(email) {
+        if (email.payload?.headers) {
+            const fromHeader = email.payload.headers.find((h) => h.name === 'From');
+            return fromHeader?.value || '';
+        }
+        return '';
+    }
+    findEntityMatches(entities1, entities2) {
+        const matches = [];
+        // PAN number matches
+        const panMatches = entities1.panNumbers?.filter((pan) => entities2.panNumbers?.includes(pan)) || [];
+        if (panMatches.length > 0) {
+            matches.push(`PAN: ${panMatches.join(', ')}`);
+        }
+        // DIN number matches
+        const dinMatches = entities1.dinNumbers?.filter((din) => entities2.dinNumbers?.includes(din)) || [];
+        if (dinMatches.length > 0) {
+            matches.push(`DIN: ${dinMatches.join(', ')}`);
+        }
+        // Organization matches
+        const orgMatches = entities1.organizations?.filter((org) => entities2.organizations?.includes(org)) || [];
+        if (orgMatches.length > 0) {
+            matches.push(`Organization: ${orgMatches.join(', ')}`);
+        }
+        return matches;
+    }
+    calculateTopicSimilarity(email1, email2) {
+        const content1 = `${email1.subject || ''} ${email1.snippet || ''}`.toLowerCase();
+        const content2 = `${email2.subject || ''} ${email2.snippet || ''}`.toLowerCase();
+        const words1 = content1.split(/\s+/);
+        const words2 = content2.split(/\s+/);
+        const commonWords = words1.filter(word => word.length > 3 && words2.includes(word));
+        const totalWords = Math.max(words1.length, words2.length);
+        return totalWords === 0 ? 0 : (commonWords.length / totalWords) * 100;
+    }
+}
+/**
+ * Enhanced Search Manager
+ * Combines all enhanced search capabilities
+ */
+export class EnhancedSearchManager {
+    constructor(fuzzyThreshold = 80) {
+        this.nlParser = new NLQueryParser();
+        this.fuzzyMatcher = new FuzzyMatcher(fuzzyThreshold);
+        this.crossReferenceEngine = new CrossReferenceEngine();
+    }
+    async processNaturalLanguageQuery(naturalQuery, emails) {
+        // Parse natural language query
+        const structuredQuery = this.nlParser.parseQuery(naturalQuery);
+        // Perform fuzzy matching
+        const searchResults = this.fuzzyMatcher.findMatches(naturalQuery, emails);
+        // Find cross-references for top results
+        const crossReferences = [];
+        for (const result of searchResults.slice(0, 5)) {
+            const references = await this.crossReferenceEngine.findRelatedEmails(result.email, emails);
+            crossReferences.push(...references);
+        }
+        return {
+            structuredQuery,
+            searchResults,
+            crossReferences: this.deduplicateCrossReferences(crossReferences)
+        };
+    }
+    deduplicateCrossReferences(references) {
+        const seen = new Set();
+        return references.filter(ref => {
+            if (seen.has(ref.emailId)) {
+                return false;
+            }
+            seen.add(ref.emailId);
+            return true;
+        });
+    }
+}

--- a/vendor/gmail-mcp-server/dist/utils/error-handling-resilience.js
+++ b/vendor/gmail-mcp-server/dist/utils/error-handling-resilience.js
@@ -1,0 +1,483 @@
+/**
+ * Error Handling & Resilience System
+ * Provides comprehensive error handling, retry mechanisms, circuit breakers, and graceful degradation
+ */
+import { logger } from './api.js';
+export class ResilientError extends Error {
+    constructor(message, errorType, retryable = false, context) {
+        super(message);
+        this.errorType = errorType;
+        this.retryable = retryable;
+        this.context = context;
+        this.name = 'ResilientError';
+    }
+}
+/**
+ * Exponential Backoff Retry Manager
+ */
+export class RetryManager {
+    constructor(config = {}) {
+        this.config = {
+            maxAttempts: 3,
+            baseDelayMs: 1000,
+            maxDelayMs: 30000,
+            backoffMultiplier: 2,
+            jitterPercent: 10,
+            ...config
+        };
+    }
+    async executeWithRetry(operation, operationName, customConfig) {
+        const config = { ...this.config, ...customConfig };
+        let lastError;
+        const startTime = Date.now();
+        for (let attempt = 1; attempt <= config.maxAttempts; attempt++) {
+            try {
+                logger.log(`Attempt ${attempt}/${config.maxAttempts} for operation: ${operationName}`);
+                const result = await operation();
+                if (attempt > 1) {
+                    logger.log(`Operation ${operationName} succeeded on attempt ${attempt}`);
+                }
+                return result;
+            }
+            catch (error) {
+                lastError = error;
+                const errorType = this.classifyError(error);
+                const retryable = this.isRetryable(errorType, error);
+                const context = {
+                    operation: operationName,
+                    attempt,
+                    totalTime: Date.now() - startTime,
+                    errorType,
+                    retryable,
+                    metadata: { originalError: error }
+                };
+                logger.error(`Attempt ${attempt}/${config.maxAttempts} failed for ${operationName}:`, error);
+                // If not retryable or last attempt, throw enhanced error
+                if (!retryable || attempt === config.maxAttempts) {
+                    throw new ResilientError(`Operation ${operationName} failed after ${attempt} attempts: ${lastError.message}`, errorType, retryable, context);
+                }
+                // Wait before retry with exponential backoff and jitter
+                if (attempt < config.maxAttempts) {
+                    const delay = this.calculateDelay(attempt, config);
+                    logger.log(`Waiting ${delay}ms before retry ${attempt + 1}`);
+                    await this.sleep(delay);
+                }
+            }
+        }
+        // This shouldn't be reached, but TypeScript requires it
+        throw lastError;
+    }
+    classifyError(error) {
+        const message = error?.message?.toLowerCase() || '';
+        const status = error?.status || error?.response?.status;
+        // Rate limiting
+        if (status === 429 || message.includes('rate limit') || message.includes('quota exceeded')) {
+            return 'RATE_LIMITED';
+        }
+        // Authentication
+        if (status === 401 || status === 403 || message.includes('unauthorized') || message.includes('forbidden')) {
+            return 'AUTHENTICATION_ERROR';
+        }
+        // Network errors
+        if (message.includes('network') || message.includes('timeout') || message.includes('enotfound')) {
+            return 'NETWORK_ERROR';
+        }
+        // Timeout errors
+        if (message.includes('timeout') || error?.code === 'ETIMEDOUT') {
+            return 'TIMEOUT_ERROR';
+        }
+        // API errors - both client (4xx) and server (5xx) errors
+        if (status >= 400) {
+            return 'API_ERROR';
+        }
+        // Parsing errors
+        if (message.includes('parse') || message.includes('json') || message.includes('syntax')) {
+            return 'PARSING_ERROR';
+        }
+        return 'UNKNOWN_ERROR';
+    }
+    isRetryable(errorType, error) {
+        switch (errorType) {
+            case 'RATE_LIMITED':
+            case 'NETWORK_ERROR':
+            case 'TIMEOUT_ERROR':
+                return true;
+            case 'AUTHENTICATION_ERROR':
+                return false; // Don't retry auth errors
+            case 'API_ERROR':
+                const status = error?.status || error?.response?.status;
+                return status >= 500; // Retry server errors, not client errors
+            case 'PARSING_ERROR':
+                return false; // Don't retry parsing errors
+            case 'UNKNOWN_ERROR':
+                return true; // Be optimistic about unknown errors
+            default:
+                return false;
+        }
+    }
+    calculateDelay(attempt, config) {
+        // Exponential backoff: baseDelay * multiplier^(attempt-1)
+        let delay = config.baseDelayMs * Math.pow(config.backoffMultiplier, attempt - 1);
+        // Cap at maxDelay
+        delay = Math.min(delay, config.maxDelayMs);
+        // Add jitter to prevent thundering herd
+        const jitter = delay * (config.jitterPercent / 100) * Math.random();
+        delay = delay + jitter;
+        return Math.round(delay);
+    }
+    sleep(ms) {
+        return new Promise(resolve => setTimeout(resolve, ms));
+    }
+}
+/**
+ * Circuit Breaker Pattern Implementation
+ */
+export class CircuitBreaker {
+    constructor(config = {}) {
+        this.state = 'CLOSED';
+        this.failureCount = 0;
+        this.successCount = 0;
+        this.lastFailureTime = 0;
+        this.config = {
+            failureThreshold: 5,
+            recoveryTimeoutMs: 60000,
+            monitoringWindowMs: 300000,
+            ...config
+        };
+    }
+    async execute(operation, operationName) {
+        if (this.state === 'OPEN') {
+            if (Date.now() - this.lastFailureTime < this.config.recoveryTimeoutMs) {
+                throw new ResilientError(`Circuit breaker is OPEN for ${operationName}. Failing fast.`, 'API_ERROR', false);
+            }
+            else {
+                this.state = 'HALF_OPEN';
+                this.successCount = 0;
+                logger.log(`Circuit breaker for ${operationName} moving to HALF_OPEN state`);
+            }
+        }
+        try {
+            const result = await operation();
+            this.onSuccess(operationName);
+            return result;
+        }
+        catch (error) {
+            this.onFailure(operationName, error);
+            throw error;
+        }
+    }
+    onSuccess(operationName) {
+        this.successCount++;
+        if (this.state === 'HALF_OPEN') {
+            if (this.successCount >= 2) { // Require multiple successes to close
+                this.state = 'CLOSED';
+                this.failureCount = 0;
+                logger.log(`Circuit breaker for ${operationName} moving to CLOSED state`);
+            }
+        }
+        else if (this.state === 'CLOSED') {
+            this.failureCount = 0;
+        }
+    }
+    onFailure(operationName, error) {
+        this.failureCount++;
+        this.lastFailureTime = Date.now();
+        if (this.state === 'CLOSED' && this.failureCount >= this.config.failureThreshold) {
+            this.state = 'OPEN';
+            logger.error(`Circuit breaker for ${operationName} moving to OPEN state after ${this.failureCount} failures`);
+        }
+        else if (this.state === 'HALF_OPEN') {
+            this.state = 'OPEN';
+            logger.error(`Circuit breaker for ${operationName} moving back to OPEN state from HALF_OPEN`);
+        }
+    }
+    getState() {
+        return this.state;
+    }
+    getStats() {
+        return {
+            state: this.state,
+            failureCount: this.failureCount,
+            successCount: this.successCount
+        };
+    }
+}
+/**
+ * Rate Limiting Handler
+ */
+export class RateLimitHandler {
+    constructor() {
+        this.rateLimitedUntil = 0;
+        this.requestCount = 0;
+        this.windowStart = Date.now();
+        this.windowSizeMs = 60000; // 1 minute window
+        this.maxRequestsPerWindow = 100;
+    }
+    async handleRateLimit(error) {
+        if (this.isRateLimited(error)) {
+            const retryAfter = this.extractRetryAfter(error);
+            const waitTime = retryAfter || this.calculateBackoffTime();
+            this.rateLimitedUntil = Date.now() + waitTime;
+            logger.log(`Rate limited. Waiting ${waitTime}ms before next request`);
+            await this.sleep(waitTime);
+        }
+    }
+    async checkRateLimit() {
+        const now = Date.now();
+        // Check if still in rate limit period
+        if (now < this.rateLimitedUntil) {
+            const waitTime = this.rateLimitedUntil - now;
+            logger.log(`Still rate limited. Waiting ${waitTime}ms`);
+            await this.sleep(waitTime);
+        }
+        // Reset window if needed
+        if (now - this.windowStart > this.windowSizeMs) {
+            this.windowStart = now;
+            this.requestCount = 0;
+        }
+        // Check request count in current window
+        if (this.requestCount >= this.maxRequestsPerWindow) {
+            const waitTime = this.windowSizeMs - (now - this.windowStart);
+            logger.log(`Request limit reached. Waiting ${waitTime}ms for window reset`);
+            await this.sleep(waitTime);
+            this.windowStart = Date.now();
+            this.requestCount = 0;
+        }
+        this.requestCount++;
+    }
+    isRateLimited(error) {
+        const status = error?.status || error?.response?.status;
+        const message = error?.message?.toLowerCase() || '';
+        return status === 429 ||
+            message.includes('rate limit') ||
+            message.includes('quota exceeded') ||
+            message.includes('too many requests');
+    }
+    extractRetryAfter(error) {
+        const retryAfter = error?.response?.headers?.['retry-after'] ||
+            error?.headers?.['retry-after'];
+        if (retryAfter) {
+            const seconds = parseInt(retryAfter);
+            return isNaN(seconds) ? null : seconds * 1000;
+        }
+        return null;
+    }
+    calculateBackoffTime() {
+        // Exponential backoff based on how recently we were rate limited
+        const timeSinceLastLimit = Date.now() - (this.rateLimitedUntil - 60000);
+        const backoffMultiplier = Math.min(Math.pow(2, Math.floor(timeSinceLastLimit / 30000)), 16);
+        return Math.min(1000 * backoffMultiplier, 60000); // Max 1 minute wait
+    }
+    sleep(ms) {
+        return new Promise(resolve => setTimeout(resolve, ms));
+    }
+}
+/**
+ * Timeout Manager
+ */
+export class TimeoutManager {
+    static async withTimeout(operation, timeoutMs, operationName) {
+        return Promise.race([
+            operation(),
+            new Promise((_, reject) => {
+                setTimeout(() => {
+                    reject(new ResilientError(`Operation ${operationName} timed out after ${timeoutMs}ms`, 'TIMEOUT_ERROR', true));
+                }, timeoutMs);
+            })
+        ]);
+    }
+}
+/**
+ * Graceful Degradation Manager
+ */
+export class GracefulDegradationManager {
+    constructor() {
+        this.enabledFeatures = new Set();
+        this.disabledFeatures = new Set();
+        this.featureErrors = new Map();
+        // Enable all features by default
+        this.enabledFeatures.add('enhanced_search');
+        this.enabledFeatures.add('fuzzy_matching');
+        this.enabledFeatures.add('cross_references');
+        this.enabledFeatures.add('threading_intelligence');
+        this.enabledFeatures.add('conversation_analysis');
+        this.enabledFeatures.add('proactive_reminders');
+    }
+    isFeatureEnabled(feature) {
+        // Auto-enable new features when first encountered
+        if (!this.enabledFeatures.has(feature) && !this.disabledFeatures.has(feature)) {
+            this.enabledFeatures.add(feature);
+        }
+        return this.enabledFeatures.has(feature) && !this.disabledFeatures.has(feature);
+    }
+    async executeWithDegradation(primaryOperation, fallbackOperation, featureName, operationName) {
+        if (!this.isFeatureEnabled(featureName)) {
+            logger.log(`Feature ${featureName} is disabled, using fallback for ${operationName}`);
+            return fallbackOperation();
+        }
+        try {
+            const result = await primaryOperation();
+            this.recordSuccess(featureName);
+            return result;
+        }
+        catch (error) {
+            this.recordFailure(featureName, error);
+            logger.error(`Primary operation failed for ${operationName}, falling back to basic implementation:`, error);
+            return fallbackOperation();
+        }
+    }
+    recordSuccess(feature) {
+        if (this.featureErrors.has(feature)) {
+            const errorCount = this.featureErrors.get(feature) - 1;
+            if (errorCount <= 0) {
+                this.featureErrors.delete(feature);
+                if (this.disabledFeatures.has(feature)) {
+                    this.disabledFeatures.delete(feature);
+                    this.enabledFeatures.add(feature);
+                    logger.log(`Re-enabled feature ${feature} after successful operation`);
+                }
+            }
+            else {
+                this.featureErrors.set(feature, errorCount);
+            }
+        }
+    }
+    recordFailure(feature, error) {
+        const currentErrors = this.featureErrors.get(feature) || 0;
+        const newErrorCount = currentErrors + 1;
+        this.featureErrors.set(feature, newErrorCount);
+        // Disable feature after 3 consecutive failures
+        if (newErrorCount >= 3 && this.enabledFeatures.has(feature)) {
+            this.enabledFeatures.delete(feature);
+            this.disabledFeatures.add(feature);
+            logger.error(`Disabled feature ${feature} after ${newErrorCount} failures`);
+        }
+    }
+    getFeatureStatus() {
+        const status = {};
+        for (const feature of this.enabledFeatures) {
+            status[feature] = this.featureErrors.has(feature) ? 'error' : 'enabled';
+        }
+        for (const feature of this.disabledFeatures) {
+            status[feature] = 'disabled';
+        }
+        return status;
+    }
+}
+/**
+ * Resource Manager for proper cleanup
+ */
+export class ResourceManager {
+    constructor() {
+        this.resources = new Set();
+        this.cleanupTimeout = null;
+    }
+    addResource(resource) {
+        this.resources.add(resource);
+    }
+    removeResource(resource) {
+        this.resources.delete(resource);
+    }
+    async cleanup() {
+        const cleanupPromises = Array.from(this.resources).map(async (resource) => {
+            try {
+                await resource.cleanup();
+            }
+            catch (error) {
+                logger.error('Error during resource cleanup:', error);
+            }
+        });
+        await Promise.allSettled(cleanupPromises);
+        this.resources.clear();
+    }
+    schedulePeriodicCleanup(intervalMs = 300000) {
+        if (this.cleanupTimeout) {
+            clearInterval(this.cleanupTimeout);
+        }
+        this.cleanupTimeout = setInterval(async () => {
+            logger.log('Performing periodic resource cleanup');
+            await this.cleanup();
+        }, intervalMs);
+    }
+    stopPeriodicCleanup() {
+        if (this.cleanupTimeout) {
+            clearInterval(this.cleanupTimeout);
+            this.cleanupTimeout = null;
+        }
+    }
+}
+/**
+ * Main Resilience Manager
+ * Combines all resilience features
+ */
+export class ResilienceManager {
+    constructor(config = {}) {
+        this.circuitBreakers = new Map();
+        this.config = {
+            retry: {
+                maxAttempts: 3,
+                baseDelayMs: 1000,
+                maxDelayMs: 30000,
+                backoffMultiplier: 2,
+                jitterPercent: 10
+            },
+            circuitBreaker: {
+                failureThreshold: 5,
+                recoveryTimeoutMs: 60000,
+                monitoringWindowMs: 300000
+            },
+            timeout: {
+                operationTimeoutMs: 30000,
+                connectionTimeoutMs: 10000
+            },
+            enableGracefulDegradation: true,
+            ...config
+        };
+        this.retryManager = new RetryManager(this.config.retry);
+        this.rateLimitHandler = new RateLimitHandler();
+        this.degradationManager = new GracefulDegradationManager();
+        this.resourceManager = new ResourceManager();
+        // Start periodic cleanup
+        this.resourceManager.schedulePeriodicCleanup();
+    }
+    async executeResilientOperation(operation, operationName, options = {}) {
+        const { useCircuitBreaker = false, feature, fallback, timeout = this.config.timeout.operationTimeoutMs, customRetryConfig } = options;
+        // Check rate limiting
+        await this.rateLimitHandler.checkRateLimit();
+        // Wrap operation with timeout
+        const timeoutOperation = () => TimeoutManager.withTimeout(operation, timeout, operationName);
+        // Apply circuit breaker if requested
+        const circuitBreakerOperation = useCircuitBreaker
+            ? () => this.getCircuitBreaker(operationName).execute(timeoutOperation, operationName)
+            : timeoutOperation;
+        // Apply retry logic
+        const retryOperation = () => this.retryManager.executeWithRetry(circuitBreakerOperation, operationName, customRetryConfig);
+        // Apply graceful degradation if feature and fallback provided
+        if (this.config.enableGracefulDegradation && feature && fallback) {
+            return this.degradationManager.executeWithDegradation(retryOperation, fallback, feature, operationName);
+        }
+        return retryOperation();
+    }
+    getCircuitBreaker(operationName) {
+        if (!this.circuitBreakers.has(operationName)) {
+            this.circuitBreakers.set(operationName, new CircuitBreaker(this.config.circuitBreaker));
+        }
+        return this.circuitBreakers.get(operationName);
+    }
+    getSystemStatus() {
+        const circuitBreakerStats = {};
+        for (const [name, cb] of this.circuitBreakers) {
+            circuitBreakerStats[name] = cb.getStats();
+        }
+        return {
+            features: this.degradationManager.getFeatureStatus(),
+            circuitBreakers: circuitBreakerStats,
+            rateLimiting: { active: Date.now() < this.rateLimitHandler['rateLimitedUntil'] }
+        };
+    }
+    async shutdown() {
+        logger.log('Shutting down resilience manager...');
+        this.resourceManager.stopPeriodicCleanup();
+        await this.resourceManager.cleanup();
+    }
+}

--- a/vendor/gmail-mcp-server/dist/utils/gmail-auth.js
+++ b/vendor/gmail-mcp-server/dist/utils/gmail-auth.js
@@ -1,0 +1,513 @@
+import { google } from 'googleapis';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import open from 'open';
+import { createServer } from 'http';
+import { URL } from 'url';
+import { logger } from './api.js';
+// Scopes required for Gmail operations
+const SCOPES = [
+    'profile',
+    'email',
+    'openid',
+    'https://www.googleapis.com/auth/gmail.readonly',
+    'https://www.googleapis.com/auth/gmail.send',
+    'https://www.googleapis.com/auth/gmail.modify',
+    'https://www.googleapis.com/auth/gmail.labels'
+];
+// Configuration directory and file paths
+const CONFIG_DIR = process.env.GMAIL_CONFIG_DIR || path.join(os.homedir(), '.gmail-mcp');
+const CREDENTIALS_FILE = path.join(CONFIG_DIR, 'credentials.json');
+const TOKEN_FILE = path.join(CONFIG_DIR, 'token.json');
+/**
+ * Gmail authentication manager class
+ */
+export class GmailAuth {
+    constructor() {
+        this.oAuth2Client = null;
+        this.credentials = null;
+        this.activeServer = null;
+        this.activeServerPort = null;
+        this.activeServerTimeout = null;
+        this.ensureConfigDir();
+    }
+    /**
+     * Ensure configuration directory exists
+     */
+    ensureConfigDir() {
+        if (!fs.existsSync(CONFIG_DIR)) {
+            fs.mkdirSync(CONFIG_DIR, { recursive: true });
+            logger.log('Created Gmail MCP configuration directory');
+        }
+    }
+    /**
+     * Load credentials from file or environment
+     */
+    async loadCredentials() {
+        try {
+            // Try environment variables first
+            if (process.env.GMAIL_CLIENT_ID && process.env.GMAIL_CLIENT_SECRET) {
+                this.credentials = {
+                    client_id: process.env.GMAIL_CLIENT_ID,
+                    client_secret: process.env.GMAIL_CLIENT_SECRET,
+                    redirect_uris: [process.env.GMAIL_REDIRECT_URI || 'http://localhost:44000/oauth2callback']
+                };
+                logger.log('Loaded Gmail credentials from environment variables');
+                return true;
+            }
+            // Try credentials file
+            if (fs.existsSync(CREDENTIALS_FILE)) {
+                const credentialsData = fs.readFileSync(CREDENTIALS_FILE, 'utf8');
+                const parsedCredentials = JSON.parse(credentialsData);
+                // Handle both desktop and web app credential formats
+                if (parsedCredentials.installed) {
+                    this.credentials = parsedCredentials.installed;
+                }
+                else if (parsedCredentials.web) {
+                    this.credentials = parsedCredentials.web;
+                }
+                else {
+                    this.credentials = parsedCredentials;
+                }
+                logger.log('Loaded Gmail credentials from file');
+                return true;
+            }
+            return false;
+        }
+        catch (error) {
+            logger.error('Error loading Gmail credentials:', error);
+            return false;
+        }
+    }
+    /**
+     * Save credentials to file
+     */
+    async saveCredentials(credentials) {
+        try {
+            fs.writeFileSync(CREDENTIALS_FILE, JSON.stringify(credentials, null, 2));
+            logger.log('Saved Gmail credentials to file');
+        }
+        catch (error) {
+            logger.error('Error saving Gmail credentials:', error);
+            throw new Error('Failed to save credentials');
+        }
+    }
+    /**
+     * Initialize OAuth2 client
+     */
+    initializeOAuth2Client() {
+        if (!this.credentials) {
+            throw new Error('Credentials not loaded');
+        }
+        this.oAuth2Client = new google.auth.OAuth2(this.credentials.client_id, this.credentials.client_secret, this.credentials.redirect_uris?.[0] || 'http://localhost:44000/oauth2callback');
+        return this.oAuth2Client;
+    }
+    /**
+     * Load stored access token
+     */
+    loadStoredToken() {
+        try {
+            if (fs.existsSync(TOKEN_FILE)) {
+                const tokenData = fs.readFileSync(TOKEN_FILE, 'utf8');
+                return JSON.parse(tokenData);
+            }
+        }
+        catch (error) {
+            logger.error('Error loading stored token:', error);
+        }
+        return null;
+    }
+    /**
+     * Save access token to file
+     */
+    saveToken(token) {
+        try {
+            fs.writeFileSync(TOKEN_FILE, JSON.stringify(token, null, 2));
+            logger.log('Saved Gmail access token');
+        }
+        catch (error) {
+            logger.error('Error saving token:', error);
+        }
+    }
+    /**
+     * Find an available port starting from a base port
+     */
+    async findAvailablePort(basePort) {
+        const net = await import('net');
+        return new Promise((resolve, reject) => {
+            const server = net.createServer();
+            server.listen(basePort, () => {
+                const port = server.address()?.port;
+                server.close(() => {
+                    resolve(port);
+                });
+            });
+            server.on('error', (err) => {
+                if (err.code === 'EADDRINUSE') {
+                    // Try next port
+                    this.findAvailablePort(basePort + 1).then(resolve).catch(reject);
+                }
+                else {
+                    reject(err);
+                }
+            });
+        });
+    }
+    /**
+     * Stop any active callback server
+     */
+    stopActiveServer() {
+        if (this.activeServer) {
+            try {
+                this.activeServer.close();
+                logger.log(`Stopped callback server on port ${this.activeServerPort}`);
+            }
+            catch (error) {
+                logger.error('Error stopping active server:', error);
+            }
+            this.activeServer = null;
+            this.activeServerPort = null;
+        }
+        if (this.activeServerTimeout) {
+            clearTimeout(this.activeServerTimeout);
+            this.activeServerTimeout = null;
+        }
+    }
+    /**
+     * Start local server for OAuth2 callback
+     */
+    async startCallbackServer(timeoutMs = 600000) {
+        // Stop any existing server first
+        this.stopActiveServer();
+        // Extract port from redirect URI or use default
+        const redirectUri = process.env.GMAIL_REDIRECT_URI || 'http://localhost:44000/oauth2callback';
+        const url = new URL(redirectUri);
+        const preferredPort = parseInt(url.port) || 44000;
+        const callbackPath = url.pathname || '/oauth2callback';
+        // Find an available port starting from preferred port
+        const availablePort = await this.findAvailablePort(preferredPort);
+        return new Promise((resolve, reject) => {
+            // Set up timeout
+            this.activeServerTimeout = setTimeout(() => {
+                this.stopActiveServer();
+                reject(new Error(`Authentication timeout after ${timeoutMs / 1000} seconds. Please try again.`));
+            }, timeoutMs);
+            this.activeServer = createServer((req, res) => {
+                if (req.url?.startsWith(callbackPath)) {
+                    const reqUrl = new URL(req.url, `http://localhost:${availablePort}`);
+                    const code = reqUrl.searchParams.get('code');
+                    const error = reqUrl.searchParams.get('error');
+                    if (error) {
+                        res.end(`<html><body><h1>Authentication Error</h1><p>${error}</p></body></html>`);
+                        this.stopActiveServer();
+                        reject(new Error(`OAuth2 error: ${error}`));
+                        return;
+                    }
+                    if (code) {
+                        res.end(`<html><body><h1>Authentication Successful!</h1><p>You can close this window and return to the terminal.</p></body></html>`);
+                        this.stopActiveServer();
+                        resolve({ code, port: availablePort });
+                        return;
+                    }
+                    res.end('<html><body><h1>Invalid Request</h1></body></html>');
+                }
+                else {
+                    res.end('<html><body><h1>Gmail MCP Server OAuth2</h1><p>Waiting for authentication...</p></body></html>');
+                }
+            });
+            this.activeServer.listen(availablePort, (err) => {
+                if (err) {
+                    this.stopActiveServer();
+                    reject(new Error(`Failed to start callback server on port ${availablePort}: ${err.message}`));
+                    return;
+                }
+                this.activeServerPort = availablePort;
+                logger.log(`OAuth2 callback server started on port ${availablePort} (path: ${callbackPath})`);
+            });
+            this.activeServer.on('error', (err) => {
+                this.stopActiveServer();
+                reject(new Error(`Callback server error: ${err.message}`));
+            });
+        });
+    }
+    /**
+     * Perform OAuth2 authentication flow
+     */
+    async authenticate() {
+        if (!await this.loadCredentials()) {
+            throw new Error('Gmail credentials not found. Please run with --setup-auth flag first.');
+        }
+        // Always create fresh OAuth2Client to handle different accounts
+        const auth = this.initializeOAuth2Client();
+        // Try to load existing token
+        const storedToken = this.loadStoredToken();
+        if (storedToken) {
+            auth.setCredentials(storedToken);
+            // Check if token is still valid
+            try {
+                await auth.getAccessToken();
+                logger.log('Using existing valid token');
+                this.oAuth2Client = auth; // Update cached client
+                return auth;
+            }
+            catch (error) {
+                logger.log('Access token invalid, attempting refresh...');
+                // Try to refresh the token if we have a refresh token
+                if (storedToken.refresh_token) {
+                    try {
+                        const refreshResponse = await auth.refreshAccessToken();
+                        const newTokens = refreshResponse.credentials;
+                        // Update stored token with new access token and expiry
+                        const updatedToken = {
+                            ...storedToken,
+                            access_token: newTokens.access_token || storedToken.access_token,
+                            expiry_date: newTokens.expiry_date || storedToken.expiry_date
+                        };
+                        // Save the updated tokens
+                        this.saveToken(updatedToken);
+                        // Set the new credentials
+                        auth.setCredentials(updatedToken);
+                        logger.log('Successfully refreshed access token');
+                        this.oAuth2Client = auth; // Update cached client
+                        return auth;
+                    }
+                    catch (refreshError) {
+                        logger.error('Failed to refresh token:', refreshError);
+                        logger.log('Refresh token invalid, requesting new authentication');
+                        // Fall through to full re-authentication
+                    }
+                }
+                else {
+                    logger.log('No refresh token available, requesting new authentication');
+                    // Fall through to full re-authentication
+                }
+            }
+        }
+        // Generate authentication URL
+        const authUrl = auth.generateAuthUrl({
+            access_type: 'offline',
+            scope: SCOPES,
+            state: process.env.USER_ID || 'localhost',
+            prompt: 'select_account consent'
+        });
+        logger.log('Starting OAuth2 authentication flow');
+        console.error('\nStarting Gmail authentication...');
+        console.error('If browser doesn\'t open automatically, visit this URL:');
+        console.error(authUrl);
+        try {
+            // Start callback server and open browser
+            const serverPromise = this.startCallbackServer();
+            // Update auth URL to use the actual port if different from preferred
+            const result = await serverPromise;
+            const actualPort = result.port;
+            // If the actual port is different from the one in the auth URL, we need to update the redirect URI
+            if (actualPort !== (parseInt(new URL(process.env.GMAIL_REDIRECT_URI || 'http://localhost:44000/oauth2callback').port) || 44000)) {
+                // Update OAuth2 client with correct redirect URI
+                const redirectUri = process.env.GMAIL_REDIRECT_URI || 'http://localhost:44000/oauth2callback';
+                const url = new URL(redirectUri);
+                url.port = actualPort.toString();
+                this.oAuth2Client = new google.auth.OAuth2(this.credentials.client_id, this.credentials.client_secret, url.toString());
+                // Regenerate auth URL with correct port
+                const updatedAuthUrl = this.oAuth2Client.generateAuthUrl({
+                    access_type: 'offline',
+                    scope: SCOPES,
+                    state: process.env.USER_ID || 'localhost',
+                    prompt: 'select_account consent'
+                });
+                await open(updatedAuthUrl);
+                logger.log(`Updated auth URL for port ${actualPort}`);
+            }
+            else {
+                await open(authUrl);
+            }
+            const code = result.code;
+            // Exchange code for tokens
+            const { tokens } = await auth.getToken(code);
+            auth.setCredentials(tokens);
+            // Save tokens for future use
+            this.saveToken(tokens);
+            logger.log('Gmail authentication completed successfully');
+            console.error('Authentication successful!\n');
+            this.oAuth2Client = auth; // Cache the new authenticated client
+            return auth;
+        }
+        catch (error) {
+            logger.error('Authentication failed:', error);
+            throw new Error(`Authentication failed: ${error instanceof Error ? error.message : 'Unknown error'}`);
+        }
+    }
+    /**
+     * Get authenticated Gmail API client
+     */
+    async getGmailClient() {
+        // Check if we have an existing authenticated client
+        if (this.oAuth2Client) {
+            try {
+                // Try to get a fresh access token (this will auto-refresh if needed)
+                await this.oAuth2Client.getAccessToken();
+                return google.gmail({ version: 'v1', auth: this.oAuth2Client });
+            }
+            catch (error) {
+                logger.log('Cached client token invalid, re-authenticating...');
+                // Clear the cached client and fall through to re-authentication
+                this.oAuth2Client = null;
+            }
+        }
+        // No cached client or cached client failed, authenticate
+        const auth = await this.authenticate();
+        return google.gmail({ version: 'v1', auth });
+    }
+    /**
+     * Prompt user for credentials setup
+     */
+    async setupCredentials() {
+        console.log('\n=== Gmail MCP Server Setup ===');
+        console.log('To use this server, you need to set up Google API credentials.');
+        console.log('\nPlease follow these steps:');
+        console.log('1. Go to https://console.developers.google.com/');
+        console.log('2. Create a new project or select existing project');
+        console.log('3. Enable the Gmail API');
+        console.log('4. Create credentials (OAuth 2.0 Client ID)');
+        console.log('5. Set redirect URI to: http://localhost:44000/oauth2callback (or your custom URI)');
+        console.log('6. Download the credentials JSON file');
+        console.log(`7. Save it as: ${CREDENTIALS_FILE}`);
+        console.log('\nAlternatively, set environment variables:');
+        console.log('- GMAIL_CLIENT_ID');
+        console.log('- GMAIL_CLIENT_SECRET');
+        console.log('- GMAIL_REDIRECT_URI (optional, defaults to http://localhost:44000/oauth2callback)');
+        console.log('- USER_ID (optional, for OAuth state validation, defaults to user id)');
+        console.log('\n📝 GMAIL_REDIRECT_URI Examples:');
+        console.log('export GMAIL_REDIRECT_URI="http://localhost:8080/auth/callback"');
+        console.log('export GMAIL_REDIRECT_URI="https://yourdomain.com/oauth2callback"');
+        console.log('export GMAIL_REDIRECT_URI="http://127.0.0.1:3000/callback"');
+        console.log('\nFor cloud deployments:');
+        console.log('- Set GMAIL_REDIRECT_URI to your server\'s callback endpoint');
+        console.log('- The callback server will automatically use the port from GMAIL_REDIRECT_URI');
+        console.log('- USER_ID is often automatically set by cloud platforms');
+        console.log('\nFor detailed instructions, visit: https://developers.google.com/gmail/api/quickstart/nodejs');
+    }
+    /**
+     * Check if user credentials are configured
+     */
+    async isConfigured() {
+        // Check environment variables first
+        if (process.env.GMAIL_CLIENT_ID && process.env.GMAIL_CLIENT_SECRET) {
+            return true;
+        }
+        // Check credentials file
+        try {
+            fs.accessSync(CREDENTIALS_FILE);
+            return true;
+        }
+        catch {
+            return false;
+        }
+    }
+    /**
+     * Check if user is currently authenticated (has valid tokens)
+     */
+    async isAuthenticated() {
+        try {
+            fs.accessSync(TOKEN_FILE);
+            const tokenData = fs.readFileSync(TOKEN_FILE, 'utf8');
+            const tokens = JSON.parse(tokenData);
+            // Check if we have both access and refresh tokens
+            if (!tokens.access_token) {
+                return false;
+            }
+            // If we have a refresh token, we can always get a new access token
+            if (tokens.refresh_token) {
+                return true;
+            }
+            // Check if access token is still valid (not expired)
+            if (tokens.expiry_date && tokens.expiry_date > Date.now()) {
+                return true;
+            }
+            return false;
+        }
+        catch {
+            return false;
+        }
+    }
+    /**
+     * Reset authentication (clear stored tokens)
+     */
+    resetAuth() {
+        try {
+            if (fs.existsSync(TOKEN_FILE)) {
+                fs.unlinkSync(TOKEN_FILE);
+                logger.log('Cleared stored authentication tokens');
+            }
+            // Stop any active callback server
+            this.stopActiveServer();
+            // Reset cached OAuth2Client
+            this.resetClient();
+        }
+        catch (error) {
+            logger.error('Error clearing tokens:', error);
+        }
+    }
+    /**
+     * Get authentication URL without starting the full authentication flow
+     * This allows for manual authentication control
+     */
+    async getAuthUrl() {
+        if (!await this.loadCredentials()) {
+            throw new Error('Gmail credentials not found. Please configure OAuth2 credentials first.');
+        }
+        const auth = this.initializeOAuth2Client();
+        // Start callback server with shorter timeout for manual mode
+        // This ensures the link works if clicked immediately, but doesn't hang forever
+        this.startCallbackServer(180000).then(async (result) => {
+            try {
+                // Exchange code for tokens
+                const { tokens } = await auth.getToken(result.code);
+                auth.setCredentials(tokens);
+                // Save tokens for future use
+                this.saveToken(tokens);
+                // Cache the new authenticated client
+                this.oAuth2Client = auth;
+                logger.log('Gmail authentication completed successfully via manual link');
+            }
+            catch (error) {
+                logger.error('Authentication failed via manual link:', error);
+            }
+        }).catch((error) => {
+            logger.log(`Manual authentication callback server timeout or error: ${error instanceof Error ? error.message : 'Unknown error'}`);
+        });
+        // Generate authentication URL
+        const authUrl = auth.generateAuthUrl({
+            access_type: 'offline',
+            scope: SCOPES,
+            state: process.env.USER_ID || 'localhost',
+            prompt: 'select_account consent'
+        });
+        logger.log('Generated Gmail authentication URL for manual mode with 3-minute callback server');
+        return authUrl;
+    }
+    /**
+     * Complete manual authentication flow
+     * Call this after user has visited the auth URL to finalize authentication
+     */
+    async completeManualAuth() {
+        try {
+            // Check if we now have valid tokens (from the callback server)
+            return await this.isAuthenticated();
+        }
+        catch (error) {
+            logger.error('Error checking authentication status:', error);
+            return false;
+        }
+    }
+    /**
+     * Reset cached OAuth2Client (called when switching accounts)
+     */
+    resetClient() {
+        this.oAuth2Client = null;
+        // Also stop any active servers when resetting client
+        this.stopActiveServer();
+    }
+}
+// Export singleton instance
+export const gmailAuth = new GmailAuth();

--- a/vendor/gmail-mcp-server/dist/utils/gmail-operations.js
+++ b/vendor/gmail-mcp-server/dist/utils/gmail-operations.js
@@ -1,0 +1,911 @@
+import { gmailAuth } from './gmail-auth.js';
+import { logger } from './api.js';
+import * as fs from 'fs';
+import * as path from 'path';
+import mimeTypes from 'mime-types';
+import { EnhancedSearchManager } from './enhanced-search.js';
+import { ResilienceManager } from './error-handling-resilience.js';
+import { PerformanceOptimizationManager } from './performance-optimization.js';
+/**
+ * Gmail operations manager class
+ */
+export class GmailOperations {
+    constructor() {
+        this.gmail = null;
+        this.enhancedSearchManager = new EnhancedSearchManager(80); // Default 80% threshold
+        this.resilienceManager = new ResilienceManager();
+        this.performanceManager = new PerformanceOptimizationManager({ maxSize: 2000, ttlMs: 1800000 }, // 30 min cache
+        { maxBatchSize: 50, batchTimeoutMs: 3000 }, // Optimized batch settings
+        { maxConnections: 5, idleTimeoutMs: 300000 } // Connection pool
+        );
+    }
+    /**
+     * Reset cached Gmail client (called when authentication changes)
+     */
+    resetClient() {
+        this.gmail = null;
+    }
+    /**
+     * Get system status including resilience metrics
+     */
+    getSystemStatus() {
+        return this.resilienceManager.getSystemStatus();
+    }
+    /**
+     * Get performance metrics
+     */
+    getPerformanceMetrics() {
+        return this.performanceManager.getPerformanceMetrics();
+    }
+    /**
+     * Get authenticated Gmail client
+     */
+    async getGmailClient() {
+        // Always get fresh client to handle re-authentication with different accounts
+        this.gmail = await gmailAuth.getGmailClient();
+        return this.gmail;
+    }
+    /**
+     * Encode string to base64url
+     */
+    encodeBase64Url(str) {
+        return Buffer.from(str)
+            .toString('base64')
+            .replace(/\+/g, '-')
+            .replace(/\//g, '_')
+            .replace(/=/g, '');
+    }
+    /**
+     * Decode base64url string
+     */
+    decodeBase64Url(str) {
+        // Add padding if needed
+        const padding = 4 - (str.length % 4);
+        const paddedStr = str + '='.repeat(padding % 4);
+        return Buffer.from(paddedStr.replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString();
+    }
+    /**
+     * Create email message in RFC 2822 format
+     */
+    createRawMessage(message) {
+        const lines = [];
+        // Headers
+        lines.push(`To: ${message.to.join(', ')}`);
+        if (message.cc && message.cc.length > 0) {
+            lines.push(`Cc: ${message.cc.join(', ')}`);
+        }
+        if (message.bcc && message.bcc.length > 0) {
+            lines.push(`Bcc: ${message.bcc.join(', ')}`);
+        }
+        if (message.replyTo) {
+            lines.push(`Reply-To: ${message.replyTo}`);
+        }
+        // Subject with proper encoding for international characters
+        const encodedSubject = message.subject
+            .replace(/[^\x00-\x7F]/g, (match) => `=?UTF-8?B?${Buffer.from(match).toString('base64')}?=`);
+        lines.push(`Subject: ${encodedSubject}`);
+        lines.push('MIME-Version: 1.0');
+        if (message.attachments && message.attachments.length > 0) {
+            // Multipart with attachments
+            const boundary = `boundary_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+            lines.push(`Content-Type: multipart/mixed; boundary="${boundary}"`);
+            lines.push('');
+            // Message body part
+            lines.push(`--${boundary}`);
+            if (message.html && message.text) {
+                // Multipart alternative for HTML and text
+                const altBoundary = `alt_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+                lines.push(`Content-Type: multipart/alternative; boundary="${altBoundary}"`);
+                lines.push('');
+                lines.push(`--${altBoundary}`);
+                lines.push('Content-Type: text/plain; charset=UTF-8');
+                lines.push('Content-Transfer-Encoding: 8bit');
+                lines.push('');
+                lines.push(message.text);
+                lines.push('');
+                lines.push(`--${altBoundary}`);
+                lines.push('Content-Type: text/html; charset=UTF-8');
+                lines.push('Content-Transfer-Encoding: 8bit');
+                lines.push('');
+                lines.push(message.html);
+                lines.push('');
+                lines.push(`--${altBoundary}--`);
+            }
+            else {
+                lines.push(`Content-Type: ${message.html ? 'text/html' : 'text/plain'}; charset=UTF-8`);
+                lines.push('Content-Transfer-Encoding: 8bit');
+                lines.push('');
+                lines.push(message.html || message.text || '');
+                lines.push('');
+            }
+            // Attachments
+            for (const attachment of message.attachments) {
+                lines.push(`--${boundary}`);
+                const contentType = attachment.contentType || mimeTypes.lookup(attachment.filename) || 'application/octet-stream';
+                lines.push(`Content-Type: ${contentType}`);
+                lines.push('Content-Transfer-Encoding: base64');
+                lines.push(`Content-Disposition: attachment; filename="${attachment.filename}"`);
+                lines.push('');
+                let content;
+                if (Buffer.isBuffer(attachment.content)) {
+                    // Already a Buffer - use directly
+                    content = attachment.content;
+                }
+                else if (typeof attachment.content === 'string') {
+                    // Check if it's a file path or base64 content
+                    if (this.isFilePath(attachment.content)) {
+                        // It's a file path - read the file
+                        try {
+                            content = fs.readFileSync(attachment.content);
+                        }
+                        catch (error) {
+                            if (error.code === 'ENOENT') {
+                                throw new Error(`Failed to read attachment file '${attachment.content}': File not found. Please provide the ABSOLUTE/FULL path to the file (e.g., '/Users/username/Documents/${attachment.filename}' or 'C:\\Users\\username\\Documents\\${attachment.filename}'). Relative paths like 'uploads/${attachment.filename}' will not work.`);
+                            }
+                            else {
+                                throw new Error(`Failed to read attachment file '${attachment.content}': ${error}`);
+                            }
+                        }
+                    }
+                    else {
+                        // It's base64 encoded content - decode it properly
+                        try {
+                            content = Buffer.from(attachment.content, 'base64');
+                        }
+                        catch (error) {
+                            throw new Error(`Failed to decode base64 attachment '${attachment.filename}': ${error}`);
+                        }
+                    }
+                }
+                else {
+                    throw new Error(`Invalid attachment content type for '${attachment.filename}'. Expected Buffer, base64 string, or file path.`);
+                }
+                // Convert to base64 for email transmission
+                lines.push(content.toString('base64'));
+                lines.push('');
+            }
+            lines.push(`--${boundary}--`);
+        }
+        else if (message.html && message.text) {
+            // Multipart alternative for HTML and text
+            const boundary = `boundary_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+            lines.push(`Content-Type: multipart/alternative; boundary="${boundary}"`);
+            lines.push('');
+            lines.push(`--${boundary}`);
+            lines.push('Content-Type: text/plain; charset=UTF-8');
+            lines.push('Content-Transfer-Encoding: 8bit');
+            lines.push('');
+            lines.push(message.text);
+            lines.push('');
+            lines.push(`--${boundary}`);
+            lines.push('Content-Type: text/html; charset=UTF-8');
+            lines.push('Content-Transfer-Encoding: 8bit');
+            lines.push('');
+            lines.push(message.html);
+            lines.push('');
+            lines.push(`--${boundary}--`);
+        }
+        else {
+            // Simple message
+            lines.push(`Content-Type: ${message.html ? 'text/html' : 'text/plain'}; charset=UTF-8`);
+            lines.push('Content-Transfer-Encoding: 8bit');
+            lines.push('');
+            lines.push(message.html || message.text || '');
+        }
+        return lines.join('\r\n');
+    }
+    /**
+     * Send an email with resilience
+     */
+    async sendEmail(message, overrideClient) {
+        return this.resilienceManager.executeResilientOperation(async () => {
+            const gmail = overrideClient || await this.getGmailClient();
+            const rawMessage = this.createRawMessage(message);
+            const encodedMessage = this.encodeBase64Url(rawMessage);
+            logger.log(`Sending email to: ${message.to.join(', ')}`);
+            logger.log(`Subject: ${message.subject}`);
+            const response = await gmail.users.messages.send({
+                userId: 'me',
+                requestBody: {
+                    raw: encodedMessage
+                }
+            });
+            if (!response.data.id || !response.data.threadId) {
+                throw new Error('Failed to send email: Invalid response from Gmail API');
+            }
+            logger.log(`Email sent successfully: ${response.data.id}`);
+            return {
+                id: response.data.id,
+                threadId: response.data.threadId
+            };
+        }, 'send_email', {
+            useCircuitBreaker: true,
+            timeout: 15000, // 15 second timeout for sending
+            customRetryConfig: {
+                maxAttempts: 3,
+                baseDelayMs: 2000
+            }
+        });
+    }
+    /**
+     * Get email by ID with caching and batch optimization
+     */
+    async getEmail(messageId, format = 'full', overrideClient) {
+        try {
+            // Use cached version when possible
+            const cacheKey = `email:${messageId}:${format}`;
+            let cached = await this.performanceManager['cache'].get(cacheKey);
+            if (!cached) {
+                const gmail = overrideClient || await this.getGmailClient();
+                logger.log(`Retrieving email: ${messageId}`);
+                const response = await gmail.users.messages.get({
+                    userId: 'me',
+                    id: messageId,
+                    format
+                });
+                cached = response.data;
+                await this.performanceManager['cache'].set(cacheKey, cached, { compress: true, priority: 'normal' });
+            }
+            return cached;
+        }
+        catch (error) {
+            logger.error('Error retrieving email:', error);
+            throw new Error(`Failed to retrieve email: ${error instanceof Error ? error.message : 'Unknown error'}`);
+        }
+    }
+    /**
+     * Get email attachment
+     */
+    async getAttachment(messageId, attachmentId, overrideClient) {
+        try {
+            const gmail = overrideClient || await this.getGmailClient();
+            logger.log(`Retrieving attachment: ${attachmentId} from message: ${messageId}`);
+            const response = await gmail.users.messages.attachments.get({
+                userId: 'me',
+                messageId,
+                id: attachmentId
+            });
+            return {
+                data: response.data.data,
+                size: response.data.size
+            };
+        }
+        catch (error) {
+            logger.error('Error retrieving attachment:', error);
+            throw new Error(`Failed to retrieve attachment: ${error instanceof Error ? error.message : 'Unknown error'}`);
+        }
+    }
+    /**
+     * Get email attachment and save to local file system
+     * Converts base64 data to binary file and returns file path
+     */
+    async getAttachmentToLocal(messageId, attachmentId, customPath, overrideClient) {
+        try {
+            const gmail = overrideClient || await this.getGmailClient();
+            logger.log(`Downloading attachment to local: ${attachmentId} from message: ${messageId}`);
+            // First, get the message to find available attachments
+            const messageResponse = await gmail.users.messages.get({
+                userId: 'me',
+                id: messageId,
+                format: 'full'
+            });
+            // Find all attachments in the message
+            const attachments = this.findAllAttachments(messageResponse.data);
+            if (attachments.length === 0) {
+                throw new Error('No attachments found in this message');
+            }
+            logger.log(`Found ${attachments.length} attachments in message`);
+            // If attachmentId is "0" or a number, treat it as an index
+            let targetAttachment;
+            if (/^\d+$/.test(attachmentId)) {
+                const index = parseInt(attachmentId);
+                if (index >= attachments.length) {
+                    throw new Error(`Attachment index ${index} not found. Message has ${attachments.length} attachments (0-${attachments.length - 1})`);
+                }
+                targetAttachment = attachments[index];
+                logger.log(`Using attachment at index ${index}: ${targetAttachment.filename}`);
+            }
+            else {
+                // Find attachment by ID
+                targetAttachment = attachments.find(att => att.attachmentId === attachmentId);
+                if (!targetAttachment) {
+                    const availableIds = attachments.map(att => att.attachmentId).join(', ');
+                    throw new Error(`Attachment ID ${attachmentId} not found. Available IDs: ${availableIds}`);
+                }
+            }
+            // Get attachment data using the correct attachment ID
+            const attachmentResponse = await gmail.users.messages.attachments.get({
+                userId: 'me',
+                messageId,
+                id: targetAttachment.attachmentId
+            });
+            // Create downloads directory if it doesn't exist
+            const downloadsDir = customPath || path.resolve(process.cwd(), 'downloads');
+            if (!fs.existsSync(downloadsDir)) {
+                fs.mkdirSync(downloadsDir, { recursive: true });
+            }
+            // Generate unique filename with timestamp
+            const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+            const uniqueFilename = `${timestamp}_${targetAttachment.filename}`;
+            const filePath = path.join(downloadsDir, uniqueFilename);
+            // Decode base64 and save to file
+            const base64Data = attachmentResponse.data.data;
+            const binaryData = Buffer.from(base64Data, 'base64');
+            fs.writeFileSync(filePath, binaryData);
+            logger.log(`Attachment saved to: ${filePath}`);
+            return {
+                filePath: path.resolve(filePath),
+                filename: targetAttachment.filename,
+                size: attachmentResponse.data.size,
+                contentType: targetAttachment.contentType,
+                fileUrl: `file://${path.resolve(filePath)}`
+            };
+        }
+        catch (error) {
+            logger.error('Error downloading attachment to local:', error);
+            throw new Error(`Failed to download attachment to local: ${error instanceof Error ? error.message : 'Unknown error'}`);
+        }
+    }
+    /**
+     * Find all attachments in message payload
+     */
+    findAllAttachments(message) {
+        const attachments = [];
+        const findInParts = (parts) => {
+            for (const part of parts) {
+                if (part.body?.attachmentId && part.body.size && part.body.size > 0) {
+                    const filename = this.extractFilename(part) || 'attachment';
+                    const contentType = this.extractContentType(part) || 'application/octet-stream';
+                    attachments.push({
+                        attachmentId: part.body.attachmentId,
+                        filename,
+                        contentType,
+                        size: part.body.size
+                    });
+                }
+                if (part.parts) {
+                    findInParts(part.parts);
+                }
+            }
+        };
+        if (message.payload?.parts) {
+            findInParts(message.payload.parts);
+        }
+        return attachments;
+    }
+    /**
+     * Find attachment part in message payload
+     */
+    findAttachmentPart(message, attachmentId) {
+        const findInParts = (parts) => {
+            for (const part of parts) {
+                if (part.body?.attachmentId === attachmentId) {
+                    return part;
+                }
+                if (part.parts) {
+                    const found = findInParts(part.parts);
+                    if (found)
+                        return found;
+                }
+            }
+            return null;
+        };
+        if (message.payload?.parts) {
+            return findInParts(message.payload.parts);
+        }
+        return null;
+    }
+    /**
+     * Extract filename from message part headers
+     */
+    extractFilename(part) {
+        if (!part?.headers)
+            return 'attachment';
+        const contentDisposition = part.headers.find(h => h.name?.toLowerCase() === 'content-disposition');
+        if (contentDisposition?.value) {
+            const match = contentDisposition.value.match(/filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/);
+            if (match) {
+                return match[1].replace(/['"]/g, '');
+            }
+        }
+        return 'attachment';
+    }
+    /**
+     * Extract content type from message part headers
+     */
+    extractContentType(part) {
+        if (!part?.headers)
+            return 'application/octet-stream';
+        const contentType = part.headers.find(h => h.name?.toLowerCase() === 'content-type');
+        return contentType?.value || 'application/octet-stream';
+    }
+    /**
+     * Check if a string is likely a file path
+     */
+    isFilePath(str) {
+        // Check for common file path patterns
+        // Unix/Linux/Mac paths starting with / or ./
+        // Windows paths with drive letters or UNC paths
+        // Relative paths
+        const filePathPatterns = [
+            /^\/[^\/]/, // Unix absolute path
+            /^\.\//, // Relative path starting with ./
+            /^\.\.\//, // Relative path starting with ../
+            /^~\//, // Home directory path
+            /^[A-Za-z]:[\\\/]/, // Windows drive letter
+            /^\\\\/, // Windows UNC path
+            /^[^\/\\]*\.[a-zA-Z0-9]{1,10}$/, // Simple filename with extension
+            /[\/\\]/ // Contains path separators
+        ];
+        // Also check if it doesn't look like base64
+        const isLikelyBase64 = /^[A-Za-z0-9+\/]+=*$/.test(str) && str.length % 4 === 0;
+        // If it matches file path patterns and doesn't look like base64, it's probably a file path
+        return filePathPatterns.some(pattern => pattern.test(str)) && !isLikelyBase64;
+    }
+    /**
+     * List all attachments in a message
+     */
+    async listAttachments(messageId, overrideClient) {
+        try {
+            const gmail = overrideClient || await this.getGmailClient();
+            logger.log(`Listing attachments for message: ${messageId}`);
+            const messageResponse = await gmail.users.messages.get({
+                userId: 'me',
+                id: messageId,
+                format: 'full'
+            });
+            const attachments = this.findAllAttachments(messageResponse.data);
+            return attachments.map((attachment, index) => ({
+                index,
+                ...attachment
+            }));
+        }
+        catch (error) {
+            logger.error('Error listing attachments:', error);
+            throw new Error(`Failed to list attachments: ${error instanceof Error ? error.message : 'Unknown error'}`);
+        }
+    }
+    /**
+     * Enhanced search emails with natural language processing, fuzzy matching, resilience, and caching
+     */
+    async searchEmails(criteria = {}, overrideClient) {
+        // Check cache first for search results
+        return await this.performanceManager.getCachedSearchResults(criteria, async () => {
+            // If enhanced search is requested or query looks like natural language
+            if (criteria.useEnhancedSearch || this.isNaturalLanguageQuery(criteria.query || '')) {
+                return this.resilienceManager.executeResilientOperation(() => this.performEnhancedSearch(criteria, overrideClient), 'enhanced_search', {
+                    feature: 'enhanced_search',
+                    fallback: () => this.performTraditionalSearch(criteria, overrideClient),
+                    timeout: 20000, // 20 second timeout for enhanced search
+                    customRetryConfig: {
+                        maxAttempts: 2, // Fewer retries for search
+                        baseDelayMs: 1000
+                    }
+                });
+            }
+            // Traditional search with basic resilience
+            return this.resilienceManager.executeResilientOperation(() => this.performTraditionalSearch(criteria, overrideClient), 'traditional_search', {
+                timeout: 10000, // 10 second timeout for basic search
+                customRetryConfig: {
+                    maxAttempts: 3,
+                    baseDelayMs: 1000
+                }
+            });
+        });
+    }
+    /**
+     * Perform enhanced search with natural language processing
+     */
+    async performEnhancedSearch(criteria, overrideClient) {
+        const gmail = overrideClient || await this.getGmailClient();
+        // First, get a broader set of emails to search through
+        const baseQuery = this.buildBaseQuery(criteria);
+        logger.log(`Enhanced search - fetching emails with base query: ${baseQuery}`);
+        const response = await gmail.users.messages.list({
+            userId: 'me',
+            q: baseQuery,
+            maxResults: Math.min(criteria.maxResults || 100, 500) // Get more emails for enhanced search
+        });
+        if (!response.data.messages) {
+            return {
+                messages: [],
+                enhancedResults: {
+                    structuredQuery: { text: criteria.query || '' },
+                    searchResults: [],
+                    crossReferences: []
+                }
+            };
+        }
+        // Get full message details for enhanced processing
+        const allEmails = await Promise.all(response.data.messages.map(msg => this.getEmail(msg.id, 'metadata', overrideClient)));
+        // Perform enhanced search
+        const naturalQuery = criteria.query || '';
+        const enhancedResults = await this.enhancedSearchManager.processNaturalLanguageQuery(naturalQuery, allEmails);
+        // Convert enhanced results back to EmailInfo format
+        const messages = enhancedResults.searchResults.map(result => result.email);
+        // Limit results if specified
+        const limitedMessages = criteria.maxResults ? messages.slice(0, criteria.maxResults) : messages;
+        return {
+            messages: limitedMessages,
+            nextPageToken: response.data.nextPageToken || undefined,
+            enhancedResults: criteria.includeCrossReferences !== false ? enhancedResults : undefined
+        };
+    }
+    /**
+     * Perform traditional Gmail search
+     */
+    async performTraditionalSearch(criteria, overrideClient) {
+        const gmail = overrideClient || await this.getGmailClient();
+        // Build search query
+        const queryParts = [];
+        if (criteria.query)
+            queryParts.push(criteria.query);
+        if (criteria.from)
+            queryParts.push(`from:${criteria.from}`);
+        if (criteria.to)
+            queryParts.push(`to:${criteria.to}`);
+        if (criteria.subject)
+            queryParts.push(`subject:${criteria.subject}`);
+        if (criteria.after)
+            queryParts.push(`after:${criteria.after}`);
+        if (criteria.before)
+            queryParts.push(`before:${criteria.before}`);
+        if (criteria.hasAttachment)
+            queryParts.push('has:attachment');
+        if (criteria.label)
+            queryParts.push(`label:${criteria.label}`);
+        if (criteria.isUnread)
+            queryParts.push('is:unread');
+        const query = queryParts.join(' ');
+        logger.log(`Traditional search with query: ${query}`);
+        const response = await gmail.users.messages.list({
+            userId: 'me',
+            q: query,
+            maxResults: criteria.maxResults || 100
+        });
+        if (!response.data.messages) {
+            return { messages: [] };
+        }
+        // Get full message details
+        const messages = await Promise.all(response.data.messages.map(msg => this.getEmail(msg.id, 'metadata', overrideClient)));
+        return {
+            messages,
+            nextPageToken: response.data.nextPageToken || undefined
+        };
+    }
+    /**
+     * Build base query for enhanced search to get a broader set of emails
+     */
+    buildBaseQuery(criteria) {
+        const queryParts = [];
+        // Include basic filters that are always useful
+        if (criteria.label)
+            queryParts.push(`label:${criteria.label}`);
+        if (criteria.after)
+            queryParts.push(`after:${criteria.after}`);
+        if (criteria.before)
+            queryParts.push(`before:${criteria.before}`);
+        if (criteria.hasAttachment)
+            queryParts.push('has:attachment');
+        if (criteria.isUnread)
+            queryParts.push('is:unread');
+        // Don't include the main query here - let enhanced search handle it
+        return queryParts.join(' ');
+    }
+    /**
+     * Detect if a query looks like natural language
+     */
+    isNaturalLanguageQuery(query) {
+        if (!query)
+            return false;
+        const naturalLanguageIndicators = [
+            // Time references
+            /\b(few weeks ago|last week|last month|yesterday|today|this week|this month)\b/i,
+            // Action words
+            /\b(find|search|locate|get|retrieve|show me|look for)\b/i,
+            // Context words
+            /\b(about|regarding|concerning|related to|similar to)\b/i,
+            // Entity patterns
+            /\bPAN\s+[A-Z]{5}\d{4}[A-Z]\b/i,
+            /\bDIN\s+[A-Z0-9]+\b/i,
+            // Government references
+            /\b(gov\.in|government|ministry|department|tax|income tax)\b/i
+        ];
+        return naturalLanguageIndicators.some(pattern => pattern.test(query));
+    }
+    /**
+     * Mark email as read/unread
+     */
+    async markEmail(messageId, read, overrideClient) {
+        try {
+            const gmail = overrideClient || await this.getGmailClient();
+            logger.log(`Marking email ${messageId} as ${read ? 'read' : 'unread'}`);
+            if (read) {
+                await gmail.users.messages.modify({
+                    userId: 'me',
+                    id: messageId,
+                    requestBody: {
+                        removeLabelIds: ['UNREAD']
+                    }
+                });
+            }
+            else {
+                await gmail.users.messages.modify({
+                    userId: 'me',
+                    id: messageId,
+                    requestBody: {
+                        addLabelIds: ['UNREAD']
+                    }
+                });
+            }
+        }
+        catch (error) {
+            logger.error('Error marking email:', error);
+            throw new Error(`Failed to mark email: ${error instanceof Error ? error.message : 'Unknown error'}`);
+        }
+    }
+    /**
+     * Move email to label/folder
+     */
+    async moveToLabel(messageId, labelId, removeLabelIds, overrideClient) {
+        try {
+            const gmail = overrideClient || await this.getGmailClient();
+            logger.log(`Moving email ${messageId} to label ${labelId}`);
+            await gmail.users.messages.modify({
+                userId: 'me',
+                id: messageId,
+                requestBody: {
+                    addLabelIds: [labelId],
+                    removeLabelIds: removeLabelIds || []
+                }
+            });
+        }
+        catch (error) {
+            logger.error('Error moving email:', error);
+            throw new Error(`Failed to move email: ${error instanceof Error ? error.message : 'Unknown error'}`);
+        }
+    }
+    /**
+     * Delete email
+     */
+    async deleteEmail(messageId, overrideClient) {
+        try {
+            const gmail = overrideClient || await this.getGmailClient();
+            logger.log(`Deleting email: ${messageId}`);
+            await gmail.users.messages.delete({
+                userId: 'me',
+                id: messageId
+            });
+        }
+        catch (error) {
+            logger.error('Error deleting email:', error);
+            throw new Error(`Failed to delete email: ${error instanceof Error ? error.message : 'Unknown error'}`);
+        }
+    }
+    /**
+     * Create a draft email
+     */
+    async createDraft(message, overrideClient) {
+        try {
+            const gmail = overrideClient || await this.getGmailClient();
+            const rawMessage = this.createRawMessage(message);
+            const encodedMessage = this.encodeBase64Url(rawMessage);
+            logger.log(`Creating draft for: ${message.to.join(', ')}`);
+            logger.log(`Subject: ${message.subject}`);
+            const response = await gmail.users.drafts.create({
+                userId: 'me',
+                requestBody: {
+                    message: {
+                        raw: encodedMessage
+                    }
+                }
+            });
+            logger.log(`Draft created successfully: ${response.data.id}`);
+            return {
+                id: response.data.id,
+                message: response.data.message
+            };
+        }
+        catch (error) {
+            logger.error('Error creating draft:', error);
+            throw new Error(`Failed to create draft: ${error instanceof Error ? error.message : 'Unknown error'}`);
+        }
+    }
+    /**
+     * List draft emails
+     */
+    async listDrafts(maxResults = 50, overrideClient) {
+        try {
+            const gmail = overrideClient || await this.getGmailClient();
+            logger.log('Listing draft emails');
+            const response = await gmail.users.drafts.list({
+                userId: 'me',
+                maxResults
+            });
+            if (!response.data.drafts) {
+                return { drafts: [] };
+            }
+            // Get full draft details
+            const drafts = await Promise.all(response.data.drafts.map(async (draft) => {
+                const fullDraft = await this.getDraft(draft.id, overrideClient);
+                return fullDraft;
+            }));
+            return {
+                drafts,
+                nextPageToken: response.data.nextPageToken || undefined
+            };
+        }
+        catch (error) {
+            logger.error('Error listing drafts:', error);
+            throw new Error(`Failed to list drafts: ${error instanceof Error ? error.message : 'Unknown error'}`);
+        }
+    }
+    /**
+     * Get draft by ID
+     */
+    async getDraft(draftId, overrideClient) {
+        try {
+            const gmail = overrideClient || await this.getGmailClient();
+            logger.log(`Retrieving draft: ${draftId}`);
+            const response = await gmail.users.drafts.get({
+                userId: 'me',
+                id: draftId
+            });
+            return {
+                id: response.data.id,
+                message: response.data.message
+            };
+        }
+        catch (error) {
+            logger.error('Error retrieving draft:', error);
+            throw new Error(`Failed to retrieve draft: ${error instanceof Error ? error.message : 'Unknown error'}`);
+        }
+    }
+    /**
+     * Update draft email
+     */
+    async updateDraft(draftId, message, overrideClient) {
+        try {
+            const gmail = overrideClient || await this.getGmailClient();
+            const rawMessage = this.createRawMessage(message);
+            const encodedMessage = this.encodeBase64Url(rawMessage);
+            logger.log(`Updating draft: ${draftId}`);
+            logger.log(`Subject: ${message.subject}`);
+            const response = await gmail.users.drafts.update({
+                userId: 'me',
+                id: draftId,
+                requestBody: {
+                    message: {
+                        raw: encodedMessage
+                    }
+                }
+            });
+            logger.log(`Draft updated successfully: ${response.data.id}`);
+            return {
+                id: response.data.id,
+                message: response.data.message
+            };
+        }
+        catch (error) {
+            logger.error('Error updating draft:', error);
+            throw new Error(`Failed to update draft: ${error instanceof Error ? error.message : 'Unknown error'}`);
+        }
+    }
+    /**
+     * Delete draft email
+     */
+    async deleteDraft(draftId, overrideClient) {
+        try {
+            const gmail = overrideClient || await this.getGmailClient();
+            logger.log(`Deleting draft: ${draftId}`);
+            await gmail.users.drafts.delete({
+                userId: 'me',
+                id: draftId
+            });
+            logger.log(`Draft deleted successfully: ${draftId}`);
+        }
+        catch (error) {
+            logger.error('Error deleting draft:', error);
+            throw new Error(`Failed to delete draft: ${error instanceof Error ? error.message : 'Unknown error'}`);
+        }
+    }
+    /**
+     * Send draft email
+     */
+    async sendDraft(draftId, overrideClient) {
+        try {
+            const gmail = overrideClient || await this.getGmailClient();
+            logger.log(`Sending draft: ${draftId}`);
+            const response = await gmail.users.drafts.send({
+                userId: 'me',
+                requestBody: {
+                    id: draftId
+                }
+            });
+            logger.log(`Draft sent successfully: ${response.data.id}`);
+            return {
+                id: response.data.id,
+                threadId: response.data.threadId
+            };
+        }
+        catch (error) {
+            logger.error('Error sending draft:', error);
+            throw new Error(`Failed to send draft: ${error instanceof Error ? error.message : 'Unknown error'}`);
+        }
+    }
+    /**
+     * List emails in inbox, sent, or custom label
+     */
+    async listEmails(labelId = 'INBOX', maxResults = 50, overrideClient) {
+        try {
+            const gmail = overrideClient || await this.getGmailClient();
+            logger.log(`Listing emails in label: ${labelId}`);
+            const response = await gmail.users.messages.list({
+                userId: 'me',
+                labelIds: [labelId],
+                maxResults
+            });
+            if (!response.data.messages) {
+                return { messages: [] };
+            }
+            // Get message details
+            const messages = await Promise.all(response.data.messages.map(msg => this.getEmail(msg.id, 'metadata', overrideClient)));
+            return {
+                messages,
+                nextPageToken: response.data.nextPageToken || undefined
+            };
+        }
+        catch (error) {
+            logger.error('Error listing emails:', error);
+            throw new Error(`Failed to list emails: ${error instanceof Error ? error.message : 'Unknown error'}`);
+        }
+    }
+    /**
+     * Extract email content from payload
+     */
+    extractEmailContent(payload) {
+        const result = { attachments: [] };
+        const extractParts = (parts) => {
+            for (const part of parts) {
+                if (part.parts) {
+                    extractParts(part.parts);
+                }
+                else if (part.body && part.body.data) {
+                    const mimeType = part.mimeType;
+                    const data = this.decodeBase64Url(part.body.data);
+                    if (mimeType === 'text/plain') {
+                        result.text = data;
+                    }
+                    else if (mimeType === 'text/html') {
+                        result.html = data;
+                    }
+                }
+                // Handle attachments
+                if (part.filename && part.body && (part.body.attachmentId || part.body.data)) {
+                    result.attachments.push({
+                        filename: part.filename,
+                        mimeType: part.mimeType,
+                        size: part.body.size,
+                        attachmentId: part.body.attachmentId
+                    });
+                }
+            }
+        };
+        if (payload.parts) {
+            extractParts(payload.parts);
+        }
+        else if (payload.body && payload.body.data) {
+            const mimeType = payload.mimeType;
+            const data = this.decodeBase64Url(payload.body.data);
+            if (mimeType === 'text/plain') {
+                result.text = data;
+            }
+            else if (mimeType === 'text/html') {
+                result.html = data;
+            }
+        }
+        return result;
+    }
+}
+// Export singleton instance
+export const gmailOperations = new GmailOperations();

--- a/vendor/gmail-mcp-server/dist/utils/multi-user-auth.js
+++ b/vendor/gmail-mcp-server/dist/utils/multi-user-auth.js
@@ -1,0 +1,322 @@
+import { google } from 'googleapis';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { createServer } from 'http';
+import { URL } from 'url';
+import { logger } from './api.js';
+import { createHash, randomBytes } from 'crypto';
+// Scopes required for Gmail operations
+const SCOPES = [
+    'https://www.googleapis.com/auth/gmail.readonly',
+    'https://www.googleapis.com/auth/gmail.send',
+    'https://www.googleapis.com/auth/gmail.modify',
+    'https://www.googleapis.com/auth/gmail.labels'
+];
+// Configuration directory
+const CONFIG_DIR = path.join(os.homedir(), '.gmail-mcp');
+/**
+ * Multi-user Gmail authentication manager
+ */
+export class MultiUserGmailAuth {
+    constructor() {
+        this.sessions = new Map();
+        this.credentials = null;
+        this.authServers = new Map();
+        this.ensureConfigDir();
+        this.loadCredentials();
+        this.loadExistingSessions();
+    }
+    ensureConfigDir() {
+        if (!fs.existsSync(CONFIG_DIR)) {
+            fs.mkdirSync(CONFIG_DIR, { recursive: true });
+        }
+    }
+    /**
+     * Load credentials from environment or file
+     */
+    loadCredentials() {
+        try {
+            // Try environment variables first
+            if (process.env.GMAIL_CLIENT_ID && process.env.GMAIL_CLIENT_SECRET) {
+                this.credentials = {
+                    client_id: process.env.GMAIL_CLIENT_ID,
+                    client_secret: process.env.GMAIL_CLIENT_SECRET,
+                    redirect_uris: [process.env.GMAIL_REDIRECT_URI || 'http://localhost:44000/oauth2callback']
+                };
+                logger.log('Loaded Gmail credentials from environment variables');
+                return;
+            }
+            // Try credentials file
+            const credentialsFile = path.join(CONFIG_DIR, 'credentials.json');
+            if (fs.existsSync(credentialsFile)) {
+                const credentialsData = fs.readFileSync(credentialsFile, 'utf8');
+                const parsedCredentials = JSON.parse(credentialsData);
+                if (parsedCredentials.installed) {
+                    this.credentials = parsedCredentials.installed;
+                }
+                else if (parsedCredentials.web) {
+                    this.credentials = parsedCredentials.web;
+                }
+                else {
+                    this.credentials = parsedCredentials;
+                }
+                logger.log('Loaded Gmail credentials from file');
+            }
+        }
+        catch (error) {
+            logger.error('Error loading Gmail credentials:', error);
+        }
+    }
+    /**
+     * Load existing user sessions
+     */
+    loadExistingSessions() {
+        try {
+            const sessionsFile = path.join(CONFIG_DIR, 'user-sessions.json');
+            if (fs.existsSync(sessionsFile)) {
+                const sessionsData = fs.readFileSync(sessionsFile, 'utf8');
+                const sessions = JSON.parse(sessionsData);
+                for (const [userId, session] of Object.entries(sessions)) {
+                    this.sessions.set(userId, session);
+                }
+                logger.log(`Loaded ${this.sessions.size} existing user sessions`);
+            }
+        }
+        catch (error) {
+            logger.error('Error loading existing sessions:', error);
+        }
+    }
+    /**
+     * Save user sessions to file
+     */
+    saveUserSessions() {
+        try {
+            const sessionsFile = path.join(CONFIG_DIR, 'user-sessions.json');
+            const sessionsObj = Object.fromEntries(this.sessions);
+            fs.writeFileSync(sessionsFile, JSON.stringify(sessionsObj, null, 2));
+            logger.log('Saved user sessions');
+        }
+        catch (error) {
+            logger.error('Error saving user sessions:', error);
+        }
+    }
+    /**
+     * Generate a unique user ID
+     */
+    generateUserId(userEmail) {
+        const timestamp = Date.now().toString();
+        const random = randomBytes(8).toString('hex');
+        if (userEmail) {
+            const emailHash = createHash('sha256').update(userEmail).digest('hex').substring(0, 8);
+            return `user_${emailHash}_${timestamp.substring(-6)}_${random.substring(0, 4)}`;
+        }
+        return `user_${timestamp}_${random}`;
+    }
+    /**
+     * Create OAuth2 client for a user
+     */
+    createOAuth2Client(redirectUri) {
+        if (!this.credentials) {
+            throw new Error('Gmail credentials not configured');
+        }
+        return new google.auth.OAuth2(this.credentials.client_id, this.credentials.client_secret, redirectUri || this.credentials.redirect_uris?.[0] || 'http://localhost:44000/oauth2callback');
+    }
+    /**
+     * Start authentication flow for a new user
+     */
+    async authenticateNewUser(userEmail) {
+        if (!this.credentials) {
+            throw new Error('Gmail credentials not configured. Please set GMAIL_CLIENT_ID and GMAIL_CLIENT_SECRET environment variables.');
+        }
+        const userId = this.generateUserId(userEmail);
+        // Find available port
+        const port = await this.findAvailablePort();
+        const redirectUri = `http://localhost:${port}/oauth2callback`;
+        // Create OAuth2 client with specific redirect URI
+        const auth = this.createOAuth2Client(redirectUri);
+        // Generate authentication URL
+        const authUrl = auth.generateAuthUrl({
+            access_type: 'offline',
+            scope: SCOPES,
+            prompt: 'consent',
+            state: `${userId}:${process.env.USER_ID || 'localhost'}` // Include user ID and USER_ID in state for identification
+        });
+        // Start callback server for this user
+        await this.startCallbackServer(userId, auth, port);
+        logger.log(`Started authentication flow for user ${userId} on port ${port}`);
+        return { userId, authUrl, port };
+    }
+    /**
+     * Find an available port for OAuth callback
+     */
+    async findAvailablePort(startPort = 44000) {
+        return new Promise((resolve) => {
+            const server = createServer();
+            server.listen(startPort, () => {
+                const port = server.address()?.port || startPort;
+                server.close(() => resolve(port));
+            });
+            server.on('error', () => {
+                resolve(this.findAvailablePort(startPort + 1));
+            });
+        });
+    }
+    /**
+     * Start callback server for OAuth2
+     */
+    async startCallbackServer(userId, auth, port) {
+        return new Promise((resolve, reject) => {
+            const server = createServer(async (req, res) => {
+                if (req.url?.startsWith('/oauth2callback')) {
+                    const url = new URL(req.url, `http://localhost:${port}`);
+                    const code = url.searchParams.get('code');
+                    const state = url.searchParams.get('state');
+                    const error = url.searchParams.get('error');
+                    if (error) {
+                        res.end(`<html><body><h1>Authentication Error</h1><p>${error}</p></body></html>`);
+                        server.close();
+                        this.authServers.delete(userId);
+                        reject(new Error(`OAuth2 error: ${error}`));
+                        return;
+                    }
+                    if (code && state && state.startsWith(`${userId}:`)) {
+                        try {
+                            // Exchange code for tokens
+                            const { tokens } = await auth.getToken(code);
+                            // Get user info
+                            auth.setCredentials(tokens);
+                            const gmail = google.gmail({ version: 'v1', auth });
+                            const profile = await gmail.users.getProfile({ userId: 'me' });
+                            // Create user session
+                            const session = {
+                                userId,
+                                userEmail: profile.data.emailAddress || undefined,
+                                accessToken: tokens.access_token,
+                                refreshToken: tokens.refresh_token,
+                                expiryDate: tokens.expiry_date,
+                                authenticated: true
+                            };
+                            this.sessions.set(userId, session);
+                            this.saveUserSessions();
+                            res.end(`<html><body><h1>Authentication Successful!</h1><p>Welcome ${profile.data.emailAddress}!</p><p>You can close this window.</p></body></html>`);
+                            server.close();
+                            this.authServers.delete(userId);
+                            logger.log(`User ${profile.data.emailAddress} authenticated successfully`);
+                            resolve();
+                        }
+                        catch (error) {
+                            res.end(`<html><body><h1>Authentication Error</h1><p>Failed to complete authentication</p></body></html>`);
+                            server.close();
+                            this.authServers.delete(userId);
+                            reject(error);
+                        }
+                        return;
+                    }
+                    res.end('<html><body><h1>Invalid Request</h1></body></html>');
+                }
+                else {
+                    res.end(`<html><body><h1>Gmail MCP Server OAuth2</h1><p>Waiting for authentication for user ${userId}...</p></body></html>`);
+                }
+            });
+            server.listen(port, () => {
+                this.authServers.set(userId, server);
+                logger.log(`OAuth2 callback server started for user ${userId} on port ${port}`);
+                resolve();
+            });
+            server.on('error', (err) => {
+                reject(err);
+            });
+            // Auto-cleanup after 10 minutes
+            setTimeout(() => {
+                if (this.authServers.has(userId)) {
+                    server.close();
+                    this.authServers.delete(userId);
+                    logger.log(`Authentication timeout for user ${userId}`);
+                }
+            }, 600000);
+        });
+    }
+    /**
+     * Get authenticated Gmail client for a user
+     */
+    async getGmailClientForUser(userId) {
+        let session = this.sessions.get(userId);
+        if (!session) {
+            // Allow callers to address a session by its email address
+            // instead of the generated userId, for a friendlier API.
+            session = Array.from(this.sessions.values()).find(s => s.userEmail === userId);
+        }
+        if (!session || !session.authenticated) {
+            throw new Error(`User ${userId} is not authenticated`);
+        }
+        const auth = this.createOAuth2Client();
+        auth.setCredentials({
+            access_token: session.accessToken,
+            refresh_token: session.refreshToken,
+            expiry_date: session.expiryDate
+        });
+        // Check if token needs refresh
+        try {
+            await auth.getAccessToken();
+        }
+        catch (error) {
+            // Token expired, try to refresh
+            if (session.refreshToken) {
+                try {
+                    const refreshResponse = await auth.refreshAccessToken();
+                    const newTokens = refreshResponse.credentials;
+                    if (newTokens.access_token) {
+                        session.accessToken = newTokens.access_token;
+                    }
+                    if (newTokens.expiry_date) {
+                        session.expiryDate = newTokens.expiry_date;
+                    }
+                    this.saveUserSessions();
+                    logger.log(`Refreshed tokens for user ${userId}`);
+                }
+                catch (refreshError) {
+                    logger.error(`Failed to refresh tokens for user ${userId}:`, refreshError);
+                    throw new Error(`Authentication expired for user ${userId}. Please re-authenticate.`);
+                }
+            }
+            else {
+                throw new Error(`Authentication expired for user ${userId}. Please re-authenticate.`);
+            }
+        }
+        return google.gmail({ version: 'v1', auth });
+    }
+    /**
+     * Get user session info
+     */
+    getUserSession(userId) {
+        return this.sessions.get(userId) || null;
+    }
+    /**
+     * List all authenticated users
+     */
+    getAuthenticatedUsers() {
+        return Array.from(this.sessions.values()).filter(session => session.authenticated);
+    }
+    /**
+     * Remove user session
+     */
+    removeUser(userId) {
+        const removed = this.sessions.delete(userId);
+        if (removed) {
+            this.saveUserSessions();
+            logger.log(`Removed user session: ${userId}`);
+        }
+        return removed;
+    }
+    /**
+     * Clear all user sessions
+     */
+    clearAllSessions() {
+        this.sessions.clear();
+        this.saveUserSessions();
+        logger.log('Cleared all user sessions');
+    }
+}
+// Export singleton instance
+export const multiUserAuth = new MultiUserGmailAuth();

--- a/vendor/gmail-mcp-server/dist/utils/performance-optimization.js
+++ b/vendor/gmail-mcp-server/dist/utils/performance-optimization.js
@@ -1,0 +1,555 @@
+/**
+ * Performance Optimization Module
+ * Implements caching, batch operations, connection pooling, and memory management
+ */
+import { logger } from './api.js';
+/**
+ * High-Performance Email Cache System
+ * LRU cache with compression and persistence options
+ */
+export class EmailCacheManager {
+    constructor(config = {}) {
+        this.cache = new Map();
+        this.accessOrder = new Set();
+        this.currentSize = 0;
+        this.hits = 0;
+        this.misses = 0;
+        this.config = {
+            maxSize: 1000,
+            ttlMs: 3600000, // 1 hour
+            enablePersistence: false,
+            compressionLevel: 1,
+            ...config
+        };
+        // Schedule periodic cleanup
+        setInterval(() => this.cleanup(), 300000); // 5 minutes
+    }
+    async get(key) {
+        const entry = this.cache.get(key);
+        if (!entry) {
+            this.misses++;
+            return null;
+        }
+        // Check TTL
+        if (Date.now() - entry.timestamp > this.config.ttlMs) {
+            this.delete(key);
+            this.misses++;
+            return null;
+        }
+        // Update access tracking
+        entry.lastAccessed = Date.now();
+        entry.accessCount++;
+        this.updateAccessOrder(key);
+        this.hits++;
+        // Decompress if needed
+        if (entry.compressed) {
+            return this.decompress(entry.data);
+        }
+        return entry.data;
+    }
+    async set(key, data, options = {}) {
+        const { compress = false, priority = 'normal' } = options;
+        // Calculate size
+        const size = this.calculateSize(data);
+        // Check if we need to evict entries
+        while (this.currentSize + size > this.config.maxSize && this.cache.size > 0) {
+            await this.evictLRU();
+        }
+        // Compress if enabled
+        let finalData = data;
+        let isCompressed = false;
+        if (compress && this.config.compressionLevel > 0) {
+            try {
+                finalData = await this.compress(data);
+                isCompressed = true;
+            }
+            catch (error) {
+                logger.error('Compression failed, storing uncompressed:', error);
+            }
+        }
+        const entry = {
+            data: finalData,
+            timestamp: Date.now(),
+            accessCount: 1,
+            lastAccessed: Date.now(),
+            size,
+            compressed: isCompressed
+        };
+        this.cache.set(key, entry);
+        this.updateAccessOrder(key);
+        this.currentSize += size;
+        // Handle priority
+        if (priority === 'high') {
+            // Move to front of access order
+            this.accessOrder.delete(key);
+            this.accessOrder.add(key);
+        }
+    }
+    delete(key) {
+        const entry = this.cache.get(key);
+        if (entry) {
+            this.currentSize -= entry.size;
+            this.cache.delete(key);
+            this.accessOrder.delete(key);
+            return true;
+        }
+        return false;
+    }
+    clear() {
+        this.cache.clear();
+        this.accessOrder.clear();
+        this.currentSize = 0;
+        this.hits = 0;
+        this.misses = 0;
+    }
+    getStats() {
+        const total = this.hits + this.misses;
+        return {
+            hitRate: total > 0 ? this.hits / total : 0,
+            size: this.cache.size,
+            memoryUsage: this.currentSize
+        };
+    }
+    // Generate cache keys for different email operations
+    static emailKey(messageId) {
+        return `email:${messageId}`;
+    }
+    static searchKey(criteria) {
+        return `search:${JSON.stringify(criteria)}`;
+    }
+    static threadKey(threadId) {
+        return `thread:${threadId}`;
+    }
+    static attachmentKey(messageId, attachmentId) {
+        return `attachment:${messageId}:${attachmentId}`;
+    }
+    updateAccessOrder(key) {
+        this.accessOrder.delete(key);
+        this.accessOrder.add(key);
+    }
+    async evictLRU() {
+        const lruKey = this.accessOrder.values().next().value;
+        if (lruKey) {
+            this.delete(lruKey);
+        }
+    }
+    calculateSize(data) {
+        return JSON.stringify(data).length;
+    }
+    async compress(data) {
+        // Simple compression simulation - in real implementation, use zlib or similar
+        return JSON.stringify(data);
+    }
+    async decompress(data) {
+        // Simple decompression simulation
+        return typeof data === 'string' ? JSON.parse(data) : data;
+    }
+    cleanup() {
+        const now = Date.now();
+        const keysToDelete = [];
+        for (const [key, entry] of this.cache.entries()) {
+            if (now - entry.timestamp > this.config.ttlMs) {
+                keysToDelete.push(key);
+            }
+        }
+        keysToDelete.forEach(key => this.delete(key));
+        logger.log(`Cache cleanup: removed ${keysToDelete.length} expired entries`);
+    }
+}
+/**
+ * Batch Operation Manager
+ * Efficiently handles bulk email operations
+ */
+export class BatchOperationManager {
+    constructor(config = {}) {
+        this.pendingOperations = new Map();
+        this.batchTimers = new Map();
+        this.activeBatches = 0;
+        this.metrics = {
+            totalOperations: 0,
+            batchedOperations: 0,
+            successfulBatches: 0,
+            failedBatches: 0
+        };
+        this.config = {
+            maxBatchSize: 100,
+            batchTimeoutMs: 5000,
+            concurrentBatches: 3,
+            retryAttempts: 2,
+            ...config
+        };
+    }
+    async addToBatch(operationType, operation, executor) {
+        return new Promise((resolve, reject) => {
+            // Add operation to pending batch
+            if (!this.pendingOperations.has(operationType)) {
+                this.pendingOperations.set(operationType, []);
+            }
+            const batch = this.pendingOperations.get(operationType);
+            batch.push({ operation, resolve, reject });
+            // Check if batch is full
+            if (batch.length >= this.config.maxBatchSize) {
+                this.executeBatch(operationType, executor);
+            }
+            else {
+                // Set timer for batch execution
+                this.setBatchTimer(operationType, executor);
+            }
+            this.metrics.totalOperations++;
+        });
+    }
+    setBatchTimer(operationType, executor) {
+        // Clear existing timer
+        if (this.batchTimers.has(operationType)) {
+            clearTimeout(this.batchTimers.get(operationType));
+        }
+        // Set new timer
+        const timer = setTimeout(() => {
+            this.executeBatch(operationType, executor);
+        }, this.config.batchTimeoutMs);
+        this.batchTimers.set(operationType, timer);
+    }
+    async executeBatch(operationType, executor) {
+        const batch = this.pendingOperations.get(operationType);
+        if (!batch || batch.length === 0)
+            return;
+        // Check concurrent batch limit
+        if (this.activeBatches >= this.config.concurrentBatches) {
+            // Delay execution
+            setTimeout(() => this.executeBatch(operationType, executor), 1000);
+            return;
+        }
+        // Clear timer and pending operations
+        if (this.batchTimers.has(operationType)) {
+            clearTimeout(this.batchTimers.get(operationType));
+            this.batchTimers.delete(operationType);
+        }
+        this.pendingOperations.set(operationType, []);
+        this.activeBatches++;
+        this.metrics.batchedOperations += batch.length;
+        try {
+            logger.log(`Executing batch of ${batch.length} ${operationType} operations`);
+            // Extract operations
+            const operations = batch.map(item => item.operation);
+            // Execute batch
+            const results = await executor(operations);
+            // Resolve individual promises
+            batch.forEach((item, index) => {
+                item.resolve(results[index]);
+            });
+            this.metrics.successfulBatches++;
+            logger.log(`Batch execution successful for ${operationType}`);
+        }
+        catch (error) {
+            logger.error(`Batch execution failed for ${operationType}:`, error);
+            // Reject all promises in batch
+            batch.forEach(item => {
+                item.reject(error);
+            });
+            this.metrics.failedBatches++;
+        }
+        finally {
+            this.activeBatches--;
+        }
+    }
+    getBatchStats() {
+        const totalBatches = this.metrics.successfulBatches + this.metrics.failedBatches;
+        return {
+            totalOperations: this.metrics.totalOperations,
+            batchedOperations: this.metrics.batchedOperations,
+            batchEfficiency: this.metrics.totalOperations > 0 ? this.metrics.batchedOperations / this.metrics.totalOperations : 0,
+            successRate: totalBatches > 0 ? this.metrics.successfulBatches / totalBatches : 0
+        };
+    }
+    async shutdown() {
+        // Execute all pending batches
+        for (const [operationType, timer] of this.batchTimers.entries()) {
+            clearTimeout(timer);
+            // Note: executor not available here, so we'll just clear
+        }
+        this.pendingOperations.clear();
+        this.batchTimers.clear();
+    }
+}
+/**
+ * Connection Pool Manager
+ * Manages Gmail API connection pooling and optimization
+ */
+export class ConnectionPoolManager {
+    constructor(config = {}) {
+        this.activeConnections = new Set();
+        this.idleConnections = new Map();
+        this.connectionPromises = new Map();
+        this.metrics = {
+            connectionsCreated: 0,
+            connectionsReused: 0,
+            connectionTimeouts: 0,
+            avgConnectionTime: 0
+        };
+        this.config = {
+            maxConnections: 10,
+            idleTimeoutMs: 300000, // 5 minutes
+            connectionTimeoutMs: 10000,
+            keepAliveMs: 60000,
+            ...config
+        };
+        // Schedule connection cleanup
+        setInterval(() => this.cleanupIdleConnections(), 60000); // 1 minute
+    }
+    async getConnection(connectionId = 'default') {
+        // Check for existing connection promise
+        if (this.connectionPromises.has(connectionId)) {
+            return this.connectionPromises.get(connectionId);
+        }
+        // Check for idle connection
+        const idleConnection = this.idleConnections.get(connectionId);
+        if (idleConnection) {
+            this.idleConnections.delete(connectionId);
+            this.activeConnections.add(connectionId);
+            this.metrics.connectionsReused++;
+            logger.log(`Reusing connection: ${connectionId}`);
+            return idleConnection.connection;
+        }
+        // Check connection limit
+        if (this.activeConnections.size >= this.config.maxConnections) {
+            // Wait for connection to become available
+            await this.waitForAvailableConnection();
+        }
+        // Create new connection
+        const connectionPromise = this.createConnection(connectionId);
+        this.connectionPromises.set(connectionId, connectionPromise);
+        try {
+            const connection = await connectionPromise;
+            this.activeConnections.add(connectionId);
+            this.metrics.connectionsCreated++;
+            logger.log(`Created new connection: ${connectionId}`);
+            return connection;
+        }
+        finally {
+            this.connectionPromises.delete(connectionId);
+        }
+    }
+    releaseConnection(connectionId = 'default', connection) {
+        this.activeConnections.delete(connectionId);
+        // Add to idle connections
+        this.idleConnections.set(connectionId, {
+            timestamp: Date.now(),
+            connection
+        });
+        logger.log(`Released connection to idle pool: ${connectionId}`);
+    }
+    closeConnection(connectionId = 'default') {
+        this.activeConnections.delete(connectionId);
+        this.idleConnections.delete(connectionId);
+        this.connectionPromises.delete(connectionId);
+        logger.log(`Closed connection: ${connectionId}`);
+    }
+    async createConnection(connectionId) {
+        const startTime = Date.now();
+        return new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => {
+                this.metrics.connectionTimeouts++;
+                reject(new Error(`Connection timeout for ${connectionId}`));
+            }, this.config.connectionTimeoutMs);
+            // Simulate connection creation (replace with actual Gmail client creation)
+            setTimeout(() => {
+                clearTimeout(timeout);
+                const connectionTime = Date.now() - startTime;
+                this.updateAvgConnectionTime(connectionTime);
+                // Mock connection object
+                const connection = {
+                    id: connectionId,
+                    created: Date.now(),
+                    keepAlive: setInterval(() => {
+                        logger.log(`Keep-alive ping for connection: ${connectionId}`);
+                    }, this.config.keepAliveMs)
+                };
+                resolve(connection);
+            }, 100); // Simulate 100ms connection time
+        });
+    }
+    async waitForAvailableConnection() {
+        return new Promise((resolve) => {
+            const checkInterval = setInterval(() => {
+                if (this.activeConnections.size < this.config.maxConnections || this.idleConnections.size > 0) {
+                    clearInterval(checkInterval);
+                    resolve();
+                }
+            }, 100);
+        });
+    }
+    cleanupIdleConnections() {
+        const now = Date.now();
+        const expiredConnections = [];
+        for (const [connectionId, { timestamp, connection }] of this.idleConnections.entries()) {
+            if (now - timestamp > this.config.idleTimeoutMs) {
+                expiredConnections.push(connectionId);
+                // Clean up keep-alive if exists
+                if (connection.keepAlive) {
+                    clearInterval(connection.keepAlive);
+                }
+            }
+        }
+        expiredConnections.forEach(id => {
+            this.idleConnections.delete(id);
+            logger.log(`Cleaned up expired idle connection: ${id}`);
+        });
+    }
+    updateAvgConnectionTime(connectionTime) {
+        const currentAvg = this.metrics.avgConnectionTime;
+        const count = this.metrics.connectionsCreated;
+        this.metrics.avgConnectionTime = (currentAvg * (count - 1) + connectionTime) / count;
+    }
+    getConnectionStats() {
+        const total = this.metrics.connectionsCreated + this.metrics.connectionsReused;
+        return {
+            activeConnections: this.activeConnections.size,
+            idleConnections: this.idleConnections.size,
+            connectionsCreated: this.metrics.connectionsCreated,
+            connectionsReused: this.metrics.connectionsReused,
+            reuseRate: total > 0 ? this.metrics.connectionsReused / total : 0,
+            avgConnectionTime: this.metrics.avgConnectionTime
+        };
+    }
+    async shutdown() {
+        // Close all connections
+        for (const connectionId of this.activeConnections) {
+            this.closeConnection(connectionId);
+        }
+        for (const [connectionId] of this.idleConnections) {
+            this.closeConnection(connectionId);
+        }
+    }
+}
+/**
+ * Memory Management and Streaming
+ * Handles large result sets efficiently
+ */
+export class MemoryManager {
+    constructor() {
+        this.memoryThreshold = 100 * 1024 * 1024; // 100MB
+        this.streamingThreshold = 1000; // Stream results larger than 1000 items
+        this.currentMemoryUsage = 0;
+    }
+    async processLargeResultSet(data, processor, chunkSize = 100) {
+        logger.log(`Processing large result set of ${data.length} items`);
+        for (let i = 0; i < data.length; i += chunkSize) {
+            const chunk = data.slice(i, i + chunkSize);
+            await processor(chunk);
+            // Check memory usage
+            if (this.shouldTriggerGC()) {
+                this.triggerGarbageCollection();
+            }
+            // Yield control to event loop
+            await new Promise(resolve => setImmediate(resolve));
+        }
+    }
+    createAsyncIterator(data, chunkSize = 100) {
+        const chunks = Math.ceil(data.length / chunkSize);
+        let currentChunk = 0;
+        return {
+            async next() {
+                if (currentChunk >= chunks) {
+                    return { done: true, value: undefined };
+                }
+                const start = currentChunk * chunkSize;
+                const end = Math.min(start + chunkSize, data.length);
+                const chunk = data.slice(start, end);
+                currentChunk++;
+                return { done: false, value: chunk };
+            },
+            [Symbol.asyncIterator]() {
+                return this;
+            }
+        };
+    }
+    shouldTriggerGC() {
+        const memUsage = process.memoryUsage();
+        this.currentMemoryUsage = memUsage.heapUsed;
+        return memUsage.heapUsed > this.memoryThreshold;
+    }
+    triggerGarbageCollection() {
+        if (global.gc) {
+            global.gc();
+            logger.log('Triggered garbage collection');
+        }
+    }
+    getMemoryStats() {
+        const memUsage = process.memoryUsage();
+        return {
+            heapUsed: memUsage.heapUsed,
+            heapTotal: memUsage.heapTotal,
+            external: memUsage.external
+        };
+    }
+}
+/**
+ * Performance Optimization Manager
+ * Orchestrates all performance features
+ */
+export class PerformanceOptimizationManager {
+    constructor(cacheConfig, batchConfig, connectionConfig) {
+        this.cache = new EmailCacheManager(cacheConfig);
+        this.batchManager = new BatchOperationManager(batchConfig);
+        this.connectionPool = new ConnectionPoolManager(connectionConfig);
+        this.memoryManager = new MemoryManager();
+        this.startTime = Date.now();
+    }
+    // Cached email operations
+    async getCachedEmail(messageId, fetcher) {
+        const cacheKey = EmailCacheManager.emailKey(messageId);
+        let email = await this.cache.get(cacheKey);
+        if (!email) {
+            email = await fetcher();
+            await this.cache.set(cacheKey, email, { compress: true, priority: 'normal' });
+        }
+        return email;
+    }
+    async getCachedSearchResults(criteria, searcher) {
+        const cacheKey = EmailCacheManager.searchKey(criteria);
+        let results = await this.cache.get(cacheKey);
+        if (!results) {
+            results = await searcher();
+            await this.cache.set(cacheKey, results, { compress: true, priority: 'high' });
+        }
+        return results;
+    }
+    // Batch operations
+    async batchEmailOperation(operationType, operation, executor) {
+        return this.batchManager.addToBatch(operationType, operation, executor);
+    }
+    // Connection management
+    async getOptimizedConnection(connectionId) {
+        return this.connectionPool.getConnection(connectionId);
+    }
+    releaseOptimizedConnection(connectionId = 'default', connection) {
+        this.connectionPool.releaseConnection(connectionId, connection);
+    }
+    // Memory management
+    async processLargeEmailSet(emails, processor, chunkSize) {
+        return this.memoryManager.processLargeResultSet(emails, processor, chunkSize);
+    }
+    createEmailIterator(emails, chunkSize) {
+        return this.memoryManager.createAsyncIterator(emails, chunkSize);
+    }
+    // Performance metrics
+    getPerformanceMetrics() {
+        const cacheStats = this.cache.getStats();
+        const batchStats = this.batchManager.getBatchStats();
+        const connectionStats = this.connectionPool.getConnectionStats();
+        const memoryStats = this.memoryManager.getMemoryStats();
+        return {
+            cacheHitRate: cacheStats.hitRate,
+            avgResponseTime: 0, // Would be calculated from actual operation timings
+            memoryUsage: memoryStats.heapUsed,
+            activeConnections: connectionStats.activeConnections,
+            batchSuccessRate: batchStats.successRate,
+            apiCallsReduced: Math.round(cacheStats.hitRate * 100) // Simplified metric
+        };
+    }
+    async shutdown() {
+        await this.batchManager.shutdown();
+        await this.connectionPool.shutdown();
+        this.cache.clear();
+    }
+}

--- a/vendor/gmail-mcp-server/dist/utils/threading-intelligence.js
+++ b/vendor/gmail-mcp-server/dist/utils/threading-intelligence.js
@@ -1,0 +1,202 @@
+/**
+ * Threading & Intelligence Utilities for Gmail MCP
+ * - Thread reconstruction (including forwards/replies)
+ * - Conversation context extraction
+ * - Email classification & urgency detection
+ * - Proactive alert/reminder suggestion
+ */
+export class ThreadReconstructor {
+    /**
+     * Reconstructs a conversation thread given an email and all emails
+     */
+    reconstructConversation(emailId, allEmails) {
+        // Find the target email
+        const target = allEmails.find(e => e.id === emailId);
+        if (!target)
+            return [];
+        // Strategy 1: Use threadId
+        const threadEmails = allEmails.filter(e => e.threadId === target.threadId);
+        // Strategy 2: Subject line analysis (Re:, Fwd:)
+        const baseSubject = this.normalizeSubject(target.subject);
+        const subjectRelated = allEmails.filter(e => this.normalizeSubject(e.subject) === baseSubject);
+        // Strategy 3: Content analysis for forwarded emails
+        const forwarded = allEmails.filter(e => this.containsForwardedContent(e.snippet || ''));
+        // Merge and deduplicate
+        const allRelated = [...threadEmails, ...subjectRelated, ...forwarded];
+        const unique = Object.values(allRelated.reduce((acc, e) => { acc[e.id] = e; return acc; }, {}));
+        // Sort chronologically
+        return unique.sort((a, b) => (new Date(a.internalDate).getTime() - new Date(b.internalDate).getTime()));
+    }
+    normalizeSubject(subject) {
+        return subject.replace(/^(re:|fwd:|fw:)/i, '').trim().toLowerCase();
+    }
+    containsForwardedContent(content) {
+        const patterns = [
+            /Begin forwarded message:/i,
+            /---------- Forwarded message ---------/i,
+            /From:.*?Date:.*?Subject:/is
+        ];
+        return patterns.some(p => p.test(content));
+    }
+}
+export class ConversationManager {
+    /**
+     * Extracts context for a conversation thread
+     */
+    async preserveContext(emails) {
+        const sorted = emails.sort((a, b) => (new Date(a.internalDate).getTime() - new Date(b.internalDate).getTime()));
+        const participants = Array.from(new Set(sorted.flatMap(e => this.extractParticipants(e))));
+        const timeline = sorted.map(e => ({ id: e.id, date: new Date(e.internalDate), subject: e.subject }));
+        const topics = this.extractTopics(sorted);
+        const references = this.extractReferences(sorted);
+        const metadata = {
+            totalMessages: sorted.length,
+            duration: this.calculateDuration(sorted),
+            lastActivity: new Date(sorted[sorted.length - 1].internalDate)
+        };
+        return {
+            threadId: sorted[0].threadId,
+            participants,
+            timeline,
+            topics,
+            references,
+            metadata
+        };
+    }
+    extractParticipants(email) {
+        const headers = email.payload?.headers || [];
+        const from = headers.find((h) => h.name === 'From')?.value;
+        const to = headers.find((h) => h.name === 'To')?.value;
+        const cc = headers.find((h) => h.name === 'Cc')?.value;
+        return [from, ...(to ? to.split(',') : []), ...(cc ? cc.split(',') : [])].filter(Boolean).map(s => s.trim());
+    }
+    extractTopics(emails) {
+        // Simple keyword extraction from subjects
+        const allSubjects = emails.map(e => e.subject).join(' ');
+        const keywords = allSubjects.match(/\b\w{5,}\b/g) || [];
+        return Array.from(new Set(keywords.map(w => w.toLowerCase()))).slice(0, 10);
+    }
+    extractReferences(emails) {
+        // Find URLs, document names, and attachment names
+        const urls = [];
+        const docs = [];
+        const attachments = [];
+        for (const e of emails) {
+            const content = e.snippet || '';
+            const urlMatches = content.match(/https?:\/\/\S+/g) || [];
+            urls.push(...urlMatches);
+            // Simulate document/attachment extraction
+            if (content.match(/pdf|docx|xls|statement|notice|assessment/i)) {
+                docs.push(e.subject);
+            }
+            if (e.payload?.parts) {
+                for (const part of e.payload.parts) {
+                    if (part.filename)
+                        attachments.push(part.filename);
+                }
+            }
+        }
+        return {
+            documents: Array.from(new Set(docs)),
+            urls: Array.from(new Set(urls)),
+            attachments: Array.from(new Set(attachments))
+        };
+    }
+    calculateDuration(emails) {
+        if (emails.length < 2)
+            return '0 days';
+        const start = new Date(emails[0].internalDate).getTime();
+        const end = new Date(emails[emails.length - 1].internalDate).getTime();
+        const days = Math.round((end - start) / (1000 * 60 * 60 * 24));
+        return `${days} days`;
+    }
+}
+export class EmailIntelligence {
+    constructor() {
+        this.governmentDomains = [
+            'insight.gov.in', 'incometax.gov.in', 'cbdt.gov.in',
+            'gst.gov.in', 'rbi.org.in'
+        ];
+        this.urgencyKeywords = [
+            'final opportunity', 'last chance', 'immediate action',
+            'deadline', 'penalty', 'legal action', 'compliance'
+        ];
+        this.legalKeywords = [
+            'notice', 'assessment', 'compliance', 'section', 'act'
+        ];
+    }
+    classifyEmail(email) {
+        let score = 0;
+        let category = 'GENERAL';
+        let reason = '';
+        const from = email.payload?.headers?.find((h) => h.name === 'From')?.value || '';
+        const content = `${email.subject} ${email.snippet}`.toLowerCase();
+        // Government sender
+        if (this.governmentDomains.some(domain => from.includes(domain))) {
+            score += 50;
+            category = 'GOVERNMENT';
+            reason += 'Government sender. ';
+        }
+        // Urgency
+        const urgencyMatches = this.urgencyKeywords.filter(kw => content.includes(kw));
+        score += urgencyMatches.length * 20;
+        if (urgencyMatches.length)
+            reason += `Urgency: ${urgencyMatches.join(', ')}. `;
+        // Legal/tax
+        const legalMatches = this.legalKeywords.filter(kw => content.includes(kw));
+        score += legalMatches.length * 10;
+        if (legalMatches.length)
+            reason += `Legal: ${legalMatches.join(', ')}. `;
+        // Set importance
+        let importance = 'LOW';
+        let actionRequired = false;
+        if (score >= 70) {
+            importance = 'CRITICAL';
+            actionRequired = true;
+        }
+        else if (score >= 40) {
+            importance = 'HIGH';
+        }
+        // Extract deadline (simple pattern)
+        const deadlineMatch = content.match(/by (\d{1,2} [a-zA-Z]+ \d{4})/);
+        let deadline = null;
+        if (deadlineMatch) {
+            deadline = new Date(deadlineMatch[1]);
+            reason += `Deadline detected: ${deadlineMatch[1]}. `;
+        }
+        // Related docs
+        const relatedDocs = content.match(/PAN [A-Z]{5}\d{4}[A-Z]/g) || [];
+        return {
+            importance,
+            category,
+            actionRequired,
+            deadline,
+            relatedDocuments: relatedDocs,
+            detectedEntities: relatedDocs,
+            reason: reason.trim()
+        };
+    }
+}
+export class ProactiveReminderSystem {
+    /**
+     * Suggests reminders for important emails (e.g., deadlines)
+     */
+    createSmartReminders(email, classification) {
+        const reminders = [];
+        if (classification.category === 'GOVERNMENT' && classification.deadline) {
+            // 7 days before
+            reminders.push({
+                reminderDate: new Date(classification.deadline.getTime() - 7 * 24 * 60 * 60 * 1000),
+                type: 'DEADLINE',
+                context: { originalDeadline: classification.deadline }
+            });
+            // 1 day before
+            reminders.push({
+                reminderDate: new Date(classification.deadline.getTime() - 24 * 60 * 60 * 1000),
+                type: 'DEADLINE',
+                context: { originalDeadline: classification.deadline }
+            });
+        }
+        return reminders;
+    }
+}

--- a/vendor/gmail-mcp-server/install.js
+++ b/vendor/gmail-mcp-server/install.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+console.log('Setting up Gmail MCP Server...');
+
+// Make CLI executable
+const binPath = path.join(__dirname, 'bin', 'cli.js');
+if (fs.existsSync(binPath)) {
+  try {
+    fs.chmodSync(binPath, '755');
+    console.log('✓ Made CLI executable');
+  } catch (error) {
+    console.warn('Warning: Could not make CLI executable:', error.message);
+  }
+} else {
+  console.warn('Warning: CLI file not found at', binPath);
+}
+
+// Display setup message
+console.log(`
+✓ Gmail MCP Server installed successfully!
+
+Quick Start:
+1. Get OAuth2 credentials from Google Cloud Console
+2. Start server: npx gmail-mcp-server@latest --client-id "your-id" --client-secret "your-secret"
+3. Use authentication tools when needed
+
+🔐 On-Demand Authentication - Server starts immediately!
+
+For help: npx gmail-mcp-server@latest --help
+Documentation: Check README.md for complete setup guide
+`); 

--- a/vendor/gmail-mcp-server/package.json
+++ b/vendor/gmail-mcp-server/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "gmail-mcp-server",
+  "version": "1.0.30",
+  "description": "Gmail MCP Server with on-demand authentication for SIYA/Claude Desktop. Complete Gmail integration with multi-user support and OAuth2 security.",
+  "main": "dist/index.js",
+  "type": "module",
+  "bin": {
+    "gmail-mcp-server": "bin/cli.js"
+  },
+  "scripts": {
+    "test": "npx @modelcontextprotocol/inspector node dist/index.js",
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "tsx src/index.ts",
+    "postinstall": "node install.js",
+    "prepare": "chmod +x bin/cli.js && npm run build",
+    "install-global": "npm install -g .",
+    "postpublish": "echo 'Package published! Note: Users can test with: npx gmail-mcp-server --help'",
+    "test-npx": "cd /tmp && npx -y gmail-mcp-server@latest --help",
+    "version-bump": "node scripts/version-bump.js"
+  },
+  "keywords": [
+    "mcp",
+    "gmail",
+    "email",
+    "google",
+    "api",
+    "oauth2",
+    "claude",
+    "claude-desktop",
+    "siya",
+    "siya-desktop",
+    "on-demand",
+    "authentication",
+    "multi-user",
+    "model-context-protocol"
+  ],
+  "license": "MIT",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.18.1",
+    "googleapis": "^140.0.1",
+    "mime-types": "^3.0.1",
+    "open": "^10.2.0",
+    "typescript": "^5.7.2"
+  },
+  "devDependencies": {
+    "@types/mime-types": "^2.1.4",
+    "@types/node": "^20.2.3",
+    "ts-node": "^10.9.1",
+    "tsx": "^4.19.4"
+  },
+  "files": [
+    "bin/",
+    "dist/",
+    "README.md",
+    "install.js"
+  ],
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}


### PR DESCRIPTION
Supersedes #1050 -- that branch is 113 commits behind current develop and its
underlying fix has been superseded by a more complete local one.

## Summary

The published npm package (`gmail-mcp-server@1.0.30`) advertises a `userId`
parameter in `--multi-user` mode but never actually uses it: every tool
handler always calls the single legacy `gmailOperations` singleton, so every
authenticated account silently reads/sends through whichever account was
authenticated first via `gmail_authenticate`.

- Threads an `overrideClient` param through all ~18 `GmailOperations` methods
  and the 9 affected tool handlers in `dist/index.js`, resolved from `userId`
  (now also matchable by email address, not just the generated hash id).
  Missing `userId` now falls back to the default account instead of
  throwing, so existing callers unaware of multi-user mode keep working.
- Makes `gmail-auth.js`'s token/credentials directory overridable via
  `GMAIL_CONFIG_DIR`, fixing a follow-on bug where the `gmail-private` MCP
  server (single-user mode) read the same `~/.gmail-mcp/token.json` as the
  `gmail` server and kept hitting an expired token belonging to the other
  account.
- `mcp-catalog.json` now points the gmail server entry at the vendored build
  instead of `npx`, with `.gitignore` and `ATTRIBUTIONS.md` updated
  accordingly.

See `vendor/gmail-mcp-server/MARVEEN_PATCH.md` for the full patch rationale.

## Test plan

- [x] `scripts/secret-gate.ts --staged` passed on commit
- [x] Live-verified in the running fleet: `gmail` (multi-user, info@webkit.hu)
      and `gmail-private` (personal account) MCP servers both authenticate
      and operate independently against their own tokens post-patch.