### PR TITLE
fix(restart-gate): an unanswered inbound holds the gate only until the drain shows it

### DIFF
--- a/src/__tests__/context-restart-gate.test.ts
+++ b/src/__tests__/context-restart-gate.test.ts
@@ -8,6 +8,7 @@ import {
   isNonWorkHelperProcess,
   parseEtimeSeconds,
   commBasename,
+  openQuestionBlocks,
   TASKSTATE_FRESH_WINDOW_MS,
 } from '../web/context-restart-gate-runner.js'
 import {
@@ -765,3 +766,35 @@ describe('gateWakePrompt', () => {
     expect(gateWakePrompt()).toContain('ne talalj ki magadnak feladatot')
   })
 })
+
+// LEDGERACK905: an unanswered inbound holds the gate only until the drain has
+// actually put it in front of the agent. Laszlo's bare "ok" on 2026-09-04
+// 22:24 held it for eight hours at 630% of the threshold, and the only escape
+// would have been a midnight reply nobody needed. His call: block until
+// surfaced, not on a timer.
+describe('openQuestionBlocks', () => {
+  it('does not block when nothing is open', () => {
+    expect(openQuestionBlocks(null, null)).toBe(false)
+    expect(openQuestionBlocks(null, '8246')).toBe(false)
+  })
+
+  it('blocks an open question the drain has not surfaced yet', () => {
+    expect(openQuestionBlocks('8246', null)).toBe(true)
+  })
+
+  it('stops blocking once the drain surfaced THAT message', () => {
+    expect(openQuestionBlocks('8246', '8246')).toBe(false)
+  })
+
+  it('still blocks when the drain last surfaced a DIFFERENT message', () => {
+    expect(openQuestionBlocks('8250', '8246')).toBe(true)
+  })
+
+  it('holds when the open question carries no identifiable message id', () => {
+    // Unknown id cannot be matched against a marker, and "unknown" must read
+    // as "the agent has not seen it".
+    expect(openQuestionBlocks('', '8246')).toBe(true)
+    expect(openQuestionBlocks('', null)).toBe(true)
+  })
+})
+

