### PR TITLE
fix(email-gate): bcc joins the content anchor (EMAILBCCHORGONY903)

### DIFF
--- a/scripts/__tests__/email-approval-gate.test.py
+++ b/scripts/__tests__/email-approval-gate.test.py
@@ -241,6 +241,46 @@ with tempfile.TemporaryDirectory() as td:
     check("fail-closed: unparseable stdin -> DENIED (exit 2, never 0/1)",
           proc.returncode == 2, f"exit={proc.returncode}")
 
+    # --- EMAILBCCHORGONY903: bcc is part of the anchor -----------------------
+    # The gap this pins closed: with a to+cc+text anchor, an approved letter
+    # could be re-sent with an ADDED bcc -- identical hash, the approval was
+    # consumed, and a recipient nobody approved got the letter. Both send
+    # paths are covered, plus the backward-compat golden below.
+    store = make_store(os.path.join(td, "bcc-mcp"))
+    _, _, err = run_gate(store, mcp_send())          # harvest the letter's anchor
+    bccless_anchor = anchor_from_stderr(err)
+    approve(store, bccless_anchor)
+    bcc_payload = mcp_send()
+    bcc_payload["tool_input"]["bcc"] = ["rejtett@idegen.example"]
+    code, _, _ = run_gate(store, bcc_payload)
+    check("bcc/MCP: approved bcc-less letter re-sent WITH bcc -> DENIED",
+          code == 2, f"exit={code}")
+    code, _, _ = run_gate(store, mcp_send())
+    check("bcc/MCP: the bcc-less letter itself still sends on that approval",
+          code == 0, f"exit={code}")
+
+    store = make_store(os.path.join(td, "bcc-bash"))
+    bash_cmd = ('python3 scripts/send.py --to "a@b.hu" --subject "Teszt tárgy" '
+                '--body "Kedves Ügyfelünk! Törzs."')
+    _, _, err = run_gate(store, {"tool_name": "Bash", "tool_input": {"command": bash_cmd}})
+    approve(store, anchor_from_stderr(err))
+    code, _, _ = run_gate(store, {"tool_name": "Bash",
+                                  "tool_input": {"command": bash_cmd + ' --bcc "rejtett@idegen.example"'}})
+    check("bcc/Bash: approved bcc-less command re-sent WITH --bcc -> DENIED",
+          code == 2, f"exit={code}")
+    code, _, _ = run_gate(store, {"tool_name": "Bash", "tool_input": {"command": bash_cmd}})
+    check("bcc/Bash: the bcc-less command itself still sends on that approval",
+          code == 0, f"exit={code}")
+
+    # Backward-compat golden: the bcc-less canon is BYTE-STABLE across the bcc
+    # fix (bcc joins the hash ONLY when non-empty), so approvals recorded
+    # before the change stay valid for the letters they approved. If this hash
+    # ever changes, EVERY open approval silently invalidates -- that must be a
+    # loud, deliberate decision failing here, never a side effect.
+    check("bcc/golden: bcc-less anchor is byte-stable across the bcc fix",
+          bccless_anchor == "de87bdb699dcab419b68811bb57b6fab44b34e2fe16bff11cf90b2a5848f82ec",
+          f"got {bccless_anchor}")
+
     # SQLite-version portability, kept as a STATIC check on purpose. The
     # behavioural cases above only catch the bad call on a host whose sqlite is
     # older than 3.38 -- on CI (newer) they stay green while the live install

--- a/scripts/__tests__/email-extract-parity.test.py
+++ b/scripts/__tests__/email-extract-parity.test.py
@@ -128,34 +128,48 @@ with tempfile.TemporaryDirectory() as td:
           proc.returncode == 2, f"exit={proc.returncode}")
 
 # --- 4. recipient extraction (new surface; deterministic-or-deny) ------------
-to, cc, reason = mod.collect_bash_recipients(
+to, cc, bcc, reason = mod.collect_bash_recipients(
     'send.py --to a@b.hu --cc "c@d.hu" --to=\'e@f.hu\' --subject x')
 check("bash recipients: quoted/unquoted/= forms, order kept",
-      (to, cc, reason) == (["a@b.hu", "e@f.hu"], ["c@d.hu"], None),
-      f"got {(to, cc, reason)!r}")
+      (to, cc, bcc, reason) == (["a@b.hu", "e@f.hu"], ["c@d.hu"], [], None),
+      f"got {(to, cc, bcc, reason)!r}")
 
