### PR TITLE
fix(channels): singleton lock so two supervisors starting channels.sh at once cannot kill each other's session

### DIFF
--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -60,6 +60,34 @@ fi
 CHANNEL_PROVIDER="${CHANNEL_PROVIDER:-telegram}"
 SESSION="${MAIN_AGENT_ID:-marveen}-channels"
 
+# hu: Szingleton-zar a SESSION nevere. Ket fuggetlen felugyelo -- launchd
+# com.marveen.channels (KeepAlive=true) es a dashboard channel-monitor.ts
+# createMainChannelsSession() -- egyszerre is elindithatja ezt a scriptet
+# ugyanarra a SESSION-re; a lenti "Regi session takaritas" feltetel nelkul
+# kill-session-el, tehat a kesobb indulo megolne a korabban indult, mar elo
+# sessiont (mert teny). A zar a teljes script elettartamara szol (trap EXIT),
+# igy csak EGY channels.sh peldany kezelheti
+# ugyanazt a SESSION-t egyszerre; a masodik azonnal, a kill-session ELOTT
+# kilep, a session-t erintetlenul hagyja.
+# en: Singleton lock on SESSION. Two independent supervisors -- launchd
+# com.marveen.channels (KeepAlive=true) and the dashboard's
+# channel-monitor.ts createMainChannelsSession() -- can both start this
+# script for the same SESSION at the same time; the "old session cleanup"
+# below kill-sessions unconditionally, so the later starter would kill the
+# already-live session the earlier one just created (measured fact). The
+# lock is held for the script's whole lifetime (trap EXIT), so only ONE
+# channels.sh instance may manage a given SESSION
+# at a time; the second exits immediately, BEFORE the kill-session, leaving
+# the live session untouched.
+mkdir -p "$INSTALL_DIR/store" 2>/dev/null || true
+. "$INSTALL_DIR/scripts/lib/singleton-lock.sh"
+CHANNELS_LOCK_DIR="$INSTALL_DIR/store/.channels-lock-$SESSION"
+if ! acquire_singleton_lock "$CHANNELS_LOCK_DIR"; then
+  echo "$(date '+%Y-%m-%d %H:%M:%S') channels.sh: singleton lock for session $SESSION held by a live process -- another supervisor is already starting/running it, exiting without touching the session" >> "$INSTALL_DIR/store/channels-failures.log"
+  exit 0
+fi
+trap 'release_singleton_lock "$CHANNELS_LOCK_DIR"' EXIT
+
 # Resolve plugin ID from provider.
 #
 # PLUGIN_ID is the marketplace-qualified id the `--channels` flag takes.

