### PR TITLE
fix(notify): reject the ALLOWED_CHAT_ID=0 placeholder everywhere (CHA…

### DIFF
--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -21,7 +21,10 @@ if [ -z "$TOKEN" ]; then
   exit 1
 fi
 
-if [ -z "$CHAT_ID" ]; then
+# CHATID0: "0" is the installer placeholder, not a chat. Without this the
+# FALLBACK channel fails exactly where it is needed most -- it fires when the
+# plugin is down, and on a placeholder install it would post to chat_id=0.
+if [ -z "$CHAT_ID" ] || [ "$CHAT_ID" = "0" ]; then
   echo "Hiba: ALLOWED_CHAT_ID nincs beallitva"
   exit 1
 fi

--- a/src/__tests__/notify-chat-id-placeholder.test.ts
+++ b/src/__tests__/notify-chat-id-placeholder.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// CHATID0. The installer writes ALLOWED_CHAT_ID=0 when the operator has not
+// bound a chat yet. Every guard on this path tested truthiness, and "0" is
+// neither empty nor falsy, so the guard passed and the send went out with
+// chat_id=0 -- a guaranteed Bot API 400, discarded by notifyChannel's two
+// nested catches. Measured on a live install (2026-09-05): the fleet's alerts
+// had been dropping for weeks with ZERO "kihagyva" lines in dashboard.log,
+// because the branch that prints that line was never reached. These tests pin
+// the placeholder as "not configured" so the operator gets the warning instead
+// of silence.
+const { cfg, mockSend } = vi.hoisted(() => ({
+  cfg: { provider: 'telegram', token: 'bot-token', chatId: '0' },
+  mockSend: vi.fn(async () => {}),
+}))
+
+vi.mock('../config.js', () => ({
+  get CHANNEL_PROVIDER() { return cfg.provider },
+  get CHANNEL_TOKEN() { return cfg.token },
+  get CHANNEL_CHAT_ID() { return cfg.chatId },
+  get ALLOWED_CHAT_ID() { return cfg.chatId },
+  MAIN_AGENT_ID: 'marveen',
+  PROJECT_ROOT: '/tmp/notify-placeholder-test',
+}))
+
+vi.mock('../channel-provider.js', () => ({
+  getProvider: () => ({
+    formatMessage: (t: string) => t,
+    splitMessage: (t: string) => [t],
+    sendMessage: mockSend,
+  }),
+  channelStateDir: () => '/tmp/notify-placeholder-test',
+}))
+
+const { mockWarn } = vi.hoisted(() => ({ mockWarn: vi.fn() }))
+vi.mock('../logger.js', () => ({
+  logger: { info: vi.fn(), warn: mockWarn, debug: vi.fn(), error: vi.fn() },
+}))
+
+vi.mock('../test-run-marker.js', () => ({ markIfTestRun: (t: string) => t }))
+
+import { notifyChannel, notifySecurityEvent } from '../notify.js'
+
+beforeEach(() => {
+  mockSend.mockClear()
+  mockWarn.mockClear()
+  cfg.provider = 'telegram'
+  cfg.token = 'bot-token'
+})
+
+describe('notifyChannel: the ALLOWED_CHAT_ID=0 placeholder', () => {
+  it('does NOT send when the chat id is the "0" placeholder', async () => {
+    cfg.chatId = '0'
+    await notifyChannel('alert')
+    expect(mockSend).not.toHaveBeenCalled()
+  })
+
+  // The whole point: an install in this state must SAY so. Before the fix the
+  // guard was skipped, so this line never appeared and the failure was mute.
+  it('logs the "kihagyva" warning for the placeholder', async () => {
+    cfg.chatId = '0'
+    await notifyChannel('alert')
+    expect(mockWarn).toHaveBeenCalledWith(expect.stringContaining('Channel ertesites kihagyva'))
+  })
+
+  it('treats a padded placeholder the same way', async () => {
+    cfg.chatId = '  0  '
+    await notifyChannel('alert')
+    expect(mockSend).not.toHaveBeenCalled()
+  })
+
+  it('still skips an empty chat id (unchanged behaviour)', async () => {
+    cfg.chatId = ''
+    await notifyChannel('alert')
+    expect(mockSend).not.toHaveBeenCalled()
+    expect(mockWarn).toHaveBeenCalled()
+  })
+
+  it('still skips when the token is missing', async () => {
+    cfg.chatId = '5040302010'
+    cfg.token = ''
+    await notifyChannel('alert')
+    expect(mockSend).not.toHaveBeenCalled()
+  })
+
+  // A real id must be unaffected -- and must arrive at the provider verbatim,
+  // not via the module-level constant the guard no longer trusts.
+  it('sends with a real chat id, passing it through unchanged', async () => {
+    cfg.chatId = '5040302010'
+    await notifyChannel('alert')
+    expect(mockSend).toHaveBeenCalledTimes(1)
+    expect(mockSend).toHaveBeenCalledWith('bot-token', '5040302010', 'alert', 'HTML')
+  })
+
+  // "0" is a valid-looking id only for Telegram's numeric space; a Slack
+  // channel id is a string. The helper is provider-agnostic on purpose.
+  it('does not treat a legitimate non-numeric id as a placeholder', async () => {
+    cfg.provider = 'slack'
+    cfg.chatId = 'C01ABCDEF'
+    await notifyChannel('alert')
+    expect(mockSend).toHaveBeenCalledWith('bot-token', 'C01ABCDEF', 'alert', undefined)
+  })
+})
+
+describe('notifySecurityEvent: same placeholder rule', () => {
+  // This path is deliberately silent about missing config (a channel-less
+  // install is expected here), so the assertion is only that nothing is sent.
+  it('does not send to the "0" placeholder', async () => {
+    cfg.chatId = '0'
+    await notifySecurityEvent('security event')
+    expect(mockSend).not.toHaveBeenCalled()
+  })
+
+  it('sends with a real chat id', async () => {
+    cfg.chatId = '5040302010'
+    await notifySecurityEvent('security event')
+    expect(mockSend).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/__tests__/notify-delivery-honesty.test.ts
+++ b/src/__tests__/notify-delivery-honesty.test.ts
@@ -19,14 +19,14 @@ let stage: string
 
 // The script resolves .env relative to its own location, so stage a full copy
 // of the script one level below a temp root that carries the fake .env.
-function stageScript(): { scriptCopy: string } {
+function stageScript(chatId = '42'): { scriptCopy: string } {
   const scriptsDir = join(stage, 'scripts')
   mkdirSync(join(scriptsDir, 'lib'), { recursive: true })
   const scriptCopy = join(scriptsDir, 'notify.sh')
   execFileSync('/bin/cp', [SCRIPT, scriptCopy])
   // notify.sh sources the shared send contract from its own lib/ sibling.
   execFileSync('/bin/cp', [join(ROOT, 'scripts', 'lib', 'send-telegram.sh'), join(scriptsDir, 'lib', 'send-telegram.sh')])
-  writeFileSync(join(stage, '.env'), `TELEGRAM_BOT_TOKEN=${FAKE_TOKEN}\nALLOWED_CHAT_ID=42\nMAIN_AGENT_ID=mainbot\n`)
+  writeFileSync(join(stage, '.env'), `TELEGRAM_BOT_TOKEN=${FAKE_TOKEN}\nALLOWED_CHAT_ID=${chatId}\nMAIN_AGENT_ID=mainbot\n`)
   return { scriptCopy }
 }
 
@@ -39,8 +39,8 @@ function writeCurlStub(dir: string): void {
   chmodSync(stub, 0o755)
 }
 
-function runNotify(env: Record<string, string>): { status: number | null; stdout: string; stderr: string } {
-  const { scriptCopy } = stageScript()
+function runNotify(env: Record<string, string>, chatId = '42'): { status: number | null; stdout: string; stderr: string } {
+  const { scriptCopy } = stageScript(chatId)
   const binDir = join(stage, 'bin')
   mkdirSync(binDir, { recursive: true })
   writeCurlStub(binDir)
@@ -90,5 +90,47 @@ describe('notify.sh delivery honesty (NOTIFYVAK826)', () => {
     const r = runNotify({ CURL_STUB_EXIT: '6' })
     expect(r.stderr).not.toContain(FAKE_TOKEN)
     expect(r.stderr).toContain('<token>')
+  })
+})
+
+// CHATID0. notify.sh is the FALLBACK channel: it fires precisely when the
+// Telegram plugin is down. Its guard was `[ -z "$CHAT_ID" ]`, and the
+// installer's ALLOWED_CHAT_ID=0 placeholder is not empty -- so on an install
+// with no chat bound, the primary path AND the fallback both posted to
+// chat_id=0. Each case below hands the script a curl stub that would report
+// SUCCESS if it were reached, so a passing test proves the send was prevented
+// rather than merely failing downstream.
+describe('notify.sh rejects the ALLOWED_CHAT_ID placeholder (CHATID0)', () => {
+  const WOULD_SUCCEED = { CURL_STUB_BODY: '{"ok":true,"result":{"message_id":7}}' }
+
+  it('refuses to send when the chat id is "0"', () => {
+    const r = runNotify(WOULD_SUCCEED, '0')
+    expect(r.status).toBe(1)
+    expect(r.stdout).not.toContain('Ertesites elkuldve.')
+  })
+
+  it('names ALLOWED_CHAT_ID so the operator knows what to set', () => {
+    const r = runNotify(WOULD_SUCCEED, '0')
+    expect(r.stdout + r.stderr).toContain('ALLOWED_CHAT_ID')
+  })
+
+  it('still refuses an empty chat id (unchanged behaviour)', () => {
+    const r = runNotify(WOULD_SUCCEED, '')
+    expect(r.status).toBe(1)
+    expect(r.stdout).not.toContain('Ertesites elkuldve.')
+  })
+
+  // Guard against over-matching: only the bare placeholder is rejected, not
+  // any id that merely contains a zero or starts with one.
+  it('does NOT reject a real id that contains zeros', () => {
+    const r = runNotify(WOULD_SUCCEED, '5040302010')
+    expect(r.status).toBe(0)
+    expect(r.stdout).toContain('Ertesites elkuldve.')
+  })
+
+  it('does NOT reject an id that merely begins with a zero', () => {
+    const r = runNotify(WOULD_SUCCEED, '0123456789')
+    expect(r.status).toBe(0)
+    expect(r.stdout).toContain('Ertesites elkuldve.')
   })
 })

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -1,10 +1,20 @@
 import { CHANNEL_PROVIDER, CHANNEL_TOKEN, CHANNEL_CHAT_ID } from './config.js'
+import { normalizeChatId } from './owner-chat.js'
 import { getProvider } from './channel-provider.js'
 import { logger } from './logger.js'
 import { markIfTestRun } from './test-run-marker.js'
 
 export async function notifyChannel(text: string): Promise<void> {
-  if (!CHANNEL_TOKEN || !CHANNEL_CHAT_ID) {
+  // CHATID0 -- normalizeChatId, not a truthiness test. The installer writes
+  // ALLOWED_CHAT_ID=0 as its placeholder, and "0" is neither empty nor falsy,
+  // so this guard used to PASS on exactly the installs that had no owner chat:
+  // the send went out with chat_id=0, the Bot API answered 400, and the two
+  // nested catches below discarded it. Result on such an install: every alert
+  // in the fleet is silently dropped, and the "kihagyva" warning that exists to
+  // say so never fires. owner-chat.ts already owns this decision -- its comment
+  // asks every consumer to reuse it rather than reinvent the hole.
+  const chatId = normalizeChatId(CHANNEL_CHAT_ID)
+  if (!CHANNEL_TOKEN || !chatId) {
     logger.warn('Channel ertesites kihagyva: token vagy chat ID hianyzik')
     return
   }
@@ -19,10 +29,10 @@ export async function notifyChannel(text: string): Promise<void> {
   for (const chunk of chunks) {
     try {
       const parseMode = CHANNEL_PROVIDER === 'telegram' ? 'HTML' : undefined
-      await provider.sendMessage(CHANNEL_TOKEN, CHANNEL_CHAT_ID, chunk, parseMode)
+      await provider.sendMessage(CHANNEL_TOKEN, chatId, chunk, parseMode)
     } catch {
       try {
-        await provider.sendMessage(CHANNEL_TOKEN, CHANNEL_CHAT_ID, outbound.slice(0, 4096))
+        await provider.sendMessage(CHANNEL_TOKEN, chatId, outbound.slice(0, 4096))
       } catch { /* last resort, give up */ }
     }
   }
@@ -36,7 +46,7 @@ export const notifyTelegram = notifyChannel
 // (fresh installs, channel-less deployments), so it stays fully silent -- the
 // recovery path must never depend on, or be noisy about, Telegram being wired.
 export async function notifySecurityEvent(text: string): Promise<void> {
-  if (!CHANNEL_TOKEN || !CHANNEL_CHAT_ID) return
+  if (!CHANNEL_TOKEN || !normalizeChatId(CHANNEL_CHAT_ID)) return
   try {
     await notifyChannel(text)
   } catch {

--- a/src/web/discord-group-bootstrap.ts
+++ b/src/web/discord-group-bootstrap.ts
@@ -24,6 +24,7 @@ import { CHANNEL_PROVIDER, CHANNEL_CHAT_ID } from '../config.js'
 import { channelStateDir } from '../channel-provider.js'
 import { atomicWriteFileSync } from './atomic-write.js'
 import { logger } from '../logger.js'
+import { normalizeChatId } from '../owner-chat.js'
 
 interface AccessFile {
   dmPolicy?: 'pairing' | 'allowlist' | 'disabled'
@@ -35,7 +36,8 @@ interface AccessFile {
 
 export function ensureDiscordChannelGroup(): void {
   if (CHANNEL_PROVIDER !== 'discord') return
-  if (!CHANNEL_CHAT_ID) return
+  // CHATID0: same placeholder rule as notify.ts -- "0" is not a channel.
+  if (!normalizeChatId(CHANNEL_CHAT_ID)) return
   const dir = channelStateDir('discord')
   const path = join(dir, 'access.json')
 


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)
- [ ] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

**HU:** A telepítő `ALLOWED_CHAT_ID=0`-t ír be, amíg nincs csevegés hozzákötve. Az értesítési út minden őre **igazságértéket** tesztelt, a `"0"` viszont se nem üres, se nem hamis — ezért az őrök pontosan azokon a telepítéseken **átengedték** a küldést, ahol nem volt hova küldeni. A hívás kiment `chat_id=0`-val, a Bot API 400-at adott, a hibát pedig a `notifyChannel` két egymásba ágyazott `catch`-e eldobta.

Az eredmény nem hibás riasztás, hanem **néma riasztás**: az adott telepítésen a teljes flotta összes értesítése elveszett, és az a figyelmeztetés, ami épp ezt hivatott kimondani (`Channel ertesites kihagyva`), **sosem futott le**, mert az az ág elérhetetlen volt.

**A projekt ezt a döntést már meghozta.** Az `owner-chat.ts` `normalizeChatId()`-je a `"0"`-t helyesen „nincs beállítva"-ként kezeli, és a kommentje kifejezetten kéri, hogy minden felhasználó ezt vegye át — *„so a future consumer cannot reinvent the same hole"*. Ezt eddig egyedül a `schedule-runner.ts` tette meg. A maradék három nyers ürességteszt itt kap javítást:

| Hely | Mi ez |
|---|---|
| `notify.ts:7` — `notifyChannel` | **minden flotta-riasztás tölcsére** |
| `notify.ts:39` — `notifySecurityEvent` | biztonsági események |
| `web/discord-group-bootstrap.ts:38` | Discord-bootstrap |

A `scripts/notify.sh` ugyanezt a lyukat hordozta a `[ -z "$CHAT_ID" ]`-ben, és **ott számít a legtöbbet**: a `notify.sh` a TARTALÉK csatorna, vagyis pontosan akkor lép be, amikor a plugin halott. Helykitöltős telepítésen tehát az elsődleges út és a tartaléka is a `chat_id=0`-ra küldött.

**Éles mérés (2026-09-05).** Egy watchdog-riasztás elsült, a dashboard naplója rögzítette a döntést, és **semmi nem érkezett meg** — miközben **nulla** `kihagyva` sor magyarázta volna, mert az az ág elérhetetlen volt. A javítás után ugyanaz a hívás ugyanazon a telepítésen kiírja a figyelmeztetést; igazi azonosítóval változatlanul kézbesít.

Az üzenetek szövege **bájtra azonos marad**: ez a PR azt változtatja meg, mely bemenet számít „nincs beállítva"-nak, nem azt, hogy mit mondunk az üzemeltetőnek.

**Szándékosan kimarad:** a `notifyChannel` továbbra is elnyeli a valódi küldési hibát (a beágyazott `catch`, illetve a `sendAlert` saját `.catch(() => {})`-je). Az külön hiba, külön döntés arról, mit és milyen gyakran naplózzunk — külön PR-t érdemel.

**EN:** The installer writes `ALLOWED_CHAT_ID=0` until a chat is bound. Every guard on the notification path tested truthiness, and `"0"` is neither empty nor falsy, so the guards passed on exactly the installs with no owner chat: the send went out with `chat_id=0`, the Bot API answered 400, and `notifyChannel`'s two nested catches discarded it. The install's alerts were dropped in full, and the `kihagyva` warning that exists to report this was never reached — silence, not a symptom.

`owner-chat.ts` already owns this decision: `normalizeChatId()` treats `"0"` as "not set", and its comment asks every consumer to reuse it. Only `schedule-runner.ts` had adopted it; the three remaining raw checks are fixed here, plus `scripts/notify.sh`, which matters most because it is the fallback channel — it fires precisely when the plugin is down.

Messages are left byte-identical: this changes which inputs count as "not configured", not what the operator is told. Swallowed send failures are deliberately out of scope.

**Tesztek / Tests:** a javítás **nélkül 6 teszt bukik**, vele mind zöld. A shell-esetek olyan curl-csonkot kapnak, ami sikert jelentene, **ha egyáltalán eljutna hozzá** — így nem azt bizonyítják, hogy a küldés lejjebb elhasal, hanem hogy **el sem indul**. Két negatív kontroll rögzíti, hogy a nullát tartalmazó (`5040302010`) és a nullával kezdődő (`0123456789`) valódi azonosítók érintetlenek maradnak. Teljes suite: **4616 zöld**, 1 kihagyott, plusz az a két bukás, ami ebben a checkoutban a változtatás nélkül is megvan (nincs `ssh-keygen` a konténeremben; és egy márkanév-teszt, amit a `marveen` nevű home könyvtár buktat meg).

## Kapcsolódó issue / Related issue

Closes #

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [ ] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).

## Titok-kapu / Secret gate

- [x] Nincs a valtoztatasban bizonyitek-/artefaktum-mappa, titok-alaku string vagy idezett csatorna-uzenet.
      / No evidence or artifact directory, secret-shaped string, or quoted channel message in this change.