### PR TITLE
Tell a restarted agent what it was in the middle of, or say nothing

### DIFF
--- a/src/__tests__/restart-recovery-brief.test.ts
+++ b/src/__tests__/restart-recovery-brief.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest'
+import { buildRecoveryBrief, parseGitStatusShort, RECOVERY_BRIEF_MAX_CHARS, type RecoveryFacts } from '../web/restart-recovery-brief.js'
+
+const facts = (over: Partial<RecoveryFacts> = {}): RecoveryFacts => ({
+  agent: 'devy',
+  branch: 'devy/some-task',
+  dirty: [],
+  dirtyTruncated: false,
+  inProgress: [],
+  ...over,
+})
+
+describe('an idle agent is never interrupted', () => {
+  it('says nothing when there is no work in flight', () => {
+    // The guard that makes auto-injection safe at all. A restart of a genuinely
+    // idle agent must not put "you were doing nothing" into its fresh prompt --
+    // that is noise the agent then has to spend a turn answering.
+    expect(buildRecoveryBrief(facts())).toBeNull()
+  })
+
+  it('says nothing even when a branch is known but nothing is dirty', () => {
+    expect(buildRecoveryBrief(facts({ branch: 'develop' }))).toBeNull()
+  })
+})
+
+describe('a brief is sent when there is something concrete to resume', () => {
+  it('names the in_progress cards', () => {
+    const b = buildRecoveryBrief(facts({ inProgress: [{ id: 'abc12345', title: 'Fix the thing' }] }))!
+    expect(b).toContain('abc12345: Fix the thing')
+    expect(b).toContain('FRISS session')
+  })
+
+  it('names the branch and the uncommitted files', () => {
+    const b = buildRecoveryBrief(facts({
+      branch: 'devy/work',
+      dirty: [{ code: ' M', path: 'src/a.ts' }, { code: '??', path: 'src/b.ts' }],
+    }))!
+    expect(b).toContain('devy/work')
+    expect(b).toContain(' M src/a.ts')
+    expect(b).toContain('?? src/b.ts')
+  })
+
+  it('still works when the branch is unknown', () => {
+    const b = buildRecoveryBrief(facts({ branch: null, dirty: [{ code: ' M', path: 'x.ts' }] }))!
+    expect(b).toContain('munkakonyvtaradban')
+    expect(b).not.toContain('null')
+  })
+
+  it('says so when the file list was cut', () => {
+    const b = buildRecoveryBrief(facts({ dirty: [{ code: ' M', path: 'a' }], dirtyTruncated: true }))!
+    expect(b).toContain('levagva')
+  })
+})
+
+describe('the brief states facts, it does not order a resume', () => {
+  it('tells the agent to verify before continuing', () => {
+    // Facts collected around a restart can be stale by the time they are read,
+    // and the fleet has been burned by confident stale numbers before. The
+    // brief must send the agent to check, not to act.
+    const b = buildRecoveryBrief(facts({ inProgress: [{ id: 'c1', title: 'T' }] }))!
+    expect(b).toMatch(/ellenorizd/i)
+    expect(b).toMatch(/ne kezdd ujra/i)
+  })
+
+  it('stays within the injection cap', () => {
+    const many = Array.from({ length: 40 }, (_, i) => ({ code: ' M', path: `src/very/long/path/number/${i}/file.ts` }))
+    const b = buildRecoveryBrief(facts({ dirty: many }))!
+    expect(b.length).toBeLessThanOrEqual(RECOVERY_BRIEF_MAX_CHARS)
+    expect(b.endsWith('…')).toBe(true)
+  })
+})
+
+describe('parseGitStatusShort', () => {
+  it('keeps the two-column code verbatim, because " M" and "M " differ', () => {
+    const { dirty } = parseGitStatusShort(' M src/a.ts\nM  src/b.ts\n?? src/c.ts\n', 10)
+    expect(dirty).toEqual([
+      { code: ' M', path: 'src/a.ts' },
+      { code: 'M ', path: 'src/b.ts' },
+      { code: '??', path: 'src/c.ts' },
+    ])
+  })
+
+  it('reports truncation instead of silently dropping files', () => {
+    const out = Array.from({ length: 5 }, (_, i) => ` M f${i}.ts`).join('\n')
+    const { dirty, truncated } = parseGitStatusShort(out, 3)
+    expect(dirty).toHaveLength(3)
+    expect(truncated).toBe(true)
+  })
+
+  it('treats empty git output as a clean tree', () => {
+    expect(parseGitStatusShort('', 10)).toEqual({ dirty: [], truncated: false })
+    expect(parseGitStatusShort('\n\n', 10)).toEqual({ dirty: [], truncated: false })
+  })
+})

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -8,6 +8,8 @@ import { logger } from '../logger.js'
 import { MAIN_AGENT_ID, SERVICE_ID, BOT_NAME, CHANNEL_PROVIDER, PROJECT_ROOT, RESPAWN_ENABLED } from '../config.js'
 import { DISTRIBUTION_DEFAULT_AGENT_MODEL } from '../config-registry.js'
 import { agentDir, listAgentNames, readAgentChannelProvider } from './agent-config.js'
