### PR TITLE
feat(hooks): a branch-creation gate for sub-agents, seeded for them alone

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,3 +47,4 @@ jobs:
       # regression guard that only runs manually rots exactly like a one-shot
       # seed. Runs natively here (ubuntu = the Linux branch it asserts).
       - run: bash scripts/__tests__/stop-start-system-unit.test.sh
+      - run: bash scripts/__tests__/live-branch-switch-gate.test.sh

--- a/scripts/__tests__/live-branch-switch-gate.test.sh
+++ b/scripts/__tests__/live-branch-switch-gate.test.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# live-branch-switch-gate: behaviour test. 0 = allowed through, 2 = stopped.
+set -u
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+GATE="$ROOT/scripts/hooks/live-branch-switch-gate.py"
+pass=0; fail=0
+check() { if [ "$2" = "$3" ]; then pass=$((pass+1)); echo "ok   - $1"
+  else fail=$((fail+1)); echo "FAIL - $1 (want=$2 got=$3)"; fi; }
+run() { python3 -c 'import json,sys;print(json.dumps({"tool_name":"Bash","tool_input":{"command":sys.argv[1]}}))' "$1" \
+        | python3 "$GATE" >/dev/null 2>&1; echo $?; }
+
+check "bare checkout -b in the live tree STOPS" 2 "$(run 'git checkout -b feature/x')"
+check "switch -c stops too"                     2 "$(run 'git switch -c feature/x')"
+check "cd live && checkout -b STOPS"           2 "$(run 'git checkout -b fix/y')"
+check "from a sub-agent directory it STOPS"                2 "$(run 'cd '"$ROOT"'/agents/subagent && git checkout -b feature/subagent/z')"
+check "git -C live checkout -b STOPS"          2 "$(run 'git -C '"$ROOT"' checkout -b fix/y')"
+
+check "worktree form passes"                     0 "$(run 'git worktree add /tmp/wt -b fix/y develop && cd /tmp/wt')"
+check "cd into /tmp passes"                     0 "$(run 'cd /tmp/wt-x && git checkout -b fix/y')"
+check "a variable path passes"                 0 "$(run 'cd "$WT" && git checkout -b fix/y')"
+check "an intervening command does not fool it"      0 "$(run 'cd "$SCRATCH/wt" && rm -f node_modules && git checkout -b fix/y')"
+check "a worktree under ~ passes"              0 "$(run 'cd ~/claw-test && git checkout -b fix/y')"
+
+check "switching to an existing branch passes"              0 "$(run 'git checkout develop')"
+check "restoring a file passes"               0 "$(run 'git checkout -- scripts/x.sh')"
+check "listing branches passes"              0 "$(run 'git branch --show-current')"
+
+# The two false hits measurement produced: the forbidden form appears as DATA.
+check "MENTIONED inside a curl -d payload passes"       0 "$(run "curl -s -X POST http://localhost:3420/api/messages -d '{\"content\":\"do not run git checkout -b feature/x\"}'")"
+check "MENTIONED in backticked prose passes"      0 "$(run 'echo "not `git checkout -b feature/sub/daily-log-digest`"')"
+check "MENTIONED in a heredoc passes"               0 "$(run "cat > /tmp/a.md <<'XX'
+git checkout -b feature/x
+XX")"
+
+check "a non-Bash tool passes"  0 "$(printf '%s' '{"tool_name":"Write","tool_input":{"file_path":"/a.py","content":"git checkout -b x"}}' | python3 "$GATE" >/dev/null 2>&1; echo $?)"
+check "malformed json passes"   0 "$(printf 'nem-json' | python3 "$GATE" >/dev/null 2>&1; echo $?)"
+check "an empty command passes"   0 "$(run '')"
+check "it speaks EVERY time (second run too)" 2 "$(run 'git checkout -b feature/x')"
+
+echo '---'; echo "pass=$pass fail=$fail"; [ "$fail" -eq 0 ]

