### PR TITLE
fix(isolated-config): never let a shared MCP server shadow the agent's own (CORTEXMCP904)

### DIFF
--- a/src/__tests__/isolated-config-mcp-reconcile.test.ts
+++ b/src/__tests__/isolated-config-mcp-reconcile.test.ts
@@ -151,6 +151,41 @@ describe('isolated config dir: mcpServers reconcile', () => {
     expect(statSync(isolatedDotClaude()).mode & 0o777).toBe(0o600)
   })
 
+  it('never shadows a server the agent defines in its own project-scope .mcp.json', () => {
+    // The agent owns `cortex` at project scope, with ITS token.
+    writeFileSync(
+      join(SANDBOX, 'agents', AGENT, '.mcp.json'),
+      JSON.stringify({ mcpServers: { cortex: { url: 'https://cortex.example/mcp', headers: { Authorization: 'Bearer agent-own-token' } } } }),
+    )
+    // The router's shared config carries the SAME name with a DIFFERENT token.
+    writeShared({
+      gmail: { command: 'npx', args: ['gmail-mcp'] },
+      cortex: { url: 'https://cortex.example/mcp', headers: { Authorization: 'Bearer router-token' } },
+    })
+
+    ensureIsolatedChannelConfigDir(AGENT, 'telegram')
+
+    // `cortex` must NOT land in the isolated (local-scope) config: local wins
+    // over project, so copying it would replace the agent's own credential with
+    // the router's and kill the whole server for that agent.
+    expect(servers().cortex).toBeUndefined()
+    // The genuine gap is still filled -- the fix must not disable #834.
+    expect(servers().gmail).toEqual({ command: 'npx', args: ['gmail-mcp'] })
+  })
+
+  it('still gap-fills when the agent has no readable .mcp.json', () => {
+    // No .mcp.json at all: nothing can collide, so every shared server is a gap.
+    writeShared({ gmail: { command: 'npx', args: ['gmail-mcp'] }, extra: { command: 'x' } })
+    ensureIsolatedChannelConfigDir(AGENT, 'telegram')
+    expect(Object.keys(servers()).sort()).toEqual(['extra', 'gmail'])
+
+    // An unparseable one must behave the same way, not block the roll-out.
+    writeFileSync(join(SANDBOX, 'agents', AGENT, '.mcp.json'), '{ this is not json')
+    writeShared({ gmail: { command: 'npx', args: ['gmail-mcp'] }, extra: { command: 'x' }, third: { command: 'y' } })
+    ensureIsolatedChannelConfigDir(AGENT, 'telegram')
+    expect(Object.keys(servers()).sort()).toEqual(['extra', 'gmail', 'third'])
+  })
+
   it('leaves no staging file behind (atomic write)', () => {
     ensureIsolatedChannelConfigDir(AGENT, 'telegram')
     writeShared({ gmail: { command: 'npx', args: ['gmail-mcp'] }, extra: { command: 'x' } })

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -471,11 +471,27 @@ function writeJsonAtomic(path: string, value: unknown, opts: { groupShared?: boo
 //   - a server removed from the shared config is left in place,
 //   - a non-object mcpServers on either side means we do not touch it at all,
 //     because we cannot merge what we do not understand.
+//
+// AND NEVER ACROSS A SCOPE COLLISION (2026-09-05, measured 12-hour outage).
+// Claude Code resolves `local` scope (.claude.json) BEFORE `project` scope
+// (<cwd>/.mcp.json). Copying a shared entry whose name the agent already defines
+// in its own .mcp.json therefore does not fill a gap -- it SHADOWS the agent's
+// definition with the router's, credentials included. The failure is silent and
+// total: our shared `cortex` entry carried a token that is valid for the router
+// and unknown to the server, so every agent session that started after the
+// write-back answered the handshake with 401 and registered ZERO cortex tools,
+// while its own .mcp.json looked perfectly correct and the backend was healthy.
+// A restart never helped -- startup is what writes the shadow back. Two agents
+// lost the toolset for ~12 hours; the two whose sessions predated the write-back
+// kept working, which is what made it read as flaky client-side registration
+// instead of a config collision.
+// A name the agent already owns at project scope is NOT a gap. Skip it.
 // Returns true if the caller should persist `cur`.
 function reconcileMcpServers(
   cur: Record<string, unknown>,
   sharedDot: string,
   name: string,
+  cwd: string,
 ): boolean {
   if (!existsSync(sharedDot)) return false
   let shared: Record<string, unknown>
@@ -488,16 +504,63 @@ function reconcileMcpServers(
     return false
   }
   const own = isPlainObject(cur.mcpServers) ? cur.mcpServers : {}
+  const projectScoped = projectScopedServerNames(cwd)
   const added: string[] = []
+  const shadowed: string[] = []
   for (const [key, def] of Object.entries(shared.mcpServers)) {
     if (key in own) continue
+    if (projectScoped.has(key)) { shadowed.push(key); continue }
     own[key] = def
     added.push(key)
+  }
+  // Log the skips even when nothing was added: a silent skip is how this class
+  // of bug stays invisible, and the name alone tells the next reader where the
+  // agent's real definition lives.
+  if (shadowed.length > 0) {
+    logger.info(
+      { name, shadowed },
+      'isolated-config: skipped shared MCP servers the agent already defines in its own .mcp.json',
+    )
   }
   if (added.length === 0) return false
   cur.mcpServers = own
   logger.info({ name, added }, 'isolated-config: added missing MCP servers from the shared config')
   return true
+}
+
+// Drop from a to-be-written config every mcpServers entry whose name the agent
+// already owns at project scope. Used on the FIRST-SEED path, where the whole
+// shared config is copied: without this the very first launch of a new agent
+// starts out shadowed, which is the same outage as the gap-fill one, just
+// earlier. Mutates `cfg` in place.
+function stripProjectScopedCollisions(cfg: Record<string, unknown>, cwd: string, name: string): void {
+  const projectScoped = projectScopedServerNames(cwd)
+  if (projectScoped.size === 0) return
+  const dropped: string[] = []
+  if (isPlainObject(cfg.mcpServers)) {
+    for (const key of Object.keys(cfg.mcpServers)) {
+      if (projectScoped.has(key)) { delete (cfg.mcpServers as Record<string, unknown>)[key]; dropped.push(key) }
+    }
+  }
+  if (dropped.length > 0) {
+    logger.info(
+      { name, dropped },
+      'isolated-config: seed dropped shared MCP servers the agent defines in its own .mcp.json',
+    )
+  }
+}
+
+// Server names the agent already gets from its own project-scope <cwd>/.mcp.json.
+// A missing or unreadable file is not an error here: it just means the agent has
+// no project-scope servers, so nothing can collide.
+function projectScopedServerNames(cwd: string): Set<string> {
+  try {
+    const parsed = JSON.parse(readFileSync(join(cwd, '.mcp.json'), 'utf-8')) as Record<string, unknown>
+    if (!isPlainObject(parsed.mcpServers)) return new Set()
+    return new Set(Object.keys(parsed.mcpServers))
+  } catch {
+    return new Set()
+  }
 }
 
 function isPlainObject(v: unknown): v is Record<string, unknown> {
@@ -692,6 +755,11 @@ function provisionIsolatedConfigDir(
           try { seed = JSON.parse(readFileSync(sharedDot, 'utf-8')) as Record<string, unknown> } catch { /* keep minimal */ }
         }
         seed.hasCompletedOnboarding = true
+        // The seed is a FULL copy of the shared config, so it carries the same
+        // scope-collision risk as the gap-fill below: a shared entry whose name
+        // the agent owns in its own .mcp.json would arrive at local scope and
+        // shadow it, credentials included. Strip those before writing.
+        stripProjectScopedCollisions(seed, cwd, name)
         writeJsonAtomic(dotClaude, seed, { groupShared: perUser })
       } else {
         try {
@@ -701,7 +769,7 @@ function provisionIsolatedConfigDir(
             cur.hasCompletedOnboarding = true
             dirty = true
           }
-          if (reconcileMcpServers(cur, sharedDot, name)) dirty = true
+          if (reconcileMcpServers(cur, sharedDot, name, cwd)) dirty = true
           if (dirty) writeJsonAtomic(dotClaude, cur, { groupShared: perUser })
         } catch { /* unparseable -> leave for Claude Code to recreate */ }
       }


### PR DESCRIPTION
## Mi a hiba

A Claude Code a `local` scope-ot (`.claude.json`) a `project` scope (`<cwd>/.mcp.json`) ELŐTT oldja fel. Két helyen másoljuk a router közös `~/.claude.json`-jét egy ügynök izolált configjába -- az első seednél és a #834-es gap-fillnél --, és mindkettő csak NÉV szerint másolt. Így egy olyan közös szerver, amit az ügynök a saját `.mcp.json`-jában már definiál, local scope-on landolt, és leárnyékolta az ügynök saját bejegyzését, a hitelesítő adattal együtt.

## Mért kiesés (2026-09-05)

A közös `cortex` bejegyzésünk olyan tokent vitt, amit a Cortex szerver nem ismer. Minden ügynök-session, ami a visszaírás után indult, 401-gyel válaszolt a handshake-re és NULLA cortex-toolt regisztrált -- miközben az ügynök saját `.mcp.json`-ja helyes volt, a backend pedig egészséges (kézi handshake-kel 25 tool).

- Két ügynök ~12 órára elvesztette a toolkészletet.
- A két ügynök, akiknek a sessionje a visszaírás ELŐTT indult, végig működött. Pont ettől tűnt kliens-oldali regisztrációs törékenységnek config-ütközés helyett.
- Az újraindítás soha nem segített: **az indulás az, ami visszaírja az árnyékot**, kézi törlés után ~12 másodperccel.
- A döntő jel: a KLIENS 401-et kapott, miközben UGYANAZZAL a `.mcp.json` tokennel a `curl` 200-at adott. Ha a kliens 401-el, de a kézi hívás átmegy, akkor a kliens nem azt a hitelesítő adatot küldi.

## A javítás

Amit az ügynök project scope-on már birtokol, az nem hiány:

- `reconcileMcpServers()` megkapja az ügynök `cwd`-jét, és kihagyja az ütköző kulcsokat;
- az első-seed út ugyanezeket az ütközéseket kiszűri írás előtt;
- **mindkettő naplózza a kihagyást.** A néma kihagyás az, amitől ez a hibaosztály láthatatlan marad; a naplózott név egyben megmondja, hol van az ügynök valódi definíciója.

## Amit szándékosan NEM csinálok

Általános "hagyd ki a hitelesítő adatot tartalmazó bejegyzéseket" szabályt. A legtöbb MCP-szerverhez kell auth, tehát az kivágná a #834 alól a talajt, amiért a gap-fill létezik. A név-ütközés a pontos hibaok.

## Tesztek

- a kiesés esete: a közös config és az ügynök `.mcp.json`-ja ugyanazt a nevet definiálja -> nincs árnyék, a valódi hiány viszont továbbra is feltöltődik;
- robusztusság: hiányzó vagy értelmezhetetlen `.mcp.json` nem blokkolhatja a kiterjesztést.

Teljes suite: 354 fájl / 4606 teszt zöld, 1 skipped. `tsc --noEmit` tiszta.

## Nyitott, külön kérdés (nem ebben a PR-ben)

Az éles configokban az árnyék a `projects[<út>].mcpServers` alatt is megjelent, nem csak a legfelső szinten. Hogy azt melyik író teszi oda, még nincs lemérve, ezért nem tippelek rá javítást. Ez a PR a két bizonyított utat zárja.
