### PR TITLE
fix(channel-monitor): verify the launchd restart by effect, not by exit code (LAUNCHDNOEFFECT904)

### DIFF
--- a/src/__tests__/channel-monitor-launchd-effect.test.ts
+++ b/src/__tests__/channel-monitor-launchd-effect.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { launchdRestartTookEffect } from '../web/channel-monitor.js'
+
+const MONITOR_PATH = join(__dirname, '../web/channel-monitor.ts')
+const src = readFileSync(MONITOR_PATH, 'utf-8')
+
+// Measured 2026-09-04 on the jarvis install: the context guard's saturation net
+// fired four times in one morning, each time logging "Hard restart: launchctl
+// reload" and announcing a restart, while the main pane's claude process kept
+// the same pid for 34 hours. `launchctl print gui/501/com.jarvis.channels`
+// showed `runs = 0` -- the job had never been spawned since registration, so
+// `unload` had nothing to stop. launchctl's exit code says the COMMAND ran, not
+// that the session restarted.
+describe('hardRestartMarveenChannels: launchd reload is verified by effect, not exit code', () => {
+  describe('launchdRestartTookEffect', () => {
+    it('is true only for an observed, different pid', () => {
+      expect(launchdRestartTookEffect(6476, 70123)).toBe(true)
+    })
+
+    it('is false when the pid is unchanged (the measured no-op)', () => {
+      expect(launchdRestartTookEffect(6476, 6476)).toBe(false)
+    })
+
+    it('is false when either reading is missing -- an unreadable pane is not proof of a restart', () => {
+      expect(launchdRestartTookEffect(null, 70123)).toBe(false)
+      expect(launchdRestartTookEffect(6476, null)).toBe(false)
+      expect(launchdRestartTookEffect(null, null)).toBe(false)
+    })
+  })
+
+  const fnStart = src.indexOf('export function hardRestartMarveenChannels')
+  expect(fnStart, 'hardRestartMarveenChannels not found').toBeGreaterThan(0)
+  const fnEnd = src.indexOf('\n// Escalate a main channel input', fnStart)
+  const fnBody = src.slice(fnStart, fnEnd > fnStart ? fnEnd : undefined)
+
+  it('reads the pane pid BEFORE the launchctl calls', () => {
+    const beforeIdx = fnBody.indexOf('const pidBefore = mainPaneClaudePid()')
+    const unloadIdx = fnBody.indexOf("'unload'")
+    expect(beforeIdx, 'pre-call pid reading missing').toBeGreaterThan(0)
+    expect(beforeIdx).toBeLessThan(unloadIdx)
+  })
+
+  it('does not report success straight from the launchctl exit code', () => {
+    const loadIdx = fnBody.indexOf("'load'")
+    const okIdx = fnBody.indexOf('return { ok: true }')
+    const effectIdx = fnBody.indexOf('launchdRestartTookEffect(pidBefore, pidAfter)')
+    expect(effectIdx, 'effect check missing').toBeGreaterThan(loadIdx)
+    expect(effectIdx).toBeLessThan(okIdx)
+  })
+
+  it('falls through to the respawn-pane path when the pid did not change', () => {
+    // No `return` between the failed effect check and the respawn-pane call:
+    // the whole point is that a no-effect reload must not end the function.
+    const noEffectIdx = fnBody.indexOf('falling through to respawn-pane')
+    const respawnIdx = fnBody.indexOf('respawnMarveenSessionFresh()')
+    expect(noEffectIdx, 'no-effect log line missing').toBeGreaterThan(0)
+    expect(respawnIdx).toBeGreaterThan(noEffectIdx)
+    expect(fnBody.slice(noEffectIdx, respawnIdx)).not.toMatch(/return \{ ok: true \}/)
+  })
+
+  it('keeps the "plist absent" warning for the plist-absent case only', () => {
+    // The fall-through path now also reaches that line; claiming the plist is
+    // absent there would be false.
+    const warnIdx = fnBody.indexOf('launchd channels plist absent')
+    expect(warnIdx).toBeGreaterThan(0)
+    const guard = fnBody.slice(Math.max(0, warnIdx - 200), warnIdx)
+    expect(guard).toMatch(/!existsSync\(MAIN_CHANNELS_PLIST\)/)
+  })
+})

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -1170,6 +1170,48 @@ function schedulePostResumePluginGuard(provider: ChannelProviderType): void {
   logger.info({ delayMs: POST_RESUME_GUARD_DELAY_MS }, 'Post-resume plugin guard scheduled after --continue resume')
 }
 
