### PR TITLE
fix(alerts): a self-healing recovery reported itself once per occurrence

### DIFF
--- a/src/__tests__/routine-alert.test.ts
+++ b/src/__tests__/routine-alert.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { decideRoutineAlert, routineAlertSuffix, ROUTINE_ALERT_COOLDOWN_MS } from '../web/routine-alert.js'
+
+const COOLDOWN = ROUTINE_ALERT_COOLDOWN_MS
+
+describe('decideRoutineAlert', () => {
+  it('sends the first occurrence with no repeat counter', () => {
+    expect(decideRoutineAlert(undefined, 1_000, COOLDOWN)).toEqual({ send: true, repeats: 0 })
+  })
+
+  it('stays silent while inside the cooldown', () => {
+    const prev = { lastSentAt: 1_000, suppressed: 0 }
+    expect(decideRoutineAlert(prev, 1_000 + COOLDOWN - 1, COOLDOWN)).toEqual({ send: false })
+  })
+
+  it('speaks again once the cooldown elapsed, carrying the suppressed count', () => {
+    const prev = { lastSentAt: 1_000, suppressed: 4 }
+    expect(decideRoutineAlert(prev, 1_000 + COOLDOWN, COOLDOWN)).toEqual({ send: true, repeats: 4 })
+  })
+
+  it('a quiet cooldown produces a clean report, not a repeat warning', () => {
+    const prev = { lastSentAt: 1_000, suppressed: 0 }
+    expect(decideRoutineAlert(prev, 1_000 + COOLDOWN * 3, COOLDOWN)).toEqual({ send: true, repeats: 0 })
+  })
+})
+
+describe('routineAlertSuffix', () => {
+  it('adds nothing to a first report', () => {
+    expect(routineAlertSuffix(0, COOLDOWN)).toBe('')
+  })
+
+  it('reports the total occurrences, not just the suppressed ones', () => {
+    expect(routineAlertSuffix(4, COOLDOWN)).toContain('5 ilyen volt')
+    expect(routineAlertSuffix(4, COOLDOWN)).toContain('30 perc')
+  })
+})

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -46,6 +46,7 @@ import {
 } from '../pane-state.js'
 import { MAIN_CHANNELS_SESSION, MAIN_CHANNELS_PLIST } from './main-agent.js'
 import { notifyChannel } from '../notify.js'
+import { sendRoutineAlert } from './routine-alert.js'
 import { getProvider, channelStateDir, readChannelToken, type ChannelProviderType } from '../channel-provider.js'
 import { attemptChannelMcpReconnect } from './channel-mcp-reconnect.js'
 import { readLastIngestionTimestamp, TRANSCRIPT_DIR } from './inbound-probe.js'
