### PR TITLE
fix(email-gate): manage_email is a multiplexer, so level 1 denied reading and drafting too

### DIFF
--- a/scripts/__tests__/email-approval-gate.test.py
+++ b/scripts/__tests__/email-approval-gate.test.py
@@ -311,6 +311,29 @@ with tempfile.TemporaryDirectory() as td:
                                    "tool_input": {"operation": 42}})
     check("manage_email with a non-string operation is DENIED (fail-closed)", code == 2,
           f"exit={code}")
+    # MANAGEDRAFT905: a send OPERATION carrying an explicit draft:true is a
+    # DRAFT, not a send -- `{"operation":"reply","draft":true}` is the only way
+    # to write a threaded draft with this tool, and the sibling gate
+    # (email-send-gate.mjs) lets exactly that shape through. Without this the
+    # draft-only workflow was blocked at level 1 by its own guard.
+    for op in ("send", "reply", "reply_all", "replyAll", "forward"):
+        for flag in (True, "true"):
+            code, _, _ = run_gate(store1, manage(op, draft=flag))
+            check(f"manage_email operation={op} draft={flag!r} passes at level 1 (a draft is not a send)",
+                  code == 0, f"exit={code}")
+    # Fail-closed stays: anything but an explicit true is still a send.
+    for flag in (False, "false", "yes", 1, None, "", "True "):
+        code, _, _ = run_gate(store1, manage("reply", draft=flag))
+        check(f"manage_email operation=reply draft={flag!r} is DENIED (not an explicit draft)",
+              code == 2, f"exit={code}")
+    # Control: the draft exemption is scoped to the multiplexer, not to the
+    # dedicated send tool -- a draft flag must not buy send_email a pass.
+    code, _, _ = run_gate(store1, {"tool_name": "mcp__x__send_email",
+                                   "tool_input": {"to": ["a@b.hu"], "subject": "T",
+                                                  "body": "Torzs.", "draft": True}})
+    check("control: send_email with draft:true is still DENIED at level 1", code == 2,
+          f"exit={code}")
+
     # Control: send_email has no operations and must stay gated unconditionally,
     # otherwise the scoping above could quietly exempt the real send tool too.
     code, _, _ = run_gate(store1, mcp_send())

--- a/scripts/__tests__/email-approval-gate.test.py
+++ b/scripts/__tests__/email-approval-gate.test.py
@@ -281,6 +281,51 @@ with tempfile.TemporaryDirectory() as td:
           bccless_anchor == "de87bdb699dcab419b68811bb57b6fab44b34e2fe16bff11cf90b2a5848f82ec",
           f"got {bccless_anchor}")
 
+    # MANAGEOP904: manage_email is a MULTIPLEXER, not a send tool. Scoping the
+    # gate on the tool NAME alone denied `operation=search` and
+    # `operation=draft` at level 1 -- measured on a live install 2026-09-04,
+    # where the draft-only workflow needs exactly those two. The level exists to
+    # stop the SEND, so reading and drafting must pass and sending must not.
+    store1 = make_store(td, level=1)
+
+    def manage(op=None, **extra):
+        ti = {"to": ["a@b.hu"], "subject": "T", "body": "Torzs."}
+        if op is not None:
+            ti["operation"] = op
+        ti.update(extra)
+        return {"tool_name": "mcp__google-workspace__manage_email", "tool_input": ti}
+
+    for op in ("search", "read", "draft", "label", "list", "archive"):
+        code, _, _ = run_gate(store1, manage(op))
+        check(f"manage_email operation={op} passes at level 1 (not a send)", code == 0,
+              f"exit={code}")
+    for op in ("send", "reply", "reply_all", "replyAll", "forward", "SEND"):
+        code, _, _ = run_gate(store1, manage(op))
+        check(f"manage_email operation={op} is DENIED at level 1 (it is a send)",
+              code == 2, f"exit={code}")
+    # Fail-closed on doubt: no operation, or one we cannot read, counts as send.
+    code, _, _ = run_gate(store1, manage(None))
+    check("manage_email without an operation is DENIED (fail-closed)", code == 2,
+          f"exit={code}")
+    code, _, _ = run_gate(store1, {"tool_name": "mcp__google-workspace__manage_email",
+                                   "tool_input": {"operation": 42}})
+    check("manage_email with a non-string operation is DENIED (fail-closed)", code == 2,
+          f"exit={code}")
+    # Control: send_email has no operations and must stay gated unconditionally,
+    # otherwise the scoping above could quietly exempt the real send tool too.
+    code, _, _ = run_gate(store1, mcp_send())
+    check("control: send_email is still DENIED at level 1", code == 2, f"exit={code}")
+    # Control: the scoping is about the OPERATION, not about level 1 letting
+    # things through -- at level 3 the same send passes, which proves the deny
+    # above came from the level and not from a broken payload.
+    cfg1 = os.path.join(store1, "autonomy-config.json")
+    with open(cfg1, "w", encoding="utf-8") as fh:
+        json.dump({"version": 1, "categories": [
+            {"key": "email_send", "label": "Email", "level": 3, "locked": False}]}, fh)
+    code, _, _ = run_gate(store1, manage("send"))
+    check("control: manage_email operation=send passes at level 3", code == 0,
+          f"exit={code}")
+
     # SQLite-version portability, kept as a STATIC check on purpose. The
     # behavioural cases above only catch the bad call on a host whose sqlite is
     # older than 3.38 -- on CI (newer) they stay green while the live install

