### PR TITLE
fix(web): a malformed request body answered 500 and named no route

### DIFF
--- a/src/__tests__/malformed-body-is-client-error.test.ts
+++ b/src/__tests__/malformed-body-is-client-error.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import { isMalformedBodyError } from '../web/malformed-body.js'
+
+// The two bodies below are not invented shapes: they are the exact failures
+// that reached store/dashboard.log on 2026-09-04, one on POST /api/daily-log
+// and one on POST /api/kanban. Both answered 500, so every caller-side check
+// that looks at the HTTP status read them as "the server broke", and the
+// writes were simply gone.
+describe('isMalformedBodyError', () => {
+  const parseError = (raw: string): unknown => {
+    try { JSON.parse(raw); return null } catch (e) { return e }
+  }
+
+  it('recognises a raw newline inside a string literal', () => {
+    const err = parseError('{"agent_id":"agent","content":"## 14:00 -- Napi\nsor"}')
+    expect(err).toBeInstanceOf(SyntaxError)
+    expect(isMalformedBodyError(err)).toBe(true)
+  })
+
+  it('recognises an unterminated string', () => {
+    const err = parseError('{"title":"Kartya cim')
+    expect(isMalformedBodyError(err)).toBe(true)
+  })
+
+  it('leaves a well-formed body alone', () => {
+    expect(parseError('{"ok":true}')).toBeNull()
+  })
+
+  it('does not claim our own bugs as the caller"s fault', () => {
+    expect(isMalformedBodyError(new TypeError('x is not a function'))).toBe(false)
+    expect(isMalformedBodyError(new SyntaxError('Unexpected token in regex'))).toBe(false)
+    expect(isMalformedBodyError(new Error('boom'))).toBe(false)
+    expect(isMalformedBodyError(undefined)).toBe(false)
+  })
+})

--- a/src/web.ts
+++ b/src/web.ts
@@ -83,6 +83,7 @@ import { tryHandleVaultSsh } from './web/routes/vault-ssh.js'
 import { tryHandleFleet } from './web/routes/fleet.js'
 import { tryHandleVaultSshKeys } from './web/routes/vault-ssh-keys.js'
 import type { RouteContext } from './web/routes/types.js'
+import { isMalformedBodyError } from './web/malformed-body.js'
 
 const WEB_DIR = join(PROJECT_ROOT, 'web')
 
@@ -225,7 +226,27 @@ export function startWebServer(port = 3420): http.Server {
       res.writeHead(404)
       res.end('Not found')
     } catch (err) {
-      logger.error({ err }, 'Web szerver hiba')
+      // A malformed JSON body is the CALLER's mistake, and until 2026-09-04
+      // this handler hid both that fact and its location: it logged `err`
+      // alone (no route, no size) and answered 500, so a curl that lost a
+      // write to an unescaped newline in `content` looked like a server
+      // crash with nothing but a character offset to identify it. Two such
+      // writes are in the log from that week -- one daily-log entry and one
+      // kanban POST -- and neither caller had any way to notice. Name the
+      // route, and answer 400 so `curl -f` and every HTTP-status check see a
+      // client error instead of a server one.
+      const isBadJson = isMalformedBodyError(err)
+      if (isBadJson) {
+        logger.warn(
+          { method, path, bytes: req.headers['content-length'] ?? '?', reason: (err as Error).message },
+          'Hibas JSON torzs -- a keres NEM hajtodott vegre',
+        )
+        json(res, {
+          error: 'Hibas JSON torzs, a keres nem hajtodott vegre. Sortores es idezojel a szoveges mezokben escape-elve kell legyen.',
+        }, 400)
+        return
+      }
+      logger.error({ err, method, path }, 'Web szerver hiba')
       json(res, { error: 'Szerver hiba' }, 500)
     }
   })

--- a/src/web/malformed-body.ts
+++ b/src/web/malformed-body.ts
@@ -1,0 +1,15 @@
+/**
+ * Was this thrown by a caller's broken request body, or by our own code?
+ *
+ * Until 2026-09-04 the dashboard's top-level catch could not tell: a POST
+ * whose `content` field carried a raw newline or an unclosed quote blew up in
+ * JSON.parse, and the caller got a 500 "Szerver hiba" with a log line holding
+ * nothing but a character offset. Two writes were lost that way in one week
+ * (a daily-log entry and a kanban POST) and neither sender could have noticed
+ * -- `curl -s` exits 0 on a 500 just as happily as on a 200.
+ *
+ * A malformed body is a CLIENT error: 400, named route, no stack.
+ */
+export function isMalformedBodyError(err: unknown): boolean {
+  return err instanceof SyntaxError && /JSON/i.test(String(err.message))
+}


### PR DESCRIPTION
A malformed request body answered 500 and named no route.

The dashboard's top-level catch could not tell a caller's broken JSON from a crash of our own: a POST whose text field carried a raw newline or an unclosed quote threw in `JSON.parse`, and the sender got `500 Szerver hiba` while the log line held nothing but a character offset. Two writes were lost that way in one week on this install, a daily-log entry and a kanban POST, and neither sender could have noticed: `curl -s` exits 0 on a 500 as happily as on a 200, which is exactly the silent-send failure the agent instructions warn about for `/api/messages`.

A malformed body is a client error. It now answers 400 with a message that says what to fix, and the log line names method, path, body size and the parse reason, so a lost write can be traced to its route. Errors that really are ours keep the 500 and now carry method and path too.

Verified: four unit tests on the classifier, built from the two real failures rather than invented shapes; then live against a restarted dashboard, where the same body that produced the original error returns HTTP 400 and logs `method=POST path=/api/daily-log bytes=64` with the parse reason.

Test suite (clean clone, `npx tsc --noEmit` clean): **354 files, 4607 passed, 1 skipped**, against a `develop` baseline of 353 / 4603 measured the same way.
