### PR TITLE
fix(update): survive NODE_ENV=production on the update path (AUTOUPDNODEENV905)

### DIFF
--- a/seed-scheduled-tasks/auto-update/task-config.json
+++ b/seed-scheduled-tasks/auto-update/task-config.json
@@ -4,7 +4,7 @@
   "enabled": true,
   "type": "command",
   "description": "Auto-update (opt-in): heti egyszer meghivja a robusztus update.sh-t. ALAPERTELMEZETTEN KIKAPCSOLVA -- a parancs csak akkor futtatja a frissitest, ha az .env-ben AUTO_UPDATE_ENABLED=1. A frissites, restart, health-check es szukseg eseten a rollback a update.sh dolga; a kimenetrol a finalizer kuld Telegram-riasztast (MARVEEN_UPDATE_NOTIFY=1).",
-  "command": "AUE=$(grep '^AUTO_UPDATE_ENABLED=' '{{INSTALL_DIR}}/.env' 2>/dev/null | tail -1 | cut -d= -f2- | tr -d ' \\r\"'); [ \"$AUE\" = \"1\" ] || exit 0; cd '{{INSTALL_DIR}}' || exit 1; if command -v setsid >/dev/null 2>&1; then DETACH=setsid; else DETACH=nohup; fi; MARVEEN_UPDATE_NOTIFY=1 AUTO_STASH=1 $DETACH bash '{{INSTALL_DIR}}/update.sh' >> '{{INSTALL_DIR}}/store/update.log' 2>&1 < /dev/null & exit 0",
+  "command": "AUE=$(grep '^AUTO_UPDATE_ENABLED=' '{{INSTALL_DIR}}/.env' 2>/dev/null | tail -1 | cut -d= -f2- | tr -d ' \\r\"'); [ \"$AUE\" = \"1\" ] || exit 0; cd '{{INSTALL_DIR}}' || exit 1; if command -v setsid >/dev/null 2>&1; then DETACH=setsid; else DETACH=nohup; fi; MARVEEN_UPDATE_NOTIFY=1 AUTO_STASH=1 $DETACH env -u NODE_ENV bash '{{INSTALL_DIR}}/update.sh' >> '{{INSTALL_DIR}}/store/update.log' 2>&1 < /dev/null & exit 0",
   "timeoutMs": 30000,
   "failThreshold": 1,
   "createdAt": 0

--- a/src/__tests__/auto-update-seed-task.test.ts
+++ b/src/__tests__/auto-update-seed-task.test.ts
@@ -53,6 +53,14 @@ describe('auto-update seed task', () => {
     expect(config.command).toContain('nohup')
   })
 