+// --- launchd restart EFFECT check (LAUNCHDNOEFFECT904) ------------------------
+//
+// `launchctl unload` + `load` exiting 0 says the COMMAND ran, not that the
+// session restarted. Measured on 2026-09-04: the guard's saturation net fired
+// four times in one morning (12:10:20, 12:40:20, 13:15:20 ...), logged
+// "Hard restart: launchctl reload" every time and announced a restart to the
+// operator -- while the main pane's claude process kept the SAME pid for 34
+// hours. `launchctl print gui/<uid>/com.jarvis.channels` read
+// `state = not running`, `active count = 0` and, decisively, `runs = 0`: the
+// job had never been spawned since registration, so `unload` had nothing to
+// stop and the live process (started outside launchd) was never touched.
+// store/channels.log and channels.error.log confirm it -- neither grew during
+// any of those "restarts".
+//
+// The exit code is therefore the wrong signal. Measure the effect instead: the
+// pid of the claude process in the main pane. Unchanged pid = nothing
+// restarted, whatever launchctl returned, and we fall through to the
+// respawn-pane path that replaces the process directly.
+const LAUNCHD_EFFECT_POLL_MS = 1000
+const LAUNCHD_EFFECT_TIMEOUT_MS = 8000
+
+// Pure: did the launchd bounce actually replace the process?
+// A null reading (pane gone, tmux unreadable) is NOT evidence of a restart --
+// treat only an observed, different pid as one, so an unreadable pane falls
+// through to respawn-pane rather than reporting a success we cannot see.
+export function launchdRestartTookEffect(before: number | null, after: number | null): boolean {
+  if (before === null || after === null) return false
+  return before !== after
+}
+
+// pid of the claude process in the main channels pane, or null when unreadable.
+function mainPaneClaudePid(): number | null {
+  try {
+    const raw = execFileSync(tmuxBin(), ['list-panes', '-t', MAIN_CHANNELS_SESSION, '-F', '#{pane_pid}'],
+      { timeout: 3000, encoding: 'utf-8' })
+    const pid = parseInt(raw.trim().split('\n')[0] ?? '', 10)
+    return Number.isFinite(pid) && pid > 0 ? pid : null
+  } catch {
+    return null
+  }
+}
+
 export function hardRestartMarveenChannels(): { ok: boolean; error?: string } {
   // FABLEFALL1: the restarted session boots from the main/worker shared config
   // roots, which the per-agent spawn-time stamp never covers -- stamp them now
@@ -1182,21 +1224,40 @@ export function hardRestartMarveenChannels(): { ok: boolean; error?: string } {
   // The previous unconditional launchctl call was a silent no-op: launchctl
   // accepts a non-existent plist with exit 0, leaving the session untouched.
   if (process.platform !== 'linux' && existsSync(MAIN_CHANNELS_PLIST)) {
+    const pidBefore = mainPaneClaudePid()
     try {
       execFileSync('/bin/launchctl', ['unload', MAIN_CHANNELS_PLIST], { timeout: 5000 })
       execFileSync('/bin/sleep', ['2'], { timeout: 4000 })
       execFileSync('/bin/launchctl', ['load', MAIN_CHANNELS_PLIST], { timeout: 5000 })
-      logger.warn(`Hard restart: launchctl reload of com.${SERVICE_ID}.channels`)
-      marveenLastHardRestart = Date.now()
-      writeRespawnStamp() // coordinate with the systemd-timer watchdog
-      return { ok: true }
     } catch (err) {
       logger.error({ err }, 'Hard restart failed (launchctl)')
       return { ok: false, error: err instanceof Error ? err.message : String(err) }
     }
+    // The command returned 0. Now measure whether anything actually restarted:
+    // launchd needs a moment to tear the old process down and spawn the new one,
+    // so poll rather than read once.
+    let pidAfter = mainPaneClaudePid()
+    const deadline = Date.now() + LAUNCHD_EFFECT_TIMEOUT_MS
+    while (!launchdRestartTookEffect(pidBefore, pidAfter) && Date.now() < deadline) {
+      try { execFileSync('/bin/sleep', [String(LAUNCHD_EFFECT_POLL_MS / 1000)], { timeout: 4000 }) } catch { break }
+      pidAfter = mainPaneClaudePid()
+    }
+    if (launchdRestartTookEffect(pidBefore, pidAfter)) {
+      logger.warn({ pidBefore, pidAfter }, `Hard restart: launchctl reload of com.${SERVICE_ID}.channels`)
+      marveenLastHardRestart = Date.now()
+      writeRespawnStamp() // coordinate with the systemd-timer watchdog
+      return { ok: true }
+    }
+    logger.warn(
+      { pidBefore, pidAfter, plist: MAIN_CHANNELS_PLIST },
+      'Hard restart: launchctl reload exited 0 but the pane claude pid did not change -- launchd does not own this session; falling through to respawn-pane',
+    )
+    // fall through to the respawn-pane path below
   }
 
-  if (process.platform !== 'linux') {
+  // Plist-absent case only: the no-effect fall-through above logs its own,
+  // different reason, and claiming "plist absent" there would be false.
+  if (process.platform !== 'linux' && !existsSync(MAIN_CHANNELS_PLIST)) {
     logger.warn({ plist: MAIN_CHANNELS_PLIST }, 'Hard restart: launchd channels plist absent -- falling back to respawn-pane')
   }
 


### PR DESCRIPTION
## What the numbers say

`launchctl unload` + `load` exiting 0 says the COMMAND ran, not that the session restarted. `hardRestartMarveenChannels()` read that exit code as success, logged `Hard restart: launchctl reload` and returned `ok: true` -- so the context guard announced a restart that never happened.

Measured on the jarvis install, 2026-09-04:

- the guard's saturation net fired four times in one morning (12:10:20, 12:40:20, 13:15:20, 13:20:18), each logging the reload;
- the main pane's claude process kept the **same pid (6476)** throughout, uptime 34 hours;
- `launchctl print gui/501/com.jarvis.channels` reported `state = not running`, `active count = 0` and, decisively, **`runs = 0`** -- the job had never been spawned since registration, so `unload` had nothing to stop and the live process (started outside launchd) was never touched;
- `store/channels.log` and `store/channels.error.log` did not grow during any of those "restarts", confirming `channels.sh` never ran.

The existing `existsSync(MAIN_CHANNELS_PLIST)` guard checks the wrong thing: a plist can exist while launchd does not own the running session.

## The change

Measure the effect. Read the main pane's claude pid before the launchctl calls, poll it for up to 8s afterwards, and report success only when the pid actually changed. An unchanged pid falls through to the respawn-pane path, which replaces the process directly. A null reading counts as "no effect", so an unreadable pane falls through rather than claiming a restart nobody observed.

The `launchd channels plist absent` warning is now scoped to the plist-absent case: the fall-through reaches that line too, and claiming the plist is absent there would be false.

## Tests

`launchdRestartTookEffect()` is exported as a pure decision, so all three readings are covered (changed / unchanged / unreadable), next to static checks that the pid is read before the launchctl calls, that success is not returned straight from the exit code, and that a no-effect reload does not return early.

**Control run:** all 7 new tests FAIL against the unpatched file and pass with it.

**Merge gate, full suite both sides (vitest run):**

| | Test files | Tests |
|---|---|---|
| base (origin/develop 5c9a925) | 7 failed / 345 passed (352) | 27 failed / 4563 passed / 1 skipped |
| this branch | 7 failed / 346 passed (353) | 27 failed / 4570 passed / 1 skipped |

Identical failing set on both sides, same per-file counts (`digest-provenance-gate` 2, `email-send-gate` 4, `governance-gates` 3, `heartbeat-hook-wiring` 2, `hook-command-quoting` 7, `hook-path-guard` 7, `kanban-write-gate` 2). They read the local install's hook settings and are stable red on this machine, unrelated to this diff. The branch adds exactly the 7 new passing tests. `tsc --noEmit` clean.

## Not addressed here

WHY launchd never spawns the job despite `RunAtLoad` and `KeepAlive`. Deciding that needs a controlled `kickstart`, which cuts the live main session, so it waits for a window with the operator. The effect check is correct either way -- and it is what turns that open question from a silent no-op into a visible fall-through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RaVegq2oPcoJvdjLd2Dco4