--- a/scripts/lib/singleton-lock.sh
+++ b/scripts/lib/singleton-lock.sh
@@ -1,0 +1,109 @@
+# hu: Session-nevenkénti szingleton-zár, mkdir-alapú -- a `flock(1)` parancs
+# nem minden telepítési célplatformon elérhető (pl. macOS-en nincs a
+# rendszerben), a `mkdir` viszont igen és POSIX-on atomi (két párhuzamos
+# `mkdir` közül garantáltan csak az egyik sikerül).
+# en: Per-session-name singleton lock, mkdir-based -- the `flock(1)` command
+# is not available on every install target (macOS does not ship it), while
+# `mkdir` is, and is atomic on POSIX (of two concurrent `mkdir` calls on the
+# same path, exactly one succeeds).
+#
+# Forrásold ezt a fájlt (`. singleton-lock.sh`), majd hívd:
+#   acquire_singleton_lock <lock_dir>   # 0 = megszerezve, 1 = elo peldany tartja
+#   release_singleton_lock <lock_dir>   # csak a sajat zarat engedi el
+# Source this file (`. singleton-lock.sh`), then call:
+#   acquire_singleton_lock <lock_dir>   # 0 = acquired, 1 = held by a live process
+#   release_singleton_lock <lock_dir>   # only releases a lock this process owns
+#
+# hu: A PR #1163 (scripts/start.sh, Szotasz/marveen) egy MASIK, rokon
+# versenyhelyzetet flock-kal zart, es szandekosan NEM az mkdir-konyvtar
+# idiomat valasztotta, mert az egy `kill -9`-et (vagy aramszunetet) TULELO
+# tulajdonos eseten arva zarat hagy hatra -- a flockot viszont a kernel oldja
+# fel a tulajdonos halalakor, barmilyen okbol. Ez a lelet valos, es itt is
+# fennall: a lenti `acquire_singleton_lock` `trap ... EXIT`-tel szabadit fel,
+# ami `kill -9`-en NEM fut le. A kulonbseg, amiert itt megis az mkdir-mintat
+# valasztottuk: (1) EZ a zar NEM blokkolo -- a masodik felugyelo azonnal,
+# varakozas nelkul visszalep, mihelyt a zar FOGLALTNAK latszik, szemben a
+# start.sh `flock -w 120`-javal, ami egy hatarolt varakozast akar, nem
+# vegleges lemondast; egy `kill -9`-utani arva zar tehat legfeljebb a
+# KOVETKEZO inditasi kiserletig all fenn, nem 120 masodpercig blokkol. (2) a
+# tulajdonos-PID elettartam-ellenorzese (`kill -0`) MINDEN kovetkezo
+# `acquire_singleton_lock` hivasnal ujra lefut, tehat egy arva zar
+# onmagatol, a legkozelebbi inditasi kiserletkor felszabadul -- nem marad
+# tartosan blokkolva. (3) a `flock(1)` parancs ezen a (macOS) celplatformon,
+# ahol a tenyleges hiba jelentkezett, NINCS jelen (merve 2026-09-05, `command
+# -v flock` -> nincs talalat) -- a start.sh sajat
+# fallback-aga ("flock not found... starting WITHOUT the start lock") is ezt
+# az esetet kezeli, es pontosan az itteni pid-ellenorzo mintara tamaszkodik.
+# en: PR #1163 (scripts/start.sh, Szotasz/marveen) closed a RELATED but
+# distinct race with flock, and deliberately avoided the mkdir-directory
+# idiom because it leaves an orphaned lock behind when the owner is killed
+# with `kill -9` (or power loss) -- the kernel releases a flock on owner
+# death for any reason, an mkdir lock does not. That critique is real and
+# applies here too: `acquire_singleton_lock` below releases via `trap ...
+# EXIT`, which does not run on `kill -9`. The reasons the mkdir pattern is
+# still the right choice here: (1) this lock is NON-BLOCKING -- the second
+# supervisor backs off immediately the moment the lock looks held, unlike
+# start.sh's `flock -w 120`, which wants a bounded wait, not a final
+# give-up; an orphaned lock after `kill -9` therefore only lives until the
+# NEXT start attempt, not for a 120s block. (2) the owner-pid liveness check
+# (`kill -0`) re-runs on every subsequent `acquire_singleton_lock` call, so
+# an orphaned lock self-heals at the very next start attempt instead of
+# staying stuck. (3) `flock(1)` is simply ABSENT on this (macOS) target
+# platform, where the actual bug was measured (measured 2026-09-05: `command
+# -v flock` finds nothing) -- start.sh's own fallback
+# branch ("flock not found... starting WITHOUT the start lock") handles that
+# exact case by relying on the same kind of pid-liveness check used here.
+
+# hu: A zar egy konyvtar (mkdir letrehozasa atomi); a konyvtarban egy 'pid'
+# fajl tartja a tulajdonos process-azonositojat, hogy egy megszakadt
+# (crash-elt) tulajdonos zarja felismerheto es visszaveheto legyen.
+# en: The lock is a directory (mkdir creation is atomic); a 'pid' file inside
+# it holds the owner's process id, so a crashed owner's stale lock can be
+# detected and reclaimed.
+acquire_singleton_lock() {
+  local lock_dir="$1"
+  if mkdir "$lock_dir" 2>/dev/null; then
+    echo "$$" > "$lock_dir/pid"
+    return 0
+  fi
+
+  local owner_pid
+  owner_pid="$(cat "$lock_dir/pid" 2>/dev/null || true)"
+  # hu: ha a pid ures (a tulajdonos meg a mkdir es a pid-iras kozott tart) VAGY
+  # elo -- a zarat elonek tekintjuk, es NEM nyulunk hozza. Csak akkor bontjuk
+  # el mint elavultat, ha POZITIVAN igazolhato, hogy a tulajdonos halott (van
+  # pid, de a kill -0 sikertelen) -- a ketertelmuseget mindig a "tartva van"
+  # fele dontjuk, hogy egy friss zarat sose torolhessunk le tevesen.
+  # en: if the pid is empty (the owner is still between mkdir and writing its
+  # pid) OR alive -- treat the lock as held, and do NOT touch it. We only
+  # reclaim it as stale when we can POSITIVELY confirm the owner is dead (a
+  # pid is present but `kill -0` fails) -- ambiguity always resolves to
+  # "held", so a fresh lock can never be mistakenly torn down.
+  if [ -z "$owner_pid" ] || kill -0 "$owner_pid" 2>/dev/null; then
+    return 1
+  fi
+
+  # hu: elavult zar (a tulajdonos process mar nem el) -- visszavesszuk.
+  # en: stale lock (the owner process is no longer alive) -- reclaim it.
+  rm -rf "$lock_dir" 2>/dev/null
+  if mkdir "$lock_dir" 2>/dev/null; then
+    echo "$$" > "$lock_dir/pid"
+    return 0
+  fi
+  # hu: elvesztettuk a visszavetel versenyet egy masik peldannyal szemben.
+  # en: lost the reclaim race against another instance.
+  return 1
+}
+
+release_singleton_lock() {
+  local lock_dir="$1"
+  local owner_pid
+  owner_pid="$(cat "$lock_dir/pid" 2>/dev/null || true)"
+  # hu: csak akkor toroljuk, ha a pid fajl a MIENK -- idegen (masik peldany
+  # altal kozben megszerzett) zarat soha ne torolj.
+  # en: only remove it if the pid file is OURS -- never remove a lock another
+  # instance has since (re)acquired.
+  if [ "$owner_pid" = "$$" ]; then
+    rm -rf "$lock_dir" 2>/dev/null
+  fi
+}