+  it('strips NODE_ENV before launching update.sh (AUTOUPDNODEENV905)', () => {
+    // With NODE_ENV=production in the agent environment npm defaults to
+    // omit=dev inside update.sh, pruning tsc and locking the install into a
+    // fail-and-rollback loop the fix itself cannot escape. The env scrub at
+    // the caller is what reaches installs still running an OLD update.sh.
+    expect(config.command).toContain('env -u NODE_ENV bash')
+  })
+
   it('uses install-dir placeholders, never a hardcoded absolute path', () => {
     expect(config.command).toContain('{{INSTALL_DIR}}')
     expect(config.command).not.toMatch(/\/Users\/|\/home\//)

--- a/src/__tests__/update-npm-ci-include-dev.test.ts
+++ b/src/__tests__/update-npm-ci-include-dev.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+// AUTOUPDNODEENV905 source guard. With NODE_ENV=production in the caller's
+// environment `npm ci` defaults to omit=dev, which prunes the TypeScript
+// compiler; the update build then fails, rolls back (reverting the freshly
+// pulled update.sh too), and the install repeats the same failure on every
+// run while the customer sees green (the old dist keeps serving). Measured
+// live on 2026-09-05: five rollbacks over ten days on a customer install.
+//
+// The defense is two-layered and BOTH layers are load-bearing:
+//   1. every `npm ci` inside update.sh carries --include=dev (final, but only
+//      effective once the fixed script has arrived);
+//   2. the dashboard spawn path deletes NODE_ENV from the child env, because
+//      installs still running an OLD update.sh can only be healed by the
+//      environment they are launched with.
+
+const ROOT = join(__dirname, '..', '..')
+
+describe('update path survives NODE_ENV=production (AUTOUPDNODEENV905)', () => {
+  it('every npm ci in update.sh carries --include=dev', () => {
+    const script = readFileSync(join(ROOT, 'update.sh'), 'utf-8')
+    const ciLines = script.split('\n').filter((l) => /\bnpm ci\b/.test(l) && !l.trim().startsWith('#'))
+    expect(ciLines.length).toBeGreaterThan(0)
+    for (const line of ciLines) {
+      // Error-message hints ("futtasd: npm ci") are prose, not invocations.
+      if (/echo/.test(line)) continue
+      expect(line, `npm ci without --include=dev: ${line.trim()}`).toContain('--include=dev')
+    }
+  })
+
+  it('the dashboard update spawn deletes NODE_ENV from the child environment', () => {
+    const route = readFileSync(join(ROOT, 'src', 'web', 'routes', 'updates.ts'), 'utf-8')
+    const spawnIdx = route.indexOf("spawn('/bin/bash'")
+    expect(spawnIdx).toBeGreaterThan(-1)
+    const before = route.slice(Math.max(0, spawnIdx - 600), spawnIdx)
+    expect(before).toContain("delete updateEnv['NODE_ENV']")
+  })
+})

--- a/src/web/routes/updates.ts
+++ b/src/web/routes/updates.ts
@@ -264,11 +264,19 @@ export async function tryHandleUpdates(ctx: RouteContext): Promise<boolean> {
         json(res, { error: 'store/ is not writable; cannot run the updater safely.', reason: 'store-unwritable' }, 500)
         return true
       }
+      // NODE_ENV must not reach update.sh: with NODE_ENV=production npm defaults
+      // to omit=dev, the pruned tree loses tsc, and every update build fails and
+      // rolls back forever (AUTOUPDNODEENV905). Deleting it here shields the
+      // OLD update.sh copies already deployed at customers, which lack the
+      // script-side --include=dev fix and can only receive it through a run
+      // this spawn starts.
+      const updateEnv: NodeJS.ProcessEnv = { ...process.env, AUTO_STASH: autoStash ? '1' : '0' }
+      delete updateEnv['NODE_ENV']
       const child = spawn('/bin/bash', [join(PROJECT_ROOT, 'update.sh')], {
         cwd: PROJECT_ROOT,
         detached: true,
         stdio: ['ignore', outFd, outFd],
-        env: { ...process.env, AUTO_STASH: autoStash ? '1' : '0' },
+        env: updateEnv,
       })
       child.on('error', (err) => {
         logger.error({ err }, 'update.sh spawn reported an async error')

--- a/update.sh
+++ b/update.sh
@@ -658,7 +658,12 @@ fi
 if git diff "$OLD_VERSION" "$NEW_VERSION" --name-only | grep -qE "^package(-lock)?\.json$"; then
   echo -e "  Fuggosegek frissitese (lock-strict)..."
   RESULT_PHASE="npm-ci"
-  if ! retry 3 3 npm ci --silent; then
+  # --include=dev is load-bearing (AUTOUPDNODEENV905): with NODE_ENV=production
+  # in the caller's environment npm defaults to omit=dev, which prunes the
+  # TypeScript compiler and makes the build below fail -> rollback -> the same
+  # failure next run, forever (the rollback also reverts the freshly pulled
+  # update.sh, so a fix can never arrive through this path on its own).
+  if ! retry 3 3 npm ci --silent --include=dev; then
     echo -e "  HIBA: npm ci sikertelen. Valoszinuleg a package-lock.json nincs szinkronban."
     echo -e "  Reszletekert futtasd: npm ci"
     exit 1
@@ -697,6 +702,11 @@ if [ "${SKIP_BUILD:-0}" != "1" ]; then
     echo -e "${RED}HIBA:${NC} build sikertelen. Visszaallitas a korabbi verziora (${OLD_VERSION})..."
     if [ -n "$OLD_VERSION_FULL" ]; then
       git reset --hard "$OLD_VERSION_FULL" >/dev/null 2>&1 || true
+      # Restore the dependency tree of the OLD version before rebuilding it: the
+      # failed `npm ci` above may have pruned dev deps (NODE_ENV=production),
+      # and without the compiler this rollback build would also fail silently,
+      # leaving git=OLD + node_modules=pruned (AUTOUPDNODEENV905 finding A).
+      npm ci --silent --include=dev 2>/dev/null || true
       npm rebuild better-sqlite3 --build-from-source --silent 2>/dev/null || true
       npm run build --silent 2>/dev/null || true
       [ -d "$INSTALL_DIR/dist" ] && echo "$OLD_VERSION_FULL" > "$BUILT_COMMIT_FILE"
@@ -1087,7 +1097,10 @@ if _health; then _finish success restart 0 ""; fi
 # restart that, so the box ends on a WORKING old version.
 if [ -n "$OLD_FULL" ]; then
   git reset --hard "$OLD_FULL" >/dev/null 2>&1 || true
-  npm ci --silent 2>/dev/null || true
+  # --include=dev: same reason as the main npm ci (AUTOUPDNODEENV905) -- under
+  # NODE_ENV=production a plain ci prunes the compiler and the rebuild below
+  # dies silently, re-creating the pruned tree this rollback tries to escape.
+  npm ci --silent --include=dev 2>/dev/null || true
   npm rebuild better-sqlite3 --build-from-source --silent 2>/dev/null || true
   npm run build --silent 2>/dev/null || true
   [ -d "$INSTALL_DIR/dist" ] && echo "$OLD_FULL" > "$BUILT"


### PR DESCRIPTION
## What

A customer install with `NODE_ENV=production` in its environment has been failing every nightly update for 10 days, silently: `npm ci` prunes dev deps (tsc gone), the build fails, the rollback resets to OLD (reverting the freshly pulled update.sh too), the old dist keeps serving so every check is green, and the loop repeats. Verified independently on this host and on origin/main (card AUTOUPDNODEENV905).

## Fix (two layers, both needed)

1. **update.sh** -- `--include=dev` on every `npm ci`:
   - the main lock-strict install;
   - the build-failure rollback block, which previously ran **no** `npm ci` at all, so its own rebuild died silently on the already-pruned tree (customer end state: git=OLD, dist=OLD working, node_modules pruned);
   - the finalize health-check rollback (second call site).
2. **Callers** -- the dashboard update spawn deletes `NODE_ENV` from the child env; the seeded auto-update task launches via `env -u NODE_ENV`. This is the only layer that reaches installs still running an OLD update.sh (no re-exec by design, see update.sh:374).

## Proof

- Scratch-package repro both directions: plain `ci` under NODE_ENV=production drops the dev dep, `--include=dev` restores it.
- New source-guard test (`update-npm-ci-include-dev.test.ts`) adversarially verified to go red when the fix is reverted.
- Full suite: 4607 passed, tsc --noEmit clean.

## Not in this PR

- One-time manual recovery command for already-stuck installs (customer copy, Marveen reviews it separately).
- Any deploy/merge: draft until Marveen/gazda GO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)