@@ -1066,7 +1067,7 @@ export function createMainChannelsSession(): MainSessionCreateResult {
     // boot instead of stacking a respawn on a session that is still coming up.
     writeRespawnStamp()
     logger.warn({ session: MAIN_CHANNELS_SESSION }, 'Main channels session absent -- recreating via channels.sh')
-    sendAlert(`♻️ A ${MAIN_CHANNELS_SESSION} session eltunt -- ujrainditom (channels.sh). Enelkul minden utemezett feladat csendben kimaradna.`)
+    sendRoutineAlert('main-session-recreate', `♻️ A ${MAIN_CHANNELS_SESSION} session eltunt -- ujrainditom (channels.sh). Enelkul minden utemezett feladat csendben kimaradna.`)
     return 'started'
   } catch (err) {
     logger.error({ err }, 'Failed to recreate main channels session via channels.sh')
@@ -1169,7 +1170,7 @@ function schedulePostResumePluginGuard(provider: ChannelProviderType): void {
         return
       }
       logger.warn({ provider }, 'Post-resume guard: --continue resume came up WITHOUT the channels plugin (CC 2.1.193) -- escalating to fresh respawn (context dropped, memory persists)')
-      sendAlert(`⚠️ A --continue resume suketen jott fel (nincs channel plugin). Fresh respawn most a ${MAIN_CHANNELS_SESSION} session-on (a beszelgetes elveszik, memoria marad).`)
+      sendRoutineAlert('post-resume-fresh-respawn', `⚠️ A --continue resume suketen jott fel (nincs channel plugin). Fresh respawn most a ${MAIN_CHANNELS_SESSION} session-on (a beszelgetes elveszik, memoria marad).`)
       respawnMarveenSessionFresh()
     } catch (err) {
       logger.warn({ err }, 'Post-resume guard probe failed (leaving recovery to the down-cascade)')
@@ -1583,7 +1584,7 @@ function checkMainKeepaliveStaleness(): void {
   }
   const ageMin = Math.round((ageMs ?? 0) / 60000)
   logger.warn({ ageMs, paneState }, 'Channel keep-alive stale -- main session likely wedged/deaf, respawning via respawn-pane')
-  sendAlert(`⚠️ A fő channel keep-alive ${ageMin} perce nem frissült -- respawn-pane a ${MAIN_CHANNELS_SESSION} session-on (a beszelgetes elveszik, memoria marad).`)
+  sendRoutineAlert('keepalive-respawn', `⚠️ A fő channel keep-alive ${ageMin} perce nem frissült -- respawn-pane a ${MAIN_CHANNELS_SESSION} session-on (a beszelgetes elveszik, memoria marad).`)
   if (respawnMarveenSessionFresh()) {
     marveenLastKeepaliveRespawn = now
     // Suppress the process-down handler during the respawn window (reuses the
@@ -1860,7 +1861,7 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
             logger.warn({ session: t.session, agent: label }, 'first-run trust dialog in an unrecognised shape -- parked, NO keystrokes sent')
             sendAlert(`🛑 A(z) ${label} session a mappa-megbízhatósági dialóguson parkol, de a panel alakját nem ismerem fel, ezért NEM nyomtam meg semmit. Se az Enter, se az Escape nem semleges rajta (az Escape a "No, exit"). Válassz kézzel: tmux attach -t ${t.session}, majd a "Yes, I trust this folder" sort jelöld ki és Enter.`)
           } else {
-            sendAlert(`🧭 A(z) ${label} session a Claude Code első-indítási képernyőjén parkolt (${firstRunGate}); automatikusan továbbléptettem. A várakozó ütemezett feladatok a következő körben kézbesítődnek.`)
+            sendRoutineAlert(`firstrun-gate:${label}`, `🧭 A(z) ${label} session a Claude Code első-indítási képernyőjén parkolt (${firstRunGate}); automatikusan továbbléptettem. A várakozó ütemezett feladatok a következő körben kézbesítődnek.`)
           }
         } else {
           // FABLEFALL1: the model usage-credit consent dialog is indistinguishable
@@ -1875,7 +1876,7 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
           if (paneNow != null && detectsModelConsentDialog(paneNow)) {
             logger.warn({ session: t.session, agent: label }, 'Blocking "menu" is the model usage-credit consent dialog -- answering it safely instead of Escape')
             await dismissModelConsentDialogIfPresent(t.session)
-            sendAlert(`🎛️ A(z) ${label} session a modell-hozzájárulás dialóguson parkolt; az 1-es opcióval (a beállított modell megtartása) továbbléptettem. Modellváltás NEM történt.`)
+            sendRoutineAlert(`model-consent:${label}`, `🎛️ A(z) ${label} session a modell-hozzájárulás dialóguson parkolt; az 1-es opcióval (a beállított modell megtartása) továbbléptettem. Modellváltás NEM történt.`)
           } else {
             logger.warn({ session: t.session, agent: label }, 'Session parked in a blocking interactive menu -- sending Escape to recover')
             try {
@@ -1883,7 +1884,7 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
             } catch (err) {
               logger.warn({ err, session: t.session }, 'Menu-recovery Escape failed')
             }
-            sendAlert(`⌨️ A(z) ${label} session beragadt egy interaktív menübe (pl. /mcp) és nem dolgozott fel üzeneteket. Kiküldtem egy Escape-et, visszatérítettem a prompthoz. Ha ismétlődik: tmux attach -t ${t.session}`)
+            sendRoutineAlert(`menu-escape:${label}`, `⌨️ A(z) ${label} session beragadt egy interaktív menübe (pl. /mcp) és nem dolgozott fel üzeneteket. Kiküldtem egy Escape-et, visszatérítettem a prompthoz. Ha ismétlődik: tmux attach -t ${t.session}`)
           }
         }
       }

