### PR TITLE
fix(agent-process): verify the input box is actually empty after a clear

### DIFF
--- a/src/__tests__/parked-clear-sequence.test.ts
+++ b/src/__tests__/parked-clear-sequence.test.ts
@@ -78,7 +78,37 @@ describe('clearStaleParkedInput uses the sequence instead of the old C-u cascade
   // characters across successive scheduled ticks until nothing could submit.
   it('clearInputBuffer also drives the sequence, so a pre-flight clear cannot silently no-op', () => {
     const fn = AGENT_PROCESS.slice(AGENT_PROCESS.indexOf('export async function clearInputBuffer'))
-    const body = fn.slice(0, fn.indexOf('\n}'))
+    const body = fn.slice(0, fn.indexOf('\n}\n'))
     expect(body).toContain('parkedClearSequence')
+  })
+
+  // 2026-09-04 incident: driving the right key sequence is not enough if nobody
+  // checks the box afterwards. The clear-scheduled path fired, left a truncated
+  // fragment behind, and that leftover read as a human draft on every later
+  // restart decision -- the session sat wedged 25.4h. The clear must therefore
+  // VERIFY emptiness, retry, and report failure to its caller.
+  it('clearInputBuffer verifies the box is empty, retries, and returns the outcome', () => {
+    const fn = AGENT_PROCESS.slice(AGENT_PROCESS.indexOf('export async function clearInputBuffer'))
+    const body = fn.slice(0, fn.indexOf('\n}\n'))
+    // re-reads the pane after sending the keys
+    expect(body).toContain('stuckInputSignature')
+    // bounded retry rather than a single fire-and-forget pass
+    expect(body).toContain('CLEAR_INPUT_MAX_ATTEMPTS')
+    // the caller can tell a clean clear from a leftover
+    expect(body).toContain('return true')
+    expect(body).toContain('return false')
+  })
+
+  it('the signature is boolean, so callers are able to branch on a failed clear', () => {
+    expect(AGENT_PROCESS).toContain('export async function clearInputBuffer(session: string, host: string | null = null): Promise<boolean>')
+  })
+
+  // Both clear-only recovery actions must surface a failed clear; a silent
+  // "cleared" log for a box that still holds text is what hid the 09-03 wedge.
+  it('both clear-only recovery paths log when the box did not empty', () => {
+    const monitor = readFileSync(new URL('../web/channel-monitor.ts', import.meta.url), 'utf8')
+    const preamble = monitor.slice(monitor.indexOf("case 'clear-preamble'"), monitor.indexOf("case 'enter'"))
+    expect(preamble).toContain('left text in the box')
+    expect(preamble).toContain('left a fragment in the box')
   })
 })

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -24,6 +24,7 @@ import {
   detectsFeedbackDraftModal,
   detectsFeedbackOptOutPrompt,
   firstRunAcceptKeys,
+  stuckInputSignature,
   type FirstRunGateKind,
 } from '../pane-state.js'
 import { agentDir, listAgentNames, readAgentModel, readAgentClaudeConfigDir, readAgentClaudePlan, readAgentChannelProvider, readAgentAuthMode, readAgentDisplayName, readAgentRemoteConfig, readAgentRemoteHost, readAgentMemoryIsolation } from './agent-config.js'