+import { listKanbanCards } from '../db.js'
+import { buildRecoveryBrief, parseGitStatusShort, type RecoveryFacts } from './restart-recovery-brief.js'
 import {
   agentHasChannel,
   agentSessionName,
@@ -1732,6 +1734,79 @@ function shouldEscalateMarveenDown(): boolean {
   return now - marveenSuspectFirstSeen >= MARVEEN_DOWN_CONFIRM_MS
 }
 
+// ---- recovery brief after a fresh restart (card 3a64403b) -------------------
+// A watchdog restart brings the agent back on a FRESH session: the plugin
+// reloads, the conversation does not. The agent then sits at an empty prompt
+// while its uncommitted branch and its in_progress card wait for it. These
+// three pieces close that gap; the decision of WHETHER to speak lives in the
+// pure buildRecoveryBrief (no facts -> no message, so an idle agent restarted
+// for plugin reasons is never interrupted).
+
+// How many changed files the brief lists before it says "and more". A restart
+// after a long spell can leave dozens; the brief is a pointer, not a diff.
+const RECOVERY_BRIEF_MAX_FILES = 12
+// Wait before typing the brief into the fresh session. The restart path
+// already schedules modal dismissal and the plugin-unlock probe; this sits
+// after both so the brief does not race a dialog or the probe's keystrokes.
+// sendPromptToSession still waits for idle on its own -- this delay is about
+// ORDER, not about hoping the session happens to be ready.
+const RECOVERY_BRIEF_DELAY_MS = 90_000
+
+// Collect what the fleet knew about an agent at restart time. Every failure is
+// swallowed into a null/empty field: a brief is a convenience, and a monitor
+// sweep must never fall over because a directory is missing or git is unhappy.
+function gatherRecoveryFacts(agent: string): RecoveryFacts {
+  let branch: string | null = null
+  let dirty: RecoveryFacts['dirty'] = []
+  let dirtyTruncated = false
+  try {
+    const dir = agentDir(agent)
+    if (existsSync(join(dir, '.git'))) {
+      try {
+        branch = execFileSync('git', ['-C', dir, 'rev-parse', '--abbrev-ref', 'HEAD'], { timeout: 5000 }).toString().trim() || null
+      } catch { /* detached HEAD or no repo -- the brief works without a branch */ }
+      const out = execFileSync('git', ['-C', dir, 'status', '--short'], { timeout: 5000 }).toString()
+      const parsed = parseGitStatusShort(out, RECOVERY_BRIEF_MAX_FILES)
+      dirty = parsed.dirty
+      dirtyTruncated = parsed.truncated
+    }
+  } catch (err) {
+    logger.debug({ err, agent }, 'recovery-brief: git facts unavailable')
+  }
+
+  let inProgress: RecoveryFacts['inProgress'] = []
+  try {
+    inProgress = listKanbanCards()
+      .filter((c) => c.assignee === agent && c.status === 'in_progress' && c.archived_at == null)
+      .map((c) => ({ id: c.id, title: c.title }))
+  } catch (err) {
+    logger.debug({ err, agent }, 'recovery-brief: kanban facts unavailable')
+  }
+
+  return { agent, branch, dirty, dirtyTruncated, inProgress }
+}
+
+// After a fresh restart, tell the new session what it was in the middle of.
+// Fire-and-forget: scheduled, never awaited by the sweep.
+export function scheduleRecoveryBrief(agent: string, session: string): void {
+  setTimeout(() => {
+    void (async () => {
+      try {
+        const facts = gatherRecoveryFacts(agent)
+        const brief = buildRecoveryBrief(facts)
+        if (!brief) {
+          logger.info({ agent, session }, 'recovery-brief: nothing in flight, staying quiet')
+          return
+        }
+        const res = await sendPromptToSession(session, brief, null, { lockMode: 'deliver' })
+        logger.info({ agent, session, res, cards: facts.inProgress.length, dirty: facts.dirty.length }, 'recovery-brief sent after restart')
+      } catch (err) {
+        logger.warn({ err, agent, session }, 'recovery-brief could not be delivered')
+      }
+    })()
+  }, RECOVERY_BRIEF_DELAY_MS)
+}
+
 export function startChannelPluginMonitor(): NodeJS.Timeout | null {
   // Respawn/keep-alive is production-only. On any non-production host (e.g. a
   // local dev checkout) we never respawn the main agent or auto-restart
@@ -2115,6 +2190,10 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
           // and no poller (verified: continue -> "Plugin not found" in /mcp; fresh
           // -> plugin loads + poller attaches). Context is dropped, memory persists.
           await startAgentProcess(t.agentName!, { fresh: true })
+          // The fresh session has no memory of what it was doing. If work was
+          // in flight, tell it -- once, after the modal/probe traffic settles,
+          // and only when there is something concrete to say.
+          scheduleRecoveryBrief(t.agentName!, t.session)
           agentLastRestart.set(t.agentName!, Date.now())
           agentDownSince.delete(t.session)
           agentBusyDeferAlerted.delete(t.session)

--- a/src/web/restart-recovery-brief.ts
+++ b/src/web/restart-recovery-brief.ts
@@ -1,0 +1,103 @@
+// After a watchdog restart the agent comes back on a FRESH session: the plugin
+// loads again, but the conversation is gone. The agent has no way to know it
+// was in the middle of something, so it sits at an empty prompt while its
+// uncommitted branch and its in_progress card wait for it (card 3a64403b,
+// follow-up to PR #612).
+//
+// This module builds the one message that closes that gap, and decides when
+// NOT to send one.
+//
+// THE RULE THAT MAKES THIS SAFE: no facts, no message. A brief is only worth
+// injecting when there is something concrete to resume -- uncommitted work in
+// the agent's own directory, or a card it had taken. An agent restarted while
+// genuinely idle gets nothing, because injecting "you were doing nothing"
+// into a fresh prompt is noise the agent then has to answer.
+//
+// The text is deliberately a STATEMENT OF FACTS plus one instruction to check
+// them, not a command to resume. The facts are collected around a restart --
+// a moment when the fleet's own state can be stale -- so the agent verifies
+// before acting, exactly as it would after any handoff.
+
+/** A file the agent left modified in its working directory. */
+export interface DirtyFile {
+  /** git status --short XY code, e.g. ' M', '??', 'A '. */
+  code: string
+  path: string
+}
+
+export interface RecoveryFacts {
+  agent: string
+  /** Branch the agent's working directory is on, null when undeterminable. */
+  branch: string | null
+  /** Uncommitted entries from `git status --short`, already capped by the caller. */
+  dirty: DirtyFile[]
+  /** True when the dirty list was truncated, so the brief can say so. */
+  dirtyTruncated: boolean
+  /** Cards this agent had in_progress at restart time. */
+  inProgress: { id: string; title: string }[]
+}
+
+/** Longest brief we are willing to type into a fresh prompt. */
+export const RECOVERY_BRIEF_MAX_CHARS = 1200
+
+/**
+ * Build the recovery brief, or null when there is nothing to say.
+ *
+ * Pure: no git, no database, no tmux. The caller gathers the facts; this
+ * decides whether they are worth a message and how to word it.
+ */
+export function buildRecoveryBrief(facts: RecoveryFacts): string | null {
+  const hasDirty = facts.dirty.length > 0
+  const hasCards = facts.inProgress.length > 0
+  // The whole point of the guard: an idle agent is not interrupted.
+  if (!hasDirty && !hasCards) return null
+
+  const lines: string[] = [
+    '[recovery-brief] Ujraindultal, es ez egy FRISS session: az elozo beszelgetesed nincs meg.',
+    'Amit a restart pillanataban a rendszer latott rolad:',
+  ]
+
+  if (hasCards) {
+    lines.push('')
+    lines.push(facts.inProgress.length === 1 ? 'Folyamatban levo kartyad:' : 'Folyamatban levo kartyaid:')
+    for (const c of facts.inProgress) lines.push(`  - ${c.id}: ${c.title}`)
+  }
+
+  if (hasDirty) {
+    lines.push('')
+    const where = facts.branch ? `a(z) ${facts.branch} agon` : 'a munkakonyvtaradban'
+    lines.push(`Commitolatlan valtozasok ${where}:`)
+    for (const f of facts.dirty) lines.push(`  ${f.code} ${f.path}`)
+    if (facts.dirtyTruncated) lines.push('  ... (a lista levagva)')
+  }
+
+  lines.push('')
+  lines.push(
+    'Ezek MERESEK a restart pillanatabol, nem utasitas: ellenorizd oket (git status, kanban), ' +
+    'mielott barmit folytatnal. Ha kozben mar lezarult, ne kezdd ujra.',
+  )
+
+  const text = lines.join('\n')
+  return text.length > RECOVERY_BRIEF_MAX_CHARS
+    ? text.slice(0, RECOVERY_BRIEF_MAX_CHARS - 1).trimEnd() + '…'
+    : text
+}
+
+/**
+ * Parse `git status --short` output into entries.
+ *
+ * Kept separate (and pure) so the brief can be tested against real git output
+ * without running git.
+ */
+export function parseGitStatusShort(out: string, max: number): { dirty: DirtyFile[]; truncated: boolean } {
+  const rows = out.split('\n').map((l) => l.replace(/\s+$/, '')).filter((l) => l.trim() !== '')
+  const dirty: DirtyFile[] = []
+  for (const row of rows.slice(0, max)) {
+    // Format: XY<space>path -- the code is the first two columns, verbatim,
+    // because ' M' (worktree) and 'M ' (staged) mean different things.
+    const code = row.slice(0, 2)
+    const path = row.slice(3).trim()
+    if (path) dirty.push({ code, path })
+  }
+  return { dirty, truncated: rows.length > max }
+}


### PR DESCRIPTION
## A hiányzó lépés

A `#612` óta a watchdog már nem öli meg a **dolgozó** agenst. De ha egy restart mégis megtörténik, az agens **friss** sessionnel jön vissza: a plugin újratöltődik, a beszélgetés nem. Nem tudja, hogy volt-e folyamatban munkája, és üres prompton áll, miközben a commitolatlan ága és az `in_progress` kártyája vár rá.

Ez a PR a restart után beírja neki, amit a flotta tudott róla.

## Amitől ez biztonságos: ha nincs mit mondani, nem szól

Egy valóban tétlen agens, akit plugin-okból indítottak újra, **semmit** nem kap. A „nem csináltál semmit" injektálás zaj, amire az agensnek még válaszolnia is kell egy fordulóban. A szabály a pure `buildRecoveryBrief`-ben él, és teszt őrzi mindkét irányban (a kivétele két tesztet pirosít).

## A szöveg tényeket közöl, nem utasít folytatásra

A tények egy restart körül gyűlnek — abban a pillanatban, amikor a flotta saját állapota a legkevésbé megbízható. Ezért a brief **ellenőrzésre** küld: „ezek mérések a restart pillanatából, nézd meg őket (git status, kanban), mielőtt bármit folytatnál; ha közben lezárult, ne kezdd újra."

## Szerkezet

- **Pure**: `restart-recovery-brief.ts` — a döntés (szóljon-e) és a szöveg. Se git, se db, se tmux, így a szabály tesztelhető futó flotta nélkül.
- **I/O**: a monitorban. A gyűjtés minden hibát elnyel (hiányzó könyvtár, mérges git) — a brief kényelem, egy monitor-sweep nem borulhat fel tőle.
- **Küldés**: `sendPromptToSession` (megvárja az idle-t, kezeli a parkolt inputot), nem nyers `send-keys`. A 90 s késleltetés a **sorrendről** szól: a modal-dismiss és a plugin-unlock probe után fusson, ne versenyezzen velük.

## Amit a saját korábbi aggályaimból ez old meg

A kártyán három okot írtam, amiért hajnalban nem PR-oztam:

1. *„a restart-flow változhat a függő root-cause döntéstől"* — megnéztem: az `a664f9b2` a restart **döntését** érinti (`decideDownAgentAction`, failure-counter, `channel-monitor.ts` ~2028), a brief a `startAgentProcess({fresh:true})` **utánra** kerül (~2117). Külön terület; a döntés azt befolyásolja, hogy eljutunk-e ide, nem azt, hogy mi történik utána.
2. *„az automatikus injektálás félresülhet"* — a robusztus küldési út + a sorrendet biztosító késleltetés kezeli.
3. *„melyik restart érdemel briefet, és mi legyen ha nincs munka"* — ez volt a valódi design-kérdés, és a konzervatív válasz nem igényel steert: **akkor és csak akkor**, ha van konkrét mondanivaló.

## Verify

- **11 teszt**, mutáció-próbával: a néma-ág kivétele → 2 piros, a hossz-vágás → 1 piros, a git-kód két oszlopának trimmelése (`'M '` vs `' M'` mást jelent) → 1 piros; visszaállítás után mind zöld.
- Teljes suite **360 fájl / 4665 teszt zöld**, `tsc --noEmit` tiszta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5utRgfreZE6g7T2W82ryY