### PR TITLE
fix(schedule-runner): the hang alert fired on normal work, not on hangs

### DIFF
--- a/src/__tests__/schedule-task-timeout.test.ts
+++ b/src/__tests__/schedule-task-timeout.test.ts
@@ -17,7 +17,7 @@ import { OWNER_ESCALATION_EXTRA_MS } from '../pending-retries.js'
 // guards against the test becoming a false guard.
 
 const GRACE = TASK_FIRE_GRACE_MS   // 30_000
-const TIMEOUT = TASK_FIRE_TIMEOUT_MS // 300_000
+const TIMEOUT = TASK_FIRE_TIMEOUT_MS // 2_700_000 (45 min)
 const MAX_TRACK = 6 * 60 * 60_000   // 6 hours
 const OWNER_EXTRA = OWNER_ESCALATION_EXTRA_MS // 75 minutes, shared with the pending-retry escalation
 

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -96,7 +96,18 @@ const RESUBMIT_LANE_BUSY_MAX_SKIPS = 20
 // Maximum tracking age: entries that age past TASK_FIRE_MAX_TRACK_MS are
 // evicted regardless, so a permanently stuck agent does not accumulate entries.
 export const TASK_FIRE_GRACE_MS = 30_000
-export const TASK_FIRE_TIMEOUT_MS = 300_000
+// 2026-09-01: raised from 5 minutes to 45. Five minutes measures "the session
+// is still busy", not "the task is wedged", and those two are the same thing
+// only when the agent does nothing else. In practice the owner talks to the
+// agent mid-task, so a heartbeat that fired at 12:00 is still the in-flight
+// entry at 12:40 while the session is busy with a conversation -- and every one
+// of those produced a "possible hang" Telegram alert. The owner got four or
+// five of them in a single morning (2026-09-01) and asked for it to stop,
+// which is the correct reading: an alert that fires on normal work is noise,
+// and noise is what makes a real hang invisible. 45 minutes still catches a
+// genuinely wedged tool call well inside the 6-hour tracking window, and a
+// task that legitimately needs longer sets stuckAfterMinutes.
+export const TASK_FIRE_TIMEOUT_MS = 2_700_000
 const TASK_FIRE_MAX_TRACK_MS = 6 * 60 * 60_000
 
 export interface TaskInflightEntry {
@@ -133,9 +144,8 @@ export interface TaskInflightEntry {
 }
 
 // How long a fired task may stay busy before the watchdog calls it stuck.
-// TASK_FIRE_TIMEOUT_MS is the right default for the common case -- a
-// short-cadence heartbeat still running after 5 minutes is a real signal --
-// but it is wrong for a task whose whole job is to think for a while. The
+// TASK_FIRE_TIMEOUT_MS is the default; it is wrong for a task whose whole job
+// is to think for a while, and for one the owner interrupts with a conversation. The
 // nightly analysis run tripped it at 02:12 on 2026-07-30 while working
 // normally and finished fine six minutes later: a false "possible hang" alert
 // on a task doing exactly what it was written to do. Per-task override:

--- a/src/web/scheduled-tasks-io.ts
+++ b/src/web/scheduled-tasks-io.ts
@@ -67,7 +67,7 @@ export interface ScheduledTask {
   // limit are recorded as a 'missed' run and reported, never silently dropped.
   catchUpMaxAgeMinutes?: number
   // How long this task may run before the post-fire watchdog calls it stuck and
-  // alerts the operator. Unset uses the global TASK_FIRE_TIMEOUT_MS (5 min),
+  // alerts the operator. Unset uses the global TASK_FIRE_TIMEOUT_MS (45 min),
   // which is right for a short-cadence heartbeat and wrong for a task whose job
   // is to think for a while. Clamped at both ends, see resolveStuckTimeoutMs.
   // DISTINCT from catchUpMaxAgeMinutes: that one judges a MISSED occurrence's


### PR DESCRIPTION
The hang alert fired on normal work, not on hangs.

`TASK_FIRE_TIMEOUT_MS` was 5 minutes, which measures "the session is still busy", not "the task is wedged". Those are the same thing only when the agent does nothing else. In practice the owner talks to the agent mid-task, so a heartbeat that fired at 12:00 is still the in-flight entry at 12:40 while the session handles a conversation, and every one of those produced a "possible hang" alert on the channel. The owner got four or five of them in a single morning (2026-09-01) and asked for it to stop, which is the right reading: an alert that fires on normal work is noise, and noise is what makes a real hang invisible.

Raised to 45 minutes, which still catches a genuinely wedged tool call well inside the 6-hour tracking window. A task that legitimately needs longer already has the per-task `stuckAfterMinutes` override, and the comment at the constant now says which of the two things the number measures.

Test suite (clean clone, `npx tsc --noEmit` clean): **353 files, 4603 passed, 1 skipped**, identical to the `develop` baseline measured the same way.
