### PR TITLE
fix(backup): the archive missed the memories, the local commits and everything in store/

### DIFF
--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -25,6 +25,11 @@ the Docker volumes (3) are **separate** and must be moved on their own.
 - `assets/meetings/**` — meeting transcripts/memos
 - `agents/*/CLAUDE.md`, `SOUL.md`, `.mcp.json` — per-agent identity
 - `agents/*/.claude/channels/*/.env`, `access.json` — sub-agent channel tokens + pairing
+- `local-commits.bundle` — every local git branch that `origin` does not have
+  (the source itself is NOT in the archive; it is expected on the remote). Restore:
+  clone the upstream repo, then
+  `git fetch <restored>/repo/local-commits.bundle 'refs/heads/*:refs/heads/*'`.
+  Absent when everything is already pushed.
 
 **(2) Home-relative — under `$HOME` (`home/` group in the archive)**
 - `~/.claude/skills/**` — the self-built skill library

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -25,7 +25,7 @@ the Docker volumes (3) are **separate** and must be moved on their own.
 - `assets/meetings/**` — meeting transcripts/memos
 - `agents/*/CLAUDE.md`, `SOUL.md`, `.mcp.json` — per-agent identity
 - `agents/*/.claude/channels/*/.env`, `access.json` — sub-agent channel tokens + pairing
-- `local-commits.bundle` — every local git branch that `origin` does not have
+- `local-commits.bundle`: every local git branch that `origin` does not have
   (the source itself is NOT in the archive; it is expected on the remote). Restore:
   clone the upstream repo, then
   `git fetch <restored>/repo/local-commits.bundle 'refs/heads/*:refs/heads/*'`.

--- a/docs/en/MIGRATION.md
+++ b/docs/en/MIGRATION.md
@@ -25,6 +25,11 @@ the Docker volumes (3) are **separate** and must be moved on their own.
 - `assets/meetings/**` — meeting transcripts/memos
 - `agents/*/CLAUDE.md`, `SOUL.md`, `.mcp.json` — per-agent identity
 - `agents/*/.claude/channels/*/.env`, `access.json` — sub-agent channel tokens + pairing
+- `local-commits.bundle` — every local git branch that `origin` does not have
+  (the source itself is NOT in the archive; it is expected on the remote). Restore:
+  clone the upstream repo, then
+  `git fetch <restored>/repo/local-commits.bundle 'refs/heads/*:refs/heads/*'`.
+  Absent when everything is already pushed.
 
 **(2) Home-relative — under `$HOME` (`home/` group in the archive)**
 - `~/.claude/skills/**` — the self-built skill library

--- a/docs/en/MIGRATION.md
+++ b/docs/en/MIGRATION.md
@@ -25,7 +25,7 @@ the Docker volumes (3) are **separate** and must be moved on their own.
 - `assets/meetings/**` — meeting transcripts/memos
 - `agents/*/CLAUDE.md`, `SOUL.md`, `.mcp.json` — per-agent identity
 - `agents/*/.claude/channels/*/.env`, `access.json` — sub-agent channel tokens + pairing
-- `local-commits.bundle` — every local git branch that `origin` does not have
+- `local-commits.bundle`: every local git branch that `origin` does not have
   (the source itself is NOT in the archive; it is expected on the remote). Restore:
   clone the upstream repo, then
   `git fetch <restored>/repo/local-commits.bundle 'refs/heads/*:refs/heads/*'`.

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -5,8 +5,8 @@
 # where each file belongs (see docs/MIGRATION.md):
 #
 #   repo/   -> extract under the project root (this repo)
-#     store/claudeclaw.db (+ -shm/-wal; WAL-checkpointed before copy)
-#     store/.dashboard-token   (dashboard bearer)
+#     store/**                 (DB WAL-checkpointed first; minus models,
+#                               virtualenvs, browser profile and logs)
 #     .env                     (project root secrets)
 #     scheduled-tasks.json     (legacy, if present)
 #     assets/meetings/**       (meeting transcripts/memos)
@@ -62,11 +62,30 @@ add_if() {
 }
 
 # repo/ group (relative to REPO_ROOT)