--- a/src/__tests__/channels-singleton-lock.test.ts
+++ b/src/__tests__/channels-singleton-lock.test.ts
@@ -1,0 +1,146 @@
+// Regression tests: two independent supervisors -- launchd
+// com.marveen.channels (KeepAlive=true) and the dashboard's
+// channel-monitor.ts createMainChannelsSession() -- can both start
+// scripts/channels.sh for the same SESSION at the same time. channels.sh
+// unconditionally `tmux kill-session`s any pre-existing session before
+// creating a fresh one, so the later starter kills the session the earlier
+// starter just created and is now supervising -> rapid-exit.
+//
+// scripts/lib/singleton-lock.sh adds a per-SESSION mkdir-based singleton
+// lock (not flock(1) -- measured 2026-09-05: this macOS install has no
+// flock binary on PATH; mkdir is POSIX-atomic and needs no external
+// binary). Only one channels.sh instance may hold the lock for a given
+// SESSION; a second starter backs off before touching the session at all.
+//
+// The first describe block drives the real library with real concurrent
+// bash processes -- an actual mkdir race, not a mock. The second reads
+// scripts/channels.sh and locks in that it is actually wired to the lock
+// (source, call order relative to kill-session, EXIT-trapped release) --
+// we cannot drive a real tmux + claude session from a unit test (same
+// constraint as the sibling channel-monitor structural tests), so this half
+// verifies wiring the way the rest of this suite already does for
+// tmux-touching code.
+
+import { describe, it, expect } from "vitest"
+import { readFileSync, mkdtempSync, rmSync } from "node:fs"
+import { execFileSync } from "node:child_process"
+import { tmpdir } from "node:os"
+import { join, dirname } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = join(__dirname, "..", "..")
+const LIB_PATH = join(REPO_ROOT, "scripts", "lib", "singleton-lock.sh")
+const CHANNELS_SH_PATH = join(REPO_ROOT, "scripts", "channels.sh")
+
+describe("scripts/lib/singleton-lock.sh (real concurrent bash processes)", () => {
+  it("lets exactly one of two starters racing for the same session proceed; the other backs off untouched", () => {
+    const dir = mkdtempSync(join(tmpdir(), "channels-lock-test-"))
+    const lockDir = join(dir, "session-lock")
+    const events = join(dir, "events.log")
+    try {
+      const script = `
+set -u
+. "${LIB_PATH}"
+LOCK_DIR="${lockDir}"
+EVENTS="${events}"
+run_starter() {
+  local id="$1"
+  if acquire_singleton_lock "$LOCK_DIR"; then
+    echo "acquired $id $$" >> "$EVENTS"
+    sleep 0.3
+    release_singleton_lock "$LOCK_DIR"
+    echo "released $id $$" >> "$EVENTS"
+  else
+    echo "skipped $id $$" >> "$EVENTS"
+  fi
+}
+run_starter A &
+run_starter B &
+wait
+`
+      execFileSync("/bin/bash", ["-c", script], { timeout: 10_000 })
+      const lines = readFileSync(events, "utf-8").trim().split("\n").filter(Boolean)
+      const acquired = lines.filter((l) => l.startsWith("acquired "))
+      const skipped = lines.filter((l) => l.startsWith("skipped "))
+      const released = lines.filter((l) => l.startsWith("released "))
+
+      expect(acquired, lines.join("\n")).toHaveLength(1)
+      expect(skipped, lines.join("\n")).toHaveLength(1)
+      expect(released, lines.join("\n")).toHaveLength(1)
+      // the same instance that acquired the lock is the one that released it
+      expect(released[0]?.split(" ")[2]).toBe(acquired[0]?.split(" ")[2])
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it("reclaims a lock left behind by a dead process, but never touches one whose owner is alive", () => {
+    const dir = mkdtempSync(join(tmpdir(), "channels-lock-test-"))
+    const lockDir = join(dir, "session-lock")
+    try {
+      // Simulate a crashed prior owner: the lock dir exists, its pid file
+      // names a pid that is guaranteed not to be running.
+      const staleScript = `
+set -u
+. "${LIB_PATH}"
+mkdir "${lockDir}"
+echo 999999 > "${lockDir}/pid"
+if acquire_singleton_lock "${lockDir}"; then echo reclaimed; else echo held; fi
+`
+      const staleOut = execFileSync("/bin/bash", ["-c", staleScript], { timeout: 5000 }).toString().trim()
+      expect(staleOut).toBe("reclaimed")
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+
+    const dir2 = mkdtempSync(join(tmpdir(), "channels-lock-test-"))
+    const lockDir2 = join(dir2, "session-lock")
+    try {
+      // A lock genuinely held by this same live test process must never be
+      // reclaimed as "stale" just because the pid check races on write order.
+      const liveScript = `
+set -u
+. "${LIB_PATH}"
+mkdir "${lockDir2}"
+echo $$ > "${lockDir2}/pid"
+if acquire_singleton_lock "${lockDir2}"; then echo reclaimed; else echo held; fi
+`
+      const liveOut = execFileSync("/bin/bash", ["-c", liveScript], { timeout: 5000 }).toString().trim()
+      expect(liveOut).toBe("held")
+    } finally {
+      rmSync(dir2, { recursive: true, force: true })
+    }
+  })
+})
+
+describe("scripts/channels.sh is wired to the singleton lock", () => {
+  const src = readFileSync(CHANNELS_SH_PATH, "utf-8")
+
+  it("sources scripts/lib/singleton-lock.sh", () => {
+    expect(src).toContain('"$INSTALL_DIR/scripts/lib/singleton-lock.sh"')
+  })
+
+  it("acquires the lock, keyed on $SESSION, before the unconditional old-session kill-session", () => {
+    const acquireIdx = src.indexOf("acquire_singleton_lock ")
+    expect(acquireIdx, "acquire_singleton_lock call not found").toBeGreaterThan(0)
+    const killIdx = src.indexOf('kill-session -t "$SESSION"')
+    expect(killIdx, "kill-session call not found").toBeGreaterThan(0)
+    expect(acquireIdx).toBeLessThan(killIdx)
+
+    const block = src.slice(Math.max(0, acquireIdx - 400), acquireIdx + 50)
+    expect(block).toContain("$SESSION")
+  })
+
+  it("exits before reaching kill-session when the lock is already held by a live instance", () => {
+    const acquireIdx = src.indexOf("acquire_singleton_lock ")
+    const killIdx = src.indexOf('kill-session -t "$SESSION"')
+    const block = src.slice(acquireIdx, killIdx)
+    expect(block).toContain("exit 0")
+  })
+
+  it("releases the lock via an EXIT trap so a future legitimate restart is never permanently blocked", () => {
+    expect(src).toContain("trap 'release_singleton_lock")
+    expect(src).toMatch(/trap[^\n]*\bEXIT\b/)
+  })
+})


### PR DESCRIPTION
launchd's com.marveen.channels (KeepAlive=true) and the dashboard's channel-monitor.ts createMainChannelsSession() can both start scripts/channels.sh for the same SESSION at the same time. channels.sh unconditionally `tmux kill-session`s any pre-existing session before creating a fresh one, so the later starter kills the session the earlier starter just created and is now supervising -- rapid-exit, which the script's own ELAPSED<30s check already logs but does not prevent.

Adds scripts/lib/singleton-lock.sh: a per-SESSION mkdir-based lock (mkdir is POSIX-atomic; flock(1) is not available on every install target). A 'pid' file inside the lock directory names the owner, so a lock left behind by a dead process (a crash, kill -9, power loss) is detected via `kill -0` and reclaimed by the next starter; ambiguity (pid file not yet written) always resolves to "held", never to "stale", so a fresh lock can never be torn down.

channels.sh acquires the lock right after SESSION is computed, before any session-touching code, and exits before reaching kill-session when another live instance already holds it. The lock is released via an EXIT trap, covering the script's whole supervisory lifetime, not just the startup section.

This is deliberately non-blocking (the second starter backs off at once) rather than flock-with-timeout the way #1163 closed a related race in start.sh: that lock guards a short boot-time critical section with a bounded wait, while this one guards a long-lived supervisor, where a losing starter should give up immediately, not block.

New test (src/__tests__/channels-singleton-lock.test.ts): real concurrent bash processes racing on the same lock (not mocked) prove mutual exclusion and the dead-owner reclaim; source-text checks confirm channels.sh is actually wired to the library, in the right order, with the EXIT-trapped release, the same way the rest of this suite verifies tmux-touching code it cannot drive live.