### PR TITLE
fix(update): the dashboard update button promised a run update.sh always refused

### DIFF
--- a/src/__tests__/update-preflight.test.ts
+++ b/src/__tests__/update-preflight.test.ts
@@ -10,11 +10,19 @@ import {
 // Helper: build a GitRunner from plain strings. Covers the common
 // "return this exact branch / status" fixtures without dragging in a
 // real git invocation.
-function makeGit(branch: string, porcelain = '', ahead = 0): GitRunner {
+function makeGit(
+  branch: string,
+  porcelain = '',
+  ahead = 0,
+  behind = 0,
+  onOrigin: 'yes' | 'no' | 'unknown' = 'yes',
+): GitRunner {
   return {
     currentBranch: () => branch,
     porcelainStatus: () => porcelain,
     aheadCount: () => ahead,
+    behindCount: () => behind,
+    originHasBranch: () => onOrigin,
   }
 }
 
@@ -31,8 +39,8 @@ describe('checkUpdatePreflight --happy path', () => {
 })
 
 describe('checkUpdatePreflight --local commits (diverged history)', () => {
-  it('rejects when the local checkout has commits ahead of upstream', () => {
-    const result = checkUpdatePreflight(makeGit('main', '', 2))
+  it('rejects when the checkout is both ahead of and behind the upstream', () => {
+    const result = checkUpdatePreflight(makeGit('main', '', 2, 5))
     expect(result.ok).toBe(false)
     if (result.ok) return
     expect(result.reason).toBe('local-commits')
@@ -45,11 +53,54 @@ describe('checkUpdatePreflight --local commits (diverged history)', () => {
     expect(checkUpdatePreflight(makeGit('main', '', 0)).ok).toBe(true)
   })
 
-  it('dirty-tree takes precedence over ahead (stash is offered first)', () => {
-    const result = checkUpdatePreflight(makeGit('main', ' M src/x.ts', 3))
+  // The rule update.sh actually applies since 2026-08-30: ahead with nothing
+  // behind is an install that also develops locally, the pull is a no-op, and
+  // the update proceeds. Blocking it here locked the button on a tree that
+  // was in fact current.
+  it('passes when ahead but not behind, matching update.sh', () => {
+    expect(checkUpdatePreflight(makeGit('main', '', 53, 0)).ok).toBe(true)
+  })
+
+  it('dirty-tree takes precedence over divergence (stash is offered first)', () => {
+    const result = checkUpdatePreflight(makeGit('main', ' M src/x.ts', 3, 3))
     expect(result.ok).toBe(false)
     if (result.ok) return
     expect(result.reason).toBe('dirty-tree')
+  })
+})
+
+describe('checkUpdatePreflight --branch missing on origin', () => {
+  // update.sh exits 2 on a local-only branch. Without this gate the dashboard
+  // answered {ok:true}, spawned a run that could never start, and showed the
+  // reload countdown anyway.
+  it('rejects a branch origin does not have', () => {
+    const result = checkUpdatePreflight(makeGit('fix/local-only', '', 0, 0, 'no'))
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.reason).toBe('branch-not-on-origin')
+    if (result.reason !== 'branch-not-on-origin') return
+    expect(result.branch).toBe('fix/local-only')
+    expect(result.message).toMatch(/origin/)
+  })
+
+  it('does NOT block when the probe could not answer (offline, auth failure)', () => {
+    expect(checkUpdatePreflight(makeGit('main', '', 0, 0, 'unknown')).ok).toBe(true)
+  })
+
+  // update.sh checks the branch BEFORE the dirty tree, so both entry points
+  // must name the same first reason; stashing would not have helped here.
+  it('reports the missing branch before the dirty tree, as update.sh does', () => {
+    const result = checkUpdatePreflight(makeGit('fix/local-only', ' M src/x.ts', 0, 0, 'no'))
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.reason).toBe('branch-not-on-origin')
+  })
+
+  it('still reports detached HEAD first', () => {
+    const result = checkUpdatePreflight(makeGit('HEAD', '', 0, 0, 'no'))
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.reason).toBe('detached-head')
   })
 })
 

--- a/src/update-preflight.ts
+++ b/src/update-preflight.ts
@@ -31,11 +31,23 @@ export interface GitRunner {
   // Current branch name. "HEAD" (or empty) signals a detached checkout.
   currentBranch(): string
   // Number of local commits ahead of the upstream tracking ref
-  // (git rev-list --count @{u}..HEAD). >0 means the local history has
-  // diverged, so `git pull --ff-only` will refuse -- the dominant silent
-  // failure. Returns 0 when there is no upstream or the probe fails (the
-  // safe default: do not block on an uncertain count).
+  // (git rev-list --count @{u}..HEAD). Returns 0 when there is no upstream
+  // or the probe fails (the safe default: do not block on an uncertain
+  // count -- the branch-on-origin probe below catches the no-upstream case
+  // on its own terms).
   aheadCount(): number
+  // Number of upstream commits the local checkout is missing
+  // (git rev-list --count HEAD..@{u}), same failure convention as above.
+  // Ahead ALONE is not a divergence: there is simply nothing to
+  // fast-forward to, and update.sh proceeds. Only ahead AND behind
+  // together mean the histories parted and ff-only must refuse.
+  behindCount(): number
+  // Does the branch exist on the `origin` remote? update.sh pulls
+  // origin/<branch> and exits 2 when that ref does not exist, so a
+  // local-only branch is a guaranteed-failed run. Network probe, hence
+  // three-valued: 'unknown' (offline, auth failure, timeout) must NOT
+  // block -- an uncertain probe is not evidence of a missing branch.
+  originHasBranch(branch: string): 'yes' | 'no' | 'unknown'
   // Porcelain status excluding untracked files. Non-empty = dirty tree.
   // Untracked files are excluded because the repo legitimately carries
   // ad-hoc backup files (CLAUDE.md.backup-*, SOUL.md mid-edit, etc.)
@@ -48,6 +60,7 @@ export type PreflightResult =
   | { ok: false; reason: 'dirty-tree'; message: string }
   | { ok: false; reason: 'detached-head'; message: string }
   | { ok: false; reason: 'local-commits'; message: string; ahead: number }
+  | { ok: false; reason: 'branch-not-on-origin'; message: string; branch: string }
 
 // Concurrency gate: refuse a second /api/updates/apply while the first
 // update.sh is still running. An in-memory timestamp would reset on the
@@ -144,6 +157,29 @@ export function checkUpdatePreflight(git: GitRunner): PreflightResult {
     }
   }
 
+  // update.sh guard 2: `git ls-remote --exit-code --heads origin <branch>`.
+  // A branch that exists only locally has no ref to fast-forward to, so the
+  // script exits 2 before doing anything. The dashboard spawns it detached
+  // with its output going to a log nobody is watching, answers {ok:true},
+  // and the UI shows "reloading in 30s" for a run that could never start --
+  // exactly the lie this module exists to prevent. Measured 2026-09-05 on
+  // this install: branch fix/email-gate-mcp-matcher, ls-remote exit 2,
+  // preflight ok, update.sh exit 2.
+  // Ordered to match update.sh: this check runs BEFORE the dirty-tree one
+  // there, so the operator sees the same first reason from either entry
+  // point instead of being sent to stash changes that would not have helped.
+  if (git.originHasBranch(branch) === 'no') {
+    return {
+      ok: false,
+      reason: 'branch-not-on-origin',
+      branch,
+      message:
+        `Branch '${branch}' does not exist on origin, so there is nothing to ` +
+        'pull. Updates can only run from a branch that origin also has, e.g.: ' +
+        'git checkout main',
+    }
+  }
+
   // HEARTBEAT.md is self-modifying (rewritten by the agent every heartbeat).
   // Treating it as a blocker means the update button is almost always
   // refused in practice. Skip it from the dirty check; the file is
@@ -165,23 +201,30 @@ export function checkUpdatePreflight(git: GitRunner): PreflightResult {
     }
   }
 
-  // Local commits ahead of upstream = a diverged history. `git pull --ff-only`
-  // refuses this, and because update.sh runs detached the abort is invisible
-  // (the update looks "started" then reloads to the same commit list). Catch it
-  // here with an actionable message instead of that silent death. A running
-  // agent committing to its own tracked CLAUDE.md/SOUL.md/task-config is the
-  // usual cause. The tree is clean (changes are committed), so the dirty-tree
-  // stash cannot help; reconciliation is a separate, explicit step.
+  // A DIVERGED history -- ahead AND behind together -- is what `git pull
+  // --ff-only` refuses, and because update.sh runs detached the abort is
+  // invisible (the update looks "started" then reloads to the same commit
+  // list). Catch it here with an actionable message instead of that silent
+  // death. A running agent committing to its own tracked CLAUDE.md/SOUL.md/
+  // task-config is the usual cause. The tree is clean (changes are
+  // committed), so the dirty-tree stash cannot help; reconciliation is a
+  // separate, explicit step.
+  // Ahead ALONE is deliberately NOT blocked: update.sh stopped refusing on
+  // it (the operator's checkout sat 53 ahead / 0 behind on 2026-08-30 and
+  // was locked out of its own updater), but this copy of the rule was never
+  // updated with it, so the button stayed refused where the script would
+  // have run. Both sides now use the same condition.
   const ahead = git.aheadCount()
-  if (ahead > 0) {
+  const behind = git.behindCount()
+  if (ahead > 0 && behind > 0) {
     return {
       ok: false,
       reason: 'local-commits',
       ahead,
       message:
-        `The local checkout has ${ahead} commit(s) not on the upstream, so a ` +
-        'fast-forward update is not possible. This is usually a local edit that ' +
-        'was committed. Review with: git log @{u}..HEAD',
+        `The local checkout is ${ahead} commit(s) ahead and ${behind} behind the ` +
+        'upstream (the histories have parted), so a fast-forward update is not ' +
+        'possible. Reconcile them first. Review with: git log @{u}..HEAD',
     }
   }
 

--- a/src/web/routes/updates.ts
+++ b/src/web/routes/updates.ts
@@ -199,6 +199,17 @@ export async function tryHandleUpdates(ctx: RouteContext): Promise<boolean> {
       try { unlinkSync(UPDATE_PIDFILE) } catch { /* already gone */ }
       lockHeld = false
     }
+    const countRevs = (range: string): number => {
+      try {
+        const out = execFileSync(
+          '/usr/bin/git',
+          ['rev-list', '--count', range],
+          { cwd: PROJECT_ROOT, timeout: 3000, encoding: 'utf-8' },
+        ).trim()
+        const n = parseInt(out, 10)
+        return Number.isFinite(n) ? n : 0
+      } catch { return 0 }
+    }
     const git: GitRunner = {
       currentBranch: () => execFileSync(
         '/usr/bin/git',
@@ -210,16 +221,25 @@ export async function tryHandleUpdates(ctx: RouteContext): Promise<boolean> {
         ['status', '--porcelain', '--untracked-files=no'],
         { cwd: PROJECT_ROOT, timeout: 3000, encoding: 'utf-8' },
       ),
-      aheadCount: () => {
+      aheadCount: () => countRevs('@{u}..HEAD'),
+      behindCount: () => countRevs('HEAD..@{u}'),
+      // Mirrors update.sh guard 2. `git ls-remote --exit-code --heads` exits
+      // 2 for "no such branch" and 128 for a transport/auth failure -- the
+      // difference matters: only 2 is evidence, 128 is an unknown we must not
+      // block on. status is undefined when the spawn itself failed (timeout,
+      // git missing), which is likewise unknown.
+      originHasBranch: (branch: string) => {
         try {
-          const out = execFileSync(
+          execFileSync(
             '/usr/bin/git',
-            ['rev-list', '--count', '@{u}..HEAD'],
-            { cwd: PROJECT_ROOT, timeout: 3000, encoding: 'utf-8' },
-          ).trim()
-          const n = parseInt(out, 10)
-          return Number.isFinite(n) ? n : 0
-        } catch { return 0 }
+            ['ls-remote', '--exit-code', '--heads', 'origin', branch],
+            { cwd: PROJECT_ROOT, timeout: 15000, stdio: 'ignore' },
+          )
+          return 'yes' as const
+        } catch (err) {
+          const status = (err as { status?: number }).status
+          return status === 2 ? ('no' as const) : ('unknown' as const)
+        }
       },
     }
     let preflight


### PR DESCRIPTION
The preflight is a hand-copy of update.sh's guards, and the copy drifted in
both directions.

Missing rule: update.sh exits 2 when the current branch has no ref on origin
(nothing to fast-forward to). The preflight never checked, answered ok, and
the route spawned the script detached with its output going to a log nobody
reads, then returned {ok:true} -- so the UI ran its "reloading" countdown for
a run that could not start. Measured on this install: branch
fix/email-gate-mcp-matcher, ls-remote exit 2, preflight ok, update.sh exit 2.
The probe is three-valued on purpose: only ls-remote's exit 2 is evidence of
a missing branch, 128 (offline, auth) is an unknown and must not block.

Stale rule: update.sh stopped refusing on ahead-alone (2026-08-30, a checkout
53 ahead / 0 behind was locked out of its own updater), but this copy still
did. Now both sides refuse only on ahead AND behind, the real divergence.

Verified against the live endpoint, not just the unit: POST /api/updates/apply
-> 409 branch-not-on-origin, HEAD unchanged, lockfile released. 4757 tests
green.

---

Verified on a non-tmp clone of this branch, against the same checkout for `develop`:
`tsc --noEmit` clean, `vitest run` 361 files, 4685 passed. Baseline `develop` in the same place: 361 files, 4680 passed.
