### PR TITLE
Treat an unanswered permission prompt as a question, not a wedged session

### DIFF
--- a/src/__tests__/fixtures/pane/permission-prompt-bash-grep.txt
+++ b/src/__tests__/fixtures/pane/permission-prompt-bash-grep.txt
@@ -1,0 +1,24 @@
+
+  Waiting on the reviewers before touching either worktree.
+
+✻ Waiting for 2 background agents to finish
+
+────────────────────────────────────────────────────────────────────────────────
+ Bash command · from the general-purpose agent
+
+   │ cd /Users/OPERATOR/Developer/Projects/example-wt && grep -n
+   │ "firstSymbol\|secondSymbol\|thirdSymbol\|fourthSy
+   │ mbol\|fifthSymbol\|func transition"
+   │ src/Example/ExampleController.swift
+   Locate the functions
+
+ │ grep on
+ │ 'src/Example/ExampleController.swift' after
+ │ a cd would search a directory that cannot be determined here, and a Read()
+ │ deny rule is configured; only you can approve running it anyway.
+
+ Do you want to proceed?
+ ❯ 1. Yes
+   2. No
+
+ Esc to cancel · Tab to amend

--- a/src/__tests__/fixtures/pane/permission-prompt-compound-cd.txt
+++ b/src/__tests__/fixtures/pane/permission-prompt-compound-cd.txt
@@ -1,0 +1,24 @@
+
+  The reviewer question before the merge is predictable: full target both sides. The
+  baseline for it is ready (0000000, 7 stable red + 3 flaky).
+
+✻ Waiting for 2 background agents to finish
+
+────────────────────────────────────────────────────────────────────────────────
+ Bash command · from the general-purpose agent
+
+   │ cd /Users/OPERATOR/Developer/Projects/example-wt/app/Example
+   │ && ls Example/Resources 2>/dev/null; find . -name "*.xcstrings" -o
+   │ -name "Localizable.strings" | head; echo "=== Sending / Working
+   │ occurrences ==="; grep -rn "Sending…\|Working…" --include "*.swift" . |
+   │ head
+   Check localization files
+
+ │ Compound command contains cd with a relative file read while a Read() deny
+ │ rule exists
+
+ Do you want to proceed?
+ ❯ 1. Yes
+   2. No
+
+ Esc to cancel · Tab to amend

--- a/src/__tests__/permission-prompt-not-a-stall.test.ts
+++ b/src/__tests__/permission-prompt-not-a-stall.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
-import { detectsPermissionPrompt, detectsBlockingMenu, detectPaneState } from '../pane-state.js'
+import { detectsPermissionPrompt, detectsBlockingMenu, detectPaneState, permissionPromptSummary } from '../pane-state.js'
 import { formatStuckSessionAlert } from '../web/message-router.js'
 
 // The fixture is a REAL pane, captured from agent-voicedev on 2026-09-03 while
@@ -13,10 +13,23 @@ const REAL_PANE = readFileSync(
   join(__dirname, 'fixtures/pane/permission-prompt-bash-grep.txt'),
   'utf8',
 )
