### PR TITLE
fix(scheduler): in-flight watchdog looked for transcripts in the wrong config dir -- 7.5x false-lost re-fire loop

### DIFF
--- a/src/__tests__/schedule-inflight-config-dir.test.ts
+++ b/src/__tests__/schedule-inflight-config-dir.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { resolveAgentConfigDirForRead } from '../web/claude-plans.js'
+import { resolveClaudeConfigDir } from '../web/agent-config.js'
+import { readTranscriptMtimeFromProjectDir, projectsDirFor } from '../web/active-model.js'
+
+// The post-fire watchdog's sawTurn probe, and why the config dir it is handed
+// decides whether the probe can see anything at all.
+//
+// THE BUG (measured 2026-09-04). The in-flight entry took its configDir from
+// readAgentClaudeConfigDir, which reads ONLY the `claudeConfigDir` field of
+// agent-config.json. Since the fleet auth rule (2026-07-01) that field must NOT
+// be set: every agent's config dir is AUTO-PROVISIONED at
+// <agentDir>/.claude-config. So the read returned null, the entry stored
+// `undefined`, and readTranscriptMtimeFromProjectDir fell back to
+// ~/.claude/projects/<encoded-workingDir> -- a path that does not exist for
+// such an agent. The probe therefore returned null on EVERY sweep, sawTurn
+// stayed false, and decideTaskTimeout ruled 'lost' for any task that finished
+// between two sweeps. That is every FAST task: the pane is idle before the
+// injection, briefly busy, and idle again long before the next sample.
+//
+// The consequence was a re-fire loop with no backoff. On cortex-voip-insight it
+// produced 2069 false-lost re-injections in 24 hours from a */5 task (288
+// expected), a 7.5x amplification that had been running unnoticed since
+// 2026-08-27 -- while `fired` rows kept the run log looking healthy.
+//
+// The fix reuses resolveAgentConfigDirForRead, which the context-guard and
+// restart-gate runners already used for exactly this reason. These tests pin
+// the mechanism (the probe can find a transcript) rather than only the call.
+
+describe('in-flight watchdog: config dir for the sawTurn transcript probe', () => {
+  let root: string
+  const AGENT = 'fixture-agent'
+  let agentPath: string
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'inflight-config-dir-'))
+    agentPath = join(root, 'agents', AGENT)
+    mkdirSync(agentPath, { recursive: true })
+    // Config file WITHOUT claudeConfigDir -- what the fleet auth rule mandates.
+    writeFileSync(join(agentPath, 'agent-config.json'), JSON.stringify({ displayName: 'Fixture', model: 'claude-sonnet-5' }))
+    // The auto-provisioned config dir, with the transcript where Claude Code
+    // actually writes it: <configDir>/projects/<encoded workingDir>/*.jsonl
+    const projects = projectsDirFor(agentPath, join(agentPath, '.claude-config'))
+    mkdirSync(projects, { recursive: true })
+    writeFileSync(join(projects, 'session.jsonl'), '{"type":"turn"}\n')
+  })
+
+  afterEach(() => { rmSync(root, { recursive: true, force: true }) })
+
+  it('resolves the auto-provisioned dir even though the config field is absent', () => {
+    expect(resolveAgentConfigDirForRead(AGENT, root)).toBe(join(agentPath, '.claude-config'))
+  })
+
+  it('the field-only read returns null here -- that null was the bug', () => {
+    // Not a criticism of the field read: null is its correct answer (there IS
+    // no override field). It is the wrong QUESTION for a transcript reader,
+    // which is the whole point of the fix. resolveClaudeConfigDir is the pure
+    // core of readAgentClaudeConfigDir, so this pins the behaviour without
+    // reaching into the real agents/ tree.
+    const raw = readFileSync(join(agentPath, 'agent-config.json'), 'utf-8')
+    expect(resolveClaudeConfigDir(raw, root)).toBeNull()
+  })
+
+  it('the probe SEES the transcript with the resolved dir, and is blind without it', () => {
+    const resolved = resolveAgentConfigDirForRead(AGENT, root) ?? undefined
+    expect(readTranscriptMtimeFromProjectDir(agentPath, resolved)).toBeGreaterThan(0)
+    // undefined => ~/.claude/projects/<encoded>, which does not exist for an
+    // auto-provisioned agent. A null here is what kept sawTurn false forever.
+    expect(readTranscriptMtimeFromProjectDir(agentPath, undefined)).toBeNull()
+  })
+
+  it('fix-revert guard: the entry resolves the config dir, it does not read the field', () => {
+    const src = readFileSync(join(__dirname, '../web/schedule-runner.ts'), 'utf-8')
+    expect(src).toMatch(/configDir: agentName === MAIN_AGENT_ID \? undefined : \(resolveAgentConfigDirForRead\(agentName\) \?\? undefined\)/)
+    // The old call must be gone entirely: leaving it importable invites the
+    // revert, and no other site in this file needs it.
+    expect(src).not.toMatch(/readAgentClaudeConfigDir\(/)
+  })
+})

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -37,7 +37,8 @@ import {
   SCHEDULED_TASKS_DIR,
   type ScheduledTask,
 } from './scheduled-tasks-io.js'
