### PR TITLE
fix(memory): generate embedding in saveMemory too, with a test that actually guards it

### DIFF
--- a/src/__tests__/db.test.ts
+++ b/src/__tests__/db.test.ts
@@ -79,6 +79,21 @@ describe('memories', () => {
   it('leepulesi soprest vegrehajt hiba nelkul', () => {
     expect(() => decayMemories()).not.toThrow()
   })
+
+  // Regresszio: a saveMemory sokaig csak INSERT-elt, embedding nelkul, ezert az
+  // ezen az uton irt sorok (pl. az ejszakai "[Napi naplo ...]" digest) tartosan
+  // vektorizalatlanul maradtak es kiestek a szemantikus keresesbol. A
+  // saveAgentMemory-hoz hasonloan itt is fire-and-forget embed fut; a teszt azt
+  // rogziti, hogy a hivas elinditja az embed-agat es nem dobja el a sort akkor
+  // sem, ha az embedding szolgaltatas (Ollama) nem elerheto.
+  it('saveMemory elinditja az embedding-agat es nem hasal el, ha nincs Ollama', async () => {
+    expect(() => saveMemory('mem-chat-embed', '[Napi naplo teszt] digest', 'episodic')).not.toThrow()
+    const mems = getMemoriesForChat('mem-chat-embed')
+    expect(mems.length).toBeGreaterThan(0)
+    expect(mems[0].content).toBe('[Napi naplo teszt] digest')
+    // a fire-and-forget agnak egy tick alatt sem szabad unhandled rejectiont dobnia
+    await new Promise(r => setTimeout(r, 50))
+  })
 })
 
 describe('buildFtsMatchExpression', () => {

--- a/src/__tests__/db.test.ts
+++ b/src/__tests__/db.test.ts
@@ -86,13 +86,51 @@ describe('memories', () => {
   // saveAgentMemory-hoz hasonloan itt is fire-and-forget embed fut; a teszt azt
   // rogziti, hogy a hivas elinditja az embed-agat es nem dobja el a sort akkor
   // sem, ha az embedding szolgaltatas (Ollama) nem elerheto.
-  it('saveMemory elinditja az embedding-agat es nem hasal el, ha nincs Ollama', async () => {
+  it('saveMemory nem hasal el, ha nincs Ollama', async () => {
     expect(() => saveMemory('mem-chat-embed', '[Napi naplo teszt] digest', 'episodic')).not.toThrow()
     const mems = getMemoriesForChat('mem-chat-embed')
     expect(mems.length).toBeGreaterThan(0)
     expect(mems[0].content).toBe('[Napi naplo teszt] digest')
     // a fire-and-forget agnak egy tick alatt sem szabad unhandled rejectiont dobnia
     await new Promise(r => setTimeout(r, 50))
+  })
+
+  // A fenti eset csak azt allitja, hogy a beszuras tulel egy halott Ollamat.
+  // Az NEM esik el tole, ha az embed-blokk teljesen hianyzik -- pontosan ezert
+  // maradhatott eszrevetlen, hogy a saveMemory evekig embedding nelkul INSERT-elt.
+  // Ez a teszt a MEGELOZEST rogziti: elerheto embedding-szolgaltatas mellett a
+  // saveMemory-val irt sor NEM maradhat NULL embeddinggel. Ha valaki kiveszi a
+  // fire-and-forget blokkot, ez a teszt bukik.
+  it('saveMemory vektorizalja a sort, ha az embedding-szolgaltatas valaszol', async () => {
+    const vector = Array.from({ length: 8 }, (_, i) => i / 10)
+    const realFetch = globalThis.fetch
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ embedding: vector }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })) as typeof globalThis.fetch
+
+    try {
+      saveMemory('mem-chat-embed-ok', '[Napi naplo teszt] vektorizalando', 'episodic')
+      const id = getMemoriesForChat('mem-chat-embed-ok')[0].id
+
+      // Az embed-ag fire-and-forget, ezert nem szinkron assert kell, hanem
+      // idokorlatos varakozas. Szinkron ellenorzes vagy hibasan bukna, vagy
+      // veletlenszeruen menne at.
+      const db = getDb()
+      const read = () => (db.prepare('SELECT embedding FROM memories WHERE id = ?')
+        .get(id) as { embedding: string | null }).embedding
+      const deadline = Date.now() + 2000
+      while (read() === null && Date.now() < deadline) {
+        await new Promise(r => setTimeout(r, 20))
+      }
+
+      const stored = read()
+      expect(stored).not.toBeNull()
+      expect(JSON.parse(stored!)).toEqual(vector)
+    } finally {
+      globalThis.fetch = realFetch
+    }
   })
 })
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -1176,9 +1176,21 @@ export function saveMemory(
   topicKey?: string
 ): void {
   const now = Math.floor(Date.now() / 1000)
-  db.prepare(
+  const info = db.prepare(
     'INSERT INTO memories (chat_id, topic_key, content, sector, salience, created_at, accessed_at) VALUES (?, ?, ?, ?, 1.0, ?, ?)'
   ).run(chatId, topicKey ?? null, content, sector, now, now)
+  const id = Number(info.lastInsertRowid)
+
+  // Fire-and-forget embedding, same as saveAgentMemory. Without this the rows
+  // written through THIS path stayed unvectorised for good: the nightly daily
+  // log digest (memory.ts, "[Napi naplo ...]") is saved here, so every night
+  // one memory was missing from semantic search until the Dream Engine
+  // backfilled it by hand.
+  generateEmbedding(content).then(emb => {
+    if (emb) {
+      db.prepare('UPDATE memories SET embedding = ? WHERE id = ?').run(JSON.stringify(emb), id)
+    }
+  }).catch(() => {})
 }
 
 // Build a safe FTS5 MATCH expression from a free-form user query.


### PR DESCRIPTION
## Mi ez

A `saveMemory()` csak nyers `INSERT`-et futtatott, miközben a `saveAgentMemory()` mellette elindítja a fire-and-forget embeddinget. Az ezen az úton írt sorok ezért soha nem vektorizálódtak, és kiestek a szemantikus keresésből.

Élesben ez az éjszakai napi napló digestet érinti (`src/memory.ts` a `[Napi naplo ...]` bejegyzést a `saveMemory`-val menti), tehát **minden éjjel pontosan egy emlék hiányzott** a keresésből, amíg a Dream Engine kézzel be nem backfillelte.

## Miért most

A javítás nem új: 2026-07-20-án elkészült és jóváhagyást kapott, de **soha nem landolt** (`aadc558` / `d51acf8` a `fix/savememory-embedding` ágon, PR sosem nyílt rá). Ez a PR ugyanazt a commitot hozza rebase-elve, plusz egy megerősített tesztet.

## Két commit

1. **`fix(memory)`** – az eredeti, változatlan javítás: `lastInsertRowid` elkapása és ugyanaz a fire-and-forget embed blokk, ami a `saveAgentMemory`-ban van. A szignatúra és a visszatérési típus nem változik, hívót nem érint.

2. **`test(memory)`** – az eredeti commitban lévő teszt csak azt állította, hogy a beszúrás túlél egy halott Ollamát: nem dob, a sor visszaolvasható, egy tick után nincs unhandled rejection. Az embeddingről semmit nem állított, tehát **az embed blokk újbóli kivétele mellett is zöld maradt volna**. Pont ez a vakfolt éltette a hibát: a készlet a backfillt (a takarítást) alaposan fedte, a beszúrási utat (a megelőzést) sehol.

## A teszt igazolva van

A `globalThis.fetch` stubolva van, így a `generateEmbedding` élő Ollama nélkül, determinisztikusan válaszol. A teszt időkorláttal pollozza az `embedding` oszlopot, nem szinkron assertet használ, mert az ág fire-and-forget.

Negatív kontroll: az embed blokkot kivéve a `saveMemory`-ból az új teszt bukik (`expected null not to be null`), a régi füst-teszt viszont továbbra is átmegy.

## Teszt-állapot

| | Test Files | Tests |
|---|---|---|
| `main` | 7 failed / 318 passed | 27 failed / 4351 passed |
| ez az ág | 7 failed / 318 passed | 27 failed / **4353** passed |

A bukott fájlok halmaza **azonos** a mainével (gate- és hook-tesztek, ehhez a változáshoz nincs közük). Az ág pontosan két teszttel többet futtat sikeresen, és semmit nem tör el.

🤖 Generated with [Claude Code](https://claude.com/claude-code)