### PR TITLE
fix(start,stop): idempotent Linux launch and a stop that waits for exit

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -30,6 +30,9 @@ source "${INSTALL_DIR}/install-lang.sh"
 # blocks every UserPromptSubmit, creating a silent fleet lockout (2026-07-14 incident).
 INSTALL_DIR="$INSTALL_DIR" python3 "${INSTALL_DIR}/scripts/boot-hook-prune.py" 2>&1 | grep -v '^$' | sed 's/^/[boot-hook-prune] /' || true
 
+# Timestamp every run: this script appends to store/boot.log across reboots,
+# and without a date the log cannot tell "started once" from "started twice".
+echo "=== $(date '+%Y-%m-%d %H:%M:%S %Z') ==="
 echo "${BOT_NAME:-Marveen} $(_t start.starting)"
 OS="$(uname -s)"
 LAUNCHD_FAILED=""
@@ -75,11 +78,85 @@ elif [ "$OS" = "Linux" ]; then
       echo "ERROR: no real node found on PATH (bun cannot run better-sqlite3)." >&2
       exit 1
     fi
+    # Idempotent launch. On WSL two independent autostart hooks can reach this
+    # script on the same boot -- the wsl.conf [boot] command and a Windows
+    # ONLOGON task -- and a plain relaunch would put a second dashboard on the
+    # same port and, far worse, a second channels.sh polling the same bot token,
+    # which splits incoming messages between two pollers with no error anywhere.
+    # flock serializes the two hooks; the pidfile checks below make the loser a
+    # no-op. fd 9 is closed in the children so the lock is released when this
+    # script exits, not when the daemons do.
+    #
+    # The critical section is "ensure built, THEN ensure running". `npm run build`
+    # writes into the shared dist/, so two hooks arriving on the same boot would
+    # otherwise run two concurrent compilers over the same output and the loser
+    # could launch from a half-written dist/index.js. A full build of this project
+    # measures ~10s here, well inside the wait below.
+    #
+    # The lock is taken on store/ ITSELF, so it introduces no file of its own.
+    # It is deliberately NOT taken on a pidfile: stop.sh unlinks those, and flock
+    # binds to the inode, not the name -- so a lock held on an unlinked pidfile
+    # silently stops being a mutex. Measured 2026-09-02: with the pidfile removed
+    # mid-flight the waiting hook's `exec 9>` created a FRESH inode, flock
+    # returned at once, and both hooks entered the critical section together.
+    # This is also not the mkdir-style "lock directory" idiom, which really does
+    # leave an orphaned lock behind after kill -9; here the directory is only an
+    # fd and carries no state, and the kernel drops the flock when the holder
+    # dies -- on kill -9 and on power loss alike -- so no boot can inherit a
+    # stale lock.
+    #
+    # Every way of NOT getting the lock says so. The bug this guard exists for is
+    # invisible by nature -- two pollers splitting one bot's messages, with no
+    # error anywhere -- so silently running without the guard would reintroduce
+    # exactly the failure it prevents, minus the evidence. Falling through is
+    # still the right choice: the pidfile checks below are the actual protection,
+    # and refusing to start would risk leaving the box with nothing running.
+    #
+    # "Already running" is decided from the pidfile, NOT from `pgrep -f`. An
+    # existence check on the process table cannot tell a live service from one
+    # that is still winding down, and stop.sh's callers hit exactly that: the
+    # update finalizer runs stop.sh then start.sh back to back, so a pgrep check
+    # sees the dying dashboard, skips the launch, and leaves the box with
+    # nothing running once it finally exits -- the update then fails its health
+    # check and rolls back. stop.sh removes the pidfile once the process is
+    # confirmed gone, so a deliberate stop is unambiguous here. The pid is
+    # cross-checked against /proc/<pid>/cmdline because a pidfile that survived a
+    # reboot can point at an unrelated recycled pid.
+    _service_live() { # $1 pidfile, $2 cmdline needle
+      local _pid
+      [ -f "$1" ] || return 1
+      _pid="$(cat "$1" 2>/dev/null)"
+      case "$_pid" in ''|*[!0-9]*) return 1 ;; esac
+      kill -0 "$_pid" 2>/dev/null || return 1
+      tr '\0' ' ' < "/proc/$_pid/cmdline" 2>/dev/null | grep -qF "$2"
+    }
+    _lock_held=""
+    if ! command -v flock >/dev/null 2>&1; then
+      echo "  flock not found (util-linux); starting WITHOUT the start lock -- the pidfile checks below still apply." >&2
+    elif ! exec 9<"$INSTALL_DIR/store"; then
+      echo "  cannot open $INSTALL_DIR/store for locking; starting WITHOUT the start lock." >&2
+    elif flock -w 120 9; then
+      _lock_held=1
+    else
+      echo "  another start.sh held the start lock for 120s; continuing WITHOUT it." >&2
+    fi
     [ -f "$INSTALL_DIR/dist/index.js" ] || (cd "$INSTALL_DIR" && npm run build)