--- a/src/web/routine-alert.ts
+++ b/src/web/routine-alert.ts
@@ -1,0 +1,69 @@
+import { logger } from '../logger.js'
+import { notifyChannel } from '../notify.js'
+
+// Self-healing recoveries are the fleet's normal operating noise: a session
+// died, the supervisor rebuilt it, nothing was lost. The owner still wants to
+// hear about it -- a silent wedge cost a whole morning on 2026-07-30, which is
+// why these alerts exist at all -- but on 2026-08-22 five of them landed in the
+// channel inside fifteen minutes and the owner's read was "you only ever send
+// me these". Repetition destroys the signal the first message carries.
+//
+// So: speak the first time, stay quiet for the cooldown, and when the same
+// recovery is STILL firing after the cooldown, say so WITH the count. A
+// recurring self-heal is a different (and worse) fact than a one-off, and that
+// is the one worth a ping. Every suppressed occurrence is still logged, so
+// dashboard.log keeps the full history for diagnosis.
+export const ROUTINE_ALERT_COOLDOWN_MS = 30 * 60 * 1000
+
+export type RoutineAlertState = { lastSentAt: number, suppressed: number }
+
+export type RoutineAlertDecision =
+  | { send: false }
+  | { send: true, repeats: number }
+
+// Pure decision half, so the throttle is testable without a channel.
+// `repeats` counts the occurrences suppressed since the last message went out;
+// zero means this is a clean first report.
+export function decideRoutineAlert(
+  prev: RoutineAlertState | undefined,
+  now: number,
+  cooldownMs: number,
+): RoutineAlertDecision {
+  if (prev && now - prev.lastSentAt < cooldownMs) return { send: false }
+  return { send: true, repeats: prev?.suppressed ?? 0 }
+}
+
+export function routineAlertSuffix(repeats: number, cooldownMs: number): string {
+  if (repeats <= 0) return ''
+  const minutes = Math.round(cooldownMs / 60000)
+  return `\n\n(Az elmult ${minutes} percben ${repeats + 1} ilyen volt. Ha nem all le magatol, nezz ra.)`
+}
+
+const states = new Map<string, RoutineAlertState>()
+
+// `key` groups occurrences of the SAME recovery: same code path, same agent.
+// Two different agents wedging must not silence each other, so per-agent call
+// sites put the agent name in the key.
+export function sendRoutineAlert(
+  key: string,
+  text: string,
+  opts: { cooldownMs?: number, now?: number } = {},
+): boolean {
+  const cooldownMs = opts.cooldownMs ?? ROUTINE_ALERT_COOLDOWN_MS
+  const now = opts.now ?? Date.now()
+  const prev = states.get(key)
+  const decision = decideRoutineAlert(prev, now, cooldownMs)
+  if (!decision.send) {
+    const state = prev as RoutineAlertState
+    state.suppressed += 1
+    logger.info({ key, suppressed: state.suppressed }, 'Routine recovery alert suppressed (inside cooldown) -- logged only')
+    return false
+  }
+  states.set(key, { lastSentAt: now, suppressed: 0 })
+  notifyChannel(text + routineAlertSuffix(decision.repeats, cooldownMs)).catch(() => {})
+  return true
+}
+
+export function resetRoutineAlerts(): void {
+  states.clear()
+}

--- a/src/web/stuck-tool-call-watcher.ts
+++ b/src/web/stuck-tool-call-watcher.ts
@@ -45,6 +45,7 @@ import { capturePane } from './agent-process.js'
 import { readTranscriptMtimeFromProjectDir } from './active-model.js'
 import { MAIN_CHANNELS_SESSION } from './main-agent.js'
 import { resumeMarveenSession, sendAlert, lastMainRespawnAt, MARVEEN_POST_RESPAWN_GRACE_MS } from './channel-monitor.js'