--- a/scripts/hooks/email-approval-gate.py
+++ b/scripts/hooks/email-approval-gate.py
@@ -56,6 +56,29 @@ from email_extract import collect_email_envelope  # noqa: E402
 
 _SEND_TOOL = re.compile(r"send_email|manage_email", re.I)
 
+# manage_email is a MULTIPLEXER, not a send tool: the same MCP tool searches the
+# mailbox, reads a thread, writes a draft AND sends. Scoping this gate on the
+# tool NAME alone therefore denies reading the inbox whenever email_send sits at
+# level 1 -- measured on a live install 2026-09-04, where `operation=search` and
+# `operation=draft` were both refused with "a kuldes tiltott". That is not the
+# gate this is meant to be: a draft-only workflow REQUIRES reading and drafting,
+# and the level exists to stop the SEND.
+#
+# So manage_email is in scope only for the operations that actually put a letter
+# on the wire. Anything else passes. Fail-closed on doubt: a missing or
+# unreadable operation counts as a send, because that is the case where we
+# cannot prove it is not one. `send_email` needs no such test -- it only sends.
+_MULTIPLEX_TOOL = re.compile(r"manage_email", re.I)
+_MANAGE_EMAIL_SEND_OPS = {"send", "reply", "reply_all", "replyall", "forward"}
+
+
+def manage_email_is_send(tool_input: dict) -> bool:
+    """Is this manage_email call a send? Unreadable operation -> True (closed)."""
+    op = tool_input.get("operation")
+    if not isinstance(op, str) or not op.strip():
+        return True
+    return op.strip().lower().replace("-", "_") in _MANAGE_EMAIL_SEND_OPS
+
 
 def _load_is_send_invocation():
     """Import is_send_invocation from outgoing-copy-gate.py (dashed filename,
@@ -190,7 +213,10 @@ def main():
     tool_input = tool_input if isinstance(tool_input, dict) else {}
 
     if _SEND_TOOL.search(tool):
-        pass  # MCP email send: always in scope
+        # A multiplexer tool is in scope only when the call is a send; a search,
+        # a read or a draft is not what email_send levels.
+        if _MULTIPLEX_TOOL.search(tool) and not manage_email_is_send(tool_input):
+            sys.exit(0)
     elif tool == "Bash":
         cmd = str(tool_input.get("command") or "")
         if not _load_is_send_invocation()(cmd):

--- a/scripts/hooks/email-approval-gate.py
+++ b/scripts/hooks/email-approval-gate.py
@@ -64,20 +64,48 @@ _SEND_TOOL = re.compile(r"send_email|manage_email", re.I)
 # gate this is meant to be: a draft-only workflow REQUIRES reading and drafting,
 # and the level exists to stop the SEND.
 #
-# So manage_email is in scope only for the operations that actually put a letter
-# on the wire. Anything else passes. Fail-closed on doubt: a missing or
+# So manage_email is in scope only for the calls that actually put a letter on
+# the wire: a send operation WITHOUT an explicit draft:true. Anything else
+# passes, drafts included (MANAGEDRAFT905). Fail-closed on doubt: a missing or
 # unreadable operation counts as a send, because that is the case where we
 # cannot prove it is not one. `send_email` needs no such test -- it only sends.
 _MULTIPLEX_TOOL = re.compile(r"manage_email", re.I)
 _MANAGE_EMAIL_SEND_OPS = {"send", "reply", "reply_all", "replyall", "forward"}
 
 
+def _is_explicit_draft(tool_input: dict) -> bool:
+    """Did the call EXPLICITLY ask for a draft? Only a literal true (bool) or the
+    exact string "true" counts; everything else is treated as a send.
+
+    Deliberately the SAME strict test as the sibling gate
+    (scripts/email-send-gate.mjs: `draft === true || draft === 'true'`), so a
+    call cannot be a draft for one gate and a send for the other. Anything
+    fuzzier ("True", "yes", 1) stays a send: fail-closed."""
+    draft = tool_input.get("draft")
+    return draft is True or draft == "true"
+
+
 def manage_email_is_send(tool_input: dict) -> bool:
-    """Is this manage_email call a send? Unreadable operation -> True (closed)."""
+    """Is this manage_email call a send? Unreadable operation -> True (closed).
+
+    MANAGEDRAFT905: the send OPERATIONS are also the only way to write a
+    THREADED draft with this MCP tool -- `{"operation":"reply","draft":true}`
+    is the exact call the sibling gate (scripts/email-send-gate.mjs) sends the
+    agent back to write, and which it lets through on `draft === true`. Keying
+    on the operation alone therefore denied the draft-only workflow itself at
+    level 1: measured on the live install 2026-09-04, a reply draft to a
+    customer thread was refused with "a kuldes tiltott", and the only way
+    around it would have been an untreaded new letter -- the very thing the
+    reply-as-new gate stops. A draft puts nothing on the wire; the level exists
+    to stop the SEND. Fail-closed stays: only an explicit draft:true passes,
+    a missing/ambiguous flag is a send.
+    """
     op = tool_input.get("operation")
     if not isinstance(op, str) or not op.strip():
         return True
-    return op.strip().lower().replace("-", "_") in _MANAGE_EMAIL_SEND_OPS
+    if op.strip().lower().replace("-", "_") not in _MANAGE_EMAIL_SEND_OPS:
+        return False
+    return not _is_explicit_draft(tool_input)
 
 
 def _load_is_send_invocation():


### PR DESCRIPTION
Two commits, both on `scripts/hooks/email-approval-gate.py`. The second only makes sense on top of the first, so they travel together.

## 1. `manage_email` is a multiplexer, so the level denied reading too

The gate matched on the tool NAME. `mcp__google-workspace__manage_email` is not a send tool: it is one entry point for `search`, `read`, `draft`, `label`, `archive` and `send`. At `email_send` level 1 the gate therefore refused the agent's ability to READ its own mailbox, which the level was never meant to touch.

Measured on a live install 2026-09-04: `operation=search` came back as `az email_send autonomia-szint 1: a kuldes tiltott`.

Now the gate reads `tool_input.operation` and gates only the send operations (`send`, `reply`, `reply_all`, `replyAll`, `forward`, case-insensitive). Fail-closed is kept: a missing operation, or one that is not a string, still counts as a send. `send_email` has no operations and stays denied unconditionally, so the scoping cannot quietly exempt the real send tool.

## 2. The gate blocked the draft-only workflow it exists to protect

With (1) in place a draft still could not be written, because a THREADED draft is one of those same send operations plus `draft: true` -- `{"operation":"reply","draft":true}` is literally the call the sibling gate `scripts/email-send-gate.mjs` hands back in its own deny message, and which it lets through on `draft === true`. So the two gates disagreed: the .mjs one said "write it as a draft", the .py one refused that draft as a send.

Measured on the same install 2026-09-04: a reply draft into an existing customer thread was refused. The only way around it was an unthreaded new letter -- exactly what the reply-as-new gate stops. A draft puts nothing on the wire; the level exists to stop the SEND.

The draft test is the strict one, byte-identical in intent to the .mjs gate: only a literal `true` or the exact string `"true"` counts. `1`, `"yes"`, `"True "`, `""` and `None` are all sends. That way a call can never be a draft for one gate and a send for the other. `send_email` with `draft:true` is still denied -- the flag buys it nothing there.

## Tests

`scripts/__tests__/email-approval-gate.test.py` grows 33 cases (66 total, all green). Each fix's cases fail without its fix. Controls included: the same send passes at level 3, which proves the level is what denies and not a malformed payload.

Measured in a clean clone of this branch: `npx tsc --noEmit` clean, `npx vitest run` 354 files / 4604 passed, 1 skipped.

One conflict resolution to flag: the test file's new block landed where `EMAILBCCHORGONY903` now sits on develop. Both blocks are kept, and the bcc golden-anchor test still passes unchanged.