-    nohup "$NODE_BIN" "$INSTALL_DIR/dist/index.js" > "$INSTALL_DIR/store/dashboard.log" 2>&1 &
-    echo $! > "$INSTALL_DIR/store/dashboard.pid"
-    nohup bash "$INSTALL_DIR/scripts/channels.sh" > "$INSTALL_DIR/store/channels.log" 2>&1 &
-    echo $! > "$INSTALL_DIR/store/channels.pid"
+    if _service_live "$INSTALL_DIR/store/dashboard.pid" "dist/index.js"; then
+      echo "Dashboard mar fut, ujrainditas kihagyva."
+    else
+      nohup "$NODE_BIN" "$INSTALL_DIR/dist/index.js" > "$INSTALL_DIR/store/dashboard.log" 2>&1 9>&- &
+      echo $! > "$INSTALL_DIR/store/dashboard.pid"
+    fi
+    if _service_live "$INSTALL_DIR/store/channels.pid" "channels.sh"; then
+      echo "Csatorna mar fut, ujrainditas kihagyva."
+    else
+      nohup bash "$INSTALL_DIR/scripts/channels.sh" > "$INSTALL_DIR/store/channels.log" 2>&1 9>&- &
+      echo $! > "$INSTALL_DIR/store/channels.pid"
+    fi
+    # Released here (not on daemon exit): the pidfiles are already written, so a
+    # second hook waking up now sees a live service and correctly no-ops.
+    [ -n "$_lock_held" ] && exec 9<&-
+    unset _lock_held
   fi
 fi
 

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -33,12 +33,42 @@ elif [ "$OS" = "Linux" ]; then
   elif pidof systemd >/dev/null 2>&1 && systemctl --user status >/dev/null 2>&1; then
     systemctl --user stop "${SLUG}-dashboard" "${SLUG}-channels" 2>/dev/null || true
   else
+    # Signal, then WAIT for the process to actually be gone. `kill` only queues
+    # a SIGTERM; returning immediately means this script reports "stopped" while
+    # the service is still winding down, and the next start.sh (the update
+    # finalizer runs stop.sh then start.sh back to back) races a half-dead
+    # process. SIGKILL after the grace period so a wedged service cannot make
+    # the caller hang forever.
+    #
+    # The pidfile is removed only once the process is CONFIRMED gone. Removing it
+    # up front means that a service surviving even SIGKILL -- uninterruptible
+    # sleep on a stuck mount or device -- leaves start.sh with no pidfile and
+    # therefore no reason not to launch a SECOND instance: the exact double
+    # poller this pair of scripts exists to prevent. A survivor keeps its pidfile
+    # so the next start.sh correctly reads the service as still running.
     for svc in dashboard channels; do
       pidfile="$INSTALL_DIR/store/${svc}.pid"
       if [ -f "$pidfile" ]; then
         pid=$(cat "$pidfile")
+        case "$pid" in ''|*[!0-9]*) rm -f "$pidfile"; continue ;; esac
         kill "$pid" 2>/dev/null || true
-        rm -f "$pidfile"
+        i=0
+        while [ "$i" -lt 15 ] && kill -0 "$pid" 2>/dev/null; do
+          sleep 1; i=$(( i + 1 ))
+        done
+        if kill -0 "$pid" 2>/dev/null; then
+          echo "  ${svc}: nem allt le ${i}s alatt, SIGKILL." >&2
+          kill -9 "$pid" 2>/dev/null || true
+          i=0
+          while [ "$i" -lt 5 ] && kill -0 "$pid" 2>/dev/null; do
+            sleep 1; i=$(( i + 1 ))
+          done
+        fi
+        if kill -0 "$pid" 2>/dev/null; then
+          echo "  ${svc}: pid ${pid} a SIGKILL-t is tulelte; a ${pidfile} MARAD, hogy a start.sh ne inditson masodik peldanyt." >&2
+        else
+          rm -f "$pidfile"
+        fi
       fi
     done
   fi


