### PR TITLE
fix(watchdog): a permission prompt is not a stuck menu (PERMDENY905)

### DIFF
--- a/src/__tests__/pane-state.test.ts
+++ b/src/__tests__/pane-state.test.ts
@@ -4,6 +4,7 @@ import {
   detectPermissionMode,
   detectsThinkingBlockError,
   detectsBlockingMenu,
+  detectsPermissionDialog,
   detectsPastePlaceholder,
   isReadyForPrompt,
   shouldRetrySubmit,
@@ -1836,6 +1837,142 @@ describe('detectsBlockingMenu', () => {
       '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
     ].join('\n')
     expect(detectsBlockingMenu(quoted)).toBe(false)
+  })
+})
+
+describe('detectsPermissionDialog', () => {
+  // Captured live from the bond session on 2026-09-05 with
+  // `tmux capture-pane -p`. The session runs with
+  // --dangerously-skip-permissions, yet this prompt still appeared: the edit
+  // targets a file under ~/.claude/, i.e. Claude Code's OWN configuration,
+  // which the flag deliberately does not cover. Option 2's wording is the
+  // giveaway. An identical edit to a path outside the project but outside
+  // ~/.claude/ produced NO dialog, so "outside the project" is not the trigger.
+  const PERMISSION_DIALOG = [
+    ' ../../home/marveen/.claude/bond-teszt.txt',
+    '╌'.repeat(100),
+    ' 1 -proba',
+    ' 1 +modositva',
+    '╌'.repeat(100),
+    ' Do you want to make this edit to bond-teszt.txt?',
+    ' ❯ 1. Yes',
+    '   2. Yes, and allow Claude to edit its own settings for this session',
+    '   3. No',
+    '',
+    ' Esc to cancel · Tab to amend',
+  ].join('\n')
+
+  // A command-permission prompt: no "Tab to amend" in the footer, so only the
+  // question+Yes shape identifies it.
+  const BASH_PERMISSION_DIALOG = [
+    ' Bash command',
+    '   rm -rf ./build',
+    '   Remove the build directory',
+    '',
+    ' Do you want to proceed?',
+    ' ❯ 1. Yes',
+    "   2. Yes, and don't ask again for rm commands in /home/marveen/marveen",
+    '   3. No, and tell Claude what to do differently (esc)',
+    '',
+    ' Esc to cancel',
+  ].join('\n')
+
+  // A genuine wedged modal: Escape here IS the right recovery and must stay.
+  const GENUINE_MENU = [
+    '   Manage MCP servers',
+    '   5 servers',
+    '',
+    '   ❯ claude.ai Canva · ✔ connected · 39 tools',
+    '',
+    '   ↑/↓ to navigate · Enter to confirm · Esc to cancel',
+  ].join('\n')
+
+  // The usage-credit consent dialog, answered by its own branch. It offers
+  // "1. Continue with ...", never "1. Yes", so the two must not overlap.
+  const CONSENT_DIALOG = [
+    '  Fable 5 now uses usage credits',
+    '  Fable 5 runs on usage credits, purchased separately from your plan.',
+    '    1. Continue with Fable 5',
+    '  ❯ 2. Switch to Sonnet 5 and continue',
+    '  Enter to confirm · Esc to cancel',
+  ].join('\n')
+
+  it('detects the live edit-permission prompt', () => {
+    expect(detectsPermissionDialog(PERMISSION_DIALOG)).toBe(true)
+  })
+
+  it('detects a command-permission prompt with no "Tab to amend" footer', () => {
+    expect(detectsPermissionDialog(BASH_PERMISSION_DIALOG)).toBe(true)
+  })
+
+  // PERMDENY905 regression anchor. The permission prompt ALSO satisfies the
+  // generic stuck-menu detector, because its footer says "Esc to cancel" --
+  // that shadowing is the entire bug. The menu-recovery branch sent Escape
+  // here, and on this dialog Escape is NO, so the watchdog silently denied the
+  // agent's own requests ~45s after they appeared while the operator believed
+  // they had approved them. If this assertion ever fails because
+  // detectsBlockingMenu stopped matching, the ordering guard in
+  // channel-monitor.ts has become redundant rather than wrong.
+  it('is also matched by detectsBlockingMenu (this is why the guard exists)', () => {
+    expect(detectsBlockingMenu(PERMISSION_DIALOG)).toBe(true)
+    expect(detectsBlockingMenu(BASH_PERMISSION_DIALOG)).toBe(true)
+  })
+
+  it('leaves a genuine blocking menu to the Escape recovery', () => {
+    expect(detectsPermissionDialog(GENUINE_MENU)).toBe(false)
+    expect(detectsBlockingMenu(GENUINE_MENU)).toBe(true)
+  })
+
+  it('does not claim the model-consent dialog', () => {
+    expect(detectsPermissionDialog(CONSENT_DIALOG)).toBe(false)
+  })
+
+  it('is false for a normal idle prompt (bypass/strict)', () => {
+    expect(detectsPermissionDialog(IDLE_BYPASS)).toBe(false)
+    expect(detectsPermissionDialog(IDLE_STRICT)).toBe(false)
+  })
+
+  it('is false for a busy turn even if it renders esc-to-interrupt', () => {
+    expect(detectsPermissionDialog(BUSY_FULL_FOOTER)).toBe(false)
+    expect(detectsPermissionDialog(BUSY_TOKENS_ONLY)).toBe(false)
+  })
+
+  // The alert-spam case: the operator answered Yes, the turn is running, and
+  // the answered question is still in scrollback. Re-alerting here would fire
+  // on every dialog the operator has already dealt with.
+  it('is false once the prompt has been answered and the turn is running', () => {
+    const answered = [
+      ' Do you want to make this edit to bond-teszt.txt?',
+      ' ❯ 1. Yes',
+      '   3. No',
+      '',
+      '✢ Combobulating… (12s · ↓ 340 tokens)',
+      '',
+      SEP,
+      '❯ ',
+      SEP,
+      '  ⏵⏵ bypass permissions on (shift+tab to cycle) · esc to interrupt',
+    ].join('\n')
+    expect(detectsPermissionDialog(answered)).toBe(false)
+  })
+
+  // Prose quoting the dialog above a live prompt must not read as one.
+  it('does not trigger on a reply that merely quotes the dialog', () => {
+    const quoted = [
+      '  A dialogus igy nez ki: "Do you want to make this edit to x.txt?"',
+      '  1. Yes / 2. ... / 3. No -- ezek a valaszthato opciok.',
+      '',
+      SEP,
+      '❯ ',
+      SEP,
+      '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+    ].join('\n')
+    expect(detectsPermissionDialog(quoted)).toBe(false)
+  })
+
+  it('is false for an empty pane', () => {
+    expect(detectsPermissionDialog('')).toBe(false)
+    expect(detectsPermissionDialog('   \n  ')).toBe(false)
   })
 })
 

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -677,6 +677,46 @@ const MODEL_CONSENT_TITLE_RX = /(?:now uses|runs on|requires) usage credits/
 const MODEL_CONSENT_CONTINUE_RX = /1\.\s*Continue with /
 const MODEL_CONSENT_CONFIRM_RX = /Enter to confirm/
 
+// Tool-permission prompt. Claude Code asks for one even under
+// --dangerously-skip-permissions when the target is its OWN configuration
+// (~/.claude/**: skills, settings, scheduled-tasks) -- the second option says
+// so literally: "Yes, and allow Claude to edit its own settings for this
+// session". Measured 2026-09-05 on a live session: a write to ~/.claude/ opens
+// the dialog, while a write to an ordinary path outside the project does NOT,
+// so "outside the project" is not the trigger; Claude's own config is.
+//
+// Out here the prompt is indistinguishable from a stuck menu: its footer says
+// "Esc to cancel", so detectsBlockingMenu matches it (verified against a real
+// captured pane). But Escape on a permission prompt is not a harmless dismiss
+// -- it is NO. The watchdog therefore DENIED the agent's own requests ~45s
+// after they appeared, silently, while the operator believed they had approved
+// them (confirmed by the operator: "Ment allow"). Five skill-file writes died
+// this way, which is why self-improvement in particular kept failing: the
+// skills live under ~/.claude/, so they are the writes that open the dialog.
+//
+// Same reasoning as TRUSTGATE901: no keystroke is neutral here, so the monitor
+// must send none and say so loudly instead. Detection deliberately errs BROAD
+// (footer marker OR question+Yes shape): a false positive only means a genuine
+// stuck menu is alerted instead of Escaped -- the operator still learns of it
+// -- while a false negative silently answers NO on the operator's behalf.
+const PERMISSION_AMEND_RX = /\bTab to amend\b/
+const PERMISSION_QUESTION_RX = /Do you want to [^\n?]{0,80}\?/
+const PERMISSION_YES_RX = /(?:^|\n)\s*[\u276f>]?\s*1\.\s*Yes\b/
+
+export function detectsPermissionDialog(pane: string): boolean {
+  if (!pane || !pane.trim()) return false
+  const lines = pane.split('\n')
+  const busyRegion = lines.slice(-BUSY_LIVE_REGION_LINES).join('\n')
+  for (const rx of BUSY_INDICATORS) {
+    if (rx.test(busyRegion)) return false
+  }
+  const footerRegion = lines.slice(-LIVE_FOOTER_REGION_LINES).join('\n')
+  if (BUSY_ESC_TO_INTERRUPT_RX.test(footerRegion)) return false
+  if (IDLE_FOOTER_RX.test(pane)) return false
+  return PERMISSION_AMEND_RX.test(footerRegion)
+    || (PERMISSION_QUESTION_RX.test(pane) && PERMISSION_YES_RX.test(pane))
+}
+
 export function detectsModelConsentDialog(pane: string): boolean {
   if (!pane || !pane.trim()) return false
   const lines = pane.split('\n')

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -36,7 +36,7 @@ import { probeTelegramConflict } from './channel-conflict-probe.js'
 import { schedulePluginUnlockAfterRespawn, wasPluginConfirmedAbsent, clearPluginAbsent } from './channel-plugin-unlock.js'
 import { getInjectedPrompt, matchesInjectedPrompt } from './injected-prompt-registry.js'
 import {
-  detectPaneState, decidePaneErrorAlert, detectsBlockingMenu, detectsFirstRunGate, detectsModelConsentDialog, type PaneErrorAlertState, type PaneState,
+  detectPaneState, decidePaneErrorAlert, detectsBlockingMenu, detectsPermissionDialog, detectsFirstRunGate, detectsModelConsentDialog, type PaneErrorAlertState, type PaneState,
   stuckInputSignature, decideStuckInputRecovery, parkedChannelInput,
   parkedInputText, shouldClearTruncatedPreamble,
   parkedInputRowCount, submitLanded, decideStuckInputAction,
@@ -1877,6 +1877,15 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
             logger.warn({ session: t.session, agent: label }, 'Blocking "menu" is the model usage-credit consent dialog -- answering it safely instead of Escape')
             await dismissModelConsentDialogIfPresent(t.session)
             sendRoutineAlert(`model-consent:${label}`, `🎛️ A(z) ${label} session a modell-hozzájárulás dialóguson parkolt; az 1-es opcióval (a beállított modell megtartása) továbbléptettem. Modellváltás NEM történt.`)
+          } else if (paneNow != null && detectsPermissionDialog(paneNow)) {
+            // PERMDENY905: a tool-permission prompt also says "Esc to cancel",
+            // so detectsBlockingMenu matches it -- but Escape there is NO, not a
+            // dismiss. This monitor was therefore DENYING the agent's own
+            // requests ~45s after they appeared, while the operator believed
+            // they had approved them. Same rule as the unrecognised trust dialog
+            // above: no keystroke is neutral, so send none and say so, loudly.
+            logger.warn({ session: t.session, agent: label }, 'Blocking "menu" is a tool-permission prompt -- a human decides, NO keystrokes sent')
+            sendAlert(`🔐 A(z) ${label} session egy engedélykérésen vár, és NEM nyomtam meg semmit: ott az Escape NEM-et jelentene. Döntsd el te: tmux attach -t ${t.session}`)
           } else {
             logger.warn({ session: t.session, agent: label }, 'Session parked in a blocking interactive menu -- sending Escape to recover')
             try {


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

**HU:** Az eszköz-engedélykérő dialógus lábléce is azt írja, hogy `Esc to cancel`, ezért a `detectsBlockingMenu` ráillik — a menü-helyreállító ág viszont **Escape-et küld rá**. Csakhogy ezen a dialóguson az Escape nem ártalmatlan bezárás, hanem **NEM**. A watchdog tehát a saját ügynöke kéréseit tagadta le, némán, kb. 45 másodperccel a megjelenésük után, miközben az operátor azt hitte, jóváhagyta őket.

A csapda az, hogy ez a dialógus **`--dangerously-skip-permissions` mellett is megjelenik**, ha a művelet célpontja a Claude Code **saját konfigurációja** a `~/.claude/` alatt — a 2-es opció szövege ki is mondja: *„Yes, and allow Claude to edit its own settings for this session"*. Éles installon mérve: a `~/.claude/` alá írás megnyitja a dialógust, egy projekten kívüli, de közönséges útvonalra írás **nem** — vagyis nem a „projekten kívüliség" a kiváltó ok, hanem a Claude saját configja. A skillek is a `~/.claude/` alatt laknak, és ez a magyarázata annak, hogy az önfejlesztő írások rendre elhaltak, hibaüzenet nélkül.

A javítás ugyanazt a szabályt követi, mint a fölötte lévő, fel nem ismert trust-dialógus ága: **itt egyetlen billentyű sem semleges**, tehát a monitor nem nyom le semmit, hanem hangosan szól. A 45 másodperces megerősítési idő **változatlan**; eddig azt szabta meg, mikor nyomjon Escape-et, ezután csak azt, mikor **értesítsen** — nyomni nem nyom semmit az operátor helyett.

A `detectsPermissionDialog` **szándékosan tág**: vagy a lábléc-jelölő (`Tab to amend`), vagy a kérdés+`1. Yes` alakzat elég neki. Egy téves találat legrosszabb esetben annyit jelent, hogy egy valóban beragadt menüre riasztás megy Escape helyett — az operátor akkor is értesül róla. Egy kihagyott találat viszont némán NEM-et válaszol helyette.

**EN:** The tool-permission prompt renders `Esc to cancel` in its footer, so `detectsBlockingMenu` matches it and the menu-recovery branch sent Escape. On that dialog Escape is not a dismiss — it is **NO**. The watchdog was therefore silently denying the agent's own requests ~45s after they appeared, while the operator believed they had approved them.

The prompt appears **even under `--dangerously-skip-permissions`** when the target is Claude Code's own configuration under `~/.claude/` (option 2 says so literally). Measured on a live install: an edit under `~/.claude/` opens it, an edit to an ordinary path outside the project does not — so "outside the project" is not the trigger. Skills live under `~/.claude/`, which is why self-improvement writes in particular kept failing with no error anywhere.

Same rule as the unrecognised trust dialog above it: no keystroke is neutral, so the monitor sends none and alerts loudly instead. `MENU_RECOVER_CONFIRM_MS` (45s) is unchanged and now merely sets how soon the operator is told.

**Tesztek / Tests:** a fixture egy **élesben rögzített** pane (`tmux capture-pane -p`), nem kézzel újragépelt. Negatív kontrollok: valódi `/mcp` menü (annak továbbra is Escape jár), a modell-hozzájárulás dialógus, idle és busy pane, egy **már megválaszolt** kérdés a scrollbackben futó kör közben, és próza, ami csak *idézi* a dialógust egy élő prompt fölött.

## Kapcsolódó issue / Related issue

Closes #

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [ ] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).

## Titok-kapu / Secret gate

- [x] Nincs a valtoztatasban bizonyitek-/artefaktum-mappa, titok-alaku string vagy idezett csatorna-uzenet.
      / No evidence or artifact directory, secret-shaped string, or quoted channel message in this change.