+import { sendRoutineAlert } from './routine-alert.js'
 import {
   stuckToolCallSignature,
   decideStuckToolCallRecovery,
@@ -333,16 +334,22 @@ async function checkSession(label: string, session: string): Promise<void> {
     // messaging into the void and then spent the morning pasting logs. One
     // proactive report replaces that whole loop. Sent on both outcomes -- a
     // FAILED recovery is exactly when the owner must know.
-    sendAlert(
-      ok
-        // A számot ne úgy írjuk ki, mintha időtartam lenne: a lastSeconds a
-        // KIJELZŐN BEFAGYOTT számláló értéke, a beavatkozás küszöbe viszont a
-        // stagnálás wall-clock hossza (freezeSeconds). A korábbi szöveg ("49s óta
-        // nem haladt") azt sugallta a tulajnak, hogy 49 másodperc után
-        // újraindítunk -- 2026-08-15-én pontosan ezt kérdezte vissza.
-        ? `🔧 A fő session beragadt: a kijelző számlálója ${Math.round(next.lastSeconds ?? 0)}s-nál megállt, és több mint ${THRESHOLDS.freezeSeconds}s-ig nem mozdult. Automatikusan újraindítottam a beszélgetés megtartásával. Ha volt megválaszolatlan üzeneted, mindjárt válaszolok rá.`
-        : `🚨 A fő session beragadt, és az automatikus újraindítás NEM sikerült. Kézi beavatkozás kellhet: tmux attach -t ${session}, vagy scripts/stop.sh && scripts/start.sh a marveen mappából.`,
-    )
+    // A SUCCEEDED recovery is routine: throttled, so a session that keeps
+    // wedging reports once with a count instead of once per wedge. A FAILED
+    // recovery is never throttled -- that is exactly when the owner must know.
+    if (ok) {
+      // A számot ne úgy írjuk ki, mintha időtartam lenne: a lastSeconds a
+      // KIJELZŐN BEFAGYOTT számláló értéke, a beavatkozás küszöbe viszont a
+      // stagnálás wall-clock hossza (freezeSeconds). A korábbi szöveg ("49s óta
+      // nem haladt") azt sugallta a tulajnak, hogy 49 másodperc után
+      // újraindítunk -- 2026-08-15-én pontosan ezt kérdezte vissza.
+      sendRoutineAlert(
+        `main-stuck-tool-call:${session}`,
+        `🔧 A fő session beragadt: a kijelző számlálója ${Math.round(next.lastSeconds ?? 0)}s-nál megállt, és több mint ${THRESHOLDS.freezeSeconds}s-ig nem mozdult. Automatikusan újraindítottam a beszélgetés megtartásával. Ha volt megválaszolatlan üzeneted, mindjárt válaszolok rá.`,
+      )
+    } else {
+      sendAlert(`🚨 A fő session beragadt, és az automatikus újraindítás NEM sikerült. Kézi beavatkozás kellhet: tmux attach -t ${session}, vagy scripts/stop.sh && scripts/start.sh a marveen mappából.`)
+    }
   }
 }
 


### PR DESCRIPTION
Five recovery notices landed in the owner's channel inside fifteen minutes on 2026-08-22, and the read was "you only ever send me these". Each notice was individually correct: a session wedged, the supervisor rebuilt it. The repetition is what destroyed the signal the first message carried.

The routine (`succeeded`) recoveries now go through a per-key throttle: speak the first time, stay quiet for 30 minutes, and if the same recovery is still firing after the cooldown, report it WITH the count. A self-heal that recurs is a different and worse fact than a one-off, and the count is what says so.

A FAILED recovery is never throttled. That is exactly the case where the owner has to know every time.

Suppressed occurrences still go to `dashboard.log`, so nothing is lost for diagnosis, only for the channel. Throttle keys carry the agent name, so two agents cannot silence each other's alerts.

## Tests

New `src/__tests__/routine-alert.test.ts` covers the first-send, the quiet window, the count on re-fire after cooldown, and per-agent key isolation.

Measured in a clean clone of this branch: `npx tsc --noEmit` clean, `npx vitest run` 355 files, 4610 passed / 1 skipped, against 354 files / 4604 on untouched `develop` measured the same way.

One conflict resolution to note: `stuck-tool-call-watcher.ts`'s alert text has been reworded on develop (the freezeSeconds explanation). That wording is kept verbatim; only the dispatch around it changes, so the success branch is throttled and the failure branch is not.