-to, cc, reason = mod.collect_bash_recipients('send.py --to "$DEST" --cc c@d.hu')
+# EMAILBCCHORGONY903: --bcc is a recipient field like any other -- without it
+# in the envelope, an approved letter re-sent WITH a bcc anchored identically.
+to, cc, bcc, reason = mod.collect_bash_recipients(
+    'send.py --to a@b.hu --bcc "rejtett@x.hu" --subject x')
+check("bash recipients: --bcc collected (EMAILBCCHORGONY903)",
+      (to, cc, bcc, reason) == (["a@b.hu"], [], ["rejtett@x.hu"], None),
+      f"got {(to, cc, bcc, reason)!r}")
+
+to, cc, bcc, reason = mod.collect_bash_recipients('send.py --bcc "$HIDDEN"')
+check("bash recipients: $VAR in --bcc -> unreadable_reason",
+      reason is not None and "--bcc" in reason, f"got {reason!r}")
+
+to, cc, bcc, reason = mod.collect_bash_recipients('send.py --to "$DEST" --cc c@d.hu')
 check("bash recipients: $VAR in --to -> unreadable_reason (never approximate)",
       reason is not None and "shell-behelyettesites" in reason, f"got {reason!r}")
 
-to, cc, reason = mod.collect_bash_recipients('send.py --cc "$(get-cc)"')
+to, cc, bcc, reason = mod.collect_bash_recipients('send.py --cc "$(get-cc)"')
 check("bash recipients: $(cmd) in --cc -> unreadable_reason",
       reason is not None and "--cc" in reason, f"got {reason!r}")
 
-check("mcp recipients: list + string + missing",
+check("mcp recipients: list + string + missing (+bcc)",
       mod.collect_mcp_recipients({"to": ["a@b.hu", "b@c.hu"], "cc": "c@d.hu"})
-      == (["a@b.hu", "b@c.hu"], ["c@d.hu"], None)
-      and mod.collect_mcp_recipients({}) == ([], [], None))
+      == (["a@b.hu", "b@c.hu"], ["c@d.hu"], [], None)
+      and mod.collect_mcp_recipients({"to": "a@b.hu", "bcc": ["h@x.hu"]})
+      == (["a@b.hu"], [], ["h@x.hu"], None)
+      and mod.collect_mcp_recipients({}) == ([], [], [], None))
 
 # --- 5. envelope composition (the PR2 hash input) ----------------------------
 env = mod.collect_email_envelope(
     "mcp__server-gmail-autoauth-mcp__send_email",
     {"to": ["a@b.hu"], "cc": ["x@y.hu"], "subject": "MCP tárgy",
      "body": "MCP törzs ékezettel: űrhajó."})
