### PR TITLE
chore(alerts): restore the missing Hungarian accents in operator-faci…

### DIFF
--- a/src/web/agent-worker.ts
+++ b/src/web/agent-worker.ts
@@ -597,7 +597,7 @@ function alertWorkerStuck(ctx: WorkerCtx, paneTail: string): void {
   if (Date.now() - ctx.lastStuckAlert < WORKER_STUCK_ALERT_COOLDOWN_MS) return
   ctx.lastStuckAlert = Date.now()
   void notifyChannel(
-    `⚠️ Marveen worker [${ctx.session}]: a hatter-worker session nem all keszen (beragadt dialogus vagy ismeretlen kepernyo). Onjavitas lefutott (Escape + restart), de a keszenlet nem allt helyre. Erintett: agens-generalas, capability-osszefoglalo, heartbeat, digest. Nezz ra: tmux attach -t ${ctx.session}`,
+    `⚠️ Marveen worker [${ctx.session}]: a háttér-worker session nem áll készen (beragadt dialógus vagy ismeretlen képernyő). Önjavítás lefutott (Escape + restart), de a készenlét nem állt helyre. Érintett: ágens-generálás, capability-összefoglaló, heartbeat, digest. Nézz rá: tmux attach -t ${ctx.session}`,
   ).catch(() => { /* notifyChannel logs internally */ })
 }
 

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -1736,7 +1736,7 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
       if (decision.alert) {
         const label = t.isMarveen ? BOT_NAME : (t.agentName ?? t.session)
         logger.error({ session: t.session, agent: label }, 'Agent wedged on thinking-block API error -- manual reset needed')
-        sendAlert(`🚨 A(z) ${label} agens elakadt egy thinking-block API hibaban (a session-history korrupt, minden uj prompt ugyanazt a 400-at adja). Kezi reset kell: allitsd le es inditsd ujra, friss session indul. Reszletek: tmux attach -t ${t.session}`)
+        sendAlert(`🚨 A(z) ${label} ágens elakadt egy thinking-block API hibában (a session-history korrupt, minden új prompt ugyanazt a 400-at adja). Kézi reset kell: állítsd le és indítsd újra, friss session indul. Részletek: tmux attach -t ${t.session}`)
       }
     }
 
@@ -1814,7 +1814,7 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
             } catch (err) {
               logger.warn({ err, session: t.session }, 'Menu-recovery Escape failed')
             }
-            sendAlert(`⌨️ A(z) ${label} session beragadt egy interaktiv menube (pl. /mcp) es nem dolgozott fel uzeneteket. Kikuldtem egy Escape-et, visszateritettem a prompthoz. Ha ismetlodik: tmux attach -t ${t.session}`)
+            sendAlert(`⌨️ A(z) ${label} session beragadt egy interaktív menübe (pl. /mcp) és nem dolgozott fel üzeneteket. Kiküldtem egy Escape-et, visszatérítettem a prompthoz. Ha ismétlődik: tmux attach -t ${t.session}`)
           }
         }
       }
@@ -1964,7 +1964,7 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
           // leave it deaf. Ask the operator once, then keep deferring.
           if (!agentBusyDeferAlerted.has(t.session)) {
             logger.error({ agent: t.agentName, provider: t.provider, msDown }, 'Agent channel plugin down past busy-defer cap -- agent still working, alerting operator instead of killing it')
-            sendAlert(`⚠️ A(z) ${t.agentName} agens ${t.provider} csatornaja ${Math.round(msDown / 60000)} perce halott, de az agens KOZBEN DOLGOZIK. Nem inditom ujra (a restart FRISS session -- elveszne a folyamatban levo munkaja). Dontsd el: varjuk meg amig vegez (akkor magatol ujraindul), vagy kezzel allitsd meg. Session: ${t.session}.`)
+            sendAlert(`⚠️ A(z) ${t.agentName} ágens ${t.provider} csatornája ${Math.round(msDown / 60000)} perce halott, de az ágens KÖZBEN DOLGOZIK. Nem indítom újra (a restart FRISS session -- elveszne a folyamatban lévő munkája). Döntsd el: várjuk meg amíg végez (akkor magától újraindul), vagy kézzel állítsd meg. Session: ${t.session}.`)
             agentBusyDeferAlerted.add(t.session)
           }
           continue
