### PR TITLE
fix(token-usage): a symlinked isolated projects dir booked the whole fleet under one agent

### DIFF
--- a/src/__tests__/token-usage-shared-projects-symlink.test.ts
+++ b/src/__tests__/token-usage-shared-projects-symlink.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest'
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+// A fleet where NO agent was migrated to its own OS user: every
+// agents/<name>/.claude-config/projects is a symlink back to the shared
+// ~/.claude/projects. Before the fix, discoverAgentSources() walked each
+// symlink and handed every agent the WHOLE fleet's transcript dirs, so the
+// token monitor showed three sub-agents with byte-identical totals
+// (measured on a live install 2026-09-04) while only the main agent's
+// number was real.
+const FIXTURE = mkdtempSync(join(tmpdir(), 'token-usage-symlink-'))
+const HOME = join(FIXTURE, 'home')
+const SHARED_PROJECTS = join(HOME, '.claude', 'projects')
+const PROJECT_ROOT = '/Users/x/marveen'
+const MAIN_DIR = join(SHARED_PROJECTS, '-Users-x-marveen')
+const ALPHA_DIR = join(SHARED_PROJECTS, '-Users-x-marveen-agents-alpha')
+const BETA_DIR = join(SHARED_PROJECTS, '-Users-x-marveen-agents-beta')
+
+vi.mock('node:os', async () => {
+  const actual = await vi.importActual<typeof import('node:os')>('node:os')
+  return { ...actual, homedir: () => HOME }
+})
+
+vi.mock('../config.js', async () => {
+  const actual = await vi.importActual<typeof import('../config.js')>('../config.js')
+  return { ...actual, MAIN_AGENT_ID: 'marveen', PROJECT_ROOT }
+})
+
+vi.mock('../logger.js', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+}))
+
+vi.mock('../web/agent-config.js', () => ({
+  listAgentNames: () => ['alpha', 'beta'],
+}))
+
+vi.mock('../web/claude-plans.js', () => ({
+  resolveAgentConfigDirForRead: (name: string) =>
+    join(FIXTURE, 'agents', name, '.claude-config'),
+}))
+
+describe('discoverAgentSources with a symlinked isolated projects dir', () => {
+  beforeAll(() => {
+    for (const d of [MAIN_DIR, ALPHA_DIR, BETA_DIR]) mkdirSync(d, { recursive: true })
+    for (const name of ['alpha', 'beta']) {
+      const configDir = join(FIXTURE, 'agents', name, '.claude-config')
+      mkdirSync(configDir, { recursive: true })
+      symlinkSync(SHARED_PROJECTS, join(configDir, 'projects'))
+    }
+  })
+
+  afterAll(() => {
+    rmSync(FIXTURE, { recursive: true, force: true })
+  })
+
+  it('attributes each transcript dir to exactly one agent', async () => {
+    const { discoverAgentSources } = await import('../web/token-usage.js')
+    const sources = discoverAgentSources()
+
+    expect(sources.map((s) => [s.agent, s.projectDir]).sort()).toEqual(
+      [
+        ['alpha', ALPHA_DIR],
+        ['beta', BETA_DIR],
+        ['marveen', MAIN_DIR],
+      ].sort(),
+    )
+  })
+
+  it('never hands one agent another agent\'s transcript dir', async () => {
+    const { discoverAgentSources } = await import('../web/token-usage.js')
+    const sources = discoverAgentSources()
+
+    // The defect's signature: each sub-agent ending up with all three
+    // dirs, which is what made their totals identical.
+    for (const agent of ['alpha', 'beta']) {
+      expect(sources.filter((s) => s.agent === agent)).toHaveLength(1)
+    }
+    expect(sources.some((s) => s.agent === 'alpha' && s.projectDir === BETA_DIR)).toBe(false)
+    expect(sources.some((s) => s.agent === 'beta' && s.projectDir === MAIN_DIR)).toBe(false)
+  })
+})

--- a/src/__tests__/token-usage.test.ts
+++ b/src/__tests__/token-usage.test.ts
@@ -473,3 +473,42 @@ describe('tryHandleTokenUsage route handler', () => {
     expect(handled).toBe(false)
   })
 })
+
+// An agent that was never migrated to its own OS user still has an
+// agents/<name>/.claude-config/projects entry, but it is a SYMLINK back to
+// the shared ~/.claude/projects. Walking it books the whole fleet's
+// transcripts under that one agent, which is how three sub-agents came to
+// report byte-identical totals on 2026-09-04.
+describe('resolvesToSharedProjectsRoot', () => {
+  const ROOT = join(TEST_DIR, 'shared-root-probe')
+  const shared = join(ROOT, 'shared-projects')
+  const symlinked = join(ROOT, 'agent-projects-symlink')
+  const ownDir = join(ROOT, 'agent-projects-real')
+
+  beforeAll(async () => {
+    const { symlinkSync } = await import('node:fs')
+    rmSync(ROOT, { recursive: true, force: true })
+    mkdirSync(shared, { recursive: true })
+    mkdirSync(ownDir, { recursive: true })
+    symlinkSync(shared, symlinked)
+  })
+
+  afterAll(() => {
+    rmSync(ROOT, { recursive: true, force: true })
+  })
+
+  it('detects a projects dir that is a symlink to the shared root', async () => {
+    const { resolvesToSharedProjectsRoot } = await import('../web/token-usage.js')
+    expect(resolvesToSharedProjectsRoot(symlinked, shared)).toBe(true)
+  })
+
+  it('leaves a genuinely isolated projects dir alone', async () => {
+    const { resolvesToSharedProjectsRoot } = await import('../web/token-usage.js')
+    expect(resolvesToSharedProjectsRoot(ownDir, shared)).toBe(false)
+  })
+
+  it('treats a missing path as not shared', async () => {
+    const { resolvesToSharedProjectsRoot } = await import('../web/token-usage.js')
+    expect(resolvesToSharedProjectsRoot(join(ROOT, 'nope'), shared)).toBe(false)
+  })
+})