--- a/scripts/hooks/live-branch-switch-gate.py
+++ b/scripts/hooks/live-branch-switch-gate.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""PreToolUse (Bash) gate: creating a branch in the LIVE tree.
+
+WHAT IT PROTECTS: a marveen checkout is not only a repository, it is the RUNNING
+install. The systemd units and the scheduler point at `scripts/*.sh` inside the
+working tree, so switching that tree to a feature branch makes every script that
+exists only on another branch disappear from disk, and the unit fails with
+203/EXEC. Sub-agent working directories (`agents/<name>/`) live INSIDE that same
+tree, so for them a `git checkout -b` switches the very tree the system runs from.
+
+WHY IT IS SEEDED FOR SUB-AGENTS ONLY (measured 2026-08-31 on a live fleet):
+the main agent's own transcripts held ten branch creations, ALL of them inside a
+`git worktree` -- zero real cases. Both real incidents were a sub-agent's:
+
+  * one stopped at a permission prompt on `git checkout -b` in the live tree,
+  * one created the branch and LEFT the tree on it for hours. Nothing broke,
+    because that branch only ADDED files, so the usual 203/EXEC symptom never
+    appeared. The silent damage: the updater's preflight hard-blocks on
+    `local-commits`, so the install quietly stopped being updatable.
+
+The second case is the reason this gate exists: the failure that leaves no
+symptom is the one nobody goes looking for. A gate is worth having where the
+hand it holds actually reaches for the wrong thing -- see
+`src/web/agent-scaffold.ts` `FLEET_ONLY_HOOK_SCRIPTS`.
+
+IT SPEAKS EVERY TIME, not once per file: there is a cheap correct form to use
+instead, so there is nothing to acknowledge -- the command should be rewritten.
+(Gates whose correct step cannot be checked from a machine warn once and move on.)
+
+FAIL-OPEN: any internal error exits 0. Exit 2 is the only stop.
+"""
+import json, os, re, sys
+
+# The install this hook was seeded into: two levels up from scripts/hooks/.
+# Derived from the file's own location rather than an env var, so the gate keeps
+# working when the hook runs with a minimal environment.
+LIVE = os.path.realpath(os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", ".."))
+
+
+def strip_noise(cmd):
+    """Drop heredoc bodies, comment lines and DATA payloads before scanning.
+
+    The heredoc and comment handling is taken from the remote-command gate, where
+    it was measured: without it, prose typed into a heredoc is read as commands
+    (about 60% of the hits were noise).
+
+    The DATA payload rule was added from a separate measurement (2026-08-31): a
+    `curl -d '...'` body carried an inter-agent MESSAGE that quoted the forbidden
+    command as an example. Two of the three apparently-real hits were that. A
+    message in which the wrong form APPEARS is not the wrong form being run.
+    """
+    cmd = re.sub(r"<<-?\s*(['\"]?)(\w+)\1.*?\n.*?^\s*\2\s*$", " ", cmd, flags=re.S | re.M)
+    cmd = re.sub(r"(?:--data-urlencode|--data-raw|--data|-d)\s+'(?:[^']|'\\'')*'", " ", cmd)
+    cmd = re.sub(r'(?:--data-urlencode|--data-raw|--data|-d)\s+"(?:[^"\\]|\\.)*"', " ", cmd)
+    cmd = re.sub(r"`[^`]*`", " ", cmd)          # backtick quote: prose, not a command
+    return "\n".join(s for s in cmd.split("\n") if not s.lstrip().startswith("#"))
+
+
+# Branch CREATION from command position, the flag directly after checkout/switch.
+# The `cd X ... &&` part is matched loosely because another command often sits
+# between the `cd` and the `git` (`cd "$WT" && rm -rf node_modules && git checkout
+# -b ...`); a strict form marked one such hit as live when it was not.
+NEW_BRANCH = re.compile(
+    r"(?:^|[;&|(\n]|\bthen\b|\bdo\b|\$\()\s*"
+    r"(?:cd\s+(?P<cd>\S+)[^\n]*?&&\s*)?"
+    r"git\s+(?:-C\s+(?P<C>\S+)\s+)?(?:checkout\s+-b|switch\s+-c)\s+(?P<br>\S+)", re.M)
+WORKTREE = re.compile(r"\bgit\s+worktree\s+add\b")
+
+
+def outside_live(path):
+    """Does the command target a DIFFERENT tree? Only when it says so explicitly."""
+    if not path:
+        return False
+    p = path.strip("'\"")
+    if p.startswith(("$", "~", "/tmp")):
+        return True          # a variable or tmp: in practice a worktree or scratch dir
+    if p.startswith("/"):
+        return not p.startswith(LIVE)   # anything under LIVE (incl. agents/<name>) is live
+    return False             # a relative path keeps us inside the live tree
+
+
+def main():
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)
+    try:
+        if payload.get("tool_name") != "Bash":
+            sys.exit(0)
+        cmd = (payload.get("tool_input") or {}).get("command") or ""
+        if not cmd:
+            sys.exit(0)
+        clean = strip_noise(cmd)
+        if WORKTREE.search(clean):
+            sys.exit(0)                       # building a worktree: the correct form
+        m = NEW_BRANCH.search(clean)
+        if not m:
+            sys.exit(0)
+        if outside_live(m.group("C") or m.group("cd")):
+            sys.exit(0)
+        branch = (m.group("br") or "").strip("'\"`")
+        sys.stderr.write(
+            "LIVE-TREE GATE: this would create a branch (" + branch + ") in the tree the\n"
+            "install RUNS FROM.\n\n"
+            "The " + LIVE + " checkout is also the live system: systemd units and the\n"
+            "scheduler point at its working-tree scripts/*.sh. On a branch switch, every\n"
+            "script that exists only on another branch disappears from the tree and the\n"
+            "unit fails with 203/EXEC. Sub-agent working directories (agents/<name>/) are\n"
+            "inside this same tree.\n\n"
+            "This has happened: a feature branch stood on the live tree for hours. Nothing\n"
+            "visibly broke, because that branch only ADDED files -- which is why nobody\n"
+            "noticed. The silent cost: the updater's preflight hard-blocks on local-commits.\n\n"
+            "THE CORRECT FORM:\n"
+            "  git worktree add /tmp/<name>-<task> -b " + (branch or "<branch>") + " develop\n"
+            "  # do the work THERE; the live tree is untouched\n"
+            "  # when done: git worktree remove /tmp/<name>-<task>\n\n"
+            "Check afterwards: `git branch --show-current` should still say develop.\n"
+        )
+        sys.exit(2)
+    except Exception:
+        sys.exit(0)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/__tests__/fleet-only-hook-filter.test.ts
+++ b/src/__tests__/fleet-only-hook-filter.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, mkdirSync, rmSync, readFileSync, writeFileSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+// FLEET-ONLY GATES (2026-09-03): templates/settings.json.template seeds
+// live-branch-switch-gate.py so a NEWLY scaffolded sub-agent gets the gate its six
+// live siblings already had (measured gap: template 8 hooks, slarti 9).
+//
+// The trap this filter closes: agentSettingsPath(MAIN_AGENT_ID) resolves to the
+// user-global ~/.claude/settings.json, and src/web.ts calls ensureAgentHooks() for
+// MAIN_AGENT_ID on every boot. Without the filter the template entry would register
+// a PreToolUse(Bash) hook in front of EVERY Claude Code session on the owner's
+// machine, in projects unrelated to this repo. The gate's own rationale is per-agent:
+// the main agent's transcripts held ten branch creations, all in worktrees (zero real
+// cases); both real incidents were a sub-agent's.
+//
+// The load-bearing assertion is the ASYMMETRY -- same template, two targets, present
+// for one and absent for the other. Asserting only "the main agent lacks it" would
+// also pass if the gate reached nobody, which is the state this change came from.
+
+let SANDBOX = ''
+
+vi.mock('node:os', async (orig) => {
+  const actual = await orig<typeof import('node:os')>()
+  return { ...actual, homedir: () => join(SANDBOX, 'home') }
+})
+
+const { ensureAgentHooks, agentSettingsPath, isFleetOnlyHookCommand } =
+  await import('../web/agent-scaffold.js')
+const { MAIN_AGENT_ID } = await import('../config.js')
+
+const ROOT = join(__dirname, '..', '..')
+const GATE = 'live-branch-switch-gate.py'
+const SUB = 'fleetonlyprobe'
+const SUB_DIR = join(ROOT, 'agents', SUB)
+
+function hookCommands(path: string): string[] {
+  const d = JSON.parse(readFileSync(path, 'utf-8')) as {
+    hooks?: Record<string, { hooks?: { command?: string }[] }[]>
+  }
+  return Object.values(d.hooks ?? {}).flatMap((entries) =>
+    entries.flatMap((e) => (e.hooks ?? []).map((h) => h.command ?? '')),
+  )
+}
+
+beforeEach(() => {
+  SANDBOX = mkdtempSync(join(tmpdir(), 'fleetonly-'))
+  mkdirSync(join(SANDBOX, 'home', '.claude'), { recursive: true })
+  mkdirSync(join(SUB_DIR, '.claude'), { recursive: true })
+})
+
+afterEach(() => {
+  rmSync(SANDBOX, { recursive: true, force: true })
+  rmSync(SUB_DIR, { recursive: true, force: true })
+})
+
+describe('fleet-only hook filter', () => {
+  it('classifies only the listed scripts, anchored on the hooks directory', () => {
+    expect(isFleetOnlyHookCommand(`python3 /x/scripts/hooks/${GATE}`)).toBe(true)
+    expect(isFleetOnlyHookCommand(
+      `bash -c '[ -f /x/scripts/hooks/${GATE} ] && exec python3 /x/scripts/hooks/${GATE}; exit 0'`,
+    )).toBe(true)
+    // A narrow exception, not a new default: every other template hook is unaffected.
+    expect(isFleetOnlyHookCommand('python3 /x/scripts/hooks/provenance-gate.py')).toBe(false)
+    expect(isFleetOnlyHookCommand('python3 /x/scripts/hooks/taskstate-replay.py')).toBe(false)
+    // Anchored, so a same-named script elsewhere is not silently suppressed.
+    expect(isFleetOnlyHookCommand(`python3 /x/tools/${GATE}`)).toBe(false)
+  })
+
+  it('seeds the gate for a sub-agent but NOT for the main agent (same template)', () => {
+    // Main agent: settings.json absent -> the "seed from template" branch.
+    const mainPath = agentSettingsPath(MAIN_AGENT_ID)
+    expect(mainPath.startsWith(join(SANDBOX, 'home'))).toBe(true)
+    ensureAgentHooks(MAIN_AGENT_ID)
+    expect(existsSync(mainPath)).toBe(true)
+    const mainCmds = hookCommands(mainPath)
+    expect(mainCmds.some((c) => c.includes(GATE))).toBe(false)
+    // Positive control on the same file: the shared template hooks DID arrive,
+    // so the absence above is the filter, not an empty write.
+    expect(mainCmds.some((c) => c.includes('clear-capture.py'))).toBe(true)
+
+    // Sub-agent, same template, same call: the gate must be there.
+    ensureAgentHooks(SUB)
+    const subCmds = hookCommands(agentSettingsPath(SUB))
+    expect(subCmds.some((c) => c.includes(GATE))).toBe(true)
+  })
+
+  it('does not add the gate to the main agent on the wholesale-add path either', () => {
+    // The template's PreToolUse block did not exist before this change, so an
+    // existing settings file with OTHER events is exactly how a fleet-only gate
+    // would slip in: "event entirely missing -> add it wholesale".
+    const mainPath = agentSettingsPath(MAIN_AGENT_ID)
+    writeFileSync(mainPath, JSON.stringify({
+      hooks: { SessionStart: [{ matcher: 'clear', hooks: [{ type: 'command', command: 'true' }] }] },
+    }, null, 2))
+    ensureAgentHooks(MAIN_AGENT_ID)
+    const cmds = hookCommands(mainPath)
+    expect(cmds.some((c) => c.includes(GATE))).toBe(false)
+    expect(cmds).toContain('true')            // pre-existing hook preserved
+    expect(cmds.length).toBeGreaterThan(1)    // and the merge really ran
+  })
+})

--- a/src/web/agent-scaffold.ts
+++ b/src/web/agent-scaffold.ts
@@ -145,6 +145,26 @@ export function agentSettingsPath(name: string): string {
 // the 2026-07-14 silent fleet-freeze incident.
 const _TMP_PREFIXES = ['/tmp/', '/var/tmp/', '/private/tmp/', '/dev/shm/']
 
+// FLEET-ONLY GATES: hooks the template seeds for sub-agents but MUST NOT reach the
+// main agent. agentSettingsPath(MAIN_AGENT_ID) resolves to the user-global
+// ~/.claude/settings.json, and ensureAgentHooks() is called for MAIN_AGENT_ID on
+// every boot (src/web.ts) -- so a template entry lands in front of EVERY Claude Code
+// session on the owner's machine, including projects unrelated to this repo.
+//
+// Measured 2026-09-03: live-branch-switch-gate.py was wired in all six fleet agents
+// but missing from the template. Copying it into the template closes that gap, but
+// without this filter it would also register a PreToolUse(Bash) hook globally. The
+// gate's own rationale is per-agent: the main agent's transcripts held ten branch
+// creations, ALL in worktrees (zero real cases); both real incidents were a sub-agent's.
+//
+// Add a basename here when a gate is meant for sub-agents only. Everything else in
+// the template continues to reach the main agent unchanged.
+const FLEET_ONLY_HOOK_SCRIPTS = ['live-branch-switch-gate.py']
+
+export function isFleetOnlyHookCommand(command: string): boolean {
+  return FLEET_ONLY_HOOK_SCRIPTS.some((s) => command.includes(`/hooks/${s}`))
+}
+
 // Shared hook-entry type used by ensureAgentHooks and upgradeLegacyHookCommands.
 type HookEntry = { matcher?: string; hooks?: Array<{ command?: string; timeout?: number; [k: string]: unknown }> }
 
@@ -316,8 +336,20 @@ export function ensureAgentHooks(name: string): boolean {
     if (syncHookMatchers(existingHooks, tplHooks)) changed = true
     for (const [event, handlers] of Object.entries(tplHooks)) {
       if (!existingHooks[event]) {
-        existingHooks[event] = handlers
-        changed = true
+        // Adding a whole missing event must obey the fleet-only filter too: the
+        // template's PreToolUse block did not exist before 2026-09-03, so the
+        // wholesale-add path is exactly how a fleet-only gate would reach the
+        // main agent's global settings.
+        const seeded = (handlers as HookEntry[]).map((entry) => ({
+          ...entry,
+          hooks: (entry.hooks ?? []).filter(
+            (h) => !h.command || !(name === MAIN_AGENT_ID && isFleetOnlyHookCommand(h.command)),
+          ),
+        })).filter((entry) => (entry.hooks?.length ?? 0) > 0)
+        if (seeded.length > 0) {
+          existingHooks[event] = seeded
+          changed = true
+        }
       } else {
         const tplEntries = handlers as HookEntry[]
         const existEntries = existingHooks[event] as HookEntry[]
@@ -328,7 +360,8 @@ export function ensureAgentHooks(name: string): boolean {
         for (const tplEntry of tplEntries) {
           // Add hooks that are missing AND safe to register (registration guard).
           const newHooks = (tplEntry.hooks ?? []).filter(
-            (h) => h.command && !existingCommands.has(h.command) && !isUnsafeHookCommand(h.command),
+            (h) => h.command && !existingCommands.has(h.command) && !isUnsafeHookCommand(h.command)
+              && !(name === MAIN_AGENT_ID && isFleetOnlyHookCommand(h.command)),
           )
           if (newHooks.length > 0) {
             existEntries.push({ ...tplEntry, hooks: newHooks })
@@ -356,7 +389,8 @@ export function ensureAgentHooks(name: string): boolean {
     for (const [event, entries] of Object.entries(tplHooks)) {
       const safeEntries = (entries as HookEntry[]).map((entry) => ({
         ...entry,
-        hooks: (entry.hooks ?? []).filter((h) => !h.command || !isUnsafeHookCommand(h.command)),
+        hooks: (entry.hooks ?? []).filter((h) => !h.command || (!isUnsafeHookCommand(h.command)
+          && !(name === MAIN_AGENT_ID && isFleetOnlyHookCommand(h.command)))),
       })).filter((entry) => (entry.hooks?.length ?? 0) > 0)
       if (safeEntries.length > 0) safeHooks[event] = safeEntries
     }

--- a/templates/settings.json.template
+++ b/templates/settings.json.template
@@ -49,6 +49,18 @@
         ]
       }
     ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c '[ -f {{PROJECT_ROOT}}/scripts/hooks/live-branch-switch-gate.py ] && exec python3 {{PROJECT_ROOT}}/scripts/hooks/live-branch-switch-gate.py; exit 0'",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Skill|Read",


### PR DESCRIPTION
## What

A marveen checkout is not only a repository, it is the **running install**: the systemd units and the scheduler point at scripts in the working tree. Switch that tree to a feature branch and every script that lives only on another branch disappears from disk -- the unit fails with `203/EXEC`. Sub-agent working directories (`agents/<name>/`) sit inside that same tree, so for them a `git checkout -b` switches the tree the system runs from.

This adds a fail-open PreToolUse(Bash) gate that catches branch **creation** in the live tree and prints the worktree form instead, plus the scaffold change that seeds it **for sub-agents only**.

## Why it is worth a gate

Two real incidents, both a sub-agent's. The second is the reason this exists: a feature branch stood on the live tree for hours and **nothing visibly broke**, because that branch only ADDED files -- so the usual `203/EXEC` symptom never appeared and nobody went looking. The silent cost is that the updater's preflight hard-blocks on `local-commits`: the install had quietly stopped being updatable.

A failure that leaves no symptom is the one that keeps running.

## The part that needed care: the main agent's settings file is global

`agentSettingsPath(MAIN_AGENT_ID)` resolves to the user-global `~/.claude/settings.json`, and `ensureAgentHooks()` runs for MAIN_AGENT_ID on every boot. A template hook therefore lands in front of **every Claude Code session on the owner's machine**, including projects unrelated to this repo. Seeding this gate through the template without a filter would register a PreToolUse(Bash) hook globally -- a far larger blast radius than the problem it solves.

So `FLEET_ONLY_HOOK_SCRIPTS` names the scripts the template seeds for sub-agents alone, applied on **all three** paths that write hooks: the whole-missing-event add, the per-entry add, and the seed-from-template branch. Everything else in the template continues to reach the main agent unchanged.

The measured reason for the split, rather than a preference: the main agent's transcripts held ten branch creations, **all** of them inside a `git worktree` (zero real cases), while both real incidents were a sub-agent's.

## Tests

`src/__tests__/fleet-only-hook-filter.test.ts` asserts the **asymmetry** -- same template, two targets, gate present for one and absent for the other -- with a positive control on the main agent's own file. Asserting only "the main agent lacks it" would also pass if the gate reached nobody, which is precisely the state this change came from.

`scripts/__tests__/live-branch-switch-gate.test.sh` (20 cases, wired into CI next to the existing shell test) covers both directions: the live tree stops; a worktree, a `/tmp` path, a variable path and an intervening command all pass.

Two false-positive classes were measured and are handled explicitly:

* heredoc bodies and comment lines -- taken from the remote-command gate, where prose typed into a heredoc was read as commands;
* `curl -d '...'` payloads -- two of three apparently-real hits were an inter-agent MESSAGE quoting the forbidden command as an example. A message in which the wrong form appears is not the wrong form being run.

## Safety

Fail-open by construction: any internal error in the gate exits 0, and the template entry is wrapped (`[ -f ... ] && exec python3 ...; exit 0`) so a missing script is a no-op rather than a blocked Bash tool.

## What my run does not cover

Full suite on this branch: 4587 passed, 4 failed -- all four are environment-flaky here and pass when run on their own file (two wait on a live Ollama, two are 5s auth timeouts under parallel load); verified with `git stash` before/after. Typecheck clean. The two shell tests were run directly (20/20 and the existing one), but this is the first branch where the new one runs in CI, so that pipe is unproven until it goes green here.