### PR TITLE
test(isolated-config): the reconcile path must also refuse the scope collision

### DIFF
--- a/src/__tests__/isolated-config-mcp-reconcile.test.ts
+++ b/src/__tests__/isolated-config-mcp-reconcile.test.ts
@@ -173,6 +173,32 @@ describe('isolated config dir: mcpServers reconcile', () => {
     expect(servers().gmail).toEqual({ command: 'npx', args: ['gmail-mcp'] })
   })
 
+  it('skips the collision on the RECONCILE path too, not only on first seed', () => {
+    // Provision first WITHOUT any project-scope servers: the dir now exists,
+    // so every later call takes the reconcile (gap-fill) branch -- the exact
+    // branch the measured 12-hour outage came from (startup write-back).
+    ensureIsolatedChannelConfigDir(AGENT, 'telegram')
+    expect(Object.keys(servers())).toEqual(['gmail'])
+
+    // The agent then defines `cortex` at project scope with its own token,
+    // and the router's shared config later grows a same-named entry.
+    writeFileSync(
+      join(SANDBOX, 'agents', AGENT, '.mcp.json'),
+      JSON.stringify({ mcpServers: { cortex: { url: 'https://cortex.example/mcp', headers: { Authorization: 'Bearer agent-own-token' } } } }),
+    )
+    writeShared({
+      gmail: { command: 'npx', args: ['gmail-mcp'] },
+      cortex: { url: 'https://cortex.example/mcp', headers: { Authorization: 'Bearer router-token' } },
+      'google-drive': { command: 'npx', args: ['gdrive-mcp'] },
+    })
+
+    ensureIsolatedChannelConfigDir(AGENT, 'telegram')
+
+    // The genuine gap arrives, the collision does not.
+    expect(servers().cortex).toBeUndefined()
+    expect(Object.keys(servers()).sort()).toEqual(['gmail', 'google-drive'])
+  })
+
   it('still gap-fills when the agent has no readable .mcp.json', () => {
     // No .mcp.json at all: nothing can collide, so every shared server is a gap.
     writeShared({ gmail: { command: 'npx', args: ['gmail-mcp'] }, extra: { command: 'x' } })


### PR DESCRIPTION
## What

One test: the isolated-config MCP reconcile path must also refuse a scope collision, not only the first-seed path.

## Why

#1188 fixed both halves of the shadow bug (seed copy and gap-fill reconcile), but its own test only exercised the seed path. Verified during review by mutation: with the reconcile-path skip disabled (`if (false && projectScoped.has(key))`), the whole file stayed green -- 11/11 passed. The reconcile path is the one the measured 12-hour outage came from (the startup write-back re-adds the shadow on every restart), so the merged fix currently has no regression guard on exactly that branch.

This test provisions once without collisions (so the dir exists and later calls take the reconcile branch), then adds an agent-owned `.mcp.json` server and a same-named shared entry, and asserts the collision is skipped while the genuine gap still fills. Under the mutation above it fails; on the merged fix it passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