-check("envelope/mcp: four fields present, text == copy-gate text",
+check("envelope/mcp: envelope fields present (bcc included), text == copy-gate text",
       env["to"] == ["a@b.hu"] and env["cc"] == ["x@y.hu"]
       and env["text"] == golden["mcp"]["mcp-body-subject"]["text"]
-      and env["unreadable_reason"] is None, f"got {env!r}")
+      and env["bcc"] == [] and env["unreadable_reason"] is None, f"got {env!r}")
 
 env = mod.collect_email_envelope(
     "Bash", {"command": 'send.py --to a@b.hu --subject "Teszt tárgy ékezettel" '

--- a/scripts/hooks/email-approval-gate.py
+++ b/scripts/hooks/email-approval-gate.py
@@ -11,9 +11,9 @@ The `email_send.level` in store/autonomy-config.json becomes a real switch:
   level 1  -> hard deny (signal-only autonomy).
   level 2  -> CHECK-BEFORE-SEND: the send is allowed only against an APPROVED,
               UNCONSUMED, IN-WINDOW approval whose content_hash equals the
-              sha256 anchor of THIS letter's four fields (to + cc + subject +
+              sha256 anchor of THIS letter's envelope (to + cc + bcc + subject +
               body). A body+subject hash alone would let an approved letter be
-              re-sent to a different recipient -- hence all four (msg 17936).
+              re-sent to a different recipient -- hence every recipient field, bcc included (msg 17936, EMAILBCCHORGONY903).
   level 3  -> allow (autonomous; the outgoing-copy-gate still audits copy).
 
 Anchor semantics (Marveen msg 17900, 5+1 conditions):
@@ -88,11 +88,25 @@ def read_email_level():
 
 
 def content_anchor(env: dict) -> str:
-    """sha256 over the four-field envelope. Canonical JSON so the same letter
-    always yields the same anchor; `text` is subject+body exactly as the copy
-    gate audits it, from the shared extractor."""
-    canon = json.dumps({"to": env["to"], "cc": env["cc"], "text": env["text"]},
-                       ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    """sha256 over the envelope: to + cc + bcc + text (subject+body exactly as
+    the copy gate audits it, from the shared extractor). Canonical JSON so the
+    same letter always yields the same anchor.
+
+    EMAILBCCHORGONY903: bcc joins the canon, but ONLY when non-empty. Two
+    reasons, both load-bearing:
+      - the gap this closes: without bcc in the hash, to=[owner], cc=[],
+        bcc=[stranger] anchored identically to the approved bcc-less letter,
+        so one approval could deliver to a recipient nobody approved;
+      - the conditional inclusion keeps every bcc-less anchor BYTE-IDENTICAL
+        to the pre-fix value, so open approvals (recorded before this change)
+        stay valid for the letters they approved. There is no ambiguity to
+        exploit: the extractor decides bcc deterministically, and any
+        non-empty bcc changes the hash -- fail-closed in the only direction
+        that matters."""
+    fields = {"to": env["to"], "cc": env["cc"], "text": env["text"]}
+    if env.get("bcc"):
+        fields["bcc"] = env["bcc"]
+    canon = json.dumps(fields, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
     return hashlib.sha256(canon.encode("utf-8")).hexdigest()
 
 
@@ -231,7 +245,7 @@ def main():
     }
     deny(prefix +
          f"email_send level 2 (CHECK-BEFORE-SEND). {reasons[verdict]}\n"
-         f"Tartalom-horgony (sha256; to+cc+targy+torzs): {anchor}\n"
+         f"Tartalom-horgony (sha256; to+cc+bcc+targy+torzs): {anchor}\n"
          f"{summarize(env)}\n"
          "Jovahagyas kerese: POST /api/approvals a sajat agent_id-ddal, "
          'category="email_send", content_hash=a fenti horgony, action_description='

--- a/scripts/hooks/email_extract.py
+++ b/scripts/hooks/email_extract.py
@@ -75,48 +75,54 @@ _SHELL_SUBST = re.compile(r"\$\(|`|\$\{?\w")
 
 
 def collect_bash_recipients(cmd: str):
-    """Return (to, cc, unreadable_reason); to/cc are lists of literal values."""
-    to, cc = [], []
-    for m in re.finditer(r"--(to|cc)[= ]+(\"([^\"]*)\"|'([^']*)'|(\S+))", cmd):
+    """Return (to, cc, bcc, unreadable_reason); recipient lists hold literal
+    values. bcc is part of the envelope since EMAILBCCHORGONY903: an anchor
+    that ignores it lets an approved letter be re-sent WITH an added --bcc,
+    delivering to a recipient nobody approved."""
+    to, cc, bcc = [], [], []
+    buckets = {"to": to, "cc": cc, "bcc": bcc}
+    for m in re.finditer(r"--(to|cc|bcc)[= ]+(\"([^\"]*)\"|'([^']*)'|(\S+))", cmd):
         val = m.group(3) or m.group(4) or m.group(5) or ""
         if _SHELL_SUBST.search(val):
-            return (to, cc,
+            return (to, cc, bcc,
                     f"a --{m.group(1)} shell-behelyettesitest tartalmaz, amit a hook "
                     f"nem old fel ({val[:60]}...) -- a cimzett futasidoben dol el")
-        (to if m.group(1) == "to" else cc).append(val)
-    return (to, cc, None)
+        buckets[m.group(1)].append(val)
+    return (to, cc, bcc, None)
 
 
 def collect_mcp_recipients(tool_input: dict):
-    """Return (to, cc, unreadable_reason). Values are kept RAW (no splitting,
-    no lowercasing): the hash anchor needs exact bytes, not address semantics."""
+    """Return (to, cc, bcc, unreadable_reason). Values are kept RAW (no
+    splitting, no lowercasing): the hash anchor needs exact bytes, not address
+    semantics. bcc: see collect_bash_recipients (EMAILBCCHORGONY903)."""
     def norm(v):
         if v is None or v == "":
             return []
         if isinstance(v, (list, tuple)):
             return [str(x) for x in v]
         return [str(v)]
-    return (norm(tool_input.get("to")), norm(tool_input.get("cc")), None)
+    return (norm(tool_input.get("to")), norm(tool_input.get("cc")),
+            norm(tool_input.get("bcc")), None)
 
 
 def collect_email_envelope(tool_name: str, tool_input: dict):
-    """PR2 entry point: one dict for the four-field hash anchor, built from the
+    """PR2 entry point: one dict for the recipient+content hash anchor (to/cc/bcc/text), built from the
     SAME collectors the copy gate runs (no second extraction implementation).
-    Returns {"to", "cc", "text", "unreadable_reason"}; text is the combined
+    Returns {"to", "cc", "bcc", "text", "unreadable_reason"}; text is the combined
     subject+body exactly as the copy gate audits it. The CALLER decides policy
     (e.g. an empty recipient list on a send is itself grounds to deny)."""
     if re.search(r"send_email", tool_name or "", re.I):
         ti = tool_input if isinstance(tool_input, dict) else {}
         text = collect_mcp_body(ti)
-        to, cc, reason = collect_mcp_recipients(ti)
+        to, cc, bcc, reason = collect_mcp_recipients(ti)
     elif tool_name == "Bash":
         cmd = str((tool_input or {}).get("command") or "") if isinstance(tool_input, dict) else ""
         text, reason = collect_bash_body(cmd)
         if not reason:
-            to, cc, reason = collect_bash_recipients(cmd)
+            to, cc, bcc, reason = collect_bash_recipients(cmd)
         else:
-            to, cc = [], []
+            to, cc, bcc = [], [], []
     else:
-        return {"to": [], "cc": [], "text": "",
+        return {"to": [], "cc": [], "bcc": [], "text": "",
                 "unreadable_reason": f"nem email-kuldo tool ({tool_name!r})"}
-    return {"to": to, "cc": cc, "text": text, "unreadable_reason": reason}
+    return {"to": to, "cc": cc, "bcc": bcc, "text": text, "unreadable_reason": reason}


### PR DESCRIPTION
## A rés (Marveen msg 18276)

A jóváhagyási kapu horgonya {to, cc, text}-ből számolt, a megosztott extraktor a bcc-t egyáltalán nem gyűjtötte -- így a to=[gazda], cc=[], bcc=[idegen] hívás UGYANAZT a horgonyt adta, mint a jóváhagyott bcc-mentes levél: egy jóváhagyás olyan címzettnek is kézbesíthetett, akit senki nem hagyott jóvá.

## Mutációs kontroll (a 3. kikötés szerint, ELŐTTE-UTÁNA mérve)

| eset | ELŐTTE (javítatlan) | UTÁNA (fix) |
|---|---|---|
| MCP send_email + bcc mező, bcc-mentes jóváhagyással | **ALLOWED** (rés) | **DENIED(2)** |
| Bash send.py + `--bcc` flag, bcc-mentes jóváhagyással | **ALLOWED** (rés) | **DENIED(2)** |
| bcc-mentes levél a saját jóváhagyásával (MCP és Bash) | ALLOWED | ALLOWED |

Módszertani megjegyzés: az első bash-mérés hamis képet adott, mert a próba-parancs (`gog gmail send`) alakját az is_send_invocation nem sorolja küldésnek -- az exit 0 ott "kapu be sem kapcsolt" volt, nem "átment". A végleges mérés a kanonikus `send.py --to` alakkal ment, amire a kapu bizonyítottan bekapcsol (jóváhagyás nélkül DENIED).

## A 2. kikötés (negatív kontroll): nyitott jóváhagyások NEM érvénytelenednek

A bcc CSAK nem-üres esetben kerül a canonba, így minden bcc-mentes horgony BÁJTRA azonos a fix előttivel -- mérve (referencia-horgony azonos a két fázisban), és a tesztben a literál hash GOLDEN-ként pinelve: ha a canon valaha változik, az hangosan bukjon, ne némán érvénytelenítse a jóváhagyás-könyvet. Marveen nyitott hírlevél-jóváhagyása érvényben marad.

## Az 1. kikötés: mindkét út fedve

A Bash-út (`--bcc` flag, a $VAR-os --bcc ugyanúgy unreadable=deny mint a to/cc-nél) és az MCP-út (bcc mező, lista/string/hiányzó normalizálás) is a bővített extraktoron megy; a parity-teszt mindkettőt fedi.

## Kapcsolat a gazda lazítás-döntésével

Ahogy a kártya mondja: ha a lazítás a "egyetlen címzett a gazda" bypass-t választaná, az e fix NÉLKÜL bcc-vel kikerülhető lenne -- ezért ez a fix bármely választott út ELŐFELTÉTELE. A fix maga tiszta szigorítás, viselkedés-változás a vevőnél: kizárólag a bcc-t hordozó küldések horgonya változik (azok eddig hamisan matcheltek).

Tesztek: gate-suite 26 PASS (5 új bcc-eset), parity-suite bővítve, mind a 9 python-suite zöld, typecheck tiszta, teljes vitest 4588 zöld. Kártya: EMAILBCCHORGONY903. Merge Marveennél.

🤖 Generated with [Claude Code](https://claude.com/claude-code)