-import { listAgentNames, readFileOr, readAgentRemoteHost, agentDir, readAgentClaudeConfigDir } from './agent-config.js'
+import { listAgentNames, readFileOr, readAgentRemoteHost, agentDir } from './agent-config.js'
+import { resolveAgentConfigDirForRead } from './claude-plans.js'
 import { readTranscriptMtimeFromProjectDir } from './active-model.js'
 import { channelStateDir, getProvider, readChannelToken, type ChannelProviderType } from '../channel-provider.js'
 import {
@@ -904,7 +905,19 @@ async function attemptFireTask(
       ownerAlerted: false,
       sawTurn: false,
       workingDir: agentName === MAIN_AGENT_ID ? PROJECT_ROOT : agentDir(agentName),
-      configDir: agentName === MAIN_AGENT_ID ? undefined : (readAgentClaudeConfigDir(agentName) ?? undefined),
+      // resolveAgentConfigDirForRead, not readAgentClaudeConfigDir -- same
+      // reason the context-guard and restart-gate runners use it. Since the
+      // fleet auth rule (2026-07-01) an agent's config dir is AUTO-PROVISIONED
+      // at <agentDir>/.claude-config and there is no `claudeConfigDir` field to
+      // read, so readAgentClaudeConfigDir returns null. That null made the
+      // sawTurn transcript probe look under ~/.claude/projects/<encoded>, a
+      // path that does not exist for such an agent -- so the probe returned
+      // null on every sweep, sawTurn stayed false, and any task that finished
+      // between two sweeps (i.e. any FAST task) was declared 'lost' and
+      // re-fired. Measured 2026-09-04 on cortex-voip-insight: 2069 false-lost
+      // re-injections in 24h from a */5 task (288 expected), a 7.5x
+      // amplification running unnoticed since 2026-08-27.
+      configDir: agentName === MAIN_AGENT_ID ? undefined : (resolveAgentConfigDirForRead(agentName) ?? undefined),
       timeoutMs: resolveStuckTimeoutMs(task),
     })
 


### PR DESCRIPTION
## A hiba

A `fired` utáni figyelő (`decideTaskTimeout`) akkor engedi el az in-flight bejegyzést, ha pozitív bizonyítéka van arra, hogy fordulo tortent (`sawTurn`). Ket probaja van: a pane `busy` allapota, es a transcript mtime-ja. **A masodik rossz konyvtarban keresett.**

`readAgentClaudeConfigDir` KIZAROLAG az `agent-config.json` `claudeConfigDir` mezojet olvassa. A flotta auth-szabaly (2026-07-01) ota ez a mezo NEM lehet beallitva -- minden agens config-dirje auto-provisionalt, `<agentDir>/.claude-config` alatt. Tehat a fuggveny `null`-t adott, a bejegyzesbe `undefined` kerult, es `readTranscriptMtimeFromProjectDir` a `~/.claude/projects/<encoded-workingDir>` utra esett vissza -- **ami ilyen agensnel nem letezik**. A proba minden sweepen `null`-t adott, a `sawTurn` vegig `false` maradt, es a dontes `'lost'` lett minden olyan feladatra, ami ket sweep kozott befejezodott. Vagyis MINDEN GYORS feladatra: a pane idle az injektalas elott, rovid ideig busy, es jocskan a kovetkezo mintavetel elott ujra idle.

A `'lost'` ag ezutan visszavonja a `lastRun` bejegyzest es ujra sorba teszi a kezbesitest, **backoff nelkul**. Az eredmeny ujrakuldesi hurok.

## Mert adat (ezen a telepitesen, 2026-09-04, 24 oras ablak)

```
cortex-voip-insight   2157 fired / 2069 lost    (*/5 cron -> 288 varhato)
flotta osszesen       3525 fired / 2074 lost / 132 skipped
```

**7.5-szeres felnagyitas egyetlen agensen**, 2026-08-27 16:09:54 ota folyamatosan (osszesen 4174 false-lost ujrainjektalas). Es lathatatlan volt, mert minden retry `fired` sort is ir: a futasnaplo vegig egeszsegesnek latszott.

Egy konkret lefutas, ahol az agens HAROMSZOR elvegezte ugyanazt a munkat:
```
20:50:06 fired -> 20:50:35 LOST -> 20:50:36 fired -> 20:51:05 LOST -> 20:51:06 fired
```
(az agens sajat feldolgozasi idobelyegei: 20:50:12, 20:50:42, 20:51:12 -- mindharom fordulo megtortent)

## A javitas

Azt a kerdest teszi fel, amit a testverei mar ugyis: `resolveAgentConfigDirForRead` visszaesik az auto-provisionalt konyvtarra, es megkoveteli a `projects` alkonyvtarat, tehat egy felig felhuzott dir nem tudja elarnyekolni a kozos gyokeret. A `context-guard-runner.ts` es a `context-restart-gate-runner.ts` **mar hasznalja, pontosan ezzel az indoklassal a kommentjeben** -- a scheduler volt a kimaradt hivasi hely.

## Amit NEM gyengit

A 2026-08-23-as csendes-veszteseg javitast (ami a `sawTurn`-t bevezette) nem lazitja: egy valoban beragadt session tovabbra sem ir a transcriptjebe, tehat tovabbra is helyesen minosul elveszettnek. Ami valtozik: egy session, ami DOLGOZOTT, tobbe nem latszik beragadtnak.

## Tesztek

Uj fajl, fixture-agenssel (`claudeConfigDir` mezo nelkul, transcript az auto-provisionalt dir alatt):
- a feloldott dirrel a proba MEGTALALJA a transcriptet, nelkule `null`-t ad -- ez a hurok pontos elofeltetele
- fix-revert orzo a hivasi helyre

`npx vitest run`: **355 fajl, 4608 teszt zold**, 1 skipped. `npm run typecheck` tiszta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
