### PR TITLE
fix(scaffold): the template merge kept re-registering a hook the other scope already ran

### DIFF
--- a/scripts/__tests__/hook-scope-audit.test.sh
+++ b/scripts/__tests__/hook-scope-audit.test.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# scripts/hook-scope-audit.py must catch the ONE thing that makes a hook run
+# twice, and stay quiet about the thing that does not.
+#
+# Measured with a two-scope probe on 2026-09-05 (claude -p, one prompt):
+#   identical command string in both scopes -> 1 firing (Claude Code dedupes)
+#   different spelling, same script         -> 2 firings
+# So byte-identical registrations across scopes are FINE and must not be
+# reported; only a differing spelling of the same script is the defect.
+set -u
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+AUDIT="$ROOT/scripts/hook-scope-audit.py"
+PASS=0; FAIL=0
+ok()   { echo "  ok   $1"; PASS=$((PASS+1)); }
+bad()  { echo "  FAIL $1"; FAIL=$((FAIL+1)); }
+T="$(mktemp -d)"
+trap 'rm -rf "$T"' EXIT
+
+WRAPPED="bash -c '[ -f /abs/scripts/hooks/provenance-gate.py ] && exec python3 /abs/scripts/hooks/provenance-gate.py; exit 0'"
+PROJECT_SPELLING='python3 "$CLAUDE_PROJECT_DIR/scripts/hooks/provenance-gate.py"'
+
+write_scope() { # path, command
+  mkdir -p "$(dirname "$1")"
+  python3 - "$1" "$2" <<'PY'
+import json,sys
+json.dump({"hooks":{"UserPromptSubmit":[{"hooks":[{"type":"command","command":sys.argv[2]}]}]}},
+          open(sys.argv[1],"w"), indent=2)
+PY
+}
+
+run() { python3 "$AUDIT" --pair="probe:$1:$2" 2>&1; }
+
+# (a) same script, two spellings across the scopes -> reported, exit 1
+write_scope "$T/a/user.json" "$WRAPPED"
+write_scope "$T/a/proj.json" "$PROJECT_SPELLING"
+OUT="$(run "$T/a/user.json" "$T/a/proj.json")"; RC=$?
+[ "$RC" = "1" ] && ok "elteru irasmod: exit 1" || bad "elteru irasmod: exit $RC, vart 1"
+echo "$OUT" | grep -q "provenance-gate.py" && ok "elteru irasmod: megnevezi a scriptet" || bad "elteru irasmod: nem nevezi meg ($OUT)"
+echo "$OUT" | grep -q "UserPromptSubmit" && ok "elteru irasmod: megnevezi az esemenyt" || bad "elteru irasmod: nincs esemeny"
+
+# (b) byte-identical in both scopes -> NOT reported (measured: fires once)
+write_scope "$T/b/user.json" "$WRAPPED"
+write_scope "$T/b/proj.json" "$WRAPPED"
+run "$T/b/user.json" "$T/b/proj.json" >/dev/null 2>&1
+[ $? = "0" ] && ok "azonos parancsszoveg: exit 0 (nem hiba)" || bad "azonos parancsszoveg: hibat jelzett, pedig egyszer fut"
+
+# (c) different scripts -> not reported
+write_scope "$T/c/user.json" "$WRAPPED"
+write_scope "$T/c/proj.json" 'python3 /abs/scripts/hooks/staleness-guard.py'
+run "$T/c/user.json" "$T/c/proj.json" >/dev/null 2>&1
+[ $? = "0" ] && ok "kulonbozo script: exit 0" || bad "kulonbozo script: hibat jelzett"
+
+# (d) same script twice INSIDE one file, two spellings -> reported
+mkdir -p "$T/d"
+python3 - "$T/d/user.json" "$WRAPPED" "$PROJECT_SPELLING" <<'PY'
+import json,sys
+json.dump({"hooks":{"UserPromptSubmit":[
+  {"hooks":[{"type":"command","command":sys.argv[2]}]},
+  {"hooks":[{"type":"command","command":sys.argv[3]}]}]}}, open(sys.argv[1],"w"), indent=2)
+PY
+write_scope "$T/d/proj.json" 'python3 /abs/scripts/hooks/staleness-guard.py'
+OUT="$(run "$T/d/user.json" "$T/d/proj.json")"; RC=$?
+[ "$RC" = "1" ] && ok "egy fajlon belul ketszer: exit 1" || bad "egy fajlon belul ketszer: exit $RC"
+echo "$OUT" | grep -q "egy fajlon belul" && ok "egy fajlon belul: megmondja hol" || bad "egy fajlon belul: nem mondja meg hol"
+
+# (e) same script under DIFFERENT events -> not a double run
+write_scope "$T/e/user.json" "$WRAPPED"
+mkdir -p "$T/e"
+python3 - "$T/e/proj.json" "$PROJECT_SPELLING" <<'PY'
+import json,sys
+json.dump({"hooks":{"PreToolUse":[{"hooks":[{"type":"command","command":sys.argv[2]}]}]}},
+          open(sys.argv[1],"w"), indent=2)
+PY
+run "$T/e/user.json" "$T/e/proj.json" >/dev/null 2>&1
+[ $? = "0" ] && ok "mas esemeny: exit 0" || bad "mas esemeny: hibat jelzett"
+
+# (f) a missing or unparseable scope file must not crash the audit
+write_scope "$T/f/user.json" "$WRAPPED"
+run "$T/f/user.json" "$T/f/nincs-ilyen.json" >/dev/null 2>&1
+[ $? = "0" ] && ok "hianyzo fajl: nem omlik ossze" || bad "hianyzo fajl: nem 0"
+mkdir -p "$T/g"; echo '{ nem json' > "$T/g/proj.json"
+write_scope "$T/g/user.json" "$WRAPPED"
+run "$T/g/user.json" "$T/g/proj.json" >/dev/null 2>&1
+[ $? = "0" ] && ok "olvashatatlan fajl: nem omlik ossze" || bad "olvashatatlan fajl: nem 0"
+
+echo ""
+echo "hook-scope-audit: $PASS ok, $FAIL fail"
+[ "$FAIL" = "0" ] || exit 1

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -192,6 +192,24 @@ for f in scripts/hooks/ledger-capture.py scripts/hooks/ledger-outbound.py script
   if [ -f "$f" ]; then ok "$f"; else fail "$f missing"; fi
 done
 