--- a/src/db.ts
+++ b/src/db.ts
@@ -2597,6 +2597,33 @@ export function getDispatchedPendingStats(
  * True when the agent's last inbound channel message has no later outbound
  * (unanswered question). Used by the context-restart gate.
  */
+/**
+ * The message id of the newest inbound that has no outbound after it, or null
+ * when nothing is open. Same rule as hasOpenInboundQuestion, but it hands back
+ * WHICH message, so a caller can ask whether the agent has already been shown
+ * it (see openQuestionBlocks in the restart-gate runner).
+ *
+ * Returns '' for an open question whose row carries no message id: the caller
+ * cannot match that against a marker, and the safe reading of "unknown" is
+ * that the agent has not seen it.
+ */
+export function openInboundQuestionMessageId(agentId: string): string | null {
+  const row = db.prepare(
+    `SELECT id, created_at, message_id FROM conversation_log
+       WHERE agent_id = ? AND direction = 'in'
+       ORDER BY created_at DESC, id DESC LIMIT 1`,
+  ).get(agentId) as { id: number; created_at: number; message_id: string | null } | undefined
+  if (!row) return null
+  const laterOut = db.prepare(
+    `SELECT 1 FROM conversation_log
+       WHERE agent_id = ? AND direction = 'out'
+         AND (created_at > ? OR (created_at = ? AND id > ?))
+       LIMIT 1`,
+  ).get(agentId, row.created_at, row.created_at, row.id)
+  if (laterOut) return null
+  return row.message_id == null ? '' : String(row.message_id)
+}
+
 export function hasOpenInboundQuestion(agentId: string): boolean {
   const row = db.prepare(
     `SELECT id, created_at FROM conversation_log

--- a/src/web/context-restart-gate-runner.ts
+++ b/src/web/context-restart-gate-runner.ts
@@ -17,7 +17,7 @@ import { getHardGuardPhase } from './context-guard-runner.js'
 import { readGateConfig, readGateRunState, writeGateRunState } from './context-restart-gate-store.js'
 import {
   getDispatchedPendingStats,
-  hasOpenInboundQuestion,
+  openInboundQuestionMessageId,
   createAgentMessage,
 } from '../db.js'
 import {
@@ -116,6 +116,42 @@ export function isInfrastructureChild(childAgeS: number, claudeAgeS: number): bo
   if (childAgeS < CHILD_MIN_AGE_S) return true
   if (childAgeS >= claudeAgeS - INFRA_AGE_DELTA_S) return true
   return false
+}
+
+/**
+ * The last inbound message the ledger drain surfaced for this agent, or null.
+ * The drain (scripts/hooks/ledger-live-drain.py) writes the id into
+ * store/.ledger-drain-<agent> when it puts a lost inbound in front of the
+ * agent; the sanitisation here mirrors its _statefile().
+ */
+function drainSurfacedMessageId(ledgerAgentId: string): string | null {
+  const safe = String(ledgerAgentId).replace(/[^A-Za-z0-9_-]/g, '_')
+  try {
+    const raw = readFileSync(join(PROJECT_ROOT, 'store', `.ledger-drain-${safe}`), 'utf-8').trim()
+    return raw || null
+  } catch { return null }
+}
+
+/**
+ * Does an unanswered inbound still justify holding the gate shut?
+ *
+ * Only until the agent has actually been SHOWN it. Before that, a /clear could
+ * lose a question nobody has read; after it, the agent knows and the decision
+ * to answer is its own -- and some messages rightly get no answer. Laszlo's
+ * "ok" on 2026-09-04 22:24 held the gate for eight hours at 630% of the
+ * threshold, and the only way out would have been to wake him at midnight with
+ * a reply nobody needed (LEDGERACK905, his call: block until surfaced, no
+ * arbitrary timer).
+ *
+ * Pure so the rule is testable without a database or a statefile.
+ */
+export function openQuestionBlocks(
+  openMessageId: string | null,
+  surfacedMessageId: string | null,
+): boolean {
+  if (openMessageId === null) return false      // nothing open
+  if (openMessageId === '') return true         // open, but unidentifiable: hold
+  return openMessageId !== surfacedMessageId    // held until the drain showed it
 }
 
 function sessionFor(name: string): string {
@@ -611,7 +647,11 @@ export function gatherGateInputs(name: string, nowMs: number): GateSnapshot {
   })()
 
   const openQuestion = (() => {
-    try { return hasOpenInboundQuestion(agentIdForLedger(name)) }
+    try {
+      const ledgerId = agentIdForLedger(name)
+      return openQuestionBlocks(openInboundQuestionMessageId(ledgerId),
+                                drainSurfacedMessageId(ledgerId))
+    }
     catch { return false }
   })()
 


### PR DESCRIPTION
The gate hard-blocks while the newest inbound has no outbound after it, with no
age cap and no content test. So a message that rightly gets no answer holds it
open forever: Laszlo's bare "ok" at 2026-09-04 22:24 kept the gate shut for
eight hours, at 630% of the 120k threshold, and the only way out would have
been a midnight reply nobody needed. Two other mechanisms pushed the same way
-- the drain resurfaced the "ok" as a lost question at 00:00, and the gate
alerted about itself at 120, 240, 360 and 480 minutes.

Laszlo picked the rule (LEDGERACK905): hold until the agent has actually been
SHOWN the message, not on a timer. Before that a /clear could lose a question
nobody has read. After it the agent demonstrably knows, and whether to answer
is its own call -- some messages get none.

The drain already writes what it surfaced into store/.ledger-drain-<agent>;
the gate now reads it. db.ts gained openInboundQuestionMessageId (same query
as hasOpenInboundQuestion, returning WHICH message), and the decision itself is
a pure exported function so it tests without a database or a statefile. An open
question with no identifiable message id keeps blocking: unknown must read as
unseen.

Deliberately NOT changed: auto-restart-runner.ts still uses the boolean form.
It is a different mechanism and nothing measured says it has this problem.

Five cases: nothing open, open-and-unsurfaced, open-and-surfaced, surfaced-a-
different-one, and the empty-id fallback. Mutation-checked: forcing the compare
to true turns the surfaced case red. Full suite 361 files / 4708 green.

---

Verified on a non-tmp clone of this branch, against the same checkout for `develop`:
`tsc --noEmit` clean, `vitest run` 361 files, 4685 passed. Baseline `develop` in the same place: 361 files, 4680 passed.
