### PR TITLE
fix(update-check): a fork's origin is not its own repo, so the check reported a silent zero

### DIFF
--- a/src/__tests__/update-checker-branch.test.ts
+++ b/src/__tests__/update-checker-branch.test.ts
@@ -71,7 +71,7 @@ describe('update checker current version', () => {
 //     GitHub answers 422 on /commits/<branch>), and
 //   - the compare BASE (a base the remote does not know turns the reported
 //     backlog into a fork-distance -- measured 375 against a real 5).
-import { remoteIsOwnOrigin, parseGitHubRemote, branchOnRemote, branchExistsOnOrigin, originHasTrackingRefs } from '../web/update-checker.js'
+import { remoteIsOwnOrigin, parseGitHubRemote, branchOnRemote, branchExistsOnOrigin, originHasTrackingRefs, upstreamMergeBase } from '../web/update-checker.js'
 import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 
@@ -209,5 +209,39 @@ describe('the branch we ask upstream about is answerable', () => {
     const asked = await branchOnRemote(remote, PROJECT_ROOT, async () => 'develop')
     // Either it is a branch origin really has, or it is the injected default.
     expect(branchExistsOnOrigin(asked, PROJECT_ROOT) || asked === 'develop').toBe(true)
+  })
+})
+
+// The twin half of UPDATEBRANCH904. branchOnRemote decides WHICH branch we ask
+// about; upstreamMergeBase decides which commit we measure the distance FROM.
+// Both used the same `origin` naming convention, so both resolved to a ref
+// that has never existed here -- and an empty base does not fail loudly, it
+// produces a nonsense distance (161 reported against a real backlog of 4,
+// measured 2026-09-04). A number nobody can act on is worse than an error.
+describe('upstreamMergeBase resolves a base the remote actually knows', () => {
+  it('returns a real commit for the branch we ask the remote about', () => {
+    const base = upstreamMergeBase(parseGitHubRemote(PROJECT_ROOT), 'develop')
+    expect(base).toMatch(/^[0-9a-f]{40}$/)
+  })
+
+  it('the base is an ancestor of the ref it claims to compare against', () => {
+    const base = upstreamMergeBase(parseGitHubRemote(PROJECT_ROOT), 'develop')
+    // If the base were picked from a ref the remote does not carry, this fails:
+    // merge-base --is-ancestor exits non-zero.
+    const ok = (() => {
+      try {
+        execFileSync('/usr/bin/git', ['merge-base', '--is-ancestor', base, 'origin/develop'],
+          { cwd: PROJECT_ROOT, timeout: 3000 })
+        return true
+      } catch { return false }
+    })()
+    expect(ok).toBe(true)
+  })
+
+  it('never returns an empty base while origin/develop exists', () => {
+    // The empty string is the failure that produced the nonsense count; it must
+    // not come back silently on a checkout that plainly has the ref.
+    expect(branchExistsOnOrigin('develop', PROJECT_ROOT)).toBe(true)
+    expect(upstreamMergeBase(parseGitHubRemote(PROJECT_ROOT), 'develop')).not.toBe('')
   })
 })

--- a/src/__tests__/update-checker-branch.test.ts
+++ b/src/__tests__/update-checker-branch.test.ts
@@ -195,20 +195,72 @@ describe('branchOnRemote does not trust a branch the remote has never seen', () 
   })
 })
 
