### PR TITLE
fix(ledger-capture): record when the hook ran and stored nothing

### DIFF
--- a/scripts/hooks/ledger-capture.py
+++ b/scripts/hooks/ledger-capture.py
@@ -16,6 +16,7 @@ import sys
 import os
 import json
 import re
+import time
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import ledger_lib  # noqa: E402
@@ -32,6 +33,42 @@ CHANNEL_RX = re.compile(
 )
 
 
+def _trace(reason, **fields):
+    """One line, and ONLY when the hook ran and stored nothing.
+
+    WHY: every failure path in this hook is silent. A regex miss, a missing
+    chat_id/message_id, a ledger exception and an unparseable payload all leave
+    the same trace -- none. So "the hook never ran" and "it ran and matched
+    nothing" are indistinguishable from outside, and a gap in the transcript
+    cannot be attributed to either. That is not a gap in someone's diligence: it
+    is a property of the code, and it makes the question unanswerable rather
+    than merely unanswered.
+
+    Measured on one install, 2026-09-04: in a 42-minute window the ledger held
+    six outbound replies and one inbound row, and 12 of the 19 Telegram
+    message_ids spanning it were unaccounted for. The loss is one-directional --
+    a missing inbound row can only ever produce a false "they never replied",
+    never a false "answered" -- so the visible cost is the owner being asked a
+    question they already answered.
+
+    Deliberately ONLY on the empty outcome: the happy path stays silent, so this
+    costs nothing in the common case and every line written is a question worth
+    asking. COUNTS ONLY, never message text -- the trace must not become a second
+    copy of the transcript.
+    """
+    try:
+        path = os.path.join(os.path.dirname(ledger_lib.db_path()),
+                            "ledger-capture-trace.log")
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write("%s\t%s\t%s\n" % (
+                time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+                reason,
+                " ".join("%s=%s" % kv for kv in sorted(fields.items())),
+            ))
+    except Exception:
+        pass  # a trace must never block the prompt either
+
+
 def _attr(attrs, name):
     m = re.search(name + r'="([^"]*)"', attrs)
     return m.group(1) if m else None
@@ -41,10 +78,13 @@ def main():
     try:
         payload = json.load(sys.stdin)
     except Exception:
+        _trace("payload-unparseable")
         sys.exit(0)
     agent_id = ledger_lib.agent_id_from_payload(payload)
     prompt = payload.get("prompt") or ""
+    matched = stored = skipped = failed = 0
     for m in CHANNEL_RX.finditer(prompt):
+        matched += 1
         attrs, text = m.group(1), m.group(2)
         chat_id = _attr(attrs, "chat_id")
         message_id = _attr(attrs, "message_id")
@@ -61,8 +101,20 @@ def main():
                     agent_id, chat_id, message_id, text.strip(), ts,
                     attachment_kind=att_kind, attachment_file_id=att_file_id,
                 )
-            except Exception:
-                pass  # never block the prompt on a ledger error
+                stored += 1
+            except Exception as exc:
+                failed += 1
+                _trace("ledger-error", agent=agent_id, err=type(exc).__name__)
+                # never block the prompt on a ledger error
+        else:
+            skipped += 1
+    if stored == 0:
+        # `has_tag` separates "no channel wrapper reached this prompt at all"
+        # from "one did and nothing came of it" -- the same distinction the
+        # counts below make within a matched wrapper.
+        _trace("no-row", agent=agent_id, matched=matched, skipped=skipped,
+               failed=failed, prompt_len=len(prompt),
+               has_tag=int("<channel" in prompt))
     sys.exit(0)
 
 


### PR DESCRIPTION
## The problem

Every failure path in `ledger-capture.py` is silent. A regex miss, a missing `chat_id`/`message_id`,
a ledger exception and an unparseable payload all leave the same trace: none.

So "the hook never ran" and "it ran and matched nothing" are indistinguishable from outside, and a
gap in the ledger cannot be attributed to either. That is not a gap in anyone's diligence, it is a
property of the code: it makes the question unanswerable rather than merely unanswered.

## What this measured

On one install, 2026-09-04: in a 42-minute window the ledger held six outbound replies and one
inbound row, while 12 of the 19 Telegram `message_id`s spanning that window were unaccounted for.

The loss is one-directional. A missing inbound row can only ever produce a false "they never
replied", never a false "already answered", so the visible cost is the owner being asked a question
they have already answered.

## The change

A `_trace()` line written **only when the hook ran and stored nothing**:

- The happy path stays completely silent, so this costs nothing in the common case, and every line
  written is a question worth asking.
- **Counts only, never message text.** The trace must not become a second copy of the transcript.
- `has_tag` separates "no channel wrapper reached this prompt at all" from "one did and nothing came
  of it", which is the distinction that made the original gap unattributable.
- Wrapped in `try/except: pass`. A trace must never block the prompt, which is the same contract the
  existing ledger write already honours.

## Scope

One file, 54 insertions. No behaviour change on any path that currently stores a row: the counters
are incremented alongside the existing logic and the only new output is on the `stored == 0` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