### PR DESCRIPTION
<!--
  HU + EN. Töltsd ki minden szakaszt. / Fill in every section.
  A jelölőnégyzeteket így pipáld: [x]  /  Tick a box like this: [x]
-->
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

**HU.** WSL-en két független autostart-út érheti el a `scripts/start.sh`-t ugyanazon a
bootoláson: a `wsl.conf` `[boot]` parancsa és egy Windows ONLOGON task. A jelenlegi Linux ág
feltétel nélkül indít, ezért a második futás egy második dashboardot tesz ugyanarra a portra,
és egy második `channels.sh`-t, ami **ugyanazt a bot tokent pollozza**. Ez utóbbi a súlyosabb:
két lekérdező egy tokenen felezi a bejövő üzeneteket, és hibajelzés nincs sehol, tehát
kívülről úgy látszik, mintha egyes üzenetek nem érkeznének meg. A dashboardot a port-ütközés
részben megvédi, a csatorna-figyelőt semmi.

A javítás `start.sh` oldalon: a "fut-e már" döntés pidfile + `kill -0` + a pid keresztellenőrzése
a `/proc/<pid>/cmdline` ellen, tehát egy újraindulást túlélt pidfile nem tud élő szolgáltatásnak
látszani egy újrahasznosított piden. A versenyfutást `flock` zárja a `store/` **könyvtáron**,
nem külön lock-fájlon: így a javítás egyetlen új fájlt sem hoz létre, és a zár a tartó folyamat
halálakor (`kill -9`, áramszünet) is felszabadul. A build a záron belül fut, hogy két hook ne
fordítson egyszerre ugyanabba a `dist/`-be, és a zár minden elvesztési útja kiírja magát
stderr-re. `stop.sh` oldalon a szkript megvárja a tényleges kilépést (15 s után SIGKILL, majd
még 5 s), és a pidfile csak IGAZOLT halál után törlődik.

**EN.** On WSL two independent autostart paths can reach `scripts/start.sh` during the same
boot: the `wsl.conf` `[boot]` command and a Windows ONLOGON task. The Linux branch starts
unconditionally, so a second run adds a second dashboard on the same port and a second
`channels.sh` polling **the same bot token**. The latter is the dangerous half: two pollers on
one token split the incoming updates and **nothing reports an error**, so it looks as if some
messages never arrive. The port collision partly protects the dashboard; the channel watcher
is not protected at all.

The fix reads the "already running" state from the process, not from a file's presence:
pidfile, `kill -0`, then a `/proc/<pid>/cmdline` cross-check. The check-then-act race is closed
with `flock` on the `store/` **directory** rather than a lock file, so the change creates no new
file and the kernel still releases the lock when the holder dies. The build runs inside the lock
so two hooks cannot compile into the same `dist/` concurrently, and every path that loses the
lock says so on stderr. `stop.sh` now waits for the actual exit (SIGKILL after 15 s, then 5 s
more) and removes the pidfile only once death is CONFIRMED, so a survivor cannot leave
`start.sh` with a reason to launch a second instance.

`pgrep -f` is deliberately NOT used: it cannot tell a live service from one that is still
shutting down, and it also matches the checking command itself.

The full reasoning and every measurement is in the PR discussion below.

## Kapcsolódó issue / Related issue

Nincs kapcsolódó issue; a hibát élő WSL2 telepítésen mértük. /
No related issue; the bug was measured on a live WSL2 install.
Closes #

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack >
- [x] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or ar>
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).


## Titok-kapu / Secret gate

A `secret-gate` CI-job a valodi kapu. A lokalis pre-commit hook csak gyors
elorejelzes, es `--no-verify`-jal megkerulheto -- ne tekintsd elegnek.
The `secret-gate` CI job is the real gate; the local pre-commit hook is a fast
preview and can be skipped with `--no-verify`, so it is not sufficient on its own.

- [X ] Nincs a valtoztatasban bizonyitek-/artefaktum-mappa, titok-alaku string vagy idezett csatorna-uzenet.
      / No evidence or artifact directory, secret-shaped string, or quoted channel message in this change.
