### PR TITLE
fix(context-guard): a guard restart must win the race against reconcile (DANICTXHUROK906)

### DIFF
--- a/src/__tests__/context-guard-reconcile-race.test.ts
+++ b/src/__tests__/context-guard-reconcile-race.test.ts
@@ -39,3 +39,35 @@ describe('context-guard / reconcile restart race (DANICTXHUROK906)', () => {
     expect(isWithinRestartGrace(name, t0 + 91_000)).toBe(false)
   })
 })
+
+// SOURCE-LEVEL COVERAGE of the WIRING, not just the predicate. Mutation review
+// (Marveen, 2026-09-06) removed the guard-side markAgentRestartPending(name)
+// call and all four behavioural tests above still passed -- they exercise the
+// predicate, and the bug was in the CALL SITE. This asserts the wiring the same
+// way the copy-gate coverage test does: read the guard source and require that,
+// on the non-main branch of performRestart, the grace is claimed BEFORE the
+// restart. If someone deletes that one line, this fails.
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+describe('context-guard restart wiring (DANICTXHUROK906, source-level)', () => {
+  const guardSrc = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), '..', 'web', 'context-guard-runner.ts'),
+    'utf-8',
+  )
+
+  it('claims the reconcile grace BEFORE restarting a non-main agent', () => {
+    // Scope to the else (non-main) branch of performRestart so the assertion is
+    // about the sub-agent path, not the main-agent hardRestart path.
+    const perf = guardSrc.slice(guardSrc.indexOf('async function performRestart'))
+    const elseIdx = perf.indexOf('} else {')
+    expect(elseIdx).toBeGreaterThan(-1)
+    const elseBranch = perf.slice(elseIdx)
+    const markIdx = elseBranch.indexOf('markAgentRestartPending(name)')
+    const restartIdx = elseBranch.indexOf('restartAgentProcess(name')
+    expect(markIdx).toBeGreaterThan(-1)   // the grace-claim line exists
+    expect(restartIdx).toBeGreaterThan(-1)
+    expect(markIdx).toBeLessThan(restartIdx)  // and it runs BEFORE the restart
+  })
+})

