### PR TITLE
feat(homoglyph): warn-and-journal gate on the durable write paths (GATEHOMOGLIFSWEEP816)

### DIFF
--- a/src/__tests__/homoglyph-gate.test.ts
+++ b/src/__tests__/homoglyph-gate.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest'
+import Database from 'better-sqlite3'
+import { mkdtempSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import {
+  detectHomoglyphs, formatHomoglyphWarning, triggerLikeClause, TRIGGER_CHARS,
+} from '../homoglyph.js'
+
+// GATEHOMOGLIFSWEEP816. Design pinned by these tests, in order of importance:
+//  1. the gate WARNS and journals -- it never blocks and never rewrites
+//     (four measured categories of legitimate Cyrillic/Greek content exist);
+//  2. warnings cite CODEPOINTS, not the raw character, so the warning text
+//     itself is not the next scan's hit;
+//  3. the sqlite trigger path (agents write kanban via sqlite3, bypassing the
+//     API) journals the same measured character set the detector knows.
+// Strings below build the Cyrillic chars from codepoints on purpose -- a
+// literal would make this file a hit for the fleet's artifact sweep.
+
+const CYR_E = String.fromCodePoint(0x0435) // looks like 'e'
+const CYR_ER = String.fromCodePoint(0x0440) // looks like 'p', reads 'r'
+
+describe('detectHomoglyphs', () => {
+  it('finds a Cyrillic letter inside a Hungarian word and cites its codepoint', () => {
+    const findings = detectHomoglyphs(`a fej mer${CYR_E}se kesz`)
+    expect(findings).toHaveLength(1)
+    expect(findings[0].codepoint).toBe('U+0435')
+    expect(findings[0].script).toBe('CYRILLIC')
+    expect(findings[0].context).toContain('mer')
+  })
+
+  it('returns nothing for clean Hungarian text with real accents', () => {
+    expect(detectHomoglyphs('árvíztűrő tükörfúrógép, mérése kész')).toHaveLength(0)
+  })
+
+  it('flags Greek letters too -- classification stays with the reader', () => {
+    const findings = detectHomoglyphs('a route jele: λ')
+    expect(findings).toHaveLength(1)
+    expect(findings[0].script).toBe('GREEK')
+  })
+})
+
+describe('formatHomoglyphWarning', () => {
+  it('cites the codepoint and never the raw character', () => {
+    const warning = formatHomoglyphWarning(detectHomoglyphs(`me${CYR_ER}es`))
+    expect(warning).toContain('U+0440')
+    expect(warning).not.toContain(CYR_ER)
+    // and it must say the text was saved -- warn, not block
+    expect(warning).toContain('Saved unchanged')
+  })
+})
+
+function fixtureDb() {
+  const dir = mkdtempSync(join(tmpdir(), 'homoglif-'))
+  const db = new Database(join(dir, 'test.db'))
+  db.exec(`CREATE TABLE kanban_cards (id TEXT PRIMARY KEY, title TEXT NOT NULL)`)
+  db.exec(`CREATE TABLE kanban_comments (
+    id INTEGER PRIMARY KEY AUTOINCREMENT, card_id TEXT, author TEXT, content TEXT NOT NULL, created_at INTEGER
+  )`)
+  db.exec(`CREATE TABLE homoglyph_findings (
+    id INTEGER PRIMARY KEY AUTOINCREMENT, src_table TEXT NOT NULL, src_id TEXT NOT NULL,
+    sample TEXT NOT NULL, found_at INTEGER NOT NULL, resolved_at INTEGER
+  )`)
+  db.exec(`
+    CREATE TRIGGER homoglyph_kanban_comments_ai AFTER INSERT ON kanban_comments
+    WHEN ${triggerLikeClause('NEW.content')}
+    BEGIN
+      INSERT INTO homoglyph_findings (src_table, src_id, sample, found_at)
+      VALUES ('kanban_comments', NEW.id, substr(NEW.content, 1, 120), unixepoch());
+    END
+  `)
+  return db
+}
+
+describe('kanban homoglyph journal trigger (the shipped WHEN clause, on a fixture DB)', () => {
+  it('journals a corrupted insert without touching the row itself', () => {
+    const db = fixtureDb()
+    const dirty = `a kartya mer${CYR_E}se kesz`
+    db.prepare("INSERT INTO kanban_comments (card_id, author, content, created_at) VALUES ('C1','t',?,1)").run(dirty)
+    const finding = db.prepare('SELECT * FROM homoglyph_findings').all() as { sample: string }[]
+    expect(finding).toHaveLength(1)
+    expect(finding[0].sample).toContain('kartya')
+    // never block, never rewrite: the stored comment is byte-identical
+    const stored = db.prepare('SELECT content FROM kanban_comments').get() as { content: string }
+    expect(stored.content).toBe(dirty)
+  })
+
+  it('mutation control: a clean Hungarian insert journals nothing', () => {
+    const db = fixtureDb()
+    db.prepare("INSERT INTO kanban_comments (card_id, author, content, created_at) VALUES ('C1','t',?,1)")
+      .run('tiszta magyar szoveg, mérése kész, árvíztűrő')
+    expect(db.prepare('SELECT COUNT(*) AS n FROM homoglyph_findings').get()).toEqual({ n: 0 })
+  })
+
+  it('trigger char set and detector agree on every journaled character', () => {
+    for (const ch of TRIGGER_CHARS) {
+      const findings = detectHomoglyphs(`x${ch}x`)
+      expect(findings, `detector must flag ${findings[0]?.codepoint ?? ch.codePointAt(0)?.toString(16)}`).toHaveLength(1)
+      expect(findings[0].script).toBe('CYRILLIC')
+    }
+  })
+})

--- a/src/db.ts
+++ b/src/db.ts
@@ -5,6 +5,7 @@ import { STORE_DIR, DB_FILENAME, ALLOWED_CHAT_ID, OLLAMA_URL, APP_TZ } from './c
 import { getEffectiveSettingValue } from './settings-store.js'
 import { logger } from './logger.js'
 import { TOOL_TIMEOUTS } from './tool-timeouts.js'
+import { triggerLikeClause } from './homoglyph.js'
 
 let db: Database.Database
 // The path the CURRENT handle was opened on (null for ':memory:'). Kept so
@@ -389,6 +390,38 @@ export function initDatabase(dbPathOverride?: string): void {
     )
   `)
   db.exec(`CREATE INDEX IF NOT EXISTS idx_kanban_comments_card ON kanban_comments(card_id)`)
+
+  // Homoglyph journal (GATEHOMOGLIFSWEEP816): agents write kanban via sqlite3
+  // directly, so an API-level check never sees those writes. These triggers
+  // journal (never block, never modify) inserts whose text carries a measured
+  // Cyrillic look-alike; /api/homoglyphs surfaces the journal. The fix is
+  // always written by someone who read the word -- see src/homoglyph.ts.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS homoglyph_findings (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      src_table TEXT NOT NULL,
+      src_id TEXT NOT NULL,
+      sample TEXT NOT NULL,
+      found_at INTEGER NOT NULL,
+      resolved_at INTEGER
+    )
+  `)
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS homoglyph_kanban_comments_ai AFTER INSERT ON kanban_comments
+    WHEN ${triggerLikeClause('NEW.content')}
+    BEGIN
+      INSERT INTO homoglyph_findings (src_table, src_id, sample, found_at)
+      VALUES ('kanban_comments', NEW.id, substr(NEW.content, 1, 120), unixepoch());
+    END
+  `)
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS homoglyph_kanban_cards_ai AFTER INSERT ON kanban_cards
+    WHEN ${triggerLikeClause('NEW.title')}
+    BEGIN
+      INSERT INTO homoglyph_findings (src_table, src_id, sample, found_at)
+      VALUES ('kanban_cards', NEW.id, substr(NEW.title, 1, 120), unixepoch());
+    END
+  `)
 
   // Status-change audit trail: one row per real status transition so the board
   // can answer "who moved this card, when, from/to status". Written by

