### PR TITLE
fix(channel-monitor): hard 15-minute cap on the stuck-input restart defer

### DIFF
--- a/src/__tests__/stuck-input-restart.test.ts
+++ b/src/__tests__/stuck-input-restart.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { decideStuckInputRestart, applyStuckRestartBusyGuard } from '../web/channel-monitor.js'
+import { decideStuckInputRestart, applyStuckRestartBusyGuard, STUCK_RESTART_HARD_CAP_MS } from '../web/channel-monitor.js'
 
 // The reliable backstop: when soft stuck-input recovery (Enter + clear+re-inject)
 // is exhausted but the main channel input is STILL parked, escalate to a hard
@@ -84,6 +84,46 @@ describe('applyStuckRestartBusyGuard', () => {
   it('never invents an action -- a skip stays a skip regardless of pane state', () => {
     expect(applyStuckRestartBusyGuard('idle', 'skip')).toBe('skip')
     expect(applyStuckRestartBusyGuard('busy', 'skip')).toBe('skip')
+  })
+
+  // HARD CAP (2026-09-04 incident): the carve-out above only fires for
+  // machine-origin text. A parked block the heuristic reads as a human draft
+  // (machineOrigin=false) deferred with no upper bound -- jezus-channels sat
+  // wedged 25.4h, every scheduled task skipped, inbound Telegram dropped. Past
+  // the cap the age decides, not the origin heuristic.
+  describe('hard cap on the human-draft defer', () => {
+    const CAP = STUCK_RESTART_HARD_CAP_MS
+
+    it('keeps deferring a human-looking draft below the cap', () => {
+      expect(applyStuckRestartBusyGuard('typing', 'restart',
+        { machineOrigin: false, softRemedy: false, parkedForMs: CAP - 1 })).toBe('skip')
+    })
+
+    it('escalates a human-looking draft once it is parked past the cap', () => {
+      expect(applyStuckRestartBusyGuard('typing', 'restart',
+        { machineOrigin: false, softRemedy: false, parkedForMs: CAP })).toBe('restart')
+      expect(applyStuckRestartBusyGuard('typing', 'alert',
+        { machineOrigin: false, softRemedy: false, parkedForMs: CAP + 60_000 })).toBe('alert')
+    })
+
+    it('overrides the soft-remedy defer too -- 15 minutes of unsuccessful soft recovery is a wedge', () => {
+      expect(applyStuckRestartBusyGuard('typing', 'restart',
+        { machineOrigin: true, softRemedy: true, parkedForMs: CAP })).toBe('restart')
+    })
+
+    it('still never invents an action: a rate-limited skip stays a skip past the cap', () => {
+      expect(applyStuckRestartBusyGuard('typing', 'skip',
+        { machineOrigin: false, softRemedy: false, parkedForMs: CAP * 100 })).toBe('skip')
+    })
+
+    it('leaves the busy branch alone -- a generating pane is working, not wedged', () => {
+      expect(applyStuckRestartBusyGuard('busy', 'restart',
+        { machineOrigin: false, softRemedy: false, parkedForMs: CAP * 100 })).toBe('skip')
+    })
+
+    it('behaves as before when the age is not supplied', () => {
+      expect(applyStuckRestartBusyGuard('typing', 'restart', { machineOrigin: false, softRemedy: false })).toBe('skip')
+    })
   })
 
   // Deadlock carve-out (2026-07-25 hermes incident): a parked machine-injected

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -231,6 +231,16 @@ const MAIN_STUCK_THRESHOLDS: StuckInputThresholds = {
 // wedge a restart cannot clear never becomes a restart loop.
 const STUCK_RESTART_MIN_INTERVAL_MS = 5 * 60 * 1000
 const STUCK_RESTART_MAX_CONSECUTIVE = 3
+// HARD CAP (2026-09-04 incident): the 'typing' defer below has no upper bound of
+// its own, so a parked block the heuristic reads as a human draft
+// (machineOrigin=false) defers FOREVER. Measured: jezus-channels sat wedged
+// 2026-09-03 08:45 -> 2026-09-04 10:07, 25.4h, 2667 consecutive
+// 'restart deferred' lines, every scheduled task silently skipped and inbound
+// Telegram dropped. Past this age the same parked signature is no longer a
+// plausible live draft -- nobody holds one unsent for a quarter of an hour --
+// so the carve-out stops applying and the normal escalation runs. Losing half a
+// typed sentence is cheaper than a silent day.
+export const STUCK_RESTART_HARD_CAP_MS = 15 * 60 * 1000
 let stuckRestartCount = 0
 let lastStuckRestartAt = 0
 
@@ -283,12 +293,15 @@ export function decideStuckInputRestart(
 export function applyStuckRestartBusyGuard(
   paneState: PaneState | null,
   decision: 'restart' | 'alert' | 'skip',
-  opts?: { machineOrigin: boolean; softRemedy: boolean },
+  opts?: { machineOrigin: boolean; softRemedy: boolean; parkedForMs?: number },
 ): 'restart' | 'alert' | 'skip' {
   if (paneState === 'busy') return 'skip'
   if (paneState === 'typing') {
     const unrecoverable = opts != null && opts.machineOrigin && !opts.softRemedy
-    return unrecoverable ? decision : 'skip'
+    // Age override: the same signature parked past the hard cap is a wedge, not
+    // a draft, whatever the origin heuristic thinks. See STUCK_RESTART_HARD_CAP_MS.
+    const pastHardCap = opts?.parkedForMs != null && opts.parkedForMs >= STUCK_RESTART_HARD_CAP_MS
+    return unrecoverable || pastHardCap ? decision : 'skip'
   }
   return decision
 }
@@ -1212,11 +1225,20 @@ function maybeRestartWedgedMainChannel(state: StuckInputState): void {
   const parkedView = paneState === 'typing' ? captureParkedInputView(MAIN_CHANNELS_SESSION) : null
   const machineOrigin = parkedView != null && parkedMachineOriginInput(parkedView)
   const softRemedy = parkedView != null && parkedMainInputHasRemedy(parkedView)
+  // How long THIS parked signature has been sitting there (firstSeenAt resets
+  // whenever the parked text changes, so a fresh draft never inherits the age).
+  const parkedForMs = state.firstSeenAt != null ? Date.now() - state.firstSeenAt : 0
   const action = applyStuckRestartBusyGuard(paneState, decideStuckInputRestart(
     parked, state.attempts, MAIN_STUCK_THRESHOLDS.maxAttempts,
     Date.now(), lastStuckRestartAt, stuckRestartCount,
     STUCK_RESTART_MIN_INTERVAL_MS, STUCK_RESTART_MAX_CONSECUTIVE,
-  ), { machineOrigin, softRemedy })
+  ), { machineOrigin, softRemedy, parkedForMs })
+  if (action !== 'skip' && paneState === 'typing' && !(machineOrigin && !softRemedy)) {
+    logger.warn(
+      { paneState, parkedForMs, capMs: STUCK_RESTART_HARD_CAP_MS },
+      'Stuck-input hard cap reached -- parked input looked like a human draft but has not moved, escalating anyway',
+    )
+  }
   if (action === 'skip' && shouldDeferKeepaliveRespawn(paneState)) {
     logger.info(
       { paneState, attempts: state.attempts, machineOrigin, softRemedy },


### PR DESCRIPTION
## Mi a baj

Az `applyStuckRestartBusyGuard` `'typing'` ága a deadlock-carve-out óta csak akkor engedi az újraindítást, ha a beragadt szöveg gép által injektált ÉS a soft recovery nem tud vele mit kezdeni. Ha a heurisztika emberi piszkozatnak látja (`machineOrigin=false`), a halasztásnak **nincs felső korlátja**.

Élesben mérve: a `jezus-channels` session 2026-09-03 08:45-től 2026-09-04 10:07-ig állt, **25,4 óra**, közben 2667 egymást követő `Stuck-input restart deferred -- parked input still recoverable or possibly a human draft` sor a dashboard logban, `paneState: typing`, `machineOrigin: false`.

A következmény nem csak késés:

- minden ütemezett feladat kimaradt (ORKUTYA, kanban-audit, dream-engine, memoria-heartbeat)
- a `task_runs` táblában ez **nem is látszik**: csak a `memoria-heartbeat` és a `kinai-outbox-figyelo` kapott `skipped` sort, a többi feladat egyáltalán nem írt sort, mert a kézbesítés a "busy or has pending input" ágon ragadt
- a Telegram poller a beragadt sessionben futott, tehát a bejövő üzenet megérkezett és eldobódott, nem sorbaállt

## A javítás

Új `STUCK_RESTART_HARD_CAP_MS = 15 perc`. A `'typing'` ágon a kor felülírja a származás-heurisztikát: ha ugyanaz a parkolt aláírás ennél régebb óta áll, a carve-out nem alkalmazandó, és a normál eszkaláció lefut. Tizenöt percig senki nem tart elküldetlenül egy piszkozatot; egy fél begépelt mondat olcsóbb, mint egy néma nap.

Amit szándékosan NEM változtat:

- a `'busy'` ág érintetlen, egy generáló pane dolgozik, nem beragadt
- a `STUCK_RESTART_MIN_INTERVAL_MS` (5 perc) és a `STUCK_RESTART_MAX_CONSECUTIVE` (3) továbbra is érvényes, tehát ebből nem lesz restart-hurok
- a döntést nem találja ki: ha a `decideStuckInputRestart` `skip`-et ad (pl. rate limit), az a kor felett is `skip` marad
- a `firstSeenAt` a parkolt szöveg változásakor nullázódik, tehát friss piszkozat nem örökli a kort

Plusz egy `warn` sor, amikor konkrétan a plafon oldotta fel a halasztást, hogy a logból utólag elváljon a carve-out és a plafon.

## Teszt

Hat új eset a `stuck-input-restart.test.ts`-ben: plafon alatt halaszt, plafonon és felette eszkalál, felülírja a soft-remedy halasztást is, a `skip` `skip` marad, a `busy` ág változatlan, és kor nélkül a régi viselkedés.

```
✓ src/__tests__/stuck-input-restart.test.ts (22 tests)
npx tsc --noEmit  → tiszta
teljes suite: 268 passed | 1 failed
```

Az egyetlen piros az `installer-start-and-fallback.test.ts` egy bash ERR-trap esete, ami **a szülő commiton is ugyanígy elhasal**, tehát nem ehhez a változáshoz tartozik.

🤖 Generated with [Claude Code](https://claude.com/claude-code)