--- a/src/web/token-usage.ts
+++ b/src/web/token-usage.ts
@@ -1,4 +1,4 @@
-import { statSync, readdirSync, existsSync } from 'node:fs'
+import { statSync, readdirSync, existsSync, realpathSync } from 'node:fs'
 import { join, basename } from 'node:path'
 import { homedir } from 'node:os'
 import { createReadStream } from 'node:fs'
@@ -17,6 +17,18 @@ const PROJECTS_DIR = join(homedir(), '.claude', 'projects')
 // the agent calls itself.
 function encodeProjectPath(p: string): string {
   return p.replace(/[^a-zA-Z0-9-]/g, '-')
+}
+
+// True when `dir` is the shared ~/.claude/projects wearing another name,
+// reached through a symlink. Compared by realpath, so a symlinked parent
+// counts too. A missing path is not the shared root. `sharedRoot` is a
+// parameter only so the test can point both sides at a fixture.
+export function resolvesToSharedProjectsRoot(dir: string, sharedRoot: string = PROJECTS_DIR): boolean {
+  try {
+    return realpathSync(dir) === realpathSync(sharedRoot)
+  } catch {
+    return false
+  }
 }
 
 interface AgentTranscriptSource {
@@ -77,6 +89,22 @@ export function discoverAgentSources(projectRootOverride?: string): AgentTranscr
     if (!configDir) continue
     const isolatedProjects = join(configDir, 'projects')
     if (!existsSync(isolatedProjects)) continue
+    // ...unless the agent was never actually migrated, in which case
+    // agents/<name>/.claude-config/projects is a SYMLINK back to the shared
+    // ~/.claude/projects. Then the comment below is false: the dir holds
+    // EVERY agent's work, and all of it gets booked under this one name.
+    //
+    // MEASURED 2026-09-04 18:40 on a live install: three sub-agents each
+    // reported the whole fleet's consumption, byte-identical down to the
+    // field (43844 calls, 28.5M output, 8.82G cache-read, 636 sessions),
+    // because all three symlinks resolve to the same root; only the main
+    // agent's row was real. 73% of the table was duplicate.
+    // The cursor table cannot absorb it either, being keyed by file path, and
+    // the same transcript reached the parser under three different paths.
+    //
+    // Skipping it loses nothing: the shared root is walked in the loop above,
+    // where attribution comes from the encoded directory name.
+    if (resolvesToSharedProjectsRoot(isolatedProjects)) continue
     let entries: string[]
     try { entries = readdirSync(isolatedProjects) } catch { continue }
     for (const entry of entries) {


### PR DESCRIPTION
## The bug

`discoverAgentSources()` walks `agents/<name>/.claude-config/projects` on the
assumption stated in its own comment: *"an agent's isolated dir holds only that
agent's work."*

That holds for an agent migrated to its own OS user. It is false when the agent
was never migrated: there `projects` is a **symlink back to the shared
`~/.claude/projects`**. The walk then hands that one agent every other agent's
transcript directory, and every parsed row is written under its name.

The cursor table cannot absorb it either. `token_usage_cursors` is keyed by file
path, and the same transcript file reaches the parser under a different path
through each agent's symlink, so it is parsed and inserted once per agent.

## Where it was proved

On a live install, 2026-09-04. Three sub-agents each reported the whole fleet's
consumption, byte-identical down to the field:

| agent | calls | output | cache read | sessions |
|---|---|---|---|---|
| sub-agent A | 43844 | 28 484 378 | 8 822 550 104 | 636 |
| sub-agent B | 43844 | 28 484 378 | 8 822 550 104 | 636 |
| sub-agent C | 43844 | 28 484 378 | 8 822 550 104 | 636 |
| main agent | 32260 | 20 477 629 | 7 006 389 075 | 307 |

Only the main agent's row was real: it has no isolated dir, so it is reached
only through the correct branch. Every one of the 636 sessions was claimed by
more than one agent, and 73% of `token_usage` (119 834 of 163 792 rows) was a
duplicate. The dashboard was about to inform a model-assignment decision with
those numbers.

`discoverAgentSources()` on that install returned 19 sources for 4 agents: the
4 correct ones, plus each sub-agent claiming all 5 project dirs it could see
through its symlink.

## The fix

Skip an isolated `projects` dir whose realpath is the shared root. Nothing is
lost: the shared root is walked in the loop above, where attribution comes from
the encoded directory name (`-agents-<name>`), which is correct. A genuinely
migrated agent, whose dir is its own, is unaffected.

`resolvesToSharedProjectsRoot()` takes the shared root as a defaulted parameter
so the unit test can point both sides at a fixture.

## Tests

New `src/__tests__/token-usage-shared-projects-symlink.test.ts` builds a fleet
whose config dirs are symlinks to a fixture shared root, and asserts each
transcript dir is claimed by exactly one agent. **Without the fix it sees 9
sources instead of 3 and both cases fail** (verified by reverting the source
file and re-running). Three further unit tests cover the symlink, non-symlink
and missing-path cases of the helper.

Full suite on this branch, in a clean checkout: **355 files, 4609 passed, 1
skipped, `tsc --noEmit` clean.**

## Note for existing installs

The fix stops new rows from being misattributed, but does not clean up rows
already written. On the install above, the repair was: delete rows whose
`session_id` belongs to another agent's project dir (the transcript filename
is the session id), and drop cursors under `%/.claude-config/projects/%`. After
that, a re-collect produced four distinct agents and zero sessions claimed by
more than one.
