### PR TITLE
fix(copy-gate): audit edit_message too, and test what the union left implicit

### DIFF
--- a/scripts/__tests__/outgoing-copy-gate.test.py
+++ b/scripts/__tests__/outgoing-copy-gate.test.py
@@ -198,6 +198,34 @@ def main():
         code, out, err = run_hook(email_payload(CLEAN_HU_OK), rules_file=active)
         check("fully clean body passes (exit 0)", code, 0)
 
+        # --- 6. #1184: manage_email dispatch + telegram codeblock gate ------
+        # COPYGATEMATCHER904: the multiplexed manage_email must be classified
+        # by OPERATION. Before the fix every letter fell through to exit 0.
+        def manage_payload(op, **kw):
+            return {"tool_name": "mcp__google-workspace__manage_email",
+                    "tool_input": {"operation": op, **kw}}
+
+        code, out, err = run_hook(manage_payload("send", body=CLEAN_HU_OK + " — mégis."),
+                                  rules_file=active)
+        check("manage_email send with em dash blocks (exit 2)", code, 2)
+        code, out, err = run_hook(manage_payload("send", body=CLEAN_HU_OK), rules_file=active)
+        check("manage_email send clean passes (exit 0)", code, 0)
+        code, out, err = run_hook(manage_payload("search", query="— rossz — szoveg"),
+                                  rules_file=active)
+        check("manage_email search is not audited (exit 0)", code, 0)
+        code, out, err = run_hook(manage_payload("forward", message_id="x"), rules_file=active)
+        check("manage_email bare forward passes (exit 0)", code, 0)
+
+        # GATECOPY827: a code block without format=markdownv2 has no copy
+        # button on the phone -- machine gate, not memory.
+        fenced = "Íme:\n```\nls -la\n```\nfuttasd le kérlek."
+        code, out, err = run_hook(telegram_payload(fenced), rules_file=active)
+        check("telegram codeblock without markdownv2 blocks (exit 2)", code, 2)
+        payload = telegram_payload(fenced)
+        payload["tool_input"]["format"] = "markdownv2"
+        code, out, err = run_hook(payload, rules_file=active)
+        check("telegram codeblock WITH markdownv2 passes (exit 0)", code, 0)
+
     if FAILS:
         print(f"\n{len(FAILS)} FAILED: {FAILS}", file=sys.stderr)
         sys.exit(1)

--- a/scripts/__tests__/outgoing-copy-gate.test.py
+++ b/scripts/__tests__/outgoing-copy-gate.test.py
@@ -226,6 +226,21 @@ def main():
         code, out, err = run_hook(payload, rules_file=active)
         check("telegram codeblock WITH markdownv2 passes (exit 0)", code, 0)
 
+        # edit_message goes through the same telegram gate as reply: the
+        # scaffold matcher (#1184) wires both, so both must actually audit.
+        edit_bad = {"tool_name": "mcp__plugin_telegram_telegram__edit_message",
+                    "tool_input": {"message_id": "1", "text": CLEAN_HU_OK + " — mégis."}}
+        code, out, err = run_hook(edit_bad, rules_file=active)
+        check("edit_message with em dash blocks (exit 2)", code, 2)
+        edit_fence = {"tool_name": "mcp__plugin_telegram_telegram__edit_message",
+                      "tool_input": {"message_id": "1", "text": "```\nls\n``` légy szíves."}}
+        code, out, err = run_hook(edit_fence, rules_file=active)
+        check("edit_message codeblock without markdownv2 blocks (exit 2)", code, 2)
+        edit_ok = {"tool_name": "mcp__plugin_telegram_telegram__edit_message",
+                   "tool_input": {"message_id": "1", "text": CLEAN_HU_OK}}
+        code, out, err = run_hook(edit_ok, rules_file=active)
+        check("edit_message clean passes (exit 0)", code, 0)
+
     if FAILS:
         print(f"\n{len(FAILS)} FAILED: {FAILS}", file=sys.stderr)
         sys.exit(1)

--- a/scripts/hooks/outgoing-copy-gate.py
+++ b/scripts/hooks/outgoing-copy-gate.py
@@ -863,7 +863,11 @@ def main():
     tool = str(payload.get("tool_name") or "")
     tool_input = payload.get("tool_input") or {}
 
-    if re.search(r"telegram.*__reply$", tool, re.I):
+    # GATECOPY828 (#1184): the scaffold wires this hook onto reply AND
+    # edit_message (an edit can replace a working code block with a broken
+    # one). The dispatch must recognise BOTH, or the edit half of the matcher
+    # invokes a hook that exits 0 without auditing anything.
+    if re.search(r"telegram.*__(reply|edit_message)$", tool, re.I):
         telegram_gate(tool_input)  # exits; never falls through
     # COPYGATEMATCHER904: the hook is REGISTERED for manage_email, create_draft,
     # update_draft and the Gmail connector's reply/send_message/forward tools,


### PR DESCRIPTION
## What

Stacked on #1184 (draft until it merges; the first two commits below the fork point are its rebased head).

1. **fix: the edit_message half of the wired matcher must also audit.** #1184 wires the outgoing-copy-gate onto `mcp__plugin_telegram_telegram__reply|mcp__plugin_telegram_telegram__edit_message` for every sub-agent, and its own TS test asserts that matcher. But the hook's dispatch only recognised `telegram.*__reply$`, so on an edit_message call the hook ran and exited 0 without auditing anything. Measured before the fix: an em dash edit and a fenced-code-block edit both passed with exit 0. A gate that is wired but never fires is a fail-open promise. One-line dispatch extension plus three tests (em dash blocks, fence-without-markdownv2 blocks, clean passes).

2. **test: coverage the union left implicit.**
   - The second sanctioned spelling: #1176 shipped `no_name_rule`, #1184 shipped `name_check_disabled`, and the conflict resolution accepts both. Only the first spelling had a test; if the second stopped mapping to the sanctioned state, that install's recorded decision would silently turn back into a loud "empty".
   - The manage_email dispatch fix and the codeblock-format gate from #1184 had no python-level tests. Added: send-with-em-dash blocks, clean send passes, search/bare-forward pass untouched, fence without `format="markdownv2"` blocks, with it passes. Each new test verified against a deliberate mutation (dispatch disabled, gate disabled): they fail exactly then.

## Why separate from #1184

The rebase-union on #1184 only repairs the conflict our own merge order created on already-verified work. This PR is our own new fix and coverage, so it ships under our authorship with its own review handle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
