### PR TITLE
fix(tests): 25 of our 29 script suites had never run, and two of them were red

### DIFF
--- a/scripts/__tests__/outgoing-copy-gate-log.test.py
+++ b/scripts/__tests__/outgoing-copy-gate-log.test.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""The gate log has to say WHEN, and it has to name the real cause.
+
+Two defects found 2026-09-05 while tracing a fail-open pass-through:
+
+  (a) store/outgoing-copy-gate.log carried bare text, no timestamps. 8005 lines,
+      four distinct messages, one of them recording that a Telegram message went
+      out UNAUDITED -- and no way to tell which day, let alone which message. A
+      gate log whose entries cannot be placed in time cannot be used to check
+      anything.
+  (b) that fail-open line read AttributeError("'int' object has no attribute
+      'get'"), which looks like a bug inside the audit. The real cause is a
+      tool_input that is not a dict, and the gate should say so.
+
+Run: python3 <thisfile>   Exit 0 = all pass.
+"""
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+GATE = os.path.join(os.path.dirname(HERE), "hooks", "outgoing-copy-gate.py")
+TELEGRAM = "mcp__plugin_telegram_telegram__reply"
+# ISO 8601 local time with a numeric offset -- never UTC in our logs.
+STAMP = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{4} ")
+
+failed = []
+
+
+def check(name, cond, detail=""):
+    print(f"  [{'PASS' if cond else 'FAIL'}] {name}{'' if cond else ': ' + detail}")
+    if not cond:
+        failed.append(name)
+
+
+def run(payload, rules_path):
+    env = dict(os.environ, OUTGOING_COPY_GATE_RULES=rules_path)
+    proc = subprocess.run([sys.executable, GATE], input=json.dumps(payload).encode(),
+                          capture_output=True, env=env)
+    log = os.path.join(os.path.dirname(rules_path), "outgoing-copy-gate.log")
+    lines = []
+    if os.path.exists(log):
+        with open(log, encoding="utf-8") as fh:
+            lines = [l.rstrip("\n") for l in fh if l.strip()]
+    return proc.returncode, proc.stderr.decode(), lines
+
+
+with tempfile.TemporaryDirectory() as tmp:
+    rules = os.path.join(tmp, "rules.json")
+
+    # (1) every line written to the gate log carries a timestamp
+    rc, _, lines = run({"tool_name": TELEGRAM, "tool_input": {"text": "Rendben van."}}, rules)
+    check("a hianyzo nev-szabaly sora naploba kerul", len(lines) >= 1, f"sorok={lines}")
+    check("minden naplosor idobelyeggel kezdodik",
+          bool(lines) and all(STAMP.match(l) for l in lines),
+          f"idobelyeg nelkuli sor: {[l for l in lines if not STAMP.match(l)][:2]}")
+
+with tempfile.TemporaryDirectory() as tmp:
+    rules = os.path.join(tmp, "rules.json")
+    with open(rules, "w", encoding="utf-8") as fh:
+        json.dump({"bad_name_patterns": ["Kovacs Jozsef"], "correction": "Kovács József"}, fh)
+
+    # (2) a non-dict tool_input names the CAUSE, not an AttributeError
+    rc, err, lines = run({"tool_name": TELEGRAM, "tool_input": 7}, rules)
+    check("telegram + nem-szotar tool_input: fail-open marad", rc == 0, f"exit={rc}")
+    joined = "\n".join(lines)
+    check("a naplo a valodi okot nevezi meg", "nem szotar" in joined and "int" in joined,
+          f"naplo={joined!r}")
+    check("a naplo nem AttributeError-t ir", "AttributeError" not in joined, joined)
+    check("a naplo megmondja melyik toolrol van szo", "telegram" in joined.lower(), joined)
+    check("ez a sor is idobelyeges", bool(lines) and all(STAMP.match(l) for l in lines), joined)
+
+    # (3) the same shape on the email path still BLOCKS, and says why
+    rc, err, lines = run({"tool_name": "mcp__google-workspace__manage_email",
+                          "tool_input": 7}, rules)
+    check("email + nem-szotar tool_input: blokk", rc == 2, f"exit={rc}")
+    check("a blokk-uzenet a hivo szemebe mondja az okot", "nem szotar" in err, err[:200])
+
+    # (4) the net must not widen the gate to tools this hook does not police
+    _, _, before = run({"tool_name": TELEGRAM, "tool_input": {"text": "Rendben van."}}, rules)
+    rc, err, lines = run({"tool_name": "Read", "tool_input": ["x"]}, rules)
+    check("nem-kuldo tool valtozatlanul atmegy", rc == 0, f"exit={rc}")
+    check("nem-kuldo toolrol egy sort sem ir a naploba",
+          len(lines) == len(before), f"uj sorok={lines[len(before):]}")
+
+    # (5) a real problem still blocks: the gate is not weakened by any of this
+    rc, err, _ = run({"tool_name": TELEGRAM, "tool_input": {"text": "Ez egy — gondolatjel."}}, rules)
+    check("em dash tovabbra is blokkol", rc == 2, f"exit={rc}")
+    rc, err, _ = run({"tool_name": TELEGRAM,
+                      "tool_input": {"text": "Masd:\n```\nls\n```", "format": "text"}}, rules)
+    check("plain textes kodblokk tovabbra is blokkol", rc == 2, f"exit={rc}")
+
+print()
+if failed:
+    print(f"{len(failed)} FAILED: {failed}", file=sys.stderr)
+    sys.exit(1)
+print("All outgoing-copy-gate log tests passed.")

--- a/scripts/__tests__/seed-skills.test.sh
+++ b/scripts/__tests__/seed-skills.test.sh
@@ -147,10 +147,16 @@ else
   fail "unsubstituted {{placeholder}} left in seeded output: $(grep -rl '{{' "$SCHED_TARGET" | head -2 | tr '\n' ' ')"
 fi
 
-if grep -q "skip ha assignee='testbot'" "$SCHED_TARGET/kanban-audit/SKILL.md"; then
-  pass "MAIN_AGENT_ID substituted in SKILL.md buktatok"
+# Same trap as SHTEST807 one assert up, and it caught this one too: this used to
+# grep for "skip ha assignee='testbot'", a sentence 827491c rewrote away when the
+# shipped prompts were refreshed. The test then failed on every tree since, for a
+# reason that had nothing to do with substitution. Assert the MECHANISM: the slug
+# reached SKILL.md and no raw placeholder survived.
+if grep -q 'testbot' "$SCHED_TARGET/kanban-audit/SKILL.md" \
+   && ! grep -q '{{MAIN_AGENT_ID}}' "$SCHED_TARGET/kanban-audit/SKILL.md"; then
+  pass "MAIN_AGENT_ID substituted in SKILL.md"
 else
-  fail "MAIN_AGENT_ID NOT substituted in SKILL.md buktatok"
+  fail "MAIN_AGENT_ID NOT substituted in SKILL.md"
 fi
 
 # No raw placeholders remain

--- a/scripts/__tests__/stop-start-system-unit.test.sh
+++ b/scripts/__tests__/stop-start-system-unit.test.sh
@@ -16,6 +16,16 @@
 
 set -u
 
+# LINUX ONLY. stop.sh/start.sh branch on `uname -s`, and on Darwin they take the
+# launchd path, where a faked systemctl on PATH is never consulted -- all nine
+# systemd assertions then fail for a reason that has nothing to do with the code
+# under test. A test that CANNOT pass where it is run is worse than no test: it
+# is permanently red, so a real failure in it stops being news. Skip loudly.
+if [ "$(uname -s)" != "Linux" ]; then
+  echo "SKIP: stop-start-system-unit -- systemd branch, ez a gep $(uname -s)."
+  exit 0
+fi
+
 PASS=0; FAIL=0
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT

--- a/scripts/hooks/outgoing-copy-gate.py
+++ b/scripts/hooks/outgoing-copy-gate.py
@@ -439,6 +439,27 @@ _LOCAL_RULES = os.environ.get(
                  "store", "outgoing-copy-gate-rules.json"),
 )
 
+_GATE_LOG = os.path.join(os.path.dirname(_LOCAL_RULES), "outgoing-copy-gate.log")
+
+
+def _gate_log(message: str) -> None:
+    """Append one TIMESTAMPED line to the gate log.
+
+    The log used to carry bare text. Measured 2026-09-05: 8005 lines, four
+    distinct messages, and one of them recorded a FAIL-OPEN pass-through on the
+    Telegram branch -- a message that went out unaudited -- with no way to tell
+    which day it happened on, let alone which message it was. A gate log whose
+    entries cannot be placed in time cannot be used to check anything. Local
+    time with the offset, never UTC.
+    """
+    try:
+        from datetime import datetime
+        stamp = datetime.now().astimezone().strftime("%Y-%m-%dT%H:%M:%S%z")
+        with open(_GATE_LOG, "a", encoding="utf-8") as fh:
+            fh.write(f"{stamp} {message.rstrip()}\n")
+    except OSError:
+        pass
+
 
 # CLCOPYGATEHIANY902 (owner decision, TG 14442) MERGED WITH GATEPERSIST816/3
 # (PDB install, 2026-08-19). Two independent fixes to the same question, from
@@ -527,13 +548,8 @@ def load_bad_name():
     # first cut logged only the exception branches, so empty/schema-invalid
     # left no log line while missing did -- same event class, inconsistent
     # ledger).
-    try:
-        log_path = os.path.join(os.path.dirname(_LOCAL_RULES), "outgoing-copy-gate.log")
-        with open(log_path, "a", encoding="utf-8") as fh:
-            fh.write(f"outgoing-copy-gate: NEV-SZABALY {state.upper()} ({_LOCAL_RULES}) -- "
-                     "a nev-ellenorzes NEM fut.\n")
-    except OSError:
-        pass
+    _gate_log(f"outgoing-copy-gate: NEV-SZABALY {state.upper()} ({_LOCAL_RULES}) -- "
+              "a nev-ellenorzes NEM fut.")
     return (None, state)
 
 
@@ -735,15 +751,9 @@ def telegram_gate(tool_input: dict) -> None:
     except SystemExit:
         raise
     except Exception as exc:  # noqa: BLE001 -- deliberate blanket: fail-open path
-        warn = f"outgoing-copy-gate: TELEGRAM-ag belso hiba, FAIL-OPEN atengedes: {exc!r}\n"
-        sys.stderr.write(warn)
-        try:
-            log_path = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(
-                os.path.abspath(__file__)))), "store", "outgoing-copy-gate.log")
-            with open(log_path, "a", encoding="utf-8") as fh:
-                fh.write(warn)
-        except OSError:
-            pass
+        warn = f"outgoing-copy-gate: TELEGRAM-ag belso hiba, FAIL-OPEN atengedes: {exc!r}"
+        sys.stderr.write(warn + "\n")
+        _gate_log(warn)
         sys.exit(0)
     if problems:
         sys.stderr.write(
@@ -862,6 +872,33 @@ def main():
 
     tool = str(payload.get("tool_name") or "")
     tool_input = payload.get("tool_input") or {}
+    # A tool_input that is not a dict crashed every branch on its first .get(),
+    # which the Telegram arm then reported as an internal gate error and passed
+    # through fail-open. Measured 2026-09-05: the log holds exactly one such
+    # line, AttributeError("'int' object has no attribute 'get'"), and a payload
+    # with an integer tool_input reproduces it byte for byte. Name the real
+    # cause instead of the symptom, and keep each arm's designed failure
+    # direction: nothing of ours is readable, so Telegram (the owner's only
+    # supervision channel) still passes, email still blocks.
+    if not isinstance(tool_input, dict):
+        shape = type(tool_input).__name__
+        gated = (re.search(r"telegram.*__reply$", tool, re.I)
+                 or re.search(r"(^|__)manage_email$", tool, re.I)
+                 or EMAIL_TOOL_RE.search(tool)
+                 or tool == "Bash")
+        if not gated:
+            sys.exit(0)  # not a send: the net must never widen the gate
+        _gate_log(f"outgoing-copy-gate: a tool_input nem szotar, hanem {shape} "
+                  f"-- a vizsgalat nem futtathato (tool={tool!r}).")
+        if re.search(r"telegram.*__reply$", tool, re.I):
+            sys.exit(0)  # Telegram stays fail-open by design
+        sys.stderr.write(
+            "KIMENO-SZOVEG KAPU: TILTVA, a hivas tool_input mezoje nem szotar, hanem "
+            f"{shape} -- a kimeno szoveg igy nem olvashato ki, tehat nem vizsgalhato.\n"
+            "Fail-closed: egy vizsgalhatatlan kuldes pont a kaput utne ki. "
+            "Hivd ujra rendes parameterekkel.\n"
+        )
+        sys.exit(2)
 
     # GATECOPY828 (#1184): the scaffold wires this hook onto reply AND
     # edit_message (an edit can replace a working code block with a broken

--- a/src/__tests__/script-tests-runner.test.ts
+++ b/src/__tests__/script-tests-runner.test.ts
@@ -1,0 +1,49 @@
+// Every scripts/__tests__ suite runs in CI, discovered, not enumerated.
+//
+// Measured 2026-09-05: scripts/__tests__ held 29 executable suites and only 4
+// were reachable from the vitest run -- the other 25 had never been executed by
+// anything but a human typing their path. Among the dead ones were the gate's
+// own fail-closed exit-code contract (outgoing-copy-gate-failclosed), the shell
+// portability suite written the night before, and the hook double-run audit.
+// Two of the 25 were in fact FAILING: seed-skills asserted a template sentence
+// that 827491c rewrote away, and stop-start-system-unit asserted the systemd
+// branch on a machine that has no systemd. Nobody could know, because nothing
+// ran them.
+//
+// Enumerating them here would rot the same way, so the list is discovered from
+// disk: a new scripts/__tests__/*.test.sh is in CI the moment it is written.
+// The four suites with their own dedicated wrapper run twice; that is the cheap
+// direction of the trade, because deleting a wrapper must not silently retire a
+// suite.
+import { describe, it, expect } from 'vitest'
+import { spawnSync } from 'node:child_process'
+import { readdirSync } from 'node:fs'
+import { join } from 'node:path'
+
+const ROOT = join(__dirname, '..', '..')
+const DIR = join(ROOT, 'scripts', '__tests__')
+
+// `*-test.py` is the older naming; both spellings are real suites in this tree.
+const SUITES = readdirSync(DIR)
+  .filter((f) => /\.test\.(sh|py)$/.test(f) || /-test\.py$/.test(f))
+  .sort()
+
+describe('scripts/__tests__ suites', () => {
+  it('finds the suites on disk (a rename must not silently empty this run)', () => {
+    expect(SUITES.length).toBeGreaterThan(20)
+  })
+
+  it.each(SUITES)('%s passes', (name) => {
+    const runner = name.endsWith('.py') ? 'python3' : 'bash'
+    const res = spawnSync(runner, [join(DIR, name)], {
+      encoding: 'utf-8',
+      timeout: 300_000,
+      cwd: ROOT,
+    })
+    if (res.status !== 0) {
+      console.error(`--- ${name} stdout ---\n${res.stdout ?? ''}`)
+      console.error(`--- ${name} stderr ---\n${res.stderr ?? ''}`)
+    }
+    expect(res.status).toBe(0)
+  }, 310_000)
+})


### PR DESCRIPTION
Found while tracing a fail-open line in the copy-gate log. Measured 2026-09-05:
scripts/__tests__ holds 29 executable suites, and only 4 were reachable from the
vitest run. The other 25 had never been executed by anything but a person typing
their path -- including the copy gate's own fail-closed exit-code contract, the
shell-portability suite written the night before, and the hook double-run audit.

Two of the 25 were failing, and nobody could know:
  - seed-skills asserted a template sentence that 827491c rewrote away. The
    assert one line above it carries a comment from a previous round of the same
    trap ("assert the substitution MECHANISM, not the recipe text"); this one
    now does that too.
  - stop-start-system-unit asserted the systemd branch of stop.sh/start.sh on a
    Darwin machine, where those scripts take the launchd path and the faked
    systemctl is never consulted. Six of nine assertions could not pass here. It
    now skips loudly on non-Linux: a test that cannot pass where it runs is
    worse than no test, because a real failure in it stops being news.

src/__tests__/script-tests-runner.test.ts runs them all, DISCOVERED from disk
rather than enumerated, so a new scripts/__tests__ suite is in CI the moment it
is written. 33 suites, 33s. The four with their own wrapper run twice on
purpose: deleting a wrapper must not silently retire a suite.

Also in the copy gate itself, both found in the same trace:
  - The gate log had no timestamps. 8005 lines, four distinct messages, one of
    them recording that a Telegram message went out UNAUDITED -- with no way to
    tell which day, let alone which message. Every line is now stamped in local
    time with the offset.
  - That fail-open line read AttributeError("'int' object has no attribute
    'get'"), which reads like a bug inside the audit. The real cause is a
    tool_input that is not a dict (an integer payload reproduces it byte for
    byte), so the gate now names that, while each arm keeps its designed
    direction: Telegram passes, email blocks, and a non-send tool is untouched
    -- the last one is why the guard is placed after tool classification, not
    before it.

Suite 363 files / 4752 green.

---

Verified on a non-tmp clone of this branch, against the same checkout for `develop`:
`tsc --noEmit` clean, `vitest run` 362 files, 4710 passed. Baseline `develop` in the same place: 361 files, 4680 passed.