--- a/src/__tests__/context-guard-reconcile-race.test.ts
+++ b/src/__tests__/context-guard-reconcile-race.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { markAgentRestartPending, isWithinRestartGrace } from '../web/channel-monitor.js'
+
+// DANICTXHUROK906. The context-guard restart (stop + fresh start) was invisible
+// to reconcileDesiredAgents(): the guard never wrote the agentLastRestart map,
+// so in the window between the guard's stop and its fresh start the reconcile
+// loop saw the agent "down" and re-launched it non-fresh (--continue). These
+// tests pin the fix at the seam that matters: the guard marking the restart
+// makes the reconcile grace predicate return true, so the loop defers.
+//
+// Each test uses a UNIQUE agent name because agentLastRestart is a module-level
+// Map that persists across tests -- a shared name would leak the mark.
+describe('context-guard / reconcile restart race (DANICTXHUROK906)', () => {
+  it('an unmarked agent is not in grace (reconcile is free to act)', () => {
+    expect(isWithinRestartGrace('dani-race-unmarked', Date.now())).toBe(false)
+  })
+
+  it('marking a restart puts the agent inside the grace window', () => {
+    const name = 'dani-race-marked'
+    expect(isWithinRestartGrace(name, Date.now())).toBe(false)
+    markAgentRestartPending(name)
+    // The guard's stop happens right after this; reconcile must skip the agent.
+    expect(isWithinRestartGrace(name, Date.now())).toBe(true)
+  })
+
+  it('the grace covers a full guard stop+fresh-start (still true seconds later)', () => {
+    const name = 'dani-race-window'
+    const t0 = Date.now()
+    markAgentRestartPending(name)
+    // A guard restart is 1-2s; the grace is 90s, so a check 10s later still defers.
+    expect(isWithinRestartGrace(name, t0 + 10_000)).toBe(true)
+  })
+
+  it('the grace expires so a genuinely-crashed agent is still reconciled later', () => {
+    const name = 'dani-race-expiry'
+    const t0 = Date.now()
+    markAgentRestartPending(name)
+    // Past the 90s window: if the agent is down for real, reconcile may act.
+    expect(isWithinRestartGrace(name, t0 + 91_000)).toBe(false)
+  })
+})

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -92,6 +92,29 @@ function resolveAgentProvider(name: string): ChannelProviderType {
 
 const agentDownSince: Map<string, number> = new Map()
 const agentLastRestart: Map<string, number> = new Map()
+
+// DANICTXHUROK906 (2026-09-06): the context-guard's own restart path
+// (context-guard-runner.ts) stop+fresh-starts an agent, but that stop is
+// INVISIBLE to this reconcile loop -- the guard never wrote agentLastRestart,
+// so in the ~1s window between the guard's stop and its fresh start,
+// reconcileDesiredAgents saw the agent "down" and re-launched it via
+// startAgentProcess() with NO opts -> fresh=false, i.e. --continue for a
+// channel-less agent. The guard's own fresh start then no-op'd ("already
+// running") and the heavy prior context was resumed (measured: dani hit 94% in
+// 25min on zero inbound). The guard now calls markAgentRestartPending() BEFORE
+// its stop, so this loop defers for the grace window and the guard's fresh
+// start wins the race.
+export function markAgentRestartPending(name: string): void {
+  agentLastRestart.set(name, Date.now())
+}
+
+// The reconcile grace predicate, pulled out so it is unit-testable without
+// driving the whole loop. True = a (re)start for `name` happened within the
+// grace window, so reconcile must NOT launch a second (non-fresh) session.
+export function isWithinRestartGrace(name: string, nowMs: number = Date.now()): boolean {
+  const last = agentLastRestart.get(name)
+  return last != null && nowMs - last < AGENT_RESTART_GRACE_MS
+}
 // Agents already warned about a missing channel token, so the per-sweep probe
 // does not repeat the identical WARN every minute forever (observed 2026-07-20:
 // teamer, an agent with no channel token bound, emitted the same line ~1440x/day
@@ -2202,8 +2225,7 @@ async function reconcileDesiredAgents(): Promise<void> {
   try {
     for (const name of down) {
       if (isAgentRunning(name)) continue
-      const last = agentLastRestart.get(name)
-      if (last != null && Date.now() - last < AGENT_RESTART_GRACE_MS) continue
+      if (isWithinRestartGrace(name)) continue
       if (!memGateAllowsStart(name)) continue   // Commit 3 v1: safe-mode / memory gate
       logger.warn({ agent: name }, 'Desired agent not running -- auto-starting (reconcile)')
       try {

--- a/src/web/context-guard-runner.ts
+++ b/src/web/context-guard-runner.ts
@@ -2,7 +2,7 @@ import { statSync, readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { logger } from '../logger.js'
 import { MAIN_AGENT_ID, PROJECT_ROOT } from '../config.js'
-import { hardRestartMarveenChannels, lastMainRespawnAt, MARVEEN_POST_RESPAWN_GRACE_MS } from './channel-monitor.js'
+import { hardRestartMarveenChannels, lastMainRespawnAt, MARVEEN_POST_RESPAWN_GRACE_MS, markAgentRestartPending } from './channel-monitor.js'
 import { shouldDeferForRecentRespawn } from './stuck-tool-call-watcher.js'
 import { listAgentNames, listAllAgentNames, agentDir, readAgentModel, readAgentRemoteHost } from './agent-config.js'
 import { resolveAgentConfigDirForRead } from './claude-plans.js'
@@ -260,6 +260,11 @@ async function performRestart(name: string): Promise<void> {
     const res = hardRestartMarveenChannels()
     if (!res.ok) throw new Error(res.error ?? 'main channels hard restart failed')
   } else {
+    // DANICTXHUROK906: claim the reconcile grace window BEFORE the stop, so
+    // reconcileDesiredAgents() does not see the agent "down" mid-restart and
+    // re-launch it non-fresh (--continue), which would defeat the whole point
+    // of a context-guard restart -- dropping the saturated context.
+    markAgentRestartPending(name)
     await restartAgentProcess(name, { fresh: true })
   }
 }


### PR DESCRIPTION
## What

The context-guard restarts a saturated agent to DROP its heavy context (`restartAgentProcess(name, { fresh: true })`). But that restart is stop-then-start, and the stop was invisible to `reconcileDesiredAgents()` in channel-monitor.ts: the guard never wrote the `agentLastRestart` grace map. So in the ~1s window between the guard's stop and its fresh start, the reconcile loop saw the agent "down" and re-launched it via `startAgentProcess(name)` with **no opts → fresh=false**, i.e. `--continue` for a channel-less agent. The guard's own fresh start then no-op'd ("already running"), and the agent came back up resuming the exact context the guard tried to drop.

Measured on the host tree (HEAD 9d3b77f4) from dashboard.log, dani/91718:
- `08:08:29.592` context-guard acting, `action:"restart" reason:"handoff written" pct:92`
- `08:08:30.331` `Desired agent not running -- auto-starting (reconcile)` agent:dani  ← the reconcile, non-fresh
- `08:08:30.565` tmux session started (its pane cmdline carries `--continue`)
- result: the fresh session hit 94% in 25 minutes on **zero** inbound.

dani is the only channel-less agent in the fleet (`agent-process.ts` `continueFlag = hasPriorSession && !fresh && !hasChannel`), which is why only dani surfaced this.

## Fix

The guard claims the reconcile grace window **before** its stop, so reconcile defers and the guard's fresh start wins the race:
- `markAgentRestartPending(name)` (new export) writes `agentLastRestart`, the same map the reconcile grace already reads.
- The grace check is pulled into `isWithinRestartGrace(name, now)` — behaviour-identical, single source, unit-testable.
- The guard calls `markAgentRestartPending(name)` immediately before `restartAgentProcess(name, { fresh: true })`.

## Scope

This ONLY closes the race so a guard-requested restart is actually fresh. It deliberately does **not** touch the separate product question of whether channel-less agents should keep `--continue` in general — that stays as-is.

## Tests

`context-guard-reconcile-race.test.ts`: unmarked → not in grace; marked → in grace; grace covers a 10s stop+start; grace expires at 90s so a genuinely-crashed agent is still reconciled later. Verified against a predicate mutation (grace window → 0): the two grace-positive assertions fail exactly then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
