### PR TITLE
fix(outgoing-copy-gate): add a sanctioned no-rule state so a taken decision stays silent

### DIFF
--- a/scripts/__tests__/outgoing-copy-gate.test.py
+++ b/scripts/__tests__/outgoing-copy-gate.test.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Test the outbound-copy QA gate (scripts/hooks/outgoing-copy-gate.py).
+
+Focus: the name-rule-file state distinction. Two owner decisions meet here,
+and the 2026-09-04 upstream merge combined them (see the RULES_* block in the
+hook for the full reasoning):
+  - GATEPERSIST816/3 (PDB, 2026-08-19): a file that explicitly declares
+    no_name_rule=true is a SANCTIONED state, silent everywhere -- and an
+    ordinary empty list that merely forgot to say so must never be mistaken
+    for it.
+  - CLCOPYGATEHIANY902 (upstream, 2026-09-02): a MISSING or empty file is not
+    the same as a BROKEN one. Missing/empty now fail-OPEN with a loud,
+    user-visible warning, because the file is deliberately not shipped and the
+    old fail-closed path left a fresh install unable to send mail at all.
+    A file that EXISTS but is unusable (invalid) still fails CLOSED.
+So the states are: ok / sanctioned (silent) / missing / empty (open + loud) /
+invalid (closed). What this file guards above all is the pair that looks alike
+and must not behave alike: sanctioned passes SILENTLY, empty-without-flag
+passes LOUDLY.
+
+Also carries a regression pass over the checks this task must NOT touch:
+accents, em dash, double-hyphen, mixed-script (homoglyph). Drives the hook as
+a subprocess against an isolated OUTGOING_COPY_GATE_RULES file so the real
+store/outgoing-copy-gate-rules.json is never touched. Run:
+  python3 scripts/__tests__/outgoing-copy-gate.test.py
+Exit 0 = all pass; non-zero = a failure (message on stderr).
+"""
+import json
+import os
+import sys
+import tempfile
+import subprocess
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+HOOK = os.path.join(os.path.dirname(HERE), "hooks", "outgoing-copy-gate.py")
+
+CLEAN_HU = "Szia! Koszonom szepen, holnap kuldom at a szamlat es a reszleteket."
+# proper accents, no dash, no homoglyph, no bad name -- a payload that should
+# sail through every check except whatever the test deliberately breaks.
+CLEAN_HU_OK = "Szia! Köszönöm szépen, holnap küldöm át a számlát és a részleteket."
+
+
+def rules_path(tmpdir, name="rules.json"):
+    return os.path.join(tmpdir, name)
+
+
+def write_rules(path, data):
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(data, fh)
+
+
+def run_hook(payload, rules_file=None, cwd=None):
+    env = dict(os.environ)
+    if rules_file is not None:
+        env["OUTGOING_COPY_GATE_RULES"] = rules_file
+    else:
+        env.pop("OUTGOING_COPY_GATE_RULES", None)
+    p = subprocess.run(
+        [sys.executable, HOOK],
+        input=json.dumps(payload),
+        capture_output=True, text=True, env=env, timeout=20, cwd=cwd,
+    )
+    return p.returncode, p.stdout, p.stderr
+
+
+def email_payload(body):
+    return {"tool_name": "send_email", "tool_input": {"body": body}}
+
+
+def telegram_payload(text):
+    return {"tool_name": "mcp__plugin_telegram_telegram__reply", "tool_input": {"text": text}}
+
+
+FAILS = []
+
+
+def check(name, got, want):
+    ok = got == want
+    print(f"  [{'PASS' if ok else 'FAIL'}] {name}: got={got!r} want={want!r}")
+    if not ok:
+        FAILS.append(name)
+
+
+def check_true(name, cond, detail=""):
+    print(f"  [{'PASS' if cond else 'FAIL'}] {name}" + (f" ({detail})" if detail and not cond else ""))
+    if not cond:
+        FAILS.append(name)
+
+
+def main():
+    with tempfile.TemporaryDirectory(prefix="copygate-") as tmp:
+
+        # --- 1. MISSING file -----------------------------------------------
+        missing = rules_path(tmp, "does-not-exist.json")
+        # CLCOPYGATEHIANY902: the email goes OUT, but never silently -- the
+        # sender has to see that the name check did not protect this letter.
+        code, out, err = run_hook(email_payload(CLEAN_HU_OK), rules_file=missing)
+        check("missing file: email fail-OPEN (exit 0)", code, 0)
+        check_true("missing file: the pass is LOUD (systemMessage names the absent check)",
+                   "systemMessage" in out and "HIANYZIK" in out, out)
+
+        code, out, err = run_hook(telegram_payload(CLEAN_HU_OK), rules_file=missing)
+        check("missing file: telegram fail-open (exit 0)", code, 0)
+        check_true("missing file: telegram warns via systemMessage", "NEV-SZABALY" in out, out)
+
+        # --- 2. CORRUPT file (unparseable JSON) -----------------------------
+        corrupt = rules_path(tmp, "corrupt.json")
+        with open(corrupt, "w", encoding="utf-8") as fh:
+            fh.write("{ not valid json ]")
+        code, out, err = run_hook(email_payload(CLEAN_HU_OK), rules_file=corrupt)
+        check("corrupt file: email fail-closed (exit 2)", code, 2)
+        check_true("corrupt file: email stderr names the rules file", "NEV-SZABALY" in err, err)
+
+        code, out, err = run_hook(telegram_payload(CLEAN_HU_OK), rules_file=corrupt)
+        check("corrupt file: telegram fail-open (exit 0)", code, 0)
+        check_true("corrupt file: telegram warns via systemMessage", "NEV-SZABALY" in out, out)
+
+        # --- 3. EXPLICIT no-rule (sanctioned, silent) -----------------------
+        explicit_none = rules_path(tmp, "explicit-none.json")
+        write_rules(explicit_none, {
+            "no_name_rule": True,
+            "no_name_rule_reason": "teszt: a regi szabaly-fajl elveszett, tudatosan nincs pótolva",
+        })
+        code, out, err = run_hook(email_payload(CLEAN_HU_OK), rules_file=explicit_none)
+        check("explicit no-rule: email proceeds (exit 0)", code, 0)
+        check_true("explicit no-rule: email stderr silent on name-rule", "NEV-SZABALY" not in err, err)
+
+        code, out, err = run_hook(telegram_payload(CLEAN_HU_OK), rules_file=explicit_none)
+        check("explicit no-rule: telegram proceeds (exit 0)", code, 0)
+        check_true("explicit no-rule: telegram stays silent (no systemMessage)", out.strip() == "", out)
+
+        # THE PAIR THAT MUST NOT BE CONFUSED. Since CLCOPYGATEHIANY902 both of
+        # these let the letter out, so the exit code alone no longer separates
+        # them -- the difference is now the NOISE, and that is what is asserted
+        # here. A sanctioned file passes in silence; an ordinary empty list
+        # that merely forgot the flag passes with a loud warning. If a future
+        # change makes the empty list silent, the sanctioned state would have
+        # become reachable by accident, which is what GATEPERSIST816/3 exists
+        # to prevent.
+        empty_no_flag = rules_path(tmp, "empty-no-flag.json")
+        write_rules(empty_no_flag, {"bad_name_patterns": []})
+        code, out, err = run_hook(email_payload(CLEAN_HU_OK), rules_file=empty_no_flag)
+        check("empty patterns, no explicit flag: email fail-OPEN (exit 0)", code, 0)
+        check_true("empty patterns, no explicit flag: the pass is LOUD",
+                   "systemMessage" in out and "URES" in out, out)
+
+        code, out, err = run_hook(telegram_payload(CLEAN_HU_OK), rules_file=empty_no_flag)
+        check_true("empty patterns, no explicit flag: telegram also warns",
+                   "systemMessage" in out, out)
+
+        # --- 4. ACTIVE rule (unchanged matching behaviour) ------------------
+        active = rules_path(tmp, "active.json")
+        write_rules(active, {
+            "bad_name_patterns": [r"\bTeszt[- ]?Elek\b"],
+            "correction": "a helyes alak: Teszt Elemer",
+        })
+        code, out, err = run_hook(email_payload(CLEAN_HU_OK), rules_file=active)
+        check("active rule, clean body: email proceeds (exit 0)", code, 0)
+
+        bad_body = CLEAN_HU_OK + " Udvozlettel, Teszt Elek"
+        code, out, err = run_hook(email_payload(bad_body), rules_file=active)
+        check("active rule, bad name present: email blocks (exit 2)", code, 2)
+        check_true("active rule, bad name present: stderr names the bad name", "HELYTELEN NEV" in err, err)
+        check_true("active rule, bad name present: stderr carries the correction", "Teszt Elemer" in err, err)
+
+        code, out, err = run_hook(telegram_payload(bad_body), rules_file=active)
+        check("active rule, bad name present: telegram blocks (exit 2)", code, 2)
+
+        # --- 5. Regression: checks this task must not touch -----------------
+        # 5a. em dash
+        code, out, err = run_hook(email_payload(CLEAN_HU_OK + " — mégis."), rules_file=active)
+        check("em dash still blocks (exit 2)", code, 2)
+        check_true("em dash: stderr names it", "GONDOLATJEL" in err, err)
+
+        # 5b. missing accents (accent-insensitive Hungarian detector)
+        code, out, err = run_hook(email_payload(CLEAN_HU), rules_file=active)
+        check("missing accents still blocks (exit 2)", code, 2)
+        check_true("missing accents: stderr names it", "HIANYZO EKEZETEK" in err, err)
+
+        # 5c. double-hyphen em-dash substitute
+        code, out, err = run_hook(
+            email_payload(CLEAN_HU_OK + " ez most -- szerintem -- jo lesz."), rules_file=active,
+        )
+        check("double-hyphen still blocks (exit 2)", code, 2)
+        check_true("double-hyphen: stderr names it", "DUPLA KOTOJEL" in err, err)
+
+        # 5d. mixed-script (Cyrillic homoglyph 'о' U+043E inside a Latin word)
+        homoglyph_word = "kоszonom"  # koszonom with a Cyrillic 'o'
+        code, out, err = run_hook(
+            email_payload(f"Szia! {homoglyph_word} szepen a segitseget majd irok reszletesen is."),
+            rules_file=active,
+        )
+        check("mixed-script homoglyph still blocks (exit 2)", code, 2)
+        check_true("homoglyph: stderr names it", "VEGYES IRASRENDSZERU" in err, err)
+
+        # 5e. clean, correctly-accented text with an active (matching-nothing)
+        # rule and no em dash/double-hyphen/homoglyph -> passes clean.
+        code, out, err = run_hook(email_payload(CLEAN_HU_OK), rules_file=active)
+        check("fully clean body passes (exit 0)", code, 0)
+
+    if FAILS:
+        print(f"\n{len(FAILS)} FAILED: {FAILS}", file=sys.stderr)
+        sys.exit(1)
+    print("\nAll outgoing-copy-gate tests passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/hooks/outgoing-copy-gate.py
+++ b/scripts/hooks/outgoing-copy-gate.py
@@ -440,43 +440,78 @@ _LOCAL_RULES = os.environ.get(
 )
 
 
-# CLCOPYGATEHIANY902 (owner decision, TG 14442): a MISSING rules file is not
-# the same thing as a BROKEN one, and until now both produced the same
-# email-blocking outcome. The file is deliberately NOT shipped (it names a
-# private person), so on every fresh customer install it is absent -- and the
-# old fail-closed email path made a paying customer's agent unable to send
-# mail at all (reported by Nova, 2026-09-02). New policy:
-#   "missing"/"empty" -> the name check is OFF: fail-OPEN with a LOUD,
-#                        user-visible warning on every send (the customer
-#                        must know the check is not protecting them);
-#   "invalid"         -> the file EXISTS but cannot be used (bad JSON, wrong
-#                        schema, uncompilable regex): the operator tried to
-#                        configure it and something is wrong -- the email
-#                        path stays fail-CLOSED until it is fixed;
-#   "ok"              -> patterns loaded, the check enforces as before.
+# CLCOPYGATEHIANY902 (owner decision, TG 14442) MERGED WITH GATEPERSIST816/3
+# (PDB install, 2026-08-19). Two independent fixes to the same question, from
+# opposite directions, so the merged policy has FIVE states:
+#
+#   "ok"         -> patterns loaded, the name check enforces as before.
+#   "sanctioned" -> the file EXISTS and explicitly says "no_name_rule": true.
+#                   Reported by the PDB install, 2026-08-19: their rules file
+#                   was lost with no backup, and the owner decided not to
+#                   reconstruct it. That is a taken decision, not a loss, and
+#                   an install that has made it should not be nagged about it
+#                   on every send. So this state is silent
+#                   EVERYWHERE: no log line, no systemMessage, no block. Note
+#                   the early return BELOW, which deliberately skips the
+#                   logging tail. An ordinary empty list WITHOUT the flag does
+#                   NOT reach this state, so a file emptied by accident can
+#                   never masquerade as the sanctioned one.
+#   "empty"      -> no patterns and no flag: the check is OFF.
+#   "missing"    -> file absent, which is EVERY fresh customer install, since
+#                   the file names a private person and is deliberately not
+#                   shipped. Both of these fail-OPEN with a LOUD, user-visible
+#                   warning on every send: the old fail-closed email path left
+#                   a paying customer unable to send mail at all (Nova,
+#                   2026-09-02).
+#   "invalid"    -> the file EXISTS but cannot be used (bad JSON, wrong schema,
+#                   uncompilable regex). Somebody TRIED to configure it and got
+#                   it wrong: the email path stays fail-CLOSED until repaired.
+#
+# WHY THE MERGE IS NOT A CHOICE BETWEEN THE TWO: without the sanctioned state,
+# a live rules file carrying the flag with an empty pattern list reads as
+# "empty", and a loud warning gets stamped on EVERY outgoing letter, customer
+# mail included. Without the missing/empty/invalid split, a fresh install with
+# no file at all cannot send mail at all. Each half is wrong exactly where the
+# other one is right, which is why both are here.
+RULES_OK = "ok"
+RULES_SANCTIONED = "sanctioned"
+RULES_EMPTY = "empty"
+RULES_MISSING = "missing"
+RULES_INVALID = "invalid"
+
+# The states where the name check does not run AND that is not a taken
+# decision: the ones that must stay loud.
+RULES_LOUD = (RULES_MISSING, RULES_EMPTY, RULES_INVALID)
+
+
 def load_bad_name():
-    """Return (compiled_regex_or_None, state) -- state in ok/missing/empty/invalid."""
+    """Return (compiled_regex_or_None, state) -- see the RULES_* names above."""
     try:
         with open(_LOCAL_RULES, encoding="utf-8") as fh:
             data = json.load(fh)
         if not isinstance(data, dict):
-            state = "invalid"
+            state = RULES_INVALID
         else:
             pats = data.get("bad_name_patterns") or []
             if not isinstance(pats, list) or not all(isinstance(x, str) for x in pats):
-                state = "invalid"
-            elif not pats:
-                state = "empty"
+                state = RULES_INVALID
+            elif pats:
+                return (re.compile("|".join(pats)), RULES_OK)
+            elif data.get("no_name_rule") is True:
+                # Returns HERE, before the logging tail, on purpose: a taken
+                # decision must not write a "the protection is gone" line into
+                # the ledger on every single run.
+                return (None, RULES_SANCTIONED)
             else:
-                return (re.compile("|".join(pats)), "ok")
+                state = RULES_EMPTY
     except FileNotFoundError:
-        state = "missing"
+        state = RULES_MISSING
     except Exception:
         # Present but unusable: unreadable (permissions), unparseable JSON,
         # or an uncompilable pattern. All of these mean someone TRIED to
         # configure the rule and failed -- that must stay loud AND closed.
-        state = "invalid"
-    # ONE logging tail for EVERY non-ok state (Marveen review on #1156: the
+        state = RULES_INVALID
+    # ONE logging tail for EVERY loud state (Marveen review on #1156: the
     # first cut logged only the exception branches, so empty/schema-invalid
     # left no log line while missing did -- same event class, inconsistent
     # ledger).
@@ -687,7 +722,10 @@ def telegram_gate(tool_input: dict) -> None:
     # de a figyelmeztetes ODA megy, ahol a session tenyleg latja -- a hook
     # stdout systemMessage mezoje a futo sessionben jelenik meg, nem egy
     # logfajlban, amit senki nem olvas.
-    if BAD_NAME is None:
+    # GATEPERSIST816/3: a tudatosan felfuggesztett szabaly (RULES_SANCTIONED)
+    # mar nem veszteseg, nincs mit jelezni, a Telegram-ag ott csendben marad.
+    # Minden mas nem-ok allapot (missing/empty/invalid) figyelmeztetest kap.
+    if RULES_STATE in RULES_LOUD:
         print(json.dumps({"systemMessage":
             "outgoing-copy-gate: a NEV-SZABALY fajl hianyzik/ures "
             f"({_LOCAL_RULES}) -- a nev-ellenorzes NEM fut a kimeno uzeneteken. "
@@ -801,7 +839,7 @@ def main():
     # csendben lealit nev-ellenorzes mellett kuldeni rosszabb, mint megvarni a
     # szabaly-fajl potlasat. (A telegram-ag fail-open marad systemMessage
     # figyelmeztetessel: az a felugyeleti csatorna, ott a nemulas a dragabb.)
-    if RULES_STATE == "invalid":
+    if RULES_STATE == RULES_INVALID:
         # The file EXISTS but cannot be used: someone configured it and got it
         # wrong. Silent enforcement-loss here would be invisible, so this stays
         # fail-closed until the file is repaired (negative control in tests).
@@ -824,13 +862,13 @@ def main():
         )
         sys.exit(2)
 
-    if RULES_STATE in ("missing", "empty"):
+    if RULES_STATE in (RULES_MISSING, RULES_EMPTY):
         # Fail-OPEN, but never silent: the send goes out WITHOUT the name
         # check, and the user must see that on the surface they are using --
         # a log line nobody reads is the same as nothing (CLCOPYGATEHIANY902).
         print(json.dumps({"systemMessage":
             "outgoing-copy-gate: a NEV-SZABALY fajl "
-            + ("HIANYZIK" if RULES_STATE == "missing" else "URES (nincs minta)")
+            + ("HIANYZIK" if RULES_STATE == RULES_MISSING else "URES (nincs minta)")
             + f" ({_LOCAL_RULES}) -- ez a level a nev-ellenorzes NELKUL ment ki. "
             "Ha kell a vedelem, hozd letre a fajlt: "
             '{"bad_name_patterns": ["<python-regex>"], "correction": "<helyes alak>"}.'}))


### PR DESCRIPTION
## What this changes

`CLCOPYGATEHIANY902` made a **missing** or **empty** rules file fail OPEN with a loud warning on every send, and kept an **invalid** one fail-CLOSED. That is right for a fresh install, where the file is simply absent.

It is wrong for an install that has **decided** not to have a name rule.

The PDB install lost its rules file in August with no backup and no record of its contents, and the owner decided not to reconstruct it. They marked that decision with an explicit `"no_name_rule": true` in the file. Under the current code that file reads as `empty`, so a loud *"this letter went out WITHOUT the name check"* warning gets stamped on **every outgoing message, customer mail included**, for a state the owner already knows about and chose.

This adds a fifth state, `sanctioned`, between `ok` and `empty`:

| state | condition | behaviour |
|---|---|---|
| `ok` | patterns loaded | check enforces (unchanged) |
| **`sanctioned`** | **file exists and says `"no_name_rule": true`** | **silent everywhere: no log line, no systemMessage, no block** |
| `empty` | no patterns, no flag | open + loud (unchanged) |
| `missing` | file absent | open + loud (unchanged) |
| `invalid` | exists but unusable | closed (unchanged) |

## Two details that are deliberate

**The sanctioned branch returns BEFORE the logging tail.** A taken decision must not write a "the protection is gone" line into the ledger on every single run.

**It is only reachable with the explicit flag.** A file emptied by accident still behaves exactly as it does today, loudly. That distinction is the whole point: without it, an accidental empty list and a deliberate one become indistinguishable, which is the failure the flag exists to prevent.

## Nothing else changes

Every existing state keeps its current behaviour. The three consumers now read the state through named constants (`RULES_LOUD`, `RULES_INVALID`, `RULES_MISSING`, `RULES_EMPTY`) instead of string literals, so a future state cannot be silently missed at one of them.

## Tests

Adds `scripts/__tests__/outgoing-copy-gate.test.py`, which pins the pair that looks alike and must not behave alike. Since both let the letter out, the exit code no longer separates them, so the assertion is on the **noise**: `sanctioned` passes in silence, `empty`-without-flag passes with a loud `systemMessage`, on the email and the telegram branch alike. It also carries a regression pass over the checks this must not touch (accents, em dash, double hyphen, mixed-script homoglyph).

Verified locally, all three copy-gate suites pass:

- `scripts/__tests__/outgoing-copy-gate.test.py` (new)
- `scripts/__tests__/outgoing-copy-gate-rules-policy.test.py` (yours, unchanged, so the CLCOPYGATEHIANY902 policy is pinned by its own test)
- `scripts/__tests__/outgoing-copy-gate-failclosed.test.py`
