### PR TITLE
fix(pr-monitor): grep -P does not exist on macOS, so the monitor never reported a change

### DIFF
--- a/scripts/github-pr-monitor.sh
+++ b/scripts/github-pr-monitor.sh
@@ -72,11 +72,55 @@ CUR=""
 # Watch whatever of ours is actually open right now. A hardcoded list stops
 # covering new PRs the day it is written, and keeps polling merged ones forever.
 PRS="${GITHUB_PR_MONITOR_PRS:-}"
+LIST_RC=0
+LIST_ERR=""
 if [ -z "$PRS" ]; then
-  PRS="$(gh pr list --repo "$REPO" --author "@me" --state open --limit 30 \
-         --json number --jq '.[].number' 2>/dev/null | tr '\n' ' ')"
+  # A FAILED `gh pr list` and a genuinely empty list both used to reduce to an
+  # empty PRS, and the script then said "nothing to watch" and exited 0 -- a
+  # silent zero (expired auth, no network, wrong slug): the monitor looked
+  # healthy while it watched nothing, which is exactly the outage it exists to
+  # report. Keep the exit status, and treat a failure as an incident.
+  _err_file="$(mktemp)"
+  PRS_RAW="$(gh pr list --repo "$REPO" --author "@me" --state open --limit 30 \
+         --json number --jq '.[].number' 2>"$_err_file")" || LIST_RC=$?
+  LIST_ERR="$(head -c 200 "$_err_file" 2>/dev/null || true)"
+  rm -f "$_err_file"
+  if [ "$LIST_RC" -eq 0 ]; then
+    PRS="$(printf '%s' "$PRS_RAW" | tr '\n' ' ')"
+  fi
+fi
+if [ "$LIST_RC" -ne 0 ]; then
+  MSG="github-pr-monitor: the PR list query FAILED on $REPO (rc=$LIST_RC). The monitor is watching NOTHING until this is fixed. ${LIST_ERR:-no stderr}"
+  echo "$MSG" >&2
+  # Alert the owner, at most once per AUTH_ALERT_COOLDOWN -- an alerting script
+  # that cannot see anything has to say so on the channel, not only in a log.
+  AUTH_STAMP="store/.github-pr-monitor-auth-alert"
+  AUTH_ALERT_COOLDOWN=21600
+  NOW="$(date +%s)"
+  LAST="$(cat "$AUTH_STAMP" 2>/dev/null || echo 0)"
+  case "$LAST" in (''|*[!0-9]*) LAST=0;; esac
+  if [ $((NOW - LAST)) -ge "$AUTH_ALERT_COOLDOWN" ]; then
+    if send_telegram "⚠️ $MSG"; then printf '%s' "$NOW" > "$AUTH_STAMP" || true; fi
+  fi
+  exit 1
 fi
 if [ -z "${PRS// /}" ]; then
+  # An empty list is only trustworthy if the repo itself is reachable: `gh pr
+  # list` answers rc=0 with NO rows for a slug that does not exist or that we
+  # cannot see (measured 2026-09-04 against a deliberately nonexistent slug), so
+  # "nothing to watch" would silently cover a broken configuration.
+  if ! gh repo view "$REPO" --json name >/dev/null 2>&1; then
+    MSG="github-pr-monitor: repo $REPO is NOT reachable (gh repo view failed), so the empty PR list means nothing. The monitor is watching NOTHING."
+    echo "$MSG" >&2
+    AUTH_STAMP="store/.github-pr-monitor-auth-alert"
+    NOW="$(date +%s)"
+    LAST="$(cat "$AUTH_STAMP" 2>/dev/null || echo 0)"
+    case "$LAST" in (''|*[!0-9]*) LAST=0;; esac
+    if [ $((NOW - LAST)) -ge 21600 ]; then
+      if send_telegram "⚠️ $MSG"; then printf '%s' "$NOW" > "$AUTH_STAMP" || true; fi
+    fi
+    exit 1
+  fi
   echo "no open PRs of ours on $REPO, nothing to watch"
   exit 0
 fi
@@ -114,7 +158,12 @@ CHANGES=""
 while IFS=$'\t' read -r pr sig; do
   [ -n "$pr" ] || continue
   [ "${sig%%|*}" = "ERR" ] && continue   # skip transient fetch failure
-  old="$(grep -P "^${pr}\t" "$STATE_FILE" 2>/dev/null | head -1 | cut -f2-)"
+  # NOT grep -P: BSD grep (macOS) has no -P, so this line exited 2 with EMPTY
+  # output on every tick, `old` stayed empty, the -n guard below never fired and
+  # the monitor reported NO change, ever -- while still refreshing its snapshot,
+  # so it looked healthy. Measured 2026-09-04 on macOS 26.6. awk is portable and
+  # needs no escape for the literal tab.
+  old="$(awk -F'\t' -v p="$pr" '$1 == p { sub(/^[^\t]*\t/, ""); print; exit }' "$STATE_FILE" 2>/dev/null)"
   if [ -n "$old" ] && [ "$old" != "$sig" ]; then
     IFS='|' read -r st rd nrev ncom last <<< "$sig"
     CHANGES="${CHANGES}- PR #${pr}: state=${st}, review=${rd}, reviews=${nrev}, comments=${ncom}${last:+, utolso: ${last}}


### PR DESCRIPTION
Two silent zeros in one script, both measured on macOS 26.6 on 2026-09-04.

## 1. `grep -P` does not exist on BSD grep

The per-PR state lookup used `grep -P "^${pr}\t"`. BSD grep has no `-P`: the call exits 2 with EMPTY output, `old` stays empty, the `[ -n "$old" ]` guard never fires, and no change is EVER reported. Meanwhile the script keeps refreshing its snapshot and exiting 0, so it looks perfectly healthy while watching nothing.

Negative control: with a doctored state file, the `grep -P` version printed nothing and the awk replacement printed `change detected, alerted`. The lookup is now awk with a literal field compare, which needs no PCRE and no tab escape.

## 2. A failed `gh pr list` and a genuinely empty list were the same thing

Both reduced to an empty `PRS`, and the script then said "nothing to watch" and exited 0. So expired auth, a typo in the repo slug, or a repo the token cannot see all read as good news.

An empty list is now only trusted when `gh repo view` confirms the repo is reachable; otherwise the monitor says out loud that it is watching NOTHING.

## Tests

`scripts/__tests__/ops-scripts-portable.test.sh` passes (7/7) on a clean clone of this branch, `bash -n` clean. The behaviour above was measured by hand with a doctored state file, since the script talks to `gh`.

This only bites installs on macOS or any host without GNU grep; on Linux the old code worked, which is why it went unnoticed.