@@ -1855,18 +1856,43 @@ export async function waitForPaneIdle(
 // instead of replacing it, which is how a box accumulates tick after tick until
 // nothing can be submitted at all. Keys are sent by name (no `-l` literal flag)
 // so tmux interprets them as control sequences.
-export async function clearInputBuffer(session: string, host: string | null = null): Promise<void> {
-  try {
-    const pane = capturePane(session, host)
-    for (const key of parkedClearSequence(pane != null ? parkedInputRowCount(pane) : 0)) {
-      runTmux(host, ['send-keys', '-t', session, key], { timeout: 5000 })
+// How many times the clear is attempted before we accept that the box will not
+// empty. Each pass re-reads the row count, so a partially-cleared multi-row
+// buffer gets a correctly-sized second sequence.
+const CLEAR_INPUT_MAX_ATTEMPTS = 3
+
+export async function clearInputBuffer(session: string, host: string | null = null): Promise<boolean> {
+  for (let attempt = 1; attempt <= CLEAR_INPUT_MAX_ATTEMPTS; attempt++) {
+    try {
+      const pane = capturePane(session, host)
+      for (const key of parkedClearSequence(pane != null ? parkedInputRowCount(pane) : 0)) {
+        runTmux(host, ['send-keys', '-t', session, key], { timeout: 5000 })
+      }
+      // Settle briefly so the next send-keys lands in the freshly cleared
+      // buffer rather than racing the clear.
+      await delay(100)
+    } catch (err) {
+      logger.warn({ err, session, attempt }, 'Failed to clear pane input buffer before send')
+      return false
     }
-    // Settle briefly so the next send-keys lands in the freshly cleared
-    // buffer rather than racing the clear.
-    await delay(100)
-  } catch (err) {
-    logger.warn({ err, session }, 'Failed to clear pane input buffer before send')
+    // VERIFY (2026-09-04 incident): the clear used to be fire-and-forget. On
+    // 09-03 the clear-scheduled path fired, left a truncated fragment of the
+    // parked tick behind, and that leftover no longer matched any delivery
+    // wrapper -- so every later restart decision read machineOrigin=false and
+    // deferred. The session sat wedged 25.4h. An unverified clear is the actual
+    // root cause; the restart hard cap only bounds the damage.
+    const after = capturePane(session, host)
+    if (after == null || stuckInputSignature(after) == null) return true
+    logger.warn(
+      { session, attempt, max: CLEAR_INPUT_MAX_ATTEMPTS },
+      'Input buffer still not empty after clear -- retrying',
+    )
   }
+  logger.error(
+    { session },
+    'Input buffer could not be emptied -- a leftover fragment stays parked (escalation will have to restart the pane)',
+  )
+  return false
 }
 
 // How many Ctrl-C presses the placeholder-discard will attempt before giving

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -438,14 +438,22 @@ async function performStuckInputAction(
         submitted = true
         break
       }
-      case 'clear-preamble':
+      case 'clear-preamble': {
         logger.warn({ session, attempt }, 'Stuck input -- truncated safety preamble, clearing buffer (no re-inject)')
-        await clearInputBuffer(session)
+        const cleared = await clearInputBuffer(session)
+        if (!cleared) logger.warn({ session, attempt }, 'Stuck input -- clear-preamble left text in the box; the leftover stays parked')
         break
-      case 'clear-scheduled':
+      }
+      case 'clear-scheduled': {
         logger.warn({ session, attempt }, 'Stuck input -- parked scheduled-task tick, clearing buffer (no re-inject; next schedule fire re-delivers)')
-        await clearInputBuffer(session)
+        const cleared = await clearInputBuffer(session)
+        // A half-cleared tick is the 2026-09-03 wedge: the fragment left behind
+        // stops matching a delivery wrapper, so every later restart decision
+        // reads it as a human draft. Say so in the log rather than reporting a
+        // clean clear that did not happen.
+        if (!cleared) logger.warn({ session, attempt }, 'Stuck input -- clear-scheduled left a fragment in the box; expect machineOrigin=false on the next tick')
         break
+      }
       case 'enter':
         // FABLEFALL1: same guard as the reinject-plain fallback above -- a bare
         // Enter must never reach the model consent dialog (its default SWITCHES


### PR DESCRIPTION
## A kiváltó ok

A `clearInputBuffer` elküldte a törlő billentyűsorozatot, és soha többé nem nézett a dobozba. Ha a törlés csak részben sikerült, a maradék ott maradt, de erről senki nem tudott.

Élesben ez történt 2026-09-03-án:

1. 09:00:13 az `invoice-forward` ütemezett tick beparkolt a beviteli sorba
2. 09:00:38 a `clear-scheduled` ág lefutott, `machineOrigin=true`, `softRemedy=true`, tehát a felismerés még jó volt
3. a törlés csonka töredéket hagyott a dobozban
4. 09:01-től a maradék már egyetlen delivery-wrapper előtaggal sem egyezett, ezért `machineOrigin=false` lett, azaz emberi piszkozat
5. innentől a restart-döntés minden körben halasztott, 2667 egymást követő sorban, **25,4 órán át**

A #1177-es plafon ezt a kárt korlátozza. Ez a PR a kiváltó okot javítja.

## A javítás

A törlés a billentyűk elküldése után újraolvassa a pane-t, és `stuckInputSignature`-rel ellenőrzi, hogy tényleg üres lett-e. Ha nem, újrapróbálja `CLEAR_INPUT_MAX_ATTEMPTS`-ig (3), minden körben frissen mért sorszámmal, mert egy félig törölt többsoros doboz más hosszúságú sorozatot igényel. A visszatérési érték `Promise<boolean>`, tehát a hívó meg tudja különböztetni a tiszta törlést a maradéktól.

Mindkét csak-törlő recovery ág (`clear-preamble`, `clear-scheduled`) naplózza, ha a doboz nem ürült ki. Eddig egy sikeres törlésről szóló sor ment ki olyankor is, amikor a doboz még tele volt, és pont ez fedte el a 09-03-i beragadást.

## Teszt

Négy új eset a `parked-clear-sequence.test.ts`-ben: a törlés ellenőriz és újrapróbál, a szignatúra boolean, és mindkét csak-törlő ág jelzi a sikertelen törlést.

```
npx tsc --noEmit  → tiszta
teljes suite: 325 fájl, 4381 teszt, mind zöld
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)