### PR TITLE
fix(copy-gate): the audit never ran on emails, and the Telegram gate never ran on sub-agents

### DIFF
--- a/scripts/hooks/outgoing-copy-gate.py
+++ b/scripts/hooks/outgoing-copy-gate.py
@@ -497,10 +497,22 @@ def load_bad_name():
                 state = RULES_INVALID
             elif pats:
                 return (re.compile("|".join(pats)), RULES_OK)
-            elif data.get("no_name_rule") is True:
+            elif data.get("no_name_rule") is True or data.get("name_check_disabled") is True:
                 # Returns HERE, before the logging tail, on purpose: a taken
                 # decision must not write a "the protection is gone" line into
-                # the ledger on every single run.
+                # the ledger on every single run. An alarm that can never be
+                # answered is the one people learn to ignore -- it was drowning
+                # the real signals in the same log (571 lines here by
+                # 2026-09-04, CLCOPYGATEDONTES904).
+                # TWO spellings of the SAME decision are accepted, because two
+                # installs each documented one before the branches met:
+                #   {"no_name_rule": true, "no_name_rule_reason": "why"}
+                #     (GATEPERSIST816/3, the PDB install)
+                #   {"bad_name_patterns": [], "name_check_disabled": true,
+                #    "decided_at": "2026-09-04", "note": "why"}
+                #     (CLCOPYGATEDONTES904)
+                # Dropping either spelling would silently turn that install's
+                # recorded decision back into a loud "empty".
                 return (None, RULES_SANCTIONED)
             else:
                 state = RULES_EMPTY
@@ -696,6 +708,29 @@ def telegram_gate(tool_input: dict) -> None:
         text = collect_telegram_body(tool_input)
         if not text.strip():
             sys.exit(0)  # files-only reply or empty text: nothing to audit
+        # GATECOPY827: a masolhato kodblokk CSAK markdownv2 modban lesz
+        # kodblokk. A reply tool `format` parametere alapertelmezesben "text",
+        # es plain textben a Telegram nem parsolja a harom backtickot, tehat
+        # nincs copy gomb -- a szoveg nyersen, a backslash-escape-ekkel egyutt
+        # jelenik meg. Ez 2026-08-17 ota OTSZOR ment ki igy (a memoriaban
+        # feedback_telegram_codeblock_needs_markdownv2, plusz a kotelezove tett
+        # telegram-copy-gomb skill), es egyik alkalommal sem tudashiany volt,
+        # hanem kihagyott lepes. Ezert innentol gepi kapu allitja meg, nem
+        # emlekezet. A vizsgalat a NYERS szovegen fut, mert a fence-t a
+        # MDV2_ESCAPE feloldas nem erinti.
+        raw = "\n".join(str(tool_input[f]) for f in ("text", "caption", "message")
+                        if tool_input.get(f))
+        if "```" in raw and str(tool_input.get("format", "")).lower() != "markdownv2":
+            sys.stderr.write(
+                "KIMENO-SZOVEG KAPU (Telegram): TILTVA, a kodblokk nem lenne masolhato.\n\n"
+                "  - A szoveg harom backtickes kodblokkot tartalmaz, de a hivasban\n"
+                "    format=\"" + str(tool_input.get("format") or "text") + "\". Plain textben a Telegram nem ad copy gombot,\n"
+                "    es a MarkdownV2 escape-ek (\\. \\- \\() nyersen latszanak.\n\n"
+                "Kuldd ujra ugyanezt a szoveget format=\"markdownv2\"-vel. Kodblokkon\n"
+                "belul csak a backtickot es a backslasht kell escapelni, a blokkon\n"
+                "kivuli prozat viszont teljesen (_*[]()~`>#+-=|{}.!).\n"
+            )
+            sys.exit(2)
         problems = audit(text)
     except SystemExit:
         raise
@@ -722,9 +757,10 @@ def telegram_gate(tool_input: dict) -> None:
     # de a figyelmeztetes ODA megy, ahol a session tenyleg latja -- a hook
     # stdout systemMessage mezoje a futo sessionben jelenik meg, nem egy
     # logfajlban, amit senki nem olvas.