-add_if "${REPOLIST}" "${REPO_ROOT}" store/claudeclaw.db
-add_if "${REPOLIST}" "${REPO_ROOT}" store/claudeclaw.db-shm
-add_if "${REPOLIST}" "${REPO_ROOT}" store/claudeclaw.db-wal
-add_if "${REPOLIST}" "${REPO_ROOT}" store/.dashboard-token
-add_if "${REPOLIST}" "${REPO_ROOT}" store/config-overrides.json
+# store/ -- everything EXCEPT the bulky, regenerable and transient parts.
+# Until 2026-09-04 this was a five-name whitelist (the DB, its -shm/-wal, the
+# dashboard token, config-overrides.json) and every OTHER file in store/ sat
+# outside the archive without ever saying so: the credential vault, the
+# verified-recipients ledger that gates every outgoing letter, the egress
+# allowlist, the autonomy levels, the per-service API tokens, and hand-made
+# data that exists nowhere else (the mail-partner categorisation, the SEO
+# baselines, the webshop change log). A whitelist is silent about every file
+# added after it was written, so the rule is inverted here: take store/ and
+# name only what must stay OUT.
+#   whisper, health, cowork, venv-*, dhl-chrome-profile, fedex-labels,
+#   fedex-vam, archery-basis  -- models, exports, virtualenvs, a browser
+#     profile and generated PDFs: 3.2 GB, all re-downloadable or reproducible
+#   *.log, *.out, *.pid       -- runtime noise, worthless in a restore
+# What remains is ~4 MB next to the DB, so the archive stays small.
+STORE_SKIP=" whisper health cowork venv-garmin venv-pdf dhl-chrome-profile fedex-labels fedex-vam archery-basis "
+if [[ -d store ]]; then
+  while IFS= read -r _entry; do
+    _name="$(basename "${_entry}")"
+    case "${STORE_SKIP}" in *" ${_name} "*) continue ;; esac
+    case "${_name}" in *.log|*.out|*.pid) continue ;; esac
+    echo "store/${_name}" >> "${REPOLIST}"
+  done < <(find store -mindepth 1 -maxdepth 1)
+fi
 add_if "${REPOLIST}" "${REPO_ROOT}" .env
 add_if "${REPOLIST}" "${REPO_ROOT}" scheduled-tasks.json
 add_if "${REPOLIST}" "${REPO_ROOT}" assets/meetings

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -80,6 +80,15 @@ fi
 # home/ group (relative to $HOME)
 add_if "${HOMELIST}" "${HOME}" .claude/skills
 add_if "${HOMELIST}" "${HOME}" .claude/scheduled-tasks
+# The file-based auto-memory. Until 2026-09-04 this was NOT in the archive, and
+# a restore test that day proved what that costs: 490 markdown memories for the
+# main agent alone, none of them in the tarball. The SQLite copy is not a
+# substitute -- it holds the prose, not the frontmatter, the type or the
+# [[links]] between memories. Only the memory/ directories are taken, not the
+# whole projects/ tree, which is full of transcripts and tool-result dumps.
+if [[ -d "${HOME}/.claude/projects" ]]; then
+  ( cd "${HOME}" && find .claude/projects -maxdepth 2 -type d -name memory -print ) >> "${HOMELIST}"
+fi
 # MAIN orchestrator channel tokens + pairing state, per provider. bot.pid and
 # inbox/ are runtime/transient and intentionally excluded.
 if [[ -d "${HOME}/.claude/channels" ]]; then

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -52,7 +52,8 @@ REPOLIST="$(mktemp -t claudeclaw-repo.XXXXXX)"
 HOMELIST="$(mktemp -t claudeclaw-home.XXXXXX)"
 MANIFEST="$(mktemp -t claudeclaw-manifest.XXXXXX)"
 STAGE="$(mktemp -d -t claudeclaw-stage.XXXXXX)"