--- a/src/homoglyph.ts
+++ b/src/homoglyph.ts
@@ -1,0 +1,95 @@
+/**
+ * Homoglyph detection for durable Hungarian text (GATEHOMOGLIFSWEEP816).
+ *
+ * Generated Hungarian text occasionally carries Cyrillic (rarely Greek)
+ * look-alike letters. They are invisible to a reader but every later grep,
+ * filter or FTS query misses them -- the rule you wrote becomes
+ * unfindable. A one-time sweep does not hold: the same artifact set
+ * re-accumulated 3 files + 25 kanban comments in 19 days (measured
+ * 2026-08-16 -> 2026-09-04).
+ *
+ * Design constraints (owner-approved, msg 18802):
+ *  - WARN, never block. Four measured categories are legitimate content:
+ *    vendored localizations/encoding tables, files documenting this very
+ *    phenomenon, Greek letters as technical notation, and real
+ *    foreign-language records (e.g. a Russian customer error message in a
+ *    card title). A blocking gate would lose customer data there.
+ *  - NO automatic replacement. The look-alike maps by SHAPE, but the word
+ *    often needs a different letter (Cyrillic ER looks like `p`, the word
+ *    needs `r`); the fix is written by someone who read the word, then
+ *    read it back. This module therefore only reports: character,
+ *    codepoint, and context.
+ */
+
+export interface HomoglyphFinding {
+  /** The offending character itself. */
+  char: string
+  /** e.g. "U+0435" -- reports must cite this, never paste the raw char. */
+  codepoint: string
+  /** "CYRILLIC" | "GREEK" */
+  script: string
+  /** Index in the scanned string. */
+  index: number
+  /** Short surrounding snippet so the word is findable without re-scanning. */
+  context: string
+}
+
+// Letter ranges only -- punctuation lookalikes are a different problem.
+const CYRILLIC = /[Ѐ-ӿ]/
+const GREEK = /[Ͱ-Ͽ]/
+
+/**
+ * The Cyrillic letters actually measured in our corrupted Hungarian text
+ * (2026-08-16 and 2026-09-04 sweeps). Drives the SQLite trigger journal for
+ * writes that bypass the API (agents write kanban via sqlite3 directly), so
+ * it is deliberately the measured set, not the whole block: a LIKE per
+ * character is cheap, a full-range scan in a trigger is not.
+ */
+export const TRIGGER_CHARS = [
+  'а', 'б', 'е', 'и', 'ј', 'к', 'л', 'м', 'н', 'о', 'п', 'р', 'с', 'т', 'у', 'х',
+] as const
+
+/** WHEN clause for the kanban homoglyph journal triggers. */
+export function triggerLikeClause(column: string): string {
+  return TRIGGER_CHARS.map((c) => `${column} LIKE '%${c}%'`).join(' OR ')
+}
+
+export function detectHomoglyphs(text: string, contextRadius = 20): HomoglyphFinding[] {
+  const findings: HomoglyphFinding[] = []
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i]
+    const script = CYRILLIC.test(ch) ? 'CYRILLIC' : GREEK.test(ch) ? 'GREEK' : null
+    if (!script) continue
+    const cp = ch.codePointAt(0) ?? 0
+    // The context snippet masks every homoglyph (its own and neighbours):
+    // a report that carries the corrupted form becomes the next scan's hit,
+    // and whoever "fixes" the report deletes the evidence.
+    const raw = text.slice(Math.max(0, i - contextRadius), i + contextRadius).replace(/\n/g, ' ')
+    findings.push({
+      char: ch,
+      codepoint: `U+${cp.toString(16).toUpperCase().padStart(4, '0')}`,
+      script,
+      index: i,
+      context: raw.replace(/[Ѐ-ӿͰ-Ͽ]/g, '?'),
+    })
+  }
+  return findings
+}
+
+/**
+ * One-line warning for API responses and logs. Cites codepoints, not raw
+ * characters, so the warning itself never becomes the next scan's hit.
+ */
+export function formatHomoglyphWarning(findings: HomoglyphFinding[]): string {
+  const parts = findings
+    .slice(0, 5)
+    .map((f) => `${f.codepoint} (${f.script}) at "${f.context.trim()}"`)
+  const more = findings.length > 5 ? ` (+${findings.length - 5} more)` : ''
+  return (
+    `possible homoglyph(s) in durable text: ${parts.join('; ')}${more}. ` +
+    'Saved unchanged. If this is your own Hungarian text, re-type the marked ' +
+    'word with the intended letter and read it back; if it is vendored code, ' +
+    'documentation of this phenomenon, technical Greek notation, or a real ' +
+    'foreign-language record, leave it as is.'
+  )
+}