+// A SECOND live capture, taken while the first fix was in review. Same layout,
+// DIFFERENT reason wording -- which is the point: it is the evidence that the
+// detector must key on the question and the option list, never on the reason
+// text, and that the summary extractor works on more than the shape it was
+// written against.
+const REAL_PANE_2 = readFileSync(
+  join(__dirname, 'fixtures/pane/permission-prompt-compound-cd.txt'),
+  'utf8',
+)
 
 describe('permission prompt is not a stalled session', () => {
-  it('recognises the real captured prompt', () => {
+  it('recognises both real captured prompts, whose reason wording differs', () => {
     expect(detectsPermissionPrompt(REAL_PANE)).toBe(true)
+    expect(detectsPermissionPrompt(REAL_PANE_2)).toBe(true)
+    // Guard the reason-independence explicitly: the two panes share no reason text.
+    expect(REAL_PANE).toContain('deny rule is configured')
+    expect(REAL_PANE_2).toContain('Compound command contains cd')
   })
 
   it('documents why it needs its own detector: the generic ones read it wrong', () => {
@@ -65,5 +78,46 @@ describe('stuck-session alert for a permission prompt', () => {
 
   it('still never alerts the main agent about itself', () => {
     expect(formatStuckSessionAlert('jarvis', 'jarvis', 'x', 1, 1, 'unknown', true)).toBeNull()
+  })
+})
+
+describe('what the prompt is asking, for an alert that needs no pane visit', () => {
+  it('extracts the tool card title and the full reason from both live captures', () => {
+    const a = permissionPromptSummary(REAL_PANE)!
+    expect(a.title).toBe('Bash command · from the general-purpose agent')
+    // The pane hard-wraps the reason; the first line alone would read just
+    // "grep on", so the block has to be rejoined to be useful.
+    expect(a.reason).toContain('a Read() deny rule is configured')
+    expect(a.reason).not.toBe('grep on')
+
+    const b = permissionPromptSummary(REAL_PANE_2)!
+    expect(b.title).toBe('Bash command · from the general-purpose agent')
+    expect(b.reason).toBe('Compound command contains cd with a relative file read while a Read() deny rule exists')
+  })
+
+  it('returns null rather than half a question', () => {
+    expect(permissionPromptSummary('')).toBeNull()
+    expect(permissionPromptSummary('Do you want to proceed?\n 1. Yes')).toBeNull()
+  })
+
+  it('caps a long reason instead of flooding the alert', () => {
+    const long = REAL_PANE.replace('deny rule is configured', 'deny rule is configured ' + 'x'.repeat(400))
+    const s = permissionPromptSummary(long)!
+    expect(s.reason.length).toBeLessThanOrEqual(220)
+    expect(s.reason.endsWith('…')).toBe(true)
+  })
+
+  it('puts the question into the stuck alert', () => {
+    const ask = permissionPromptSummary(REAL_PANE)
+    const alert = formatStuckSessionAlert('voicedev', 'jarvis', 'agent-voicedev', 11 * 60 * 1000, 1, 'unknown', true, ask)!
+    expect(alert).toContain('It asks: Bash command · from the general-purpose agent')
+    expect(alert).toContain('deny rule is configured')
+  })
+
+  it('still produces a usable alert when the question cannot be parsed', () => {
+    const alert = formatStuckSessionAlert('voicedev', 'jarvis', 'agent-voicedev', 11 * 60 * 1000, 1, 'unknown', true, null)!
+    expect(alert).toContain('TOOL-PERMISSION PROMPT')
+    expect(alert).not.toContain('It asks:')
+    expect(alert).toContain('tmux attach -t agent-voicedev')
   })
 })

--- a/src/__tests__/permission-prompt-not-a-stall.test.ts
+++ b/src/__tests__/permission-prompt-not-a-stall.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { detectsPermissionPrompt, detectsBlockingMenu, detectPaneState } from '../pane-state.js'
+import { formatStuckSessionAlert } from '../web/message-router.js'
+
+// The fixture is a REAL pane, captured from agent-voicedev on 2026-09-03 while
+// a general-purpose sub-agent's Bash grep waited for consent (paths and symbol
+// names anonymised, structure untouched). Every rule below is measured against
+// that shape rather than an invented one -- an invented prompt shape is how a
+// detector ends up confidently wrong about a surface nobody has seen.
+const REAL_PANE = readFileSync(
+  join(__dirname, 'fixtures/pane/permission-prompt-bash-grep.txt'),
+  'utf8',
+)
+
+describe('permission prompt is not a stalled session', () => {
+  it('recognises the real captured prompt', () => {
+    expect(detectsPermissionPrompt(REAL_PANE)).toBe(true)
+  })
+
+  it('documents why it needs its own detector: the generic ones read it wrong', () => {
+    // Both of these are the bug, not an accident of the fixture: the menu
+    // detector matches (the footer says "Esc to cancel") and the pane state is
+    // 'unknown', which is what routed the alert into the "restart it" text.
+    expect(detectsBlockingMenu(REAL_PANE)).toBe(true)
+    expect(detectPaneState(REAL_PANE)).toBe('unknown')
+  })
+
+  it('never fires on a busy pane, a live prompt quoting the question, or nothing', () => {
+    const busy = 'Do you want to proceed?\n❯ 1. Yes\n  2. No\n✻ Thinking… (12s · 1.2k tokens · esc to interrupt)'
+    const idleQuoting = '│ > │\n⏵⏵ bypass permissions on (shift+tab to cycle)\nI asked: Do you want to proceed?\n 1. Yes'
+    expect(detectsPermissionPrompt(busy)).toBe(false)
+    expect(detectsPermissionPrompt(idleQuoting)).toBe(false)
+    expect(detectsPermissionPrompt('')).toBe(false)
+  })
+
+  it('needs BOTH the question and the option list, so prose alone cannot trigger it', () => {
+    const questionOnly = 'Do you want to proceed?\n\nEsc to cancel · Tab to amend'
+    const optionsOnly = '❯ 1. Yes\n  2. No\n\nEsc to cancel · Tab to amend'
+    expect(detectsPermissionPrompt(questionOnly)).toBe(false)
+    expect(detectsPermissionPrompt(optionsOnly)).toBe(false)
+  })
+})
+
+describe('stuck-session alert for a permission prompt', () => {
+  const alertFor = (awaiting: boolean) =>
+    formatStuckSessionAlert('voicedev', 'jarvis', 'agent-voicedev', 11 * 60 * 1000, 1, 'unknown', awaiting)
+
+  it('tells the reader to answer, and explicitly not to restart or Escape', () => {
+    const alert = alertFor(true)!
+    expect(alert).toContain('TOOL-PERMISSION PROMPT')
+    expect(alert).toMatch(/Do NOT restart/)
+    expect(alert).toMatch(/do NOT send a blind Escape/)
+    expect(alert).toContain('tmux attach -t agent-voicedev')
+  })
+
+  it('does NOT recommend a restart, which the old not-ready text did', () => {
+    // The regression this guards: the not-ready text says "restart the agent
+    // if it is wedged". Following that on a permission prompt discards the
+    // running work and leaves the question unanswered.
+    expect(alertFor(true)!).not.toMatch(/restart the agent if it is wedged/)
+    expect(alertFor(false)!).toMatch(/restart the agent if it is wedged/)
+  })
+
+  it('still never alerts the main agent about itself', () => {
+    expect(formatStuckSessionAlert('jarvis', 'jarvis', 'x', 1, 1, 'unknown', true)).toBeNull()
+  })
+})

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -561,6 +561,89 @@ export function detectsPermissionPrompt(pane: string): boolean {
   return PERMISSION_QUESTION_RX.test(footerRegion) && PERMISSION_OPTION_RX.test(footerRegion)
 }
 
+// What the prompt is ASKING, in one line, for an alert that has to be
+// actionable without opening the pane.
+//
+// The orchestrator answered two of these by hand on 2026-09-03, and both times
+// the deciding step was reading the pane: which tool, on whose behalf, and
+// why consent is needed. Putting that line in the alert removes the step.
+//
+// Two live captures (fixtures permission-prompt-bash-grep.txt and
+// permission-prompt-compound-cd.txt) share the layout, and the REASON text
+// differs between them -- which is exactly why nothing here keys on the reason
+// wording:
+//
+//   ────────────────────────────────────────
+//    Bash command · from the general-purpose agent      <- title
+//
+//      │ cd ... && grep -n ...                          <- the command
+//      Locate the functions
+//
+//    │ <reason, one or more lines>                      <- why consent is needed
+//
+//    Do you want to proceed?
+//
+// Returns null when either piece is missing: an alert with a half-parsed
+// question is worse than an alert that just says "open the pane".
+const PERMISSION_RULE_LINE_RX = /^\s*─{8,}\s*$/
+const PERMISSION_QUOTE_PREFIX_RX = /^\s*│\s?/
+const PERMISSION_REASON_MAX = 220
+
+export interface PermissionPromptSummary {
+  /** The tool card's header, e.g. "Bash command · from the general-purpose agent". */
+  title: string
+  /** First line of the reason Claude gives for needing consent. */
+  reason: string
+}
+
+/**
+ * Extract a one-line summary of what a permission prompt is asking.
+ *
+ * Pure + dependency-free. Only meaningful on a pane where
+ * detectsPermissionPrompt() is true; returns null when the expected parts are
+ * not both present.
+ */
+export function permissionPromptSummary(pane: string): PermissionPromptSummary | null {
+  if (!pane) return null
+  const lines = pane.split('\n')
+  const questionIdx = lines.findIndex((l) => PERMISSION_QUESTION_RX.test(l))
+  if (questionIdx < 0) return null
+
+  // Title: first non-empty line after the horizontal rule that opens the card.
+  let title = ''
+  const ruleIdx = lines.slice(0, questionIdx).map((l) => PERMISSION_RULE_LINE_RX.test(l)).lastIndexOf(true)
+  if (ruleIdx >= 0) {
+    for (const l of lines.slice(ruleIdx + 1, questionIdx)) {
+      const t = l.trim()
+      if (t) { title = t; break }
+    }
+  }
+
+  // Reason: the LAST quoted block before the question, rejoined into one
+  // line. Two reasons for the shape:
+  //   - last block, not first: the command echo is quoted too, and the last
+  //     block is the one that says why consent is needed rather than what
+  //     would run.
+  //   - rejoined, not first-line: the pane hard-wraps at the card width, so
+  //     the first line alone can be as useless as "grep on" (measured on the
+  //     bash-grep fixture). Rejoining recovers the sentence; the cap keeps a
+  //     long reason from flooding the alert.
+  let reason = ''
+  let end = -1
+  for (let i = questionIdx - 1; i >= 0; i--) {
+    const quoted = PERMISSION_QUOTE_PREFIX_RX.test(lines[i])
+    if (quoted && end < 0) end = i
+    else if (!quoted && end >= 0) {
+      const block = lines.slice(i + 1, end + 1).map((l) => l.replace(PERMISSION_QUOTE_PREFIX_RX, '').trim())
+      reason = block.join(' ').replace(/\s+/g, ' ').trim()
+      break
+    }
+  }
+  if (reason.length > PERMISSION_REASON_MAX) reason = reason.slice(0, PERMISSION_REASON_MAX - 1).trimEnd() + '…'
+  if (!title || !reason) return null
+  return { title, reason }
+}
+
 // Claude Code FIRST-RUN gates: the interactive dialogs a brand-new install
 // parks on before the prompt ever renders -- the per-project "Do you trust the
 // files in this folder?" consent, the --dangerously-skip-permissions "Bypass

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -509,6 +509,58 @@ export function detectsBlockingMenu(pane: string): boolean {
   return MENU_NAV_RX.test(footerRegion) || MENU_ESC_RX.test(footerRegion)
 }
 
+// A TOOL-PERMISSION prompt is NOT a stalled session, and it is NOT a menu.
+//
+// Claude Code asks for approval when a tool call needs the operator's consent
+// (a deny rule matches, a command leaves the resolvable working directory,
+// etc). The pane then shows the tool card, the reason, "Do you want to
+// proceed?" and a numbered Yes/No list, with an `Esc to cancel · Tab to amend`
+// footer -- no spinner, no idle footer.
+//
+// From the queue's side that is indistinguishable from a wedged session, and
+// on 2026-09-03 the fleet handled it twice in the WRONG way:
+//   - the session-stuck alert took the not-ready branch, whose text tells the
+//     owner to "restart the agent if it is wedged". Restarting would have
+//     thrown away two running sub-agents (~165k tokens of work) and left the
+//     actual cause -- an unanswered question -- in place.
+//   - the blocking-menu recovery matched it (the footer really does say
+//     "Esc to cancel") and would send a blind Escape. On a permission prompt
+//     Escape is not "pop back to the prompt": it CANCELS the request, i.e. it
+//     answers a consent question with "no" on the owner's behalf, while the
+//     alert text tells them their session was stuck "in a menu (e.g. /mcp)".
+//
+// So this gets its own detector, and callers must treat it as "a person has to
+// answer", never as a restart target and never as a blind-Escape target.
+// Answering it automatically is out of scope by design: choosing "Yes" would
+// be the machine granting itself a permission the owner deliberately gated.
+//
+// Matching follows detectsBlockingMenu's discipline: a busy pane is never a
+// prompt, a visible idle footer means the real prompt is live, and the
+// question + option list must sit in the live footer region so a message body
+// that merely quotes "Do you want to proceed?" cannot trigger it.
+const PERMISSION_QUESTION_RX = /\bDo you want to (?:proceed|create|make|run)\b/i
+const PERMISSION_OPTION_RX = /^\s*(?:❯\s*)?1\.\s*Yes\b/m
+const PERMISSION_FOOTER_REGION_LINES = 12
+
+/**
+ * True when the pane is parked on a Claude Code tool-permission prompt.
+ *
+ * Pure + dependency-free. Recognises the shape measured on a live pane
+ * (see src/__tests__/fixtures/pane/permission-prompt-bash-grep.txt): the
+ * "Do you want to proceed?" question plus a numbered "1. Yes" option.
+ */
+export function detectsPermissionPrompt(pane: string): boolean {
+  if (!pane || !pane.trim()) return false
+  for (const rx of BUSY_INDICATORS) {
+    if (rx.test(pane)) return false
+  }
+  const lines = pane.split('\n')
+  const footerRegion = lines.slice(-PERMISSION_FOOTER_REGION_LINES).join('\n')
+  if (BUSY_ESC_TO_INTERRUPT_RX.test(footerRegion)) return false
+  if (IDLE_FOOTER_RX.test(pane)) return false
+  return PERMISSION_QUESTION_RX.test(footerRegion) && PERMISSION_OPTION_RX.test(footerRegion)
+}
+
 // Claude Code FIRST-RUN gates: the interactive dialogs a brand-new install
 // parks on before the prompt ever renders -- the per-project "Do you trust the
 // files in this folder?" consent, the --dangerously-skip-permissions "Bypass

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -36,7 +36,7 @@ import { probeTelegramConflict } from './channel-conflict-probe.js'
 import { schedulePluginUnlockAfterRespawn, wasPluginConfirmedAbsent, clearPluginAbsent } from './channel-plugin-unlock.js'
 import { getInjectedPrompt, matchesInjectedPrompt } from './injected-prompt-registry.js'
 import {
-  detectPaneState, decidePaneErrorAlert, detectsBlockingMenu, detectsFirstRunGate, detectsModelConsentDialog, detectsPermissionPrompt, type PaneErrorAlertState, type PaneState,
+  detectPaneState, decidePaneErrorAlert, detectsBlockingMenu, detectsFirstRunGate, detectsModelConsentDialog, detectsPermissionPrompt, permissionPromptSummary, type PaneErrorAlertState, type PaneState,
   stuckInputSignature, decideStuckInputRecovery, parkedChannelInput,
   parkedInputText, shouldClearTruncatedPreamble,
   parkedInputRowCount, submitLanded, decideStuckInputAction,
@@ -1815,8 +1815,10 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
           // Auto-answering "Yes" is deliberately NOT an option: that would be
           // the fleet granting itself a permission the owner gated.
           if (paneNow != null && detectsPermissionPrompt(paneNow)) {
-            logger.warn({ session: t.session, agent: label }, 'Session parked on a tool-permission prompt -- owner decision needed, alerting (no keystrokes sent)')
-            sendAlert(`🔐 A(z) ${label} agent egy eszköz-engedélyre vár (a panelen "Do you want to proceed?" kérdés áll). Ez NEM beragadt session: egy tool-hívás igent vagy nemet vár, és azt csak te adhatod meg. Ne indítsd újra, mert a futó munka elveszik. Válaszolj a panelen: tmux attach -t ${t.session}`)
+            const ask = permissionPromptSummary(paneNow)
+            logger.warn({ session: t.session, agent: label, ask }, 'Session parked on a tool-permission prompt -- a person has to decide, alerting (no keystrokes sent)')
+            const askLine = ask ? ` Ezt kérdezi: ${ask.title} -- ${ask.reason}` : ''
+            sendAlert(`🔐 A(z) ${label} agent egy eszköz-engedélyre vár.${askLine} Ez NEM beragadt session: egy tool-hívás igent vagy nemet vár, és azt csak ember adhatja meg. Ne indítsd újra, mert a futó munka elveszik. Válaszolj a panelen: tmux attach -t ${t.session}`)
           } else if (paneNow != null && detectsModelConsentDialog(paneNow)) {
             logger.warn({ session: t.session, agent: label }, 'Blocking "menu" is the model usage-credit consent dialog -- answering it safely instead of Escape')
             await dismissModelConsentDialogIfPresent(t.session)

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -36,7 +36,7 @@ import { probeTelegramConflict } from './channel-conflict-probe.js'
 import { schedulePluginUnlockAfterRespawn, wasPluginConfirmedAbsent, clearPluginAbsent } from './channel-plugin-unlock.js'
 import { getInjectedPrompt, matchesInjectedPrompt } from './injected-prompt-registry.js'
 import {
-  detectPaneState, decidePaneErrorAlert, detectsBlockingMenu, detectsFirstRunGate, detectsModelConsentDialog, type PaneErrorAlertState, type PaneState,
+  detectPaneState, decidePaneErrorAlert, detectsBlockingMenu, detectsFirstRunGate, detectsModelConsentDialog, detectsPermissionPrompt, type PaneErrorAlertState, type PaneState,
   stuckInputSignature, decideStuckInputRecovery, parkedChannelInput,
   parkedInputText, shouldClearTruncatedPreamble,
   parkedInputRowCount, submitLanded, decideStuckInputAction,
@@ -1803,7 +1803,21 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
           // first and answer it safely (option 1, keep the configured model);
           // only a genuine menu gets the blind Escape.
           const paneNow = capturePane(t.session)
-          if (paneNow != null && detectsModelConsentDialog(paneNow)) {
+          // A TOOL-PERMISSION prompt reaches this branch because its footer
+          // really does read "Esc to cancel" -- but Escape there is not the
+          // menu's "pop back to the prompt". It CANCELS the request, which is
+          // this process answering a consent question "no" on the owner's
+          // behalf, while the alert below would tell them their session was
+          // stuck "in an interactive menu (e.g. /mcp)". Measured on a live
+          // pane 2026-09-03 (agent-voicedev): detectsBlockingMenu true,
+          // detectsModelConsentDialog false -- nothing else stopped the blind
+          // Escape. Alert instead and leave the decision where it belongs.
+          // Auto-answering "Yes" is deliberately NOT an option: that would be
+          // the fleet granting itself a permission the owner gated.
+          if (paneNow != null && detectsPermissionPrompt(paneNow)) {
+            logger.warn({ session: t.session, agent: label }, 'Session parked on a tool-permission prompt -- owner decision needed, alerting (no keystrokes sent)')
+            sendAlert(`🔐 A(z) ${label} agent egy eszköz-engedélyre vár (a panelen "Do you want to proceed?" kérdés áll). Ez NEM beragadt session: egy tool-hívás igent vagy nemet vár, és azt csak te adhatod meg. Ne indítsd újra, mert a futó munka elveszik. Válaszolj a panelen: tmux attach -t ${t.session}`)
+          } else if (paneNow != null && detectsModelConsentDialog(paneNow)) {
             logger.warn({ session: t.session, agent: label }, 'Blocking "menu" is the model usage-credit consent dialog -- answering it safely instead of Escape')
             await dismissModelConsentDialogIfPresent(t.session)
             sendAlert(`🎛️ A(z) ${label} session a modell-hozzájárulás dialóguson parkolt; az 1-es opcióval (a beállított modell megtartása) továbbléptettem. Modellváltás NEM történt.`)

--- a/src/web/message-router.ts
+++ b/src/web/message-router.ts
@@ -28,7 +28,7 @@ import {
   capturePane,
   clearFeedbackModalAndRecheck,
 } from './agent-process.js'
-import { detectPaneState, type PaneState } from '../pane-state.js'
+import { detectPaneState, detectsPermissionPrompt, type PaneState } from '../pane-state.js'
 import { setLastInboundModality } from './voice-modality.js'
 import { classifyAgentMessage, wrapAgentMessageForDelivery } from './agent-message-wrap.js'
 import { maybeWakeSubAgentsForTelegram } from './telegram-inbox-wake.js'
@@ -91,10 +91,20 @@ export function formatStuckSessionAlert(
   stuckMs: number,
   pendingCount: number,
   paneState: PaneState | null = null,
+  awaitingPermission = false,
 ): string | null {
   if (agent === mainAgentId) return null
   const min = Math.round(stuckMs / 60000)
   const queue = `${pendingCount} pending message(s) queued`
+  // An unanswered tool-permission prompt looks EXACTLY like a wedged session
+  // from the queue side, and the not-ready text below tells the reader to
+  // restart. On 2026-09-03 that framing was one step away from throwing out
+  // two running sub-agents (~165k tokens) whose only problem was a question
+  // nobody had answered. A prompt needs an ANSWER, not a restart, so it gets
+  // its own sentence -- and the alert says who has to act.
+  if (awaitingPermission) {
+    return `[session-stuck] Agent '${agent}' (tmux ${session}) is parked on a TOOL-PERMISSION PROMPT for ${min} min with ${queue}. This is NOT a wedged session: a tool call is waiting for a yes/no answer, and only the owner can give it. Do NOT restart (that discards the running work and leaves the question unanswered) and do NOT send a blind Escape (that answers "no" on the owner's behalf). Open the pane and answer it: tmux attach -t ${session}`
+  }
   // A busy pane means the session is working, so the alert must not read like
   // "wedged, restart it" -- that framing is what turned the earlier busy-pane
   // alerts into wasted restarts-in-waiting. It says what it is: a long turn,
@@ -105,12 +115,12 @@ export function formatStuckSessionAlert(
   return `[session-stuck] Agent '${agent}' (tmux ${session}) has been not-ready for ${min} min with ${queue}. Run the delivery-stall diagnosis: check the pane (busy vs idle vs full context) and restart the agent if it is wedged.`
 }
 
-function notifyOrchestratorOfStuckSession(agent: string, session: string, stuckMs: number, pendingCount: number, paneState: PaneState | null): void {
+function notifyOrchestratorOfStuckSession(agent: string, session: string, stuckMs: number, pendingCount: number, paneState: PaneState | null, awaitingPermission = false): void {
   try {
-    const alert = formatStuckSessionAlert(agent, MAIN_AGENT_ID, session, stuckMs, pendingCount, paneState)
+    const alert = formatStuckSessionAlert(agent, MAIN_AGENT_ID, session, stuckMs, pendingCount, paneState, awaitingPermission)
     if (!alert) return
     createAgentMessage('system', MAIN_AGENT_ID, alert)
-    logger.info({ agent, session, stuckMs, pendingCount, paneState }, 'session-stuck surfaced to orchestrator')
+    logger.info({ agent, session, stuckMs, pendingCount, paneState, awaitingPermission }, 'session-stuck surfaced to orchestrator')
   } catch (err) {
     logger.warn({ err, agent }, 'Failed to enqueue session-stuck notification')
   }
@@ -597,7 +607,12 @@ export async function runMessageRouterTick(): Promise<void> {
             // stall to the main agent's inbox so it can run the delivery-stall
             // diagnosis (pane state, full context, restart). The escalation-window
             // reset below doubles as the notification cooldown.
-            notifyOrchestratorOfStuckSession(msg.to_agent, session, stuckMs, pendingMsgCount, paneState)
+            // The pane is already in hand; ask it whether the "stall" is in
+            // fact an unanswered permission prompt, so the alert can say what
+            // the reader has to DO (answer it) instead of what would destroy
+            // the work (restart it).
+            const awaitingPermission = pane != null && detectsPermissionPrompt(pane)
+            notifyOrchestratorOfStuckSession(msg.to_agent, session, stuckMs, pendingMsgCount, paneState, awaitingPermission)
             // Reset timer so we don't spam every tick; re-escalate after another window.
             agentStuckSince.set(msg.to_agent, now)
           } else {

--- a/src/web/message-router.ts
+++ b/src/web/message-router.ts
@@ -28,7 +28,7 @@ import {
   capturePane,
   clearFeedbackModalAndRecheck,
 } from './agent-process.js'
-import { detectPaneState, detectsPermissionPrompt, type PaneState } from '../pane-state.js'
+import { detectPaneState, detectsPermissionPrompt, permissionPromptSummary, type PaneState, type PermissionPromptSummary } from '../pane-state.js'
 import { setLastInboundModality } from './voice-modality.js'
 import { classifyAgentMessage, wrapAgentMessageForDelivery } from './agent-message-wrap.js'
 import { maybeWakeSubAgentsForTelegram } from './telegram-inbox-wake.js'
@@ -92,6 +92,7 @@ export function formatStuckSessionAlert(
   pendingCount: number,
   paneState: PaneState | null = null,
   awaitingPermission = false,
+  permissionAsk: PermissionPromptSummary | null = null,
 ): string | null {
   if (agent === mainAgentId) return null
   const min = Math.round(stuckMs / 60000)
@@ -103,7 +104,11 @@ export function formatStuckSessionAlert(
   // nobody had answered. A prompt needs an ANSWER, not a restart, so it gets
   // its own sentence -- and the alert says who has to act.
   if (awaitingPermission) {
-    return `[session-stuck] Agent '${agent}' (tmux ${session}) is parked on a TOOL-PERMISSION PROMPT for ${min} min with ${queue}. This is NOT a wedged session: a tool call is waiting for a yes/no answer, and only the owner can give it. Do NOT restart (that discards the running work and leaves the question unanswered) and do NOT send a blind Escape (that answers "no" on the owner's behalf). Open the pane and answer it: tmux attach -t ${session}`
+    // Carry WHAT is being asked. The orchestrator answered two of these by
+    // hand on 2026-09-03 and both times the deciding step was opening the
+    // pane to read the question; an alert that quotes it saves that step.
+    const ask = permissionAsk ? ` It asks: ${permissionAsk.title} -- ${permissionAsk.reason}` : ''
+    return `[session-stuck] Agent '${agent}' (tmux ${session}) is parked on a TOOL-PERMISSION PROMPT for ${min} min with ${queue}.${ask} This is NOT a wedged session: a tool call is waiting for a yes/no answer, and only a person can give it. Do NOT restart (that discards the running work and leaves the question unanswered) and do NOT send a blind Escape (that answers "no" on the asker's behalf). Answer it in the pane: tmux attach -t ${session}`
   }
   // A busy pane means the session is working, so the alert must not read like
   // "wedged, restart it" -- that framing is what turned the earlier busy-pane
@@ -115,9 +120,9 @@ export function formatStuckSessionAlert(
   return `[session-stuck] Agent '${agent}' (tmux ${session}) has been not-ready for ${min} min with ${queue}. Run the delivery-stall diagnosis: check the pane (busy vs idle vs full context) and restart the agent if it is wedged.`
 }
 
-function notifyOrchestratorOfStuckSession(agent: string, session: string, stuckMs: number, pendingCount: number, paneState: PaneState | null, awaitingPermission = false): void {
+function notifyOrchestratorOfStuckSession(agent: string, session: string, stuckMs: number, pendingCount: number, paneState: PaneState | null, awaitingPermission = false, permissionAsk: PermissionPromptSummary | null = null): void {
   try {
-    const alert = formatStuckSessionAlert(agent, MAIN_AGENT_ID, session, stuckMs, pendingCount, paneState, awaitingPermission)
+    const alert = formatStuckSessionAlert(agent, MAIN_AGENT_ID, session, stuckMs, pendingCount, paneState, awaitingPermission, permissionAsk)
     if (!alert) return
     createAgentMessage('system', MAIN_AGENT_ID, alert)
     logger.info({ agent, session, stuckMs, pendingCount, paneState, awaitingPermission }, 'session-stuck surfaced to orchestrator')
@@ -612,7 +617,8 @@ export async function runMessageRouterTick(): Promise<void> {
             // the reader has to DO (answer it) instead of what would destroy
             // the work (restart it).
             const awaitingPermission = pane != null && detectsPermissionPrompt(pane)
-            notifyOrchestratorOfStuckSession(msg.to_agent, session, stuckMs, pendingMsgCount, paneState, awaitingPermission)
+            const permissionAsk = awaitingPermission && pane != null ? permissionPromptSummary(pane) : null
+            notifyOrchestratorOfStuckSession(msg.to_agent, session, stuckMs, pendingMsgCount, paneState, awaitingPermission, permissionAsk)
             // Reset timer so we don't spam every tick; re-escalate after another window.
             agentStuckSince.set(msg.to_agent, now)
           } else {


### PR DESCRIPTION
## Mit javít

Egy eszköz-engedélyre váró Claude Code pane a sor felől pontosan úgy néz ki, mint egy beragadt session. 2026-09-03-án a flotta kétszer is rosszul kezelte: a voicedev egy sub-agent Bash-grepjének engedélykérdésén állt, egy függő üzenettel, és a riasztás restartot javasolt.

## Mit mértem a valódi panelen

A fixture (`src/__tests__/fixtures/pane/permission-prompt-bash-grep.txt`) egy **élő pane** anonimizált másolata, nem kitalált alak. A repo saját detektorait futtattam rá:

| detektor | eredmény | következmény |
|---|---|---|
| `detectPaneState` | `unknown` | a stuck-riasztás a not-ready ágra megy, aminek a szövege *„restart the agent if it is wedged"* |
| `detectsBlockingMenu` | `true` | a monitor vak `Escape`-et küldene |
| `detectsModelConsentDialog` | `false` | a FABLEFALL1 biztonságos ága nem fogja meg |

A vak `Escape` itt nem „vissza a prompthoz": a footer `Esc to cancel`, vagyis **egy engedélykérés elutasítása a tulajdonos nevében**, miközben a riasztás azt írta volna, hogy `/mcp`-szerű menüben ragadt. A restart pedig két futó sub-agent munkáját dobta volna el, és a valódi okot a helyén hagyta volna.

## Mit csinál

- **`detectsPermissionPrompt`**: külön, függőségmentes detektor a mért alakra (kérdés **és** számozott `1. Yes` a footer-régióban), ugyanazokkal a busy / idle-footer őrökkel, amiket a `detectsBlockingMenu` használ.
- **Stuck-riasztás**: engedélykérdésre külön mondat — válasz kell, ne restartolj, ne Escape-elj, és ott a pane megnyitásának módja.
- **Monitor**: a blocking-menü ágon előbb az engedélykérdést nézi, és riaszt a vak Escape helyett.

## Amit szándékosan NEM csinál

Nem válaszol automatikusan. Az `1. Yes` kiküldése azt jelentené, hogy a flotta maga adja meg magának azt az engedélyt, amit a tulajdonos szándékosan kapuzott. Ez a döntés marad emberi.

## Ami kimarad ebből a PR-ből (Zsolt döntése)

A kártya első pontja — hogy a saját worktree-ben a `grep`/`Read` ne legyen engedélyköteles — **engedélyszabály-lazítás**, biztonsági hatással. Azt nem csinálom meg magamtól; külön döntés, külön PR.

## Verify

- **7 új teszt** a valódi pane-fixture-re, plusz negatív kontrollok (busy pane, idéző idle prompt, üres, csak-kérdés, csak-opciók).
- **Mutáció-próba**: a riasztás engedély-ágának kivétele → 2 teszt piros; a detektor lazítása csak a kérdésre → 1 teszt piros; visszaállítás után mind a 7 zöld.
- Teljes suite **353 fájl / 4595 teszt zöld**, `tsc --noEmit` tiszta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5utRgfreZE6g7T2W82ryY