-trap 'rm -f "${REPOLIST}" "${HOMELIST}" "${MANIFEST}"; rm -rf "${STAGE}"' EXIT
+BUNDLE=""
+trap 'rm -f "${REPOLIST}" "${HOMELIST}" "${MANIFEST}"; [[ -n "${BUNDLE}" ]] && rm -f "${BUNDLE}"; rm -rf "${STAGE}"' EXIT
 
 # add_if <listfile> <base> <relpath>  -- append relpath when <base>/<relpath> exists.
 add_if() {
@@ -115,6 +116,29 @@ if [[ -d "${HOME}/Library/LaunchAgents" ]]; then
   ( cd "${HOME}" && find Library/LaunchAgents -maxdepth 1 -name "com.${MAIN_AGENT_ID}.*.plist" -print ) >> "${HOMELIST}"
 fi
 
+# --- Local commits that live on no remote. ---------------------------------
+# This archive deliberately carries unversioned state, not the source: the
+# source is supposed to live on a git remote. On 2026-09-04 that assumption
+# broke -- nine days of work sat committed locally and pushed nowhere, so the
+# only copy was this disk, and the tarball did not hold it either. A bundle of
+# every local branch that origin does not already have closes the gap for a few
+# hundred KB (the full history is 26 MB, but the shared part is recoverable by
+# cloning origin). Restore, after cloning origin:
+#   git fetch <restored>/repo/local-commits.bundle 'refs/heads/*:refs/heads/*'
+if command -v git >/dev/null 2>&1 && [[ -d "${REPO_ROOT}/.git" ]]; then
+  BUNDLE="$(mktemp -t claudeclaw-bundle.XXXXXX)"
+  # An empty ref set makes `git bundle` refuse with "empty bundle", which is
+  # the GOOD case (everything is already pushed), not an error -- so a failure
+  # here just drops the file instead of failing the backup.
+  if git -C "${REPO_ROOT}" bundle create "${BUNDLE}" \
+       --branches --not --remotes=origin >/dev/null 2>&1; then
+    echo "backup: local-commits.bundle $(wc -c < "${BUNDLE}" | awk '{print $1}') bytes"
+  else
+    rm -f "${BUNDLE}"; BUNDLE=""
+    echo "backup: no local-only commits to bundle"
+  fi
+fi
+
 if [[ ! -s "${REPOLIST}" && ! -s "${HOMELIST}" ]]; then
   echo "backup: nothing to archive" >&2
   exit 0
@@ -128,6 +152,9 @@ fi
   echo "Restore: tar -xpzf <archive> -C <tmp>; copy repo/* -> project root, home/* -> \$HOME."
   echo "See docs/MIGRATION.md for the full runbook (TCC, launchd paths, one-bot-one-poller, venv rebuild)."
   echo "--- repo/ ---"; sed 's,^,repo/,' "${REPOLIST}" 2>/dev/null || true
+  if [[ -n "${BUNDLE}" ]]; then
+    echo "repo/local-commits.bundle   (git bundle: local branches absent from origin)"
+  fi
   echo "--- home/ ---"; sed 's,^,home/,' "${HOMELIST}" 2>/dev/null || true
 } > "${MANIFEST}"
 
@@ -154,6 +181,12 @@ stage_group() {  # stage_group <listfile> <base> <group>
 
 stage_group "${REPOLIST}" "${REPO_ROOT}" repo
 stage_group "${HOMELIST}" "${HOME}" home
+
+if [[ -n "${BUNDLE}" ]]; then
+  mkdir -p "${STAGE}/repo"
+  cp -p "${BUNDLE}" "${STAGE}/repo/local-commits.bundle"
+  chmod 600 "${STAGE}/repo/local-commits.bundle"
+fi
 
 # Archive only the top-level entries that exist (a group dir is absent when
 # its list was empty), so tar never errors on a missing entry and the names


### PR DESCRIPTION
Three gaps in `scripts/backup.sh`, all found the same way: a restore test, not a review. Each one had the archive quietly leaving out something no other system holds.

**1. The file-based memories were never in the archive.** `home/.claude/projects` was skipped wholesale to avoid dragging transcripts and tool-result dumps into the tarball, and the memory directories went with it. A restore test on 2026-09-04 turned up 490 markdown memories for the main agent alone, none of them in the archive. The SQLite copy is not a substitute: it holds the prose, not the frontmatter, the type or the `[[links]]`. Only `projects/*/memory` is taken, so the transcripts stay out.

**2. The archive held every secret except the code itself.** The archive deliberately carries unversioned state on the assumption that the source lives on a remote. That assumption broke on this install: nine days of work sat committed locally and pushed nowhere, so the only copy was one disk, and the tarball did not hold it either. A `git bundle` of every local branch `origin` does not have closes the gap for a few hundred KB (337 KB here, against 26 MB of full history, which is recoverable by cloning origin). Restore step added to both MIGRATION.md files.

**3. `store/` was a five-name whitelist.** The repo group took `store/claudeclaw.db`, its `-shm`/`-wal`, the dashboard token and `config-overrides.json`. Everything else in `store/` was outside every archive and nothing said so: the credential vault, the verified-recipient ledger the outbound-mail hook measures every address against, the egress allowlist, the autonomy levels, the restart-gate config, the per-service API tokens, and hand-made data that exists in no other system. A whitelist is silent about every file added after it is written, which is the same shape as the two bugs above, so the rule is inverted: take `store/` and name only what stays OUT (models, virtualenvs, a browser profile, generated PDFs, `*.log`/`.out`/`.pid`).

**Verified on this install**, not by inspection:
- memories: restored a fresh copy from the archive and counted the memory files;
- bundle: `git bundle verify` on the archived file, then fetched it into an empty repo holding only `develop` and got the current HEAD back;
- store: full run before and after, 4 store entries -> 163, with `verified-recipients.json`, `vault.json`, `egress-allowlist.json`, `autonomy-config.json`, `gbp-token.json` and the rest present. Archive 24.9 MB -> 26.3 MB.

Test suite (measured in a clean clone outside /tmp, `npx tsc --noEmit` clean): **353 files, 4603 passed, 1 skipped**, identical to the `develop` baseline measured the same way at 1df099b. No test covers a shell script here; the verification above is the evidence.