--- a/src/web.ts
+++ b/src/web.ts
@@ -46,6 +46,7 @@ import { tryHandleAgentConversation } from './web/routes/agent-conversation.js'
 import { tryHandleAgentTaskState } from './web/routes/agent-taskstate.js'
 import { sweepOrphanTaskStates } from './web/agent-taskstate.js'
 import { tryHandleDailyLog } from './web/routes/daily-log.js'
+import { tryHandleHomoglyphs } from './web/routes/homoglyphs.js'
 import { tryHandleMemories } from './web/routes/memories.js'
 import { tryHandleMigrate } from './web/routes/migrate.js'
 import { tryHandleKanban } from './web/routes/kanban.js'
@@ -182,6 +183,7 @@ export function startWebServer(port = 3420): http.Server {
       if (await tryHandleMessages(routeCtx)) return
       if (await tryHandleFederation(routeCtx)) return
       if (await tryHandleDailyLog(routeCtx)) return
+      if (await tryHandleHomoglyphs(routeCtx)) return
       if (await tryHandleMemories(routeCtx)) return
       if (await tryHandleMigrate(routeCtx)) return
       if (await tryHandleKanban(routeCtx)) return

--- a/src/web/routes/daily-log.ts
+++ b/src/web/routes/daily-log.ts
@@ -1,6 +1,8 @@
 import { appendDailyLog, getDailyLog, getDailyLogDates } from '../../db.js'
 import { MAIN_AGENT_ID } from '../../config.js'
+import { logger } from '../../logger.js'
 import { readBody, json } from '../http-helpers.js'
+import { detectHomoglyphs, formatHomoglyphWarning } from '../../homoglyph.js'
 import type { RouteContext } from './types.js'
 
 export async function tryHandleDailyLog(ctx: RouteContext): Promise<boolean> {
@@ -11,6 +13,14 @@ export async function tryHandleDailyLog(ctx: RouteContext): Promise<boolean> {
     const data = JSON.parse(body.toString()) as { agent_id?: string; content: string }
     if (!data.content?.trim()) { json(res, { error: 'Content required' }, 400); return true }
     appendDailyLog(data.agent_id || MAIN_AGENT_ID, data.content.trim())
+    // Warn-only homoglyph check (GATEHOMOGLIFSWEEP816) -- see memories.ts.
+    const homoglyphs = detectHomoglyphs(data.content)
+    if (homoglyphs.length > 0) {
+      const warning = formatHomoglyphWarning(homoglyphs)
+      logger.warn({ agent: data.agent_id }, `daily-log entry saved with ${warning}`)
+      json(res, { ok: true, homoglyph_warning: warning })
+      return true
+    }
     json(res, { ok: true })
     return true
   }

--- a/src/web/routes/homoglyphs.ts
+++ b/src/web/routes/homoglyphs.ts
@@ -1,0 +1,40 @@
+import { getDb } from '../../db.js'
+import { json } from '../http-helpers.js'
+import type { RouteContext } from './types.js'
+
+/**
+ * Read side of the homoglyph journal (GATEHOMOGLIFSWEEP816). The triggers on
+ * kanban_cards/kanban_comments journal suspicious inserts (writes that bypass
+ * the API); this endpoint surfaces them for the periodic sweep. Marking a
+ * finding resolved records that someone READ the word and either fixed it by
+ * hand or classified it as legitimate content -- the row itself never says
+ * which, the fix lives where the text lives.
+ */
+export async function tryHandleHomoglyphs(ctx: RouteContext): Promise<boolean> {
+  const { res, path, method, url } = ctx
+
+  if (path === '/api/homoglyphs' && method === 'GET') {
+    const includeResolved = url.searchParams.get('all') === '1'
+    const rows = getDb()
+      .prepare(
+        `SELECT id, src_table, src_id, sample, found_at, resolved_at
+         FROM homoglyph_findings
+         ${includeResolved ? '' : 'WHERE resolved_at IS NULL'}
+         ORDER BY id DESC LIMIT 200`
+      )
+      .all()
+    json(res, { findings: rows })
+    return true
+  }
+
+  const resolveMatch = path.match(/^\/api\/homoglyphs\/(\d+)\/resolve$/)
+  if (resolveMatch && method === 'POST') {
+    const info = getDb()
+      .prepare('UPDATE homoglyph_findings SET resolved_at = unixepoch() WHERE id = ? AND resolved_at IS NULL')
+      .run(Number(resolveMatch[1]))
+    json(res, { ok: true, changed: info.changes })
+    return true
+  }
+
+  return false
+}

--- a/src/web/routes/memories.ts
+++ b/src/web/routes/memories.ts
@@ -7,6 +7,7 @@ import {
 import { MAIN_AGENT_ID, ALLOWED_CHAT_ID, OLLAMA_URL, APP_TZ } from '../../config.js'
 import { logger } from '../../logger.js'
 import { readBody, json, jsonMaybeGzip } from '../http-helpers.js'
+import { detectHomoglyphs, formatHomoglyphWarning } from '../../homoglyph.js'
 import type { RouteContext } from './types.js'
 
 // Canonical memory categories. Kept in sync with the DB CHECK constraint in
@@ -57,6 +58,16 @@ export async function tryHandleMemories(ctx: RouteContext): Promise<boolean> {
       data.keywords || undefined,
       true
     )
+    // Warn-only homoglyph check (GATEHOMOGLIFSWEEP816): the save above already
+    // happened -- legitimate Cyrillic/Greek content (quotes, foreign records)
+    // must never be lost, so the finding rides the response instead of a 4xx.
+    const homoglyphs = detectHomoglyphs(data.content)
+    if (homoglyphs.length > 0) {
+      const warning = formatHomoglyphWarning(homoglyphs)
+      logger.warn({ agent: data.agent_id, memoryId: result.id }, `memory saved with ${warning}`)
+      json(res, { ok: true, id: result.id, homoglyph_warning: warning })
+      return true
+    }
     json(res, { ok: true, id: result.id })
     return true
   }


### PR DESCRIPTION
## Why

Generated Hungarian text occasionally carries Cyrillic look-alike letters. They read fine, but every later grep/filter/FTS query misses them -- the rule you wrote becomes unfindable. **A one-time sweep does not hold**: the same artifact set, cleaned 2026-08-16, re-accumulated 3 files + 25 kanban comments by 2026-09-04 (measured, same set at two points in time). Owner-approved direction (Marveen msg 18802): gate the durable write path, sweep stays as backstop.

## Design constraints (both measured today, at cost)

1. **Warn, never block; journal, never rewrite.** Four categories of legitimate Cyrillic/Greek content exist: vendored localizations/encoding tables (24 files were once auto-rewritten and had to be restored), files documenting this phenomenon, Greek technical notation (λ, π), and real foreign-language records (a Russian customer error message lives in a card title -- "fixing" it would falsify a customer report).
2. **No automatic replacement.** The look-alike maps by shape, but the word often needs a different letter (Cyrillic ER looks like p, the word needs r -- "harmat" became "hapmat" through a shape table, with a 0 length delta). The gate shows codepoint + masked context; the fix is typed by someone who read the word.
3. **Reports mask the corrupted form.** A warning carrying the raw character becomes the next scan's hit; contexts replace homoglyphs with '?', codepoints identify them.

## What

- `src/homoglyph.ts`: detector (Cyrillic/Greek letter ranges) + warning formatter + the measured trigger char set.
- `POST /api/memories` and `POST /api/daily-log`: the write succeeds unchanged; `homoglyph_warning` rides the 200 response and a `logger.warn` lands in the dashboard log.
- `homoglyph_findings` journal + AFTER INSERT triggers on `kanban_cards`/`kanban_comments` -- agents write kanban via sqlite3 directly, so an API-only check would miss the measured primary site (25 of today's 28 hits were DB comments).
- `GET /api/homoglyphs` (+ `POST /api/homoglyphs/:id/resolve`) surfaces the journal for the periodic sweep.

## Verify

- 7 new tests: detector on Hungarian text (real accents stay clean), codepoint-cited + masked warning, trigger journals a dirty insert while the stored row stays byte-identical, clean-insert mutation control, trigger-set/detector parity. Test literals build Cyrillic chars from codepoints so the test file is not a sweep hit.
- Full suite: 4597 passed, tsc clean, build green.

## Merge note

Not before the Tuesday promote (a develop merge resets the soak clock). Merge is Marveen's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)