@@ -1986,8 +1986,8 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
           // alert for a future down-spell).
           logger.error({ agent: t.agentName, provider: t.provider, failures, absentConfirmed }, 'Agent channel plugin down after max restart attempts -- giving up, alerting operator')
           sendAlert(absentConfirmed
-            ? `⛔ A(z) ${t.agentName} agens ${t.provider} plugin-je BE SEM TOLTODOTT (absent a /mcp listabol), a fresh-restart ezt nem javitja -- tovabb nem probalom (minden restart elveszi a session kontextusat). Kezi TISZTA ujrainditas kell (uresen, mas agens indulasaval nem atlapolva): ${t.session}.`
-            : `⛔ A(z) ${t.agentName} agens ${t.provider} csatornaja ${AGENT_MAX_RESTART_ATTEMPTS} automatikus ujrainditas utan sem allt helyre. Tovabb nem indinitom ujra (minden restart elveszi a session kontextusat). Kezi beavatkozas kell: nezd meg a ${t.session} session-t es a ${SERVICE_ID} csatorna-plugint.`)
+            ? `⛔ A(z) ${t.agentName} ágens ${t.provider} plugin-je BE SEM TÖLTŐDÖTT (absent a /mcp listából), a fresh-restart ezt nem javítja -- tovább nem próbálom (minden restart elveszi a session kontextusát). Kézi TISZTA újraindítás kell (üresen, más ágens indulásával nem átlapolva): ${t.session}.`
+            : `⛔ A(z) ${t.agentName} ágens ${t.provider} csatornája ${AGENT_MAX_RESTART_ATTEMPTS} automatikus újraindítás után sem állt helyre. Tovább nem indítom újra (minden restart elveszi a session kontextusát). Kézi beavatkozás kell: nézd meg a ${t.session} session-t és a ${SERVICE_ID} csatorna-plugint.`)
           agentRestartFailures.set(t.agentName!, failures + 1)
           savePersistedAgentFailures(t.agentName!, failures + 1)
           agentDownSince.delete(t.session)

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -1770,7 +1770,7 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
       if (authUrl) {
         json(res, { ok: true, authUrl })
       } else {
-        json(res, { ok: false, error: 'Auth URL nem jelent meg 12 masodpercen belul. Probald ujra, vagy nezd a tmux session-t.' })
+        json(res, { ok: false, error: 'Auth URL nem jelent meg 12 másodpercen belül. Próbáld újra, vagy nézd a tmux session-t.' })
       }
     } catch (err) {
       logger.error({ err, name }, 'Auth init failed')

--- a/src/web/routes/onboarding.ts
+++ b/src/web/routes/onboarding.ts
@@ -408,7 +408,7 @@ export async function tryHandleOnboarding(ctx: RouteContext): Promise<boolean> {
     const probe = await liveProbeAuth(token ? { CLAUDE_CODE_OAUTH_TOKEN: token } : { ANTHROPIC_API_KEY: apiKey })
     if (probe === 'auth-rejected') {
       logger.warn({ mode: token ? 'oauth' : 'apikey' }, 'onboarding: Claude auth REJECTED by live probe; nothing persisted')
-      json(res, { error: 'A megadott token/kulcs nem ervenyes (a proba-hivast a szerver elutasitotta). Ellenorizd, hogy a teljes setup-tokent illesztetted-e be.', reason: 'verify-failed', verified: false }, 400)
+      json(res, { error: 'A megadott token/kulcs nem érvényes (a próba-hívást a szerver elutasította). Ellenőrizd, hogy a teljes setup-tokent illesztetted-e be.', reason: 'verify-failed', verified: false }, 400)
       return true
     }
     const verified = probe === 'ok'


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

**HU:** Nyolc olyan szöveg, amit **ember olvas**, ékezetek nélkül volt megírva — öt `channel-monitor.ts` riasztás, a worker készenléti riasztása, és két API-hibaüzenet —, miközben ugyanezekben a fájlokban a többi üzenet hónapok óta ékezetes.

A `channel-monitor.ts`-ben a megoszlás nem esetleges, hanem **időrendi**. A fájl 17 riasztásából 8 ékezetes, 9 nem, ami elsőre következetlenségnek látszik; dátum szerint viszont tiszta a kép:

| Időszak | Ékezet |
|---|---|
| 2026-05-18 … 07-15 | nincs (7 sor, 1 kivétellel) |
| 2026-07-22 … 09-01 | van (6 sor, 1 kivétellel) |

Mindkét szeptember 1-jei sor ékezetes. A projekt tehát már átállt — ezeket a régi sorokat egyszerűen nem írta át senki azóta.

**A hatókör szándékosan szűk: csak az, amit EMBER olvas.** Az ügynököknek injektált promptok és rendszer-direktívák (`heartbeat.ts`, `system-directive.ts`, `context-guard-runner.ts`, `context-restart-gate-runner.ts`, `agent-taskstate.ts`, `agent-scaffold.ts`, `agent-message-wrap.ts`) **érintetlenek maradtak**, pedig ott is van 13 ékezet nélküli szöveg. Azok átírása megváltoztatná, hogy a modell mit kap bemenetként — az viselkedést érintő módosítás, aminek nincs helye egy tipográfiai commitban.

**A szóhasználathoz sem nyúltam.** Az ékezetes riasztások az `agent` szót használják, az ékezet nélküliek az `agens`-t; ennek egységesítése külön döntés. Az `agens` tehát csak ékezetet kapott: `ágens`.

**Ellenőrzés:** a nyolc sorból **hét kizárólag ékezetben tér el** az eredetitől — ezt úgy igazoltam, hogy az új szövegekről leszedtem a diakritikákat, és karakterre összevetettem a régiekkel. A nyolcadik egy **elgépelést is javít**, ami az eredetiben volt: `indinitom` → `indítom`.

Viselkedésváltozás nincs, és **egyik sztringre sem illeszkedik semmilyen kód vagy teszt** (ellenőrizve az egész repóban). Teljes suite: **4602 zöld**, 1 kihagyott. Két teszt bukik, de **mindkettő a változtatás nélkül is bukik** ebben a checkoutban: a `vault-ssh-keys-import` (nincs `ssh-keygen` a konténeremben) és a `configurable-brand` (a saját HOME-om neve véletlenül `marveen`, ezért a márkanév-szivárgás-ellenőrzés téves riasztást ad).

**EN:** Eight strings a human reads — five `channel-monitor.ts` alerts, the worker readiness alert, and two API error messages — were written without Hungarian accents, while the rest of the same files have carried them for months. In `channel-monitor.ts` the split is purely chronological: every alert written between 2026-05-18 and 07-15 is unaccented, every one from 07-22 onward is accented (both September strings included). The project already switched; these lines were never revisited.

Scope is deliberately limited to text a **person** reads. Prompts and system directives injected into the agents are left untouched — editing those changes what the model receives, which is a behavioural change and does not belong in a typography commit. Vocabulary is left alone as well (`agens` only gained its accent).

Seven of the eight lines differ from their originals by accents alone, verified by stripping diacritics from the new text and comparing byte for byte. The eighth also fixes a pre-existing typo: `indinitom` → `indítom`. Nothing matches on these strings; no behaviour change.

## Kapcsolódó issue / Related issue

Closes #

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [ ] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).

## Titok-kapu / Secret gate

- [x] Nincs a valtoztatasban bizonyitek-/artefaktum-mappa, titok-alaku string vagy idezett csatorna-uzenet.
      / No evidence or artifact directory, secret-shaped string, or quoted channel message in this change.