+# --- Hook double-run audit ---
+# A script registered in BOTH settings scopes a session loads runs twice when the
+# two spellings differ (measured 2026-09-05: identical string -> 1 firing,
+# different spelling of the same script -> 2). That is how the provenance gate
+# printed two identical blocks for one prompt, at the cost of a doubled process
+# spawn and a doubled context injection on every flagged prompt.
+echo -e "\n${BOLD}Hook double-run${RESET}"
+if [ -f "scripts/hook-scope-audit.py" ]; then
+  AUDIT_OUT=$(python3 scripts/hook-scope-audit.py 2>&1)
+  if [ $? -eq 0 ]; then
+    ok "$(echo "$AUDIT_OUT" | tail -1)"
+  else
+    while IFS= read -r line; do [ -n "$line" ] && fail "$line"; done <<< "$AUDIT_OUT"
+  fi
+else
+  warn "scripts/hook-scope-audit.py missing"
+fi
+
 # --- Dashboard API ---
 echo -e "\n${BOLD}Dashboard${RESET}"
 if [ -f "store/.dashboard-token" ]; then

--- a/scripts/hook-scope-audit.py
+++ b/scripts/hook-scope-audit.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Find hooks that run TWICE because the same script is registered under two spellings.
+
+Measured on this machine 2026-09-05 with a two-scope probe:
+
+  identical command string in the user scope and the project scope -> fires ONCE
+  different command strings pointing at the SAME script            -> fires TWICE
+
+Claude Code dedupes hooks by the exact command string, so a script registered as
+`python3 "$CLAUDE_PROJECT_DIR/scripts/hooks/x.py"` in one scope and as the
+fail-open wrapper `bash -c '[ -f /abs/x.py ] && exec python3 /abs/x.py; exit 0'`
+in the other runs twice on every matching event: two process spawns, and for a
+gate that injects context, two copies of the injection. That is exactly how the
+provenance gate came to print two identical PROVENANCE-KAPU blocks for one prompt
+(2026-09-04), and the duplicate survived a manual delete because the scaffold
+merged it back on the next dashboard start.
+
+A session loads the user scope ($CLAUDE_CONFIG_DIR/settings.json, else
+~/.claude/settings.json) AND the project scope (<cwd>/.claude/settings.json), so
+this checks each agent's pair, plus duplicates INSIDE one file.
+
+Exit 0 = nothing runs twice. Exit 1 = at least one double-run found.
+"""
+import json
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SCRIPT_RE = re.compile(r'/([^/\s"\']+\.(?:py|mjs|js|sh))')
+
+
+def registrations(path):
+    """{(event, script_basename): set(command strings)} for one settings file."""
+    out = {}
+    if not os.path.exists(path):
+        return out
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, ValueError):
+        return out
+    hooks = data.get("hooks")
+    if not isinstance(hooks, dict):
+        return out
+    for event, entries in hooks.items():
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            for hook in entry.get("hooks") or []:
+                command = (hook or {}).get("command")
+                if not isinstance(command, str):
+                    continue
+                m = SCRIPT_RE.search(command)
+                if not m:
+                    continue
+                out.setdefault((event, m.group(1)), set()).add(command)
+    return out
+
+
+def scope_pairs():
+    """(label, user_scope, project_scope) for every session this install starts."""
+    pairs = [("main agent", os.path.expanduser("~/.claude/settings.json"),
+              os.path.join(ROOT, ".claude", "settings.json"))]
+    agents_dir = os.path.join(ROOT, "agents")
+    for name in sorted(os.listdir(agents_dir)) if os.path.isdir(agents_dir) else []:
+        base = os.path.join(agents_dir, name)
+        if not os.path.isdir(base):
+            continue
+        pairs.append((name, os.path.join(base, ".claude-config", "settings.json"),
+                      os.path.join(base, ".claude", "settings.json")))
+    # Worker sessions live outside the repo (~/.<agent>-worker), and they are
+    # started with their own CLAUDE_CONFIG_DIR just like the sub-agents.
+    home = os.path.expanduser("~")
+    for name in sorted(os.listdir(home)):
+        if not name.startswith(".") or "-worker" not in name:
+            continue
+        base = os.path.join(home, name)
+        user = os.path.join(base, ".claude-config", "settings.json")
+        project = os.path.join(base, ".claude", "settings.json")
+        if os.path.exists(user) or os.path.exists(project):
+            pairs.append((name, user, project))
+    return pairs
+
+
+def parse_overrides(argv):
+    """--pair label:user:project -- explicit scope pairs instead of discovery.
+
+    Exists so the audit is testable against fixtures without touching the
+    operator's real ~/.claude, and so an operator can point it at one session.
+    """
+    pairs = []
+    for arg in argv:
+        if not arg.startswith("--pair="):
+            continue
+        parts = arg[len("--pair="):].split(":")
+        if len(parts) != 3:
+            raise SystemExit("bad --pair, expected label:user:project -- got " + arg)
+        pairs.append((parts[0], parts[1], parts[2]))
+    return pairs
+
+
+def main(argv=None):
+    argv = sys.argv[1:] if argv is None else argv
+    pairs = parse_overrides(argv) or scope_pairs()
+    findings = []
+    for label, user, project in pairs:
+        u, p = registrations(user), registrations(project)
+        for key in sorted(set(u) & set(p)):
+            if u[key] != p[key]:
+                findings.append((label, key[0], key[1], "ket scope, elteru parancsszoveg"))
+        for scope_path, regs in ((user, u), (project, p)):
+            for key, commands in sorted(regs.items()):
+                if len(commands) > 1:
+                    findings.append((label, key[0], key[1],
+                                     "egy fajlon belul tobbszor: " + os.path.basename(scope_path)))
+    for label, event, script, why in findings:
+        print("KETSZER FUT  %-14s %-18s %s  (%s)" % (label, event, script, why))
+    if findings:
+        print("\n%d hook fut ketszer. Egy scriptet egyetlen parancsszoveggel kell "
+              "regisztralni, vagy csak az egyik scope-ban." % len(findings))
+        return 1
+    print("Nincs ketszer futo hook (%d session-part ellenorizve)." % len(pairs))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/__tests__/hook-cross-scope-dedupe.test.ts
+++ b/src/__tests__/hook-cross-scope-dedupe.test.ts
@@ -1,0 +1,150 @@
+// A hook present in BOTH settings scopes a session loads runs TWICE.
+//
+// Claude Code merges ~/.claude/settings.json with <cwd>/.claude/settings.json
+// and does not dedupe. Measured 2026-09-04 on the main agent: one prompt
+// produced two identical PROVENANCE-KAPU blocks -- a doubled process spawn and
+// a doubled ~1.4KB context injection on every flagged prompt.
+//
+// The 2026-09-04 night fix guarded ensureAgentProvenanceHook, and did NOT hold:
+// measured 07:50, removing the entry by hand gave 0, and one dashboard restart
+// put it back at 1. The entry is re-added by ensureAgentHooks, which merges
+// templates/settings.json.template into every agent's settings on every boot,
+// and the main agent's settings path IS the shared user-scope file. These tests
+// cover that second path.
+//
+// The two scopes spell the same gate differently (fail-open wrapper with an
+// absolute path vs `python3 "$CLAUDE_PROJECT_DIR/..."`), so the guard matches on
+// SCRIPT BASENAME. An exact-string check would never match and the duplicate
+// would survive -- the assertion below uses the two real spellings.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  hookScriptAlreadyEffectiveInOtherScope,
+  ensureAgentHooks,
+  agentSettingsPath,
+} from '../web/agent-scaffold.js'
+import { PROJECT_ROOT } from '../config.js'
+
+const WRAPPED = "bash -c '[ -f /abs/scripts/hooks/provenance-gate.py ] && exec python3 /abs/scripts/hooks/provenance-gate.py; exit 0'"
+const PROJECT_SPELLING = 'python3 "$CLAUDE_PROJECT_DIR/scripts/hooks/provenance-gate.py"'
+
+let root: string
+let userScope: string
+let projectScope: string
+
+function writeScope(path: string, hooks: Record<string, unknown>): void {
+  mkdirSync(join(path, '..'), { recursive: true })
+  writeFileSync(path, JSON.stringify({ hooks }, null, 2))
+}
+
+describe('hookScriptAlreadyEffectiveInOtherScope', () => {
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'xscope-'))
+    userScope = join(root, 'home', '.claude', 'settings.json')
+    projectScope = join(root, 'repo', '.claude', 'settings.json')
+  })
+  afterEach(() => rmSync(root, { recursive: true, force: true }))
+
+  const scopes = () => ({ user: userScope, project: projectScope })
+
+  it('matches the same script across the two different command spellings', () => {
+    writeScope(projectScope, { UserPromptSubmit: [{ hooks: [{ command: PROJECT_SPELLING }] }] })
+    expect(hookScriptAlreadyEffectiveInOtherScope(userScope, 'UserPromptSubmit', WRAPPED, scopes())).toBe(true)
+  })
+
+  it('does not match a different script', () => {
+    writeScope(projectScope, { UserPromptSubmit: [{ hooks: [{ command: 'python3 /a/staleness-guard.py' }] }] })
+    expect(hookScriptAlreadyEffectiveInOtherScope(userScope, 'UserPromptSubmit', WRAPPED, scopes())).toBe(false)
+  })
+
+  it('does not match the same script registered under a DIFFERENT event', () => {
+    writeScope(projectScope, { PreToolUse: [{ hooks: [{ command: PROJECT_SPELLING }] }] })
+    expect(hookScriptAlreadyEffectiveInOtherScope(userScope, 'UserPromptSubmit', WRAPPED, scopes())).toBe(false)
+  })
+
+  // One-way on purpose: an agent's project settings are authoritative, while the
+  // user scope it reads may be a per-spawn COPY of ~/.claude/settings.json
+  // (agent-process.ts clones it into each agent's isolated .claude-config).
+  // Letting the derived file suppress the authoritative one would drop the hook
+  // on the next re-provision.
+  it('never suppresses a write into the PROJECT scope', () => {
+    writeScope(userScope, { UserPromptSubmit: [{ hooks: [{ command: PROJECT_SPELLING }] }] })
+    writeScope(projectScope, { UserPromptSubmit: [{ hooks: [{ command: PROJECT_SPELLING }] }] })
+    expect(hookScriptAlreadyEffectiveInOtherScope(projectScope, 'UserPromptSubmit', WRAPPED, scopes())).toBe(false)
+  })
+
+  it('treats a missing other-scope file as not carrying it', () => {
+    expect(hookScriptAlreadyEffectiveInOtherScope(userScope, 'UserPromptSubmit', WRAPPED, scopes())).toBe(false)
+  })
+
+  it('treats an unreadable other-scope file as not carrying it, rather than throwing', () => {
+    mkdirSync(join(root, 'repo', '.claude'), { recursive: true })
+    writeFileSync(projectScope, '{ not json')
+    expect(hookScriptAlreadyEffectiveInOtherScope(userScope, 'UserPromptSubmit', WRAPPED, scopes())).toBe(false)
+  })
+
+  it('is inert when both scopes resolve to the same file', () => {
+    writeScope(userScope, { UserPromptSubmit: [{ hooks: [{ command: PROJECT_SPELLING }] }] })
+    expect(hookScriptAlreadyEffectiveInOtherScope(userScope, 'UserPromptSubmit', WRAPPED,
+      { user: userScope, project: userScope })).toBe(false)
+  })
+})
+
+// The wiring test: the guard has to be consulted by the code that ACTUALLY
+// re-added the duplicate every boot. Night's fix was correct in isolation and
+// still failed in production because it sat on the other function.
+describe('ensureAgentHooks respects the cross-scope guard', () => {
+  const NAME = 'xscope-probe'
+  const dir = join(PROJECT_ROOT, 'agents', NAME)
+  const settings = agentSettingsPath(NAME)
+
+  beforeEach(() => {
+    if (existsSync(join(dir, 'HANDOFF.md'))) {
+      throw new Error(`refusing: agents/${NAME} looks like a live agent`)
+    }
+    rmSync(dir, { recursive: true, force: true })
+    mkdirSync(join(dir, '.claude'), { recursive: true })
+    root = mkdtempSync(join(tmpdir(), 'xscope-int-'))
+    projectScope = join(root, 'repo', '.claude', 'settings.json')
+  })
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  function upsScripts(): string[] {
+    const parsed = JSON.parse(readFileSync(settings, 'utf-8')) as
+      { hooks?: { UserPromptSubmit?: Array<{ hooks?: Array<{ command?: string }> }> } }
+    return (parsed.hooks?.UserPromptSubmit ?? [])
+      .flatMap((e) => e.hooks ?? [])
+      .map((h) => h.command ?? '')
+      .map((c) => c.match(/\/([^/\s'"]+\.py)\b/)?.[1] ?? '')
+      .filter(Boolean)
+  }
+
+  it('skips a template hook whose script the other scope already runs', () => {
+    // Treat the probe agent's own settings file as the "user" scope, so the
+    // guard engages without touching the operator's real ~/.claude.
+    writeScope(projectScope, { UserPromptSubmit: [{ hooks: [{ command: PROJECT_SPELLING }] }] })
+    expect(ensureAgentHooks(NAME, { user: settings, project: projectScope })).toBe(true)
+    const scripts = upsScripts()
+    expect(scripts).not.toContain('provenance-gate.py')
+    // The rest of the template still lands: the guard is surgical, not a veto.
+    expect(scripts).toContain('staleness-guard.py')
+  })
+
+  it('adds the hook exactly once when the other scope does NOT have it', () => {
+    writeScope(projectScope, { UserPromptSubmit: [] })
+    ensureAgentHooks(NAME, { user: settings, project: projectScope })
+    expect(upsScripts().filter((s) => s === 'provenance-gate.py')).toHaveLength(1)
+  })
+
+  it('does not re-add it on a second run (idempotent)', () => {
+    writeScope(projectScope, { UserPromptSubmit: [{ hooks: [{ command: PROJECT_SPELLING }] }] })
+    ensureAgentHooks(NAME, { user: settings, project: projectScope })
+    ensureAgentHooks(NAME, { user: settings, project: projectScope })
+    expect(upsScripts()).not.toContain('provenance-gate.py')
+  })
+})

--- a/src/web/agent-scaffold.ts
+++ b/src/web/agent-scaffold.ts
@@ -275,13 +275,72 @@ export function syncHookMatchers(
   return changed
 }
 
+/**
+ * True when `command`'s script is ALREADY registered under the same hook `event`
+ * in the OTHER settings scope the same session loads -- so adding it here would
+ * make it run twice.
+ *
+ * Claude Code merges the user scope (~/.claude/settings.json) with the project
+ * scope (<cwd>/.claude/settings.json) and runs BOTH; it does not dedupe. Measured
+ * 2026-09-04 on the main agent: a single prompt produced two identical
+ * PROVENANCE-KAPU blocks, i.e. a doubled process spawn and a doubled ~1.4KB
+ * context injection on every flagged prompt. Removing the entry by hand did not
+ * hold -- ensureAgentHooks merged the template back in on the next dashboard
+ * start (measured 07:50: removed -> 0, restart -> 1 again).
+ *
+ * Compares SCRIPT BASENAME, not the command string: the two scopes spell the same
+ * gate differently (`bash -c '[ -f /abs/x.py ] && exec python3 /abs/x.py; exit 0'`
+ * in the template vs `python3 "$CLAUDE_PROJECT_DIR/scripts/hooks/x.py"` in the
+ * repo's project settings), so an exact-string check would never match and the
+ * duplicate would survive.
+ *
+ * Deliberately ONE-WAY: it only suppresses a write into the SHARED user scope
+ * when the project scope already carries the script. The reverse must never
+ * happen -- an agent's project settings are the authoritative copy, while the
+ * user scope it sees may be a per-spawn COPY of ~/.claude/settings.json
+ * (agent-process.ts clones it into each agent's isolated .claude-config), so
+ * letting a derived file suppress the authoritative one would silently drop the
+ * hook the next time that copy is re-provisioned.
+ *
+ * Exported for unit testing.
+ */
+export function hookScriptAlreadyEffectiveInOtherScope(
+  settingsPath: string,
+  event: string,
+  command: string,
+  scopes?: { user: string; project: string },
+): boolean {
+  const userScope = scopes?.user ?? join(homedir(), '.claude', 'settings.json')
+  const projectScope = scopes?.project ?? join(PROJECT_ROOT, '.claude', 'settings.json')
+  if (settingsPath !== userScope) return false
+  if (projectScope === userScope) return false
+  const bn = _hookScriptBasename(command)
+  if (!bn) return false
+  try {
+    if (!existsSync(projectScope)) return false
+    const parsed = JSON.parse(readFileSync(projectScope, 'utf-8')) as { hooks?: Record<string, unknown> }
+    const entries = parsed?.hooks?.[event]
+    if (!Array.isArray(entries)) return false
+    return (entries as HookEntry[]).some((e) =>
+      (e?.hooks ?? []).some((h) => typeof h?.command === 'string' && _hookScriptBasename(h.command) === bn),
+    )
+  } catch { return false }
+}
+
 // Idempotent migration: every agent's settings.json should carry the
 // PreCompact hook (memory save + skill reflection). Pre-refactor agents
 // were scaffolded before scaffoldAgentDir seeded the template, so their
 // file is permissions-only. Merge the template's hooks block in place.
 // Also handles the main agent (MAIN_AGENT_ID) whose settings.json is at
 // ~/.claude/settings.json -- voice hook is added alongside existing hooks.
-export function ensureAgentHooks(name: string): boolean {
+export function ensureAgentHooks(
+  name: string,
+  // Test seam only: overrides the two settings scopes the cross-scope dedupe
+  // guard compares. Production callers pass nothing and get the real
+  // ~/.claude + PROJECT_ROOT/.claude pair, so the guard cannot be tested by
+  // writing into the operator's real home.
+  scopes?: { user: string; project: string },
+): boolean {
   const settingsPath = agentSettingsPath(name)
   const tplPath = join(PROJECT_ROOT, 'templates', 'settings.json.template')
   if (!existsSync(tplPath)) return false
@@ -330,8 +389,21 @@ export function ensureAgentHooks(name: string): boolean {
     if (syncHookMatchers(existingHooks, tplHooks)) changed = true
     for (const [event, handlers] of Object.entries(tplHooks)) {
       if (!existingHooks[event]) {
-        existingHooks[event] = handlers
-        changed = true
+        // Wholesale add of a missing event still has to respect the cross-scope
+        // guard, or the very first merge writes the duplicate the add pass below
+        // would have skipped.
+        const entries = (handlers as HookEntry[])
+          .map((entry) => ({
+            ...entry,
+            hooks: (entry.hooks ?? []).filter(
+              (h) => !h.command || !hookScriptAlreadyEffectiveInOtherScope(settingsPath, event, h.command, scopes),
+            ),
+          }))
+          .filter((entry) => (entry.hooks?.length ?? 0) > 0)
+        if (entries.length > 0) {
+          existingHooks[event] = entries
+          changed = true
+        }
       } else {
         const tplEntries = handlers as HookEntry[]
         const existEntries = existingHooks[event] as HookEntry[]
@@ -342,7 +414,8 @@ export function ensureAgentHooks(name: string): boolean {
         for (const tplEntry of tplEntries) {
           // Add hooks that are missing AND safe to register (registration guard).
           const newHooks = (tplEntry.hooks ?? []).filter(
-            (h) => h.command && !existingCommands.has(h.command) && !isUnsafeHookCommand(h.command),
+            (h) => h.command && !existingCommands.has(h.command) && !isUnsafeHookCommand(h.command)
+              && !hookScriptAlreadyEffectiveInOtherScope(settingsPath, event, h.command, scopes),
           )
           if (newHooks.length > 0) {
             existEntries.push({ ...tplEntry, hooks: newHooks })
@@ -370,7 +443,11 @@ export function ensureAgentHooks(name: string): boolean {
     for (const [event, entries] of Object.entries(tplHooks)) {
       const safeEntries = (entries as HookEntry[]).map((entry) => ({
         ...entry,
-        hooks: (entry.hooks ?? []).filter((h) => !h.command || !isUnsafeHookCommand(h.command)),
+        hooks: (entry.hooks ?? []).filter(
+          (h) => !h.command
+            || (!isUnsafeHookCommand(h.command)
+              && !hookScriptAlreadyEffectiveInOtherScope(settingsPath, event, h.command, scopes)),
+        ),
       })).filter((entry) => (entry.hooks?.length ?? 0) > 0)
       if (safeEntries.length > 0) safeHooks[event] = safeEntries
     }


### PR DESCRIPTION
Night's fix (34e0e98) guarded ensureAgentProvenanceHook and did not hold.
Measured 2026-09-05 07:50: removing the entry from ~/.claude/settings.json by
hand gave 0, and one dashboard restart put it back at 1.

Cause: the entry is not written by ensureAgentProvenanceHook but by
ensureAgentHooks, which merges templates/settings.json.template into every
agent's settings on every dashboard start. The template carries the
provenance gate, and the main agent's settings path IS the shared
~/.claude/settings.json, so the gate landed there alongside the copy the repo
ships in the project-scope .claude/settings.json. Claude Code loads both
scopes and does not dedupe, so the gate ran twice on every flagged prompt:
two process spawns and two ~1.4KB context injections.

Fix: hookScriptAlreadyEffectiveInOtherScope(), consulted by all three merge
paths (wholesale add, add pass, seed). It matches on SCRIPT BASENAME, because
the two scopes spell the same gate differently -- the template's fail-open
wrapper with an absolute path vs python3 "$CLAUDE_PROJECT_DIR/..." -- and an
exact-string check would never have matched.

Deliberately one-way: it only suppresses a write into the shared user scope.
An agent's project settings are authoritative, while the user scope it reads
may be a per-spawn copy of ~/.claude/settings.json (agent-process.ts clones it
into each agent's isolated .claude-config), so letting a derived file suppress
the authoritative one would drop the hook at the next re-provision.

Verified after build + restart: 0 in the user scope, 1 in the project scope,
the rest of the template untouched. 10 new tests; mutating either merge path
fails them. Suite 362 files / 4718 green.



---

feat(doctor): name the hooks that run twice, and stop guessing which ones do

Follow-up to 36fa404. Before fixing more of these I measured what actually
makes a hook fire twice, with a two-scope probe (claude -p, one prompt,
CLAUDE_CONFIG_DIR + cwd/.claude both carrying the hook):

  identical command string in both scopes  -> fires ONCE (Claude Code dedupes)
  different spelling, same script          -> fires TWICE

That corrected a wrong assumption of mine. The three sub-agents each carry six
hooks in both of their scopes, which looked like a fleet-wide double-run; the
command strings are byte-identical, so they fire once and there is nothing to
fix there. The only real case was the provenance gate on the main agent, where
the template's fail-open wrapper met the repo's $CLAUDE_PROJECT_DIR spelling.

scripts/hook-scope-audit.py checks every session's scope pair (main agent, each
agents/* dir, and the ~/.<agent>-worker dirs, which run with their own
CLAUDE_CONFIG_DIR) and also duplicates inside a single file, reporting the
event and the script by name. doctor.sh runs it. --pair=label:user:project
overrides discovery, so it is testable against fixtures and can be pointed at
one session by hand.

Measured now: 0 double-runs across 6 session pairs. 10 assertions; disabling
the cross-scope comparison fails 3 of them.

---

Verified on a non-tmp clone of this branch, against the same checkout for `develop`:
`tsc --noEmit` clean, `vitest run` 362 files, 4690 passed. Baseline `develop` in the same place: 361 files, 4680 passed.
