### PR TITLE
fix(copy-gate): the main agent's own settings must gate edit_message too

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,7 +18,7 @@
       { "matcher": "Bash", "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/outgoing-copy-gate.py\"", "timeout": 15 } ] },
       { "matcher": ".*send_email.*", "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/outgoing-copy-gate.py\"", "timeout": 15 } ] },
       { "matcher": ".*manage_email.*", "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/outgoing-copy-gate.py\"", "timeout": 15 } ] },
-      { "matcher": "mcp__plugin_telegram_telegram__reply", "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/outgoing-copy-gate.py\"", "timeout": 15 } ] },
+      { "matcher": "mcp__plugin_telegram_telegram__reply|mcp__plugin_telegram_telegram__edit_message", "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/outgoing-copy-gate.py\"", "timeout": 15 } ] },
       { "matcher": "Bash", "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/email-approval-gate.py\"", "timeout": 10 } ] },
       { "matcher": ".*send_email.*", "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/email-approval-gate.py\"", "timeout": 10 } ] },
       { "matcher": ".*manage_email.*", "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/email-approval-gate.py\"", "timeout": 10 } ] }

--- a/src/__tests__/copy-gate-main-agent-coverage.test.ts
+++ b/src/__tests__/copy-gate-main-agent-coverage.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { TELEGRAM_COPY_GATE_MATCHER } from '../web/agent-scaffold.js'
+
+// GATECOPY906: the outgoing-copy gate is TWO measurements, and #1195 only fixed
+// one of them. The hook's own dispatch decides WHETHER a payload is audited
+// (the detector); the PreToolUse matcher decides whether the hook is invoked at
+// all (the trigger). #1184 widened the scaffold matcher to edit_message and
+// #1195 widened the detector to match -- but the MAIN agent is deliberately
+// exempt from the scaffold matcher (see the comment on TELEGRAM_COPY_GATE_MATCHER:
+// it "already carries the same hook in its own committed project settings"), so
+// its coverage lives in .claude/settings.json alone. That file still listed
+// reply only, which means the main agent's edit_message reached the phone
+// unaudited while every sub-agent's was gated.
+//
+// This test pins the invariant that made the exemption safe in the first place:
+// whatever tools the scaffold gates for sub-agents, the main agent's own
+// settings must gate too. It is the drift between the two that goes unnoticed.
+const REPO_ROOT = join(__dirname, '..', '..')
+const GATE_SCRIPT = 'outgoing-copy-gate.py'
+
+type HookEntry = { matcher?: string; hooks?: Array<{ command?: string }> }
+
+function copyGateMatchers(): string[] {
+  const raw = readFileSync(join(REPO_ROOT, '.claude', 'settings.json'), 'utf-8')
+  const settings = JSON.parse(raw) as { hooks?: { PreToolUse?: HookEntry[] } }
+  return (settings.hooks?.PreToolUse ?? [])
+    .filter((e) => (e.hooks ?? []).some((h) => (h.command ?? '').includes(GATE_SCRIPT)))
+    .map((e) => e.matcher ?? '')
+    .filter(Boolean)
+}
+
+describe('outgoing-copy gate: the main agent covers what the scaffold covers', () => {
+  const scaffoldTools = TELEGRAM_COPY_GATE_MATCHER.split('|')
+
+  it('the scaffold gates more than one telegram tool (guards the test itself)', () => {
+    // Without this, a scaffold regression to a single tool would make the
+    // assertion below pass for the wrong reason.
+    expect(scaffoldTools.length).toBeGreaterThan(1)
+    expect(scaffoldTools).toContain('mcp__plugin_telegram_telegram__edit_message')
+  })
+
+  it.each(TELEGRAM_COPY_GATE_MATCHER.split('|'))(
+    'the committed main-agent settings invoke the gate for %s',
+    (tool) => {
+      const covered = copyGateMatchers().some((m) => new RegExp(m).test(tool))
+      expect(covered).toBe(true)
+    },
+  )
+})


### PR DESCRIPTION
## What

`#1184` widened the agent-scaffold matcher to `reply|edit_message`; `#1195` widened the hook's own dispatch to match. Sub-agents are covered. The **main agent is not**: it is deliberately exempt from the scaffold matcher (see the comment on `TELEGRAM_COPY_GATE_MATCHER` -- it "already carries the same hook in its own committed project settings"), and that file still listed `reply` alone.

So after `#1195`, an `edit_message` from the one agent that talks to the owner most could still put a broken code block on his phone unaudited.

## Measured, not assumed

- On `origin/develop`, `.claude/settings.json` had exactly one `PreToolUse` entry invoking `outgoing-copy-gate.py` for Telegram, and its matcher was `mcp__plugin_telegram_telegram__reply`.
- The new test **fails on the pre-fix settings** (`edit_message` uncovered, `reply` covered) and passes after -- mutation control on my own change, not a green diff.
- The matcher is now byte-identical to the scaffold's, so future drift shows up as a diff between two equal strings.

## Not in scope, and I say so

The `PostToolUse` `ledger-outbound.py` hook is registered on `reply` alone as well. Whether an edit belongs in that ledger is a different question about a different subsystem; I did not measure it and did not widen it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)