-    # GATEPERSIST816/3: a tudatosan felfuggesztett szabaly (RULES_SANCTIONED)
-    # mar nem veszteseg, nincs mit jelezni, a Telegram-ag ott csendben marad.
-    # Minden mas nem-ok allapot (missing/empty/invalid) figyelmeztetest kap.
+    # GATEPERSIST816/3 + CLCOPYGATEDONTES904: a tudatosan felfuggesztett
+    # szabaly (RULES_SANCTIONED, barmelyik flag-irassal) mar nem veszteseg,
+    # nincs mit jelezni, a Telegram-ag ott csendben marad. Minden mas nem-ok
+    # allapot (missing/empty/invalid) figyelmeztetest kap.
     if RULES_STATE in RULES_LOUD:
         print(json.dumps({"systemMessage":
             "outgoing-copy-gate: a NEV-SZABALY fajl hianyzik/ures "
@@ -802,6 +838,22 @@ def audit(text: str):
     return problems
 
 
+# Outbound-shaped operations of the multiplexed manage_email tool. Everything
+# else it does (search, read, labels, trash, getAttachment...) produces no text
+# of ours, so the gate must not touch it -- classifying those as sends is how
+# the sibling email gate once denied plain mailbox READS (MANAGEOP904).
+MANAGE_EMAIL_OUTBOUND_OPS = {"send", "reply", "replyall", "forward"}
+
+# Dedicated (non-multiplexed) outbound tools: the draft tools and the Gmail
+# connector's three separate send-shaped tools. Kept in step with the matcher
+# this hook is registered under in settings.json.
+EMAIL_TOOL_RE = re.compile(
+    r"(send_email|create_draft|draft_email|update_draft"
+    r"|(^|__)gmail__(reply|reply_all|send_message|forward)$)",
+    re.I,
+)
+
+
 def main():
     try:
         payload = json.load(sys.stdin)
@@ -813,7 +865,27 @@ def main():
 
     if re.search(r"telegram.*__reply$", tool, re.I):
         telegram_gate(tool_input)  # exits; never falls through
-    if re.search(r"send_email", tool, re.I):
+    # COPYGATEMATCHER904: the hook is REGISTERED for manage_email, create_draft,
+    # update_draft and the Gmail connector's reply/send_message/forward tools,
+    # but this dispatch only ever recognised a tool NAME containing
+    # "send_email" -- so on an install whose email tool is the multiplexed
+    # mcp__google-workspace__manage_email, every letter fell through to
+    # sys.exit(0) and the copy audit NEVER ran on an outgoing email. Measured
+    # 2026-09-04: an em dash in a manage_email draft body passed the gate,
+    # while the same text was blocked on the Telegram path. Same class as the
+    # email-send-gate's MANAGEOP904 fix: a multiplexer cannot be classified by
+    # its name, only by the operation it was asked to perform.
+    if re.search(r"(^|__)manage_email$", tool, re.I):
+        op = str(tool_input.get("operation") or tool_input.get("action") or "").strip().lower()
+        if op not in MANAGE_EMAIL_OUTBOUND_OPS:
+            sys.exit(0)  # search/read/labels/trash...: no outgoing text of ours
+        # A bare forward carries someone else's text and an EMPTY note: there is
+        # nothing of ours to audit, and the fail-closed "unreadable" branch below
+        # would block it for no reason.
+        if op == "forward" and not str(tool_input.get("body") or "").strip():
+            sys.exit(0)
+        text, unreadable = collect_mcp_body(tool_input), None
+    elif EMAIL_TOOL_RE.search(tool):
         text, unreadable = collect_mcp_body(tool_input), None
     elif tool == "Bash":
         cmd = str(tool_input.get("command") or "")

--- a/src/__tests__/governance-gates.test.ts
+++ b/src/__tests__/governance-gates.test.ts
@@ -3,7 +3,10 @@ import { describe, it, expect } from 'vitest'
 import { gateDecision as selfPaceDecision, stripDataPayloads, stripGitCommitMessages } from '../../scripts/self-pace-gate.mjs'
 import {
   agentGetsGovernanceGates,
+  agentGetsTelegramCopyGate,
   injectSelfPaceGate,
+  injectTelegramCopyGate,
+  TELEGRAM_COPY_GATE_MATCHER,
 } from '../web/agent-scaffold.js'
 import { MAIN_AGENT_ID } from '../config.js'
 
@@ -426,5 +429,70 @@ describe('self-pace-gate: quoted prose cannot fake a command position', () => {
   it('fails CLOSED on an UNQUOTED heredoc tag whose body substitutes', () => {
     // <<PY (no quotes) expands the body, so its contents are not inert.
     expect(selfPaceDecision('Bash', { command: 'cat <<PY\n$(crontab -r)\nPY' }).deny).toBe(true)
+  })
+})
+
+// --- telegram copy gate: the outgoing-copy-gate must actually be WIRED ---
+//
+// GATECOPY828. The check itself lived in outgoing-copy-gate.py since 2026-08-27
+// and passed its own unit tests, but no sub-agent's settings.json bound a
+// Telegram tool to that script, so it never ran for them and an unusable code
+// block went out again. These tests assert the WIRING, which is the half that
+// was missing: a gate's script passing is not evidence that the gate runs.
+describe('telegram copy gate wiring', () => {
+  const copyEntries = (s: Record<string, unknown>) => {
+    const hooks = s.hooks as Record<string, unknown>
+    const ptu = hooks.PreToolUse as Array<Record<string, unknown>>
+    return ptu.filter((e) => JSON.stringify(e).includes('outgoing-copy-gate.py'))
+  }
+
+  it('exempts the main agent (it carries the hook in its own project settings)', () => {
+    expect(agentGetsTelegramCopyGate(MAIN_AGENT_ID)).toBe(false)
+  })
+  it('covers every sub-agent', () => {
+    for (const n of ['social', 'emma', 'chris', 'heartbeat-worker']) {
+      expect(agentGetsTelegramCopyGate(n)).toBe(true)
+    }
+  })
+  it('wires the gate onto the Telegram send AND edit tools', () => {
+    const settings: Record<string, unknown> = {}
+    injectTelegramCopyGate(settings)
+    const [entry] = copyEntries(settings)
+    expect(entry.matcher).toBe(TELEGRAM_COPY_GATE_MATCHER)
+    expect(String(entry.matcher)).toContain('mcp__plugin_telegram_telegram__reply')
+    expect(String(entry.matcher)).toContain('mcp__plugin_telegram_telegram__edit_message')
+  })
+  it('is idempotent: a second pass does not accumulate a duplicate', () => {
+    const settings: Record<string, unknown> = {}
+    injectTelegramCopyGate(settings)
+    injectTelegramCopyGate(settings)
+    expect(copyEntries(settings)).toHaveLength(1)
+  })
+  it('keeps the SAME script wired under a different matcher', () => {
+    // The main agent legitimately runs this script on Bash and on the email
+    // tools too. A dedupe filter keyed on the script basename alone would have
+    // deleted those entries on every pass -- closing one hole by opening two.
+    const settings: Record<string, unknown> = {
+      hooks: {
+        PreToolUse: [
+          { matcher: 'Bash', hooks: [{ type: 'command', command: 'python3 "/x/scripts/hooks/outgoing-copy-gate.py"' }] },
+          { matcher: '.*send_email.*', hooks: [{ type: 'command', command: 'python3 "/x/scripts/hooks/outgoing-copy-gate.py"' }] },
+        ],
+      },
+    }
+    injectTelegramCopyGate(settings)
+    const matchers = copyEntries(settings).map((e) => e.matcher)
+    expect(matchers).toContain('Bash')
+    expect(matchers).toContain('.*send_email.*')
+    expect(matchers).toContain(TELEGRAM_COPY_GATE_MATCHER)
+  })
+  it('leaves unrelated PreToolUse entries alone', () => {
+    const settings: Record<string, unknown> = {
+      hooks: { PreToolUse: [{ matcher: 'WebFetch', hooks: [{ type: 'command', command: 'node "/x/egress-gate.mjs"' }] }] },
+    }
+    injectTelegramCopyGate(settings)
+    const ptu = (settings.hooks as Record<string, unknown>).PreToolUse as unknown[]
+    expect(JSON.stringify(ptu)).toContain('egress-gate.mjs')
+    expect(ptu).toHaveLength(2)
   })
 })

--- a/src/web.ts
+++ b/src/web.ts
@@ -13,7 +13,7 @@ import { isBlockedCrossOriginWrite, originMatchesServedHost } from './web/csrf-o
 import { json } from './web/http-helpers.js'
 import { detectLanIp } from './web/network-info.js'
 import { AGENTS_BASE_DIR, listAgentNames, listAllAgentNames } from './web/agent-config.js'
-import { ensureAgentHooks, ensureAgentStalenessHook, ensureAgentProvenanceHook, ensureEgressGate, ensureGovernanceGateCommands, ensureQuarantineReader, watchEgressAllowlistForReaderRender, ensureDefaultScheduledTasks, agentSettingsPath, ensureAutonomySection, ensureSkillsPathTrapSection, ensureSystemDirectiveAuthSection } from './web/agent-scaffold.js'
+import { ensureAgentHooks, ensureAgentStalenessHook, ensureAgentProvenanceHook, ensureEgressGate, ensureGovernanceGateCommands, ensureTelegramCopyGate, ensureQuarantineReader, watchEgressAllowlistForReaderRender, ensureDefaultScheduledTasks, agentSettingsPath, ensureAutonomySection, ensureSkillsPathTrapSection, ensureSystemDirectiveAuthSection } from './web/agent-scaffold.js'
 import { shouldRegisterHooks, pruneStaleHooksFromSettingsFile } from './web/hook-registration-guard.js'
 import { refreshMarveenBotUsername } from './web/telegram.js'
 import { startMessageRouter } from './web/message-router.js'
@@ -533,6 +533,7 @@ setInterval(() => { try { sweepExpiredDesktopLock() } catch { /* never kill the 
       const provPatched: string[] = []
       const egressPatched: string[] = []
       const govPatched: string[] = []
+      const copyGatePatched: string[] = []
       const pruned: string[] = []
       // Include the main agent (MAIN_AGENT_ID) so the voice hook is also seeded
       // into ~/.claude/settings.json alongside existing hooks (e.g. telegram_progress.py).
@@ -553,6 +554,7 @@ setInterval(() => { try { sweepExpiredDesktopLock() } catch { /* never kill the 
         if (ensureAgentProvenanceHook(agentName)) provPatched.push(agentName)
         if (ensureEgressGate(agentName)) egressPatched.push(agentName)
         if (ensureGovernanceGateCommands(agentName)) govPatched.push(agentName)
+        if (ensureTelegramCopyGate(agentName)) copyGatePatched.push(agentName)
         ensureQuarantineReader(agentName)
       }
       // EGRESSRENDER824: a grant added to store/egress-allowlist.json must
@@ -570,6 +572,7 @@ setInterval(() => { try { sweepExpiredDesktopLock() } catch { /* never kill the 
       if (provPatched.length) logger.info({ patched: provPatched }, 'provenance-gate UserPromptSubmit hook backfilled into agent settings.json')
       if (egressPatched.length) logger.info({ patched: egressPatched }, 'egress-gate WebFetch hook backfilled into agent settings.json')
       if (govPatched.length) logger.info({ patched: govPatched }, 'governance gate hook commands upgraded to absolute node path in agent settings.json')
+      if (copyGatePatched.length) logger.info({ patched: copyGatePatched }, 'outgoing-copy-gate wired onto the Telegram send tools in agent settings.json (GATECOPY828)')
     } catch (err) {
       logger.warn({ err }, 'Agent hook backfill skipped')
     }

--- a/src/web/agent-scaffold.ts
+++ b/src/web/agent-scaffold.ts
@@ -83,6 +83,20 @@ export function hookCommand(scriptPath: string): string {
   return `test -x "${HOOK_NODE_BIN}" || { echo "${miss}" >&2; exit 2; }; "${HOOK_NODE_BIN}" "${scriptPath}"`
 }
 
+// The python twin of hookCommand(). The outgoing-copy-gate is a .py script, so
+// it cannot reuse HOOK_NODE_BIN. Resolving the interpreter at RUNTIME with
+// `command -v` rather than burning in an absolute path is deliberate and is the
+// better half of the lesson in hookCommand above: the burnt-in node path goes
+// dangling on a `brew upgrade`, and a python path would rot the same way (a
+// pyenv shim, a brew python bump, an Xcode CLT reinstall). What must not happen
+// is the 127 exit, because Claude Code treats 127 as NON-blocking and lets the
+// tool call through -- a gate that silently stops enforcing. So the interpreter
+// is probed first and a miss exits 2, which blocks.
+export function pythonHookCommand(scriptPath: string): string {
+  const miss = 'governance-kapu: a hook interpretere nem talalhato (python3 nincs a PATH-on). A kapu ezert BLOKKOL. Javitas: telepitsd a python3-at, vagy inditsd ujra a dashboardot.'
+  return `command -v python3 >/dev/null 2>&1 || { echo "${miss}" >&2; exit 2; }; python3 "${scriptPath}"`
+}
+
 // Wired-already predicate for the ensure* migrations: is `command` present in
 // the serialized PreToolUse array? The command must be JSON-escaped before the
 // includes() -- comparing the RAW string disagrees with the serialized form on
@@ -488,6 +502,7 @@ export function writeAgentSettingsFromProfile(name: string, profile: ProfileTemp
     injectKanbanWriteGate(existing)
     injectDigestProvenanceGate(existing)
   }
+  if (agentGetsTelegramCopyGate(name)) injectTelegramCopyGate(existing)
   injectEgressGate(existing)
   atomicWriteFileSync(settingsPath, JSON.stringify(existing, null, 2))
 }
@@ -662,6 +677,84 @@ export function injectEgressGate(existing: Record<string, unknown>): void {
     ...prev.filter((e) => !JSON.stringify(e).includes('egress-gate.mjs')),
     entry,
   ]
+}
+
+// Which Telegram tools carry copyable text out of the install. `reply` is the
+// send route; `edit_message` rewrites a message already on the phone and can
+// just as easily replace a working code block with a broken one.
+export const TELEGRAM_COPY_GATE_MATCHER =
+  'mcp__plugin_telegram_telegram__reply|mcp__plugin_telegram_telegram__edit_message'
+
+// Which agents get the outgoing-copy gate on their Telegram send tools: every
+// sub-agent. The MAIN agent is exempt HERE only because it already carries the
+// same hook in its own committed project settings (.claude/settings.json);
+// injecting a second copy from the scaffold would duplicate it.
+//
+// GATECOPY828, 2026-08-28. The gate script has checked "code block without
+// format=markdownv2" since 2026-08-27, and the memory plus the mandatory
+// telegram-copy-gomb skill both describe it as done. It was not done for the
+// sub-agents: NONE of them had a PreToolUse matcher binding a Telegram tool to
+// this script, so the check never ran outside the main agent. The social agent
+// sent yet another unusable code block that day and the owner had to notice it
+// again. A gate that exists only in the main agent's settings is not a gate,
+// it is a habit that happens to be enforced in one place.
+export function agentGetsTelegramCopyGate(name: string): boolean {
+  return name !== MAIN_AGENT_ID
+}
+
+// Idempotently wire the outgoing-copy-gate PreToolUse hook onto the Telegram
+// send tools. Same shape + dedupe discipline as injectEmailSendGate, with one
+// deliberate difference: the dedupe filter is scoped to entries that carry BOTH
+// this script AND this matcher. The same script is legitimately wired under
+// other matchers (Bash, the email tools) in the main agent's settings, and a
+// basename-only filter would silently delete those on any future pass.
+export function injectTelegramCopyGate(existing: Record<string, unknown>): void {
+  const hooks = (existing.hooks && typeof existing.hooks === 'object'
+    ? existing.hooks
+    : (existing.hooks = {})) as Record<string, unknown>
+  const command = pythonHookCommand(join(PROJECT_ROOT, 'scripts', 'hooks', 'outgoing-copy-gate.py'))
+  // Registration guard: a /tmp or missing path must never enter shared settings.
+  if (isUnsafeHookCommand(command)) return
+  const entry = {
+    matcher: TELEGRAM_COPY_GATE_MATCHER,
+    hooks: [{ type: 'command', command, timeout: 10 }],
+  }
+  const prev = Array.isArray(hooks.PreToolUse) ? (hooks.PreToolUse as unknown[]) : []
+  hooks.PreToolUse = [
+    ...prev.filter((e) => {
+      const j = JSON.stringify(e)
+      if (!j.includes('outgoing-copy-gate.py')) return true
+      return (e as { matcher?: unknown })?.matcher !== TELEGRAM_COPY_GATE_MATCHER
+    }),
+    entry,
+  ]
+}
+
+// Idempotent migration for the EXISTING fleet: the scaffold only rewrites a
+// sub-agent's settings on spawn, so without this the gate would reach the three
+// running agents no sooner than their next respawn. Returns true if written.
+export function ensureTelegramCopyGate(name: string): boolean {
+  if (!agentGetsTelegramCopyGate(name)) return false
+  const settingsPath = agentSettingsPath(name)
+  if (!existsSync(settingsPath)) return false
+  let settings: Record<string, unknown> = {}
+  try { settings = JSON.parse(readFileSync(settingsPath, 'utf-8')) } catch { return false }
+  const command = pythonHookCommand(join(PROJECT_ROOT, 'scripts', 'hooks', 'outgoing-copy-gate.py'))
+  const hooks = (settings.hooks && typeof settings.hooks === 'object')
+    ? settings.hooks as Record<string, unknown>
+    : {}
+  const ptu = Array.isArray(hooks.PreToolUse) ? hooks.PreToolUse : []
+  // Two failure modes, same as the email gate: not wired at all, or wired under
+  // a matcher that no longer names the Telegram tools.
+  const wiredHere = ptu.some((e) => {
+    const j = JSON.stringify(e)
+    return j.includes('outgoing-copy-gate.py')
+      && (e as { matcher?: unknown })?.matcher === TELEGRAM_COPY_GATE_MATCHER
+  })
+  if (wiredHere && hookCommandWired(JSON.stringify(ptu), command)) return false
+  injectTelegramCopyGate(settings)
+  atomicWriteFileSync(settingsPath, JSON.stringify(settings, null, 2))
+  return true
 }
 
 // Idempotent migration: ensure every agent's settings.json carries the egress


### PR DESCRIPTION
Two holes in the outgoing copy gate. Both mean the audit silently did not run, which is the worst failure mode for a gate: it looks installed and enforces nothing.

## 1. The audit never ran on an email, because the dispatch keyed on the tool NAME

The hook is registered for `manage_email`, `create_draft`, `update_draft` and the Gmail connector's reply/send/forward tools, but `main()` only recognised a tool name containing `send_email`. On an install whose mail tool is the multiplexed `mcp__google-workspace__manage_email` (the common case) every letter fell straight through to `sys.exit(0)`. The em-dash, accent and double-hyphen audit therefore NEVER ran on an outgoing email; only the Telegram and Bash paths were ever gated.

Measured on macOS 26.6, 2026-09-04: an em dash in a `manage_email` draft body exited 0, while the identical text on the Telegram path exited 2. After the fix the same draft exits 2, a clean draft exits 0, and `search`/`read` operations stay untouched.

## 2. The Telegram code-block gate only ever ran on the main agent

The script has checked "code block without `format=markdownv2`" since 2026-08-27, but no sub-agent had a `PreToolUse` matcher binding a Telegram tool to it, so outside the main agent the check never ran. A gate that exists in one agent's settings is not a gate.

The scaffolded matcher covers `reply` AND `edit_message`: editing a message already on someone's phone can replace a working code block with a broken one just as easily.

This adds `pythonHookCommand()`, the python twin of `hookCommand()`. It resolves the interpreter at runtime with `command -v` rather than burning in a path, and a miss exits 2 rather than 127, because Claude Code treats 127 as non-blocking, which would turn a missing interpreter into a gate that silently stops enforcing.

## Tests

`src/__tests__/governance-gates.test.ts` grows the sub-agent matcher cases. Measured in a clean clone of this branch: `npx tsc --noEmit` clean, `npx vitest run` 354 files, 4610 passed / 1 skipped, against 4604 on untouched `develop` measured the same way.

Honest gap to flag: fix (1) is covered by the manual measurement above and by the existing fail-closed suite, not by a new automated case. If you want a python case pinning `manage_email` dispatch before merge, say so and I will add it.

One conflict resolution to note: `src/web.ts`'s scaffold import line has moved on develop, so the new `ensureTelegramCopyGate` is merged into the current line rather than the one the commit was written against.