-// The end-to-end shape of UPDATEBRANCH904, asserted against THIS checkout:
-// whatever branch we end up asking the upstream remote about, it must be one
-// that remote could actually answer for. A branch only this machine has ever
-// seen is the 422 that produced the silent `behind: 0`.
+// The end-to-end shape of UPDATEBRANCH904, asserted against a checkout whose
+// remote-tracking refs we build ourselves.
+//
+// The first version of this asserted against PROJECT_ROOT and passed on the
+// workstation, then failed on CI: `actions/checkout` fetches the PR ref alone,
+// so `refs/remotes/origin/develop` is not there and every claim about "this
+// checkout has origin refs" is a claim about the checkout, not about the code.
+// The fixture below carries real refs -- a real bare origin, a real clone, real
+// `refs/remotes/origin/*` -- so the assertions measure git behaviour and stay
+// true wherever they run.
+function clonedRepoWithTrackingRefs(): { root: string; cleanup: () => void } {
+  const dir = mkdtempSync(join(tmpdir(), 'update-checker-clone-'))
+  const origin = join(dir, 'origin.git')
+  const root = join(dir, 'work')
+  const git = (cwd: string, ...args: string[]) =>
+    execFileSync('/usr/bin/git', args, { cwd, timeout: 5000, encoding: 'utf-8' })
+
+  // A real remote with a real `develop`, published the way a remote is.
+  const seed = join(dir, 'seed')
+  execFileSync('/usr/bin/git', ['init', '-q', '-b', 'develop', seed], { timeout: 5000 })
+  git(seed, '-c', 'user.email=t@example.invalid', '-c', 'user.name=t',
+      'commit', '-q', '--allow-empty', '-m', 'upstream base')
+  execFileSync('/usr/bin/git', ['init', '-q', '--bare', origin], { timeout: 5000 })
+  // The bare repo's HEAD defaults to the git build's init.defaultBranch, which
+  // is not necessarily `develop`; a clone then checks nothing out and the
+  // branch made below has no ancestry with origin/develop -- an empty
+  // merge-base produced by the FIXTURE would look exactly like the bug.
+  execFileSync('/usr/bin/git', ['symbolic-ref', 'HEAD', 'refs/heads/develop'], { cwd: origin, timeout: 5000 })
+  git(seed, 'remote', 'add', 'origin', origin)
+  git(seed, 'push', '-q', 'origin', 'develop')
+
+  // ...and a clone of it, which is what a real install looks like: HEAD on its
+  // own branch, `refs/remotes/origin/develop` present because it was fetched.
+  execFileSync('/usr/bin/git', ['clone', '-q', origin, root], { timeout: 15000 })
+  git(root, 'remote', 'set-url', 'origin', 'https://github.com/TheAuthor/marveen.git')
+  git(root, 'checkout', '-q', '-b', 'a-local-feature-branch')
+  git(root, '-c', 'user.email=t@example.invalid', '-c', 'user.name=t',
+      'commit', '-q', '--allow-empty', '-m', 'local work never pushed')
+
+  return { root, cleanup: () => rmSync(dir, { recursive: true, force: true }) }
+}
+
 describe('the branch we ask upstream about is answerable', () => {
-  it('this checkout has origin tracking refs, so the probe carries evidence', () => {
-    expect(originHasTrackingRefs(PROJECT_ROOT)).toBe(true)
+  const fixture = clonedRepoWithTrackingRefs()
+  afterAll(() => fixture.cleanup())
+
+  it('a fetched clone carries origin tracking refs, so the probe carries evidence', () => {
+    expect(originHasTrackingRefs(fixture.root)).toBe(true)
+    expect(branchExistsOnOrigin('develop', fixture.root)).toBe(true)
+  })
+
+  // Control: the probe answers about THIS checkout, so a branch that was never
+  // fetched must come back false. Without it, a probe that always said true
+  // would make the claim above pass for the wrong reason.
+  it('a branch the clone never fetched is reported absent', () => {
+    expect(branchExistsOnOrigin('a-local-feature-branch', fixture.root)).toBe(false)
+    expect(branchExistsOnOrigin('no-such-branch-9f3a1c', fixture.root)).toBe(false)
   })
 
   it('never asks upstream about a branch that is not on origin', async () => {
-    const remote = parseGitHubRemote(PROJECT_ROOT)
-    const asked = await branchOnRemote(remote, PROJECT_ROOT, async () => 'develop')
+    const remote = parseGitHubRemote(fixture.root)
+    const asked = await branchOnRemote(remote, fixture.root, async () => 'develop')
     // Either it is a branch origin really has, or it is the injected default.
-    expect(branchExistsOnOrigin(asked, PROJECT_ROOT) || asked === 'develop').toBe(true)
+    expect(branchExistsOnOrigin(asked, fixture.root) || asked === 'develop').toBe(true)
+    // The local-only branch is exactly the 422 this fix removed.
+    expect(asked).not.toBe('a-local-feature-branch')
   })
 })
 
@@ -219,19 +271,22 @@ describe('the branch we ask upstream about is answerable', () => {
 // produces a nonsense distance (161 reported against a real backlog of 4,
 // measured 2026-09-04). A number nobody can act on is worse than an error.
 describe('upstreamMergeBase resolves a base the remote actually knows', () => {
+  const fixture = clonedRepoWithTrackingRefs()
+  afterAll(() => fixture.cleanup())
+
   it('returns a real commit for the branch we ask the remote about', () => {
-    const base = upstreamMergeBase(parseGitHubRemote(PROJECT_ROOT), 'develop')
+    const base = upstreamMergeBase(parseGitHubRemote(fixture.root), 'develop', fixture.root)
     expect(base).toMatch(/^[0-9a-f]{40}$/)
   })
 
   it('the base is an ancestor of the ref it claims to compare against', () => {
-    const base = upstreamMergeBase(parseGitHubRemote(PROJECT_ROOT), 'develop')
+    const base = upstreamMergeBase(parseGitHubRemote(fixture.root), 'develop', fixture.root)
     // If the base were picked from a ref the remote does not carry, this fails:
     // merge-base --is-ancestor exits non-zero.
     const ok = (() => {
       try {
         execFileSync('/usr/bin/git', ['merge-base', '--is-ancestor', base, 'origin/develop'],
-          { cwd: PROJECT_ROOT, timeout: 3000 })
+          { cwd: fixture.root, timeout: 3000 })
         return true
       } catch { return false }
     })()
@@ -241,7 +296,19 @@ describe('upstreamMergeBase resolves a base the remote actually knows', () => {
   it('never returns an empty base while origin/develop exists', () => {
     // The empty string is the failure that produced the nonsense count; it must
     // not come back silently on a checkout that plainly has the ref.
-    expect(branchExistsOnOrigin('develop', PROJECT_ROOT)).toBe(true)
-    expect(upstreamMergeBase(parseGitHubRemote(PROJECT_ROOT), 'develop')).not.toBe('')
+    expect(branchExistsOnOrigin('develop', fixture.root)).toBe(true)
+    expect(upstreamMergeBase(parseGitHubRemote(fixture.root), 'develop', fixture.root)).not.toBe('')
+  })
+
+  // The failure itself: no ref for the queried branch anywhere, so there is
+  // nothing to measure from and the honest answer is the empty string -- the
+  // caller turns that into "unknown", never into a distance.
+  it('returns empty rather than inventing a base when no ref matches', () => {
+    const bare = repoWithRemotes({ origin: 'https://github.com/TheAuthor/marveen.git' })
+    try {
+      expect(upstreamMergeBase('TheAuthor/marveen', 'develop', bare)).toBe('')
+    } finally {
+      rmSync(bare, { recursive: true, force: true })
+    }
   })
 })

--- a/src/__tests__/update-checker-branch.test.ts
+++ b/src/__tests__/update-checker-branch.test.ts
@@ -71,7 +71,7 @@ describe('update checker current version', () => {
 //     GitHub answers 422 on /commits/<branch>), and
 //   - the compare BASE (a base the remote does not know turns the reported
 //     backlog into a fork-distance -- measured 375 against a real 5).
-import { remoteIsOwnOrigin, parseGitHubRemote, branchOnRemote } from '../web/update-checker.js'
+import { remoteIsOwnOrigin, parseGitHubRemote, branchOnRemote, branchExistsOnOrigin, originHasTrackingRefs } from '../web/update-checker.js'
 import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 
@@ -139,5 +139,75 @@ describe('update checker remote selection (fork case)', () => {
     const root = mk({ origin: 'git@github.com:TheFork/marveen.git' })
     const branch = await branchOnRemote('TheFork/marveen', root, async () => 'never-used')
     expect(branch).toBe('a-local-feature-branch')
+  })
+})
+
+// UPDATEBRANCH904: "origin is our own repo" is a naming CONVENTION, and this
+// fork inverts it -- `origin` points at the original author (Szotasz/marveen)
+// and the fork pushes to a second remote. branchOnRemote then asked the
+// AUTHOR's repo for OUR local feature branch, GitHub answered 422, the throw
+// was swallowed into `behind: 0`, and the dashboard reported "up to date" for
+// nine days while 66 upstream commits piled up. A silent zero is the worst
+// possible answer here: it looks exactly like being current.
+describe('branchOnRemote does not trust a branch the remote has never seen', () => {
+  const OURS = 'Owner/Repo'
+  const ownOrigin = (r: string) => r === OURS
+
+  it('uses the local branch when the remote actually has it', async () => {
+    const branch = await branchOnRemote(
+      OURS, PROJECT_ROOT,
+      async () => 'develop',
+      () => true,
+      ownOrigin,
+      () => true,
+    )
+    expect(branch).toBe(trackedBranch())
+  })
+
+  it('falls back to the default branch when the remote has no such branch', async () => {
+    const branch = await branchOnRemote(
+      OURS, PROJECT_ROOT,
+      async () => 'develop',
+      () => false,
+      ownOrigin,
+      () => true,
+    )
+    expect(branch).toBe('develop')
+    expect(branch).not.toBe(trackedBranch())
+  })
+
+  it('asks a foreign remote for its own default branch, never ours', async () => {
+    const branch = await branchOnRemote(
+      'SomeoneElse/repo', PROJECT_ROOT,
+      async () => 'main',
+      () => true, // even if a same-named local ref existed, it is not theirs
+      ownOrigin,
+      () => true,
+    )
+    expect(branch).toBe('main')
+  })
+
+  // Control: the existence probe answers about THIS checkout, so a branch that
+  // cannot exist must come back false. Without this, a probe stubbed to always
+  // return true would make the first test pass for the wrong reason.
+  it('the real existence probe rejects a branch that cannot exist', () => {
+    expect(branchExistsOnOrigin('no-such-branch-9f3a1c', PROJECT_ROOT)).toBe(false)
+  })
+})
+
+// The end-to-end shape of UPDATEBRANCH904, asserted against THIS checkout:
+// whatever branch we end up asking the upstream remote about, it must be one
+// that remote could actually answer for. A branch only this machine has ever
+// seen is the 422 that produced the silent `behind: 0`.
+describe('the branch we ask upstream about is answerable', () => {
+  it('this checkout has origin tracking refs, so the probe carries evidence', () => {
+    expect(originHasTrackingRefs(PROJECT_ROOT)).toBe(true)
+  })
+
+  it('never asks upstream about a branch that is not on origin', async () => {
+    const remote = parseGitHubRemote(PROJECT_ROOT)
+    const asked = await branchOnRemote(remote, PROJECT_ROOT, async () => 'develop')
+    // Either it is a branch origin really has, or it is the injected default.
+    expect(branchExistsOnOrigin(asked, PROJECT_ROOT) || asked === 'develop').toBe(true)
   })
 })

--- a/src/web/update-checker.ts
+++ b/src/web/update-checker.ts
@@ -288,16 +288,34 @@ export function groupByRelease(commits: UpdateCommit[], fullMessages: string[]):
 // the fork point -- an actual upstream commit -- so it can be compared on
 // GitHub even though the local HEAD itself never landed there. Empty string
 // when there is no local upstream ref.
-function upstreamMergeBase(remote: string, remoteBranch: string): string {
+export function upstreamMergeBase(remote: string, remoteBranch: string): string {
   // The base has to be a commit the queried remote KNOWS, otherwise the compare
   // call is meaningless. Asking `origin/<local branch>` while querying someone
   // else's repo picks our own pushed commit as the base and reports a
   // fork-distance instead of the real backlog.
-  const refs = remoteIsOwnOrigin(remote)
-    ? [`origin/${trackedBranch()}`, 'origin/main']
-    : [`upstream/${remoteBranch}`, 'upstream/develop', 'upstream/main']
+  // UPDATEBRANCH904, the twin of the bug in branchOnRemote: which ref carries
+  // the queried remote's branch is decided by CANDIDATE ORDER, not by the
+  // `origin`/`upstream` naming convention. This fork keeps `origin` on the
+  // original author and pushes elsewhere, so the old own-origin list resolved
+  // to `origin/<our local branch>` -- a ref that has never existed -- every
+  // candidate failed, the base came back empty, and the compare then reported
+  // a nonsense distance (161 commits against a real backlog of 4, measured
+  // 2026-09-04). The branch we actually ASKED the remote about is the branch
+  // whose ref we need, under whichever remote name holds it.
+  const refs = [
+    `upstream/${remoteBranch}`,
+    `origin/${remoteBranch}`,
+    ...(remoteIsOwnOrigin(remote) ? [`origin/${trackedBranch()}`] : []),
+    'upstream/develop', 'origin/develop',
+    'upstream/main', 'origin/main',
+  ]
   for (const ref of refs) {
     try {
+      // Existence first: merge-base against a missing ref throws, but an
+      // ambiguous or partially-valid name can also resolve to something we did
+      // not mean. Verify, then measure.
+      execFileSync('/usr/bin/git', ['show-ref', '--verify', '--quiet', `refs/remotes/${ref}`],
+        { cwd: PROJECT_ROOT, timeout: 3000 })
       const base = execFileSync('/usr/bin/git', ['merge-base', 'HEAD', ref], { cwd: PROJECT_ROOT, timeout: 3000, encoding: 'utf-8' }).trim()
       if (base) return base
     } catch { /* try the next ref */ }

--- a/src/web/update-checker.ts
+++ b/src/web/update-checker.ts
@@ -288,7 +288,7 @@ export function groupByRelease(commits: UpdateCommit[], fullMessages: string[]):
 // the fork point -- an actual upstream commit -- so it can be compared on
 // GitHub even though the local HEAD itself never landed there. Empty string
 // when there is no local upstream ref.
-export function upstreamMergeBase(remote: string, remoteBranch: string): string {
+export function upstreamMergeBase(remote: string, remoteBranch: string, root: string = PROJECT_ROOT): string {
   // The base has to be a commit the queried remote KNOWS, otherwise the compare
   // call is meaningless. Asking `origin/<local branch>` while querying someone
   // else's repo picks our own pushed commit as the base and reports a
@@ -305,7 +305,7 @@ export function upstreamMergeBase(remote: string, remoteBranch: string): string 
   const refs = [
     `upstream/${remoteBranch}`,
     `origin/${remoteBranch}`,
-    ...(remoteIsOwnOrigin(remote) ? [`origin/${trackedBranch()}`] : []),
+    ...(remoteIsOwnOrigin(remote, root) ? [`origin/${trackedBranch(root)}`] : []),
     'upstream/develop', 'origin/develop',
     'upstream/main', 'origin/main',
   ]
@@ -315,8 +315,8 @@ export function upstreamMergeBase(remote: string, remoteBranch: string): string 
       // ambiguous or partially-valid name can also resolve to something we did
       // not mean. Verify, then measure.
       execFileSync('/usr/bin/git', ['show-ref', '--verify', '--quiet', `refs/remotes/${ref}`],
-        { cwd: PROJECT_ROOT, timeout: 3000 })
-      const base = execFileSync('/usr/bin/git', ['merge-base', 'HEAD', ref], { cwd: PROJECT_ROOT, timeout: 3000, encoding: 'utf-8' }).trim()
+        { cwd: root, timeout: 3000 })
+      const base = execFileSync('/usr/bin/git', ['merge-base', 'HEAD', ref], { cwd: root, timeout: 3000, encoding: 'utf-8' }).trim()
       if (base) return base
     } catch { /* try the next ref */ }
   }

--- a/src/web/update-checker.ts
+++ b/src/web/update-checker.ts
@@ -113,6 +113,35 @@ export function remoteIsOwnOrigin(remote: string, root: string = PROJECT_ROOT): 
   }
 }
 
+// Does `branch` exist on the `origin` remote? Answered from the local
+// remote-tracking refs, which the periodic fetch keeps current, so this costs
+// no network call and stays truthful offline. Absent ref -> treat as absent
+// branch: the fallback (the remote's default branch) is always answerable,
+// while a wrong branch name is a silent 422.
+export function branchExistsOnOrigin(branch: string, root: string = PROJECT_ROOT): boolean {
+  try {
+    execFileSync('/usr/bin/git', ['show-ref', '--verify', '--quiet', `refs/remotes/origin/${branch}`],
+      { cwd: root, timeout: 3000 })
+    return true
+  } catch {
+    return false
+  }
+}
+
+// Has this checkout any remote-tracking refs for origin at all? The absence of
+// ONE branch is evidence; the absence of ALL of them is not -- a clone that has
+// never fetched knows nothing, and reading that silence as "the branch is gone"
+// would send every fresh install down the fallback for no reason.
+export function originHasTrackingRefs(root: string = PROJECT_ROOT): boolean {
+  try {
+    const out = execFileSync('/usr/bin/git', ['for-each-ref', '--count=1', '--format=%(refname)', 'refs/remotes/origin/'],
+      { cwd: root, timeout: 3000, encoding: 'utf-8' })
+    return out.trim().length > 0
+  } catch {
+    return false
+  }
+}
+
 // The remote's own default branch, asked of GitHub. Only needed when we are NOT
 // checking our own fork -- our local branch name means nothing over there.
 async function fetchDefaultBranch(remote: string): Promise<string> {
@@ -140,8 +169,24 @@ export async function branchOnRemote(
   remote: string,
   root: string = PROJECT_ROOT,
   defaultBranchOf: (r: string) => Promise<string> = fetchDefaultBranch,
+  branchExists: (branch: string, root: string) => boolean = branchExistsOnOrigin,
+  isOwnOrigin: (remote: string, root: string) => boolean = remoteIsOwnOrigin,
+  hasTrackingRefs: (root: string) => boolean = originHasTrackingRefs,
 ): Promise<string> {
-  return remoteIsOwnOrigin(remote, root) ? trackedBranch(root) : await defaultBranchOf(remote)
+  if (isOwnOrigin(remote, root)) {
+    // "origin is ours" is a naming CONVENTION, not a fact. A fork that keeps
+    // `origin` pointed at the original author and pushes to a second remote
+    // (`fork`) inverts it, and then the local branch name is exactly the thing
+    // the author's repo has never heard of. Measured here 2026-09-04: the
+    // check asked Szotasz/marveen for `fix/email-gate-mcp-matcher`, GitHub
+    // answered 422, the error was swallowed into `behind: 0`, and the install
+    // reported itself up to date for nine days while 66 commits piled up.
+    // Verify before trusting the convention; a branch nobody has ever pushed
+    // cannot be the one to compare against.
+    const local = trackedBranch(root)
+    if (!hasTrackingRefs(root) || branchExists(local, root)) return local
+  }
+  return await defaultBranchOf(remote)
 }
 
 export function parseGitHubRemote(root: string = PROJECT_ROOT): string {


### PR DESCRIPTION
The update checker could not see that this install was behind, and the dashboard reported "up to date" for nine days while 66 upstream commits accumulated. Two bugs, both rooted in the same assumption.

**1. A branch only this machine has seen cannot be the compare base.** `branchOnRemote` treated "origin is our own repository" as a fact. It is a naming convention, and a fork that keeps `origin` pointed at the original author while pushing to a second remote inverts it. This install does exactly that: the checker asked the upstream for a local topic branch that has never existed there, GitHub answered 422, and the throw was swallowed into `behind: 0`. A silent zero is the worst possible answer, because it is indistinguishable from being current, and nobody goes looking for an update the update check says does not exist.

The local branch is now used only when origin demonstrably carries it, answered from the local remote-tracking refs so it costs no network call and stays truthful offline. The check is deliberately tri-state: the absence of ONE branch is evidence, the absence of ALL of them is not, because a clone that has never fetched knows nothing.

**2. The compare base came from a ref that never existed.** The twin of the first, in the other half of the same check. `branchOnRemote` decides WHICH branch to ask about; `upstreamMergeBase` decides which commit to measure the distance FROM, and it keyed on the same convention. On this fork the base resolved to a ref that has never existed, every candidate threw, the base came back as the empty string, and the compare then reported 161 commits against a real backlog of 4. An empty base does not fail loudly, it produces a number, and a number nobody can act on is worse than an error, because an error gets investigated.

Candidate order now drives the resolution instead of the remote's name, and each candidate is verified to exist before it is measured.

Where this was proven: on a fork install, `git rev-list --count HEAD..origin/develop` said 66 while `/api/updates` said 0. After the fix both say the same number, verified again after the backlog was merged (both 0, with the upstream head confirmed as an ancestor of local HEAD).

Test suite (clean clone, `npx tsc --noEmit` clean): **353 files, 4612 passed, 1 skipped**, against a `develop` baseline of 353 / 4603 measured the same way. The 9 added tests are the new branch-resolution and merge-base assertions, each of which fails on `develop`.
