### PR TITLE
fix(backup): the manifest said what the archive should hold; nothing checked that it did

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -31,7 +31,9 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-BACKUP_DIR="${REPO_ROOT}/backups"
+# Overridable so a test can build a throwaway archive without touching the
+# real backup directory (and its retention sweep).
+BACKUP_DIR="${BACKUP_DIR:-${REPO_ROOT}/backups}"
 STAMP="$(date +%Y%m%d-%H%M%S)"
 ARCHIVE="${BACKUP_DIR}/claudeclaw-${STAMP}.tar.gz"
 KEEP=14
@@ -152,6 +154,73 @@ stage_group "${HOMELIST}" "${HOME}" home
 ( cd "${STAGE}" && tar -czf "${ARCHIVE}" MANIFEST.txt \
     $( [[ -d repo ]] && echo repo ) $( [[ -d home ]] && echo home ) )
 echo "backup: wrote ${ARCHIVE} ($(wc -c < "${ARCHIVE}" | awk '{print $1}') bytes)"
+
+# --- Verify the archive against the manifest. ------------------------------
+# The manifest says what the backup INTENDED to carry; until now nothing
+# checked what it actually carries. That gap is exactly how 2026-09-04
+# happened: the store/ whitelist had been silently dropping files for weeks
+# and the restore test was what finally noticed, not the backup itself. A
+# backup that cannot say what is inside it is a promise, not a copy.
+#
+# Two checks, because they fail differently:
+#   - every manifest entry has a matching path in the archive (a staging copy
+#     that silently did nothing shows up here),
+#   - a few load-bearing items are present by name (an archive that is valid,
+#     small and useless -- the 09-04 shape -- shows up here even if the
+#     manifest itself was built wrong).
+ARCHIVE_LIST="$(mktemp -t claudeclaw-verify.XXXXXX)"
+trap 'rm -f "${REPOLIST}" "${HOMELIST}" "${MANIFEST}" "${ARCHIVE_LIST}"; [[ -n "${BUNDLE}" ]] && rm -f "${BUNDLE}"; rm -rf "${STAGE}"' EXIT
+tar -tzf "${ARCHIVE}" > "${ARCHIVE_LIST}"
+
+missing=0
+while IFS= read -r want; do
+  # Manifest body lines only: the header block and the group separators are
+  # prose, not paths.
+  case "${want}" in repo/*|home/*) ;; *) continue ;; esac
+  # A directory entry is listed once in the manifest and expands to many paths
+  # in the archive, so match on the prefix, and anchor it so "store/x" cannot
+  # be satisfied by "store/xyz".
+  if ! grep -qE "^${want}(/|$)" "${ARCHIVE_LIST}"; then
+    echo "backup: MISSING from the archive: ${want}" >&2
+    missing=$((missing + 1))
+  fi
+done < <(sed -e 's/  *(.*)$//' "${MANIFEST}")
+
+# Load-bearing by name. Each one has already been lost or nearly lost once:
+# the memory directories and the local-commit bundle on 2026-09-04, the
+# credential-carrying store/ files by the whitelist that preceded it.
+for marker in "repo/store/claudeclaw.db" "home/.claude/skills" "home/.claude/scheduled-tasks"; do
+  grep -qE "^${marker}(/|$)" "${ARCHIVE_LIST}" || {
+    echo "backup: MISSING load-bearing item: ${marker}" >&2
+    missing=$((missing + 1))
+  }
+done
+# The file-based memories: only required when this host actually has some, so
+# a fresh install does not fail its first backup.
+if ( cd "${HOME}" && find .claude/projects -maxdepth 2 -type d -name memory -print -quit 2>/dev/null | grep -q . ); then
+  grep -qE "^home/\.claude/projects/.*/memory(/|$)" "${ARCHIVE_LIST}" || {
+    echo "backup: MISSING load-bearing item: the file-based memory directories" >&2
+    missing=$((missing + 1))
+  }
+fi
+
+if [[ "${missing}" -gt 0 ]]; then
+  echo "backup: FAILED verification -- ${missing} item(s) named in the manifest are not in ${ARCHIVE}." >&2
+  echo "backup: the archive is kept for inspection, but do NOT treat it as a good copy." >&2
+  # launchd sends this script's output to logs/backup.log, which nobody opens.
+  # A loud failure into an unread file is the same silence the verification
+  # above exists to break, so the failure also goes onto the agent message
+  # queue, where it survives the agent being asleep at 04:30 and gets read on
+  # the next turn. Best-effort: a messaging problem must not change the exit
+  # code or mask the real failure.
+  if [[ -x "${REPO_ROOT}/scripts/agent-msg.sh" ]]; then
+    bash "${REPO_ROOT}/scripts/agent-msg.sh" halpali halpali \
+      "[MENTES] A napi mentes ellenorzese ELBUKOTT ${STAMP}-kor: ${missing} tetel hianyzik az archivumbol (reszletek: logs/backup.log). Az archivum NEM tekintheto jo masolatnak." \
+      >/dev/null 2>&1 || true
+  fi
+  exit 6
+fi
+echo "backup: verified $(grep -cE '^(repo|home)/' "${MANIFEST}") manifest entries against the archive"
 
 # The archive contains sensitive tokens (dashboard bearer, channel bot tokens,
 # project .env secrets). Do not auto-sync ${BACKUP_DIR} to iCloud, Dropbox,


### PR DESCRIPTION
The manifest is built from the file lists, written into the archive, and then
believed. That is how 2026-09-04 happened: the store/ whitelist had been
quietly dropping files for weeks, and a restore test noticed, not the backup.
A backup that cannot say what is inside it is a promise, not a copy.

After the archive is written it is now listed and compared against the
manifest, plus a handful of load-bearing items checked by name (the DB, the
skills, the scheduled tasks, and the file-based memory directories when the
host has any). A miss exits 6 and says which item.

Measured both directions, because a check that passes when the claim is false
is worth nothing: a normal run verifies 132 manifest entries and exits 0; with
a stubbed `tar` that drops the skills from the listing, the same run names both
misses and exits 6.

The failure also goes onto the agent message queue. launchd sends this script's
output to logs/backup.log, which nobody opens -- a loud failure into an unread
file is the same silence the verification exists to break. Verified: the
message arrived (id 2313, closed afterwards).

BACKUP_DIR is now overridable so this can be exercised without touching the
real backup directory or its retention sweep.

---

Verified on a non-tmp clone of this branch, against the same checkout for `develop`:
`tsc --noEmit` clean, `vitest run` 361 files, 4680 passed (this fix is shell-side; its two-direction check is in the commit message). Baseline `develop` in the same place: 361 files, 4680 passed.
