### PR TITLE
feat(kanban): bring the fleet card tool into the repo, with its gates measured

### DIFF
--- a/scripts/__tests__/kartya-ertesites-felado.test.py
+++ b/scripts/__tests__/kartya-ertesites-felado.test.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Test the sender attribution of scripts/kartya-es-ertesites.py (KARTYAKULDO906).
+
+Boni's finding (msg 20254): the tool posted every agent's card notification with
+`from: 'marveen'` hardcoded, so a reader would attribute someone else's measurement
+to the main agent. It also mailed a self-assigned card back to its own author.
+
+Drives the script as a subprocess against an isolated DB (KARTYA_DB) and a local
+stub of the messages API (KARTYA_API) that records the posted envelope. Run:
+    python3 scripts/__tests__/kartya-ertesites-felado.test.py
+Exit 0 = all pass; non-zero = a failure (message on stderr).
+"""
+import json, os, sqlite3, subprocess, sys, tempfile, threading, time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(os.path.dirname(HERE))
+SCRIPT = os.path.join(ROOT, 'scripts', 'kartya-es-ertesites.py')
+
+POSTED = []          # every envelope the script posted
+# SANDBOX-GYOKER: lasd a masik teszt magyarazatat -- a mutacios kontroll nem erheti el az eles tablat.
+SANDBOX_ROOT = tempfile.mkdtemp(prefix='kartya-sandbox-')
+DB_PATH = None       # set in main(); the stub writes the row the script reads back
+
+
+class Stub(BaseHTTPRequestHandler):
+    def do_POST(self):
+        body = json.loads(self.rfile.read(int(self.headers['Content-Length'])))
+        POSTED.append(body)
+        db = sqlite3.connect(DB_PATH)
+        cur = db.execute(
+            'INSERT INTO agent_messages (from_agent,to_agent,content,status,created_at)'
+            ' VALUES (?,?,?,?,?)',
+            (body['from'], body['to'], body['content'], 'pending', int(time.time())))
+        db.commit()
+        mid = cur.lastrowid
+        db.close()
+        out = json.dumps({'id': mid}).encode()
+        self.send_response(200)
+        self.send_header('Content-Type', 'application/json')
+        self.send_header('Content-Length', str(len(out)))
+        self.end_headers()
+        self.wfile.write(out)
+
+    def log_message(self, *a):
+        pass
+
+
+def fresh_db(path):
+    db = sqlite3.connect(path)
+    db.executescript('''
+      CREATE TABLE kanban_cards (id TEXT PRIMARY KEY, title TEXT NOT NULL, description TEXT,
+        status TEXT NOT NULL DEFAULT 'planned', assignee TEXT, priority TEXT NOT NULL DEFAULT 'normal',
+        project TEXT, due_date INTEGER, sort_order REAL NOT NULL DEFAULT 0,
+        created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL, archived_at INTEGER,
+        parent_id TEXT, dispatched_at INTEGER);
+      CREATE TABLE kanban_comments (id INTEGER PRIMARY KEY AUTOINCREMENT, card_id TEXT NOT NULL,
+        author TEXT NOT NULL, content TEXT NOT NULL, created_at INTEGER NOT NULL);
+      CREATE TABLE agent_messages (id INTEGER PRIMARY KEY AUTOINCREMENT, from_agent TEXT NOT NULL,
+        to_agent TEXT NOT NULL, content TEXT NOT NULL, status TEXT NOT NULL DEFAULT 'pending',
+        result TEXT, created_at INTEGER NOT NULL, delivered_at INTEGER, completed_at INTEGER);
+    ''')
+    db.commit()
+    db.close()
+
+
+def run(card_id, assignee, msg_text, port, extra=()):
+    d = tempfile.mkdtemp(prefix='kartya-t-')
+    mf = os.path.join(d, 'msg.txt')
+    with open(mf, 'w', encoding='utf-8') as f:
+        f.write(msg_text)
+    env = dict(os.environ)
+    env['KARTYA_DB'] = DB_PATH
+    env['CLAUDECLAW_ROOT'] = SANDBOX_ROOT
+    env['KARTYA_TOKEN'] = 'teszt-token'
+    env['KARTYA_API'] = f'http://127.0.0.1:{port}/api/messages'
+    return subprocess.run(
+        [sys.executable, SCRIPT, '--id', card_id, '--assignee', assignee,
+         '--title', f'teszt kartya {card_id}', '--msg-file', mf, *extra],
+        capture_output=True, text=True, env=env, timeout=30)
+
+
+FAILS = []
+
+
+def check(name, cond, detail=''):
+    print(('PASS  ' if cond else 'FAIL  ') + name + (('  -- ' + detail) if detail and not cond else ''))
+    if not cond:
+        FAILS.append(name)
+
+
+def main():
+    global DB_PATH
+    fd, DB_PATH = tempfile.mkstemp(suffix='.db', prefix='kartya-')
+    os.close(fd)
+    os.remove(DB_PATH)
+    fresh_db(DB_PATH)
+
+    srv = HTTPServer(('127.0.0.1', 0), Stub)
+    port = srv.server_address[1]
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+
+    # 1. A masik agens neveben felvett kartya ertesitese AZ O NEVEBEN megy ki.
+    POSTED.clear()
+    p = run('KULDOA906', 'samu', 'Kartya: KULDOA906 -- Boni merese, Samunak.', port,
+            extra=('--from', 'boni'))
+    check('1 lefutott', p.returncode == 0, p.stdout + p.stderr)
+    check('1 felado == boni (nem marveen)', POSTED and POSTED[0]['from'] == 'boni',
+          f'kapott: {POSTED[0]["from"] if POSTED else "semmi"}')
+    check('1 cimzett == samu', POSTED and POSTED[0]['to'] == 'samu')
+
+    # 2. --from nelkul az --author dont; ez tartja a regi viselkedest (--author nelkul: marveen).
+    POSTED.clear()
+    p = run('KULDOB906', 'samu', 'Kartya: KULDOB906 -- szerzo dont a feladorol.', port,
+            extra=('--author', 'Boni'))
+    check('2 lefutott', p.returncode == 0, p.stdout + p.stderr)
+    check('2 felado az --author-bol == boni', POSTED and POSTED[0]['from'] == 'boni',
+          f'kapott: {POSTED[0]["from"] if POSTED else "semmi"}')
+
+    POSTED.clear()
+    p = run('KULDOC906', 'samu', 'Kartya: KULDOC906 -- alapertelmezes valtozatlan.', port)
+    check('3 lefutott', p.returncode == 0, p.stdout + p.stderr)
+    check('3 alapertelmezett felado marveen (regresszio-kontroll)',
+          POSTED and POSTED[0]['from'] == 'marveen')
+
+    # 4. ONHUROK: felado == felelos -> a koordinatorhoz megy, es ki is mondja.
+    POSTED.clear()
+    p = run('KULDOD906', 'boni', 'Kartya: KULDOD906 -- Boni sajat magara osztja.', port,
+            extra=('--from', 'boni'))
+    check('4 lefutott', p.returncode == 0, p.stdout + p.stderr)
+    check('4 nem onmagahoz megy', POSTED and POSTED[0]['to'] != 'boni',
+          f'kapott: {POSTED[0]["to"] if POSTED else "semmi"}')
+    check('4 a koordinatorhoz megy', POSTED and POSTED[0]['to'] == 'marveen')
+    check('4 felado tovabbra is boni', POSTED and POSTED[0]['from'] == 'boni')
+    check('4 KIMONDVA a kimeneten', 'ATIRANYITVA' in p.stdout, p.stdout)
+    check('4 KIMONDVA az uzenet torzseben', POSTED and 'ATIRANYITVA' in POSTED[0]['content'])
+
+    # 5. Elgepelt felado-nev kapu: csendes rossz attribucio helyett megtagadas, iras nelkul.
+    POSTED.clear()
+    p = run('KULDOE906', 'samu', 'Kartya: KULDOE906 -- elgepelt felado.', port,
+            extra=('--from', 'bonii'))
+    check('5 megtagadva', p.returncode != 0)
+    check('5 semmit nem kuldott', not POSTED)
+    db = sqlite3.connect(DB_PATH)
+    n = db.execute('SELECT count(*) FROM kanban_cards WHERE id=?', ('KULDOE906',)).fetchone()[0]
+    db.close()
+    check('5 a kartya sem jott letre', n == 0)
+
+    # 6. A kartya-nyom is a valodi feladot nevezi meg.
+    db = sqlite3.connect(DB_PATH)
+    nyom = db.execute("SELECT content FROM kanban_comments WHERE card_id='KULDOA906'").fetchone()
+    db.close()
+    check('6 a nyom-komment a feladot nevezi', nyom and 'boni -> samu' in nyom[0],
+          nyom[0] if nyom else 'nincs komment')
+
+    srv.shutdown()
+    os.remove(DB_PATH)
+    if FAILS:
+        sys.stderr.write('\nBUKOTT: ' + ', '.join(FAILS) + '\n')
+        return 1
+    print('\nminden teszt atment')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/__tests__/kartya-mezomozgatas.test.py
+++ b/scripts/__tests__/kartya-mezomozgatas.test.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Test the comment-mode field move of scripts/kartya-es-ertesites.py (KARTYASTATUSZ906).
+
+Boni's finding (msg 20271): `--status` and `--priority` were silently dropped in
+comment mode. The output said OK, the comment was written, and the card never
+moved -- a false success whose direction is wrong, because the card then stays
+silent in the WRONG status while the tool reports success.
+
+Drives the script as a subprocess against an isolated DB (KARTYA_DB). Run:
+    python3 scripts/__tests__/kartya-mezomozgatas.test.py
+Exit 0 = all pass; non-zero = a failure (message on stderr).
+"""
+import os, sqlite3, subprocess, sys, tempfile, time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(os.path.dirname(HERE))
+SCRIPT = os.path.join(ROOT, 'scripts', 'kartya-es-ertesites.py')
+DB_PATH = None
+FAILS = []
+# SANDBOX-GYOKER: minden futas ide oldja fel a gyokeret, ha a KARTYA_DB-t barmi elrontja.
+# Egy MUTACIOS KONTROLL, ami az ut-feloldast tori el, kulonben az ELES tablat irna --
+# 2026-09-06-an pontosan ez tortent, egy teszt-kartya keletkezett az eles tablan.
+SANDBOX_ROOT = tempfile.mkdtemp(prefix='kartya-sandbox-')
+
+
+def check(name, cond, detail=''):
+    print(('PASS  ' if cond else 'FAIL  ') + name + (('  -- ' + detail) if detail and not cond else ''))
+    if not cond:
+        FAILS.append(name)
+
+
+def fresh_db(path):
+    db = sqlite3.connect(path)
+    db.executescript('''
+      CREATE TABLE kanban_cards (id TEXT PRIMARY KEY, title TEXT NOT NULL, description TEXT,
+        status TEXT NOT NULL DEFAULT 'planned'
+          CHECK(status IN ('planned','in_progress','testing','waiting','done')),
+        assignee TEXT,
+        priority TEXT NOT NULL DEFAULT 'normal'
+          CHECK(priority IN ('low','normal','high','urgent')),
+        project TEXT, due_date INTEGER, sort_order REAL NOT NULL DEFAULT 0,
+        created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL, archived_at INTEGER,
+        parent_id TEXT, dispatched_at INTEGER);
+      CREATE TABLE kanban_comments (id INTEGER PRIMARY KEY AUTOINCREMENT, card_id TEXT NOT NULL,
+        author TEXT NOT NULL, content TEXT NOT NULL, created_at INTEGER NOT NULL);
+      CREATE TABLE agent_messages (id INTEGER PRIMARY KEY AUTOINCREMENT, from_agent TEXT NOT NULL,
+        to_agent TEXT NOT NULL, content TEXT NOT NULL, status TEXT NOT NULL DEFAULT 'pending',
+        result TEXT, created_at INTEGER NOT NULL, delivered_at INTEGER, completed_at INTEGER);
+    ''')
+    db.commit()
+    db.close()
+
+
+def seed(card_id, status='planned', priority='normal'):
+    db = sqlite3.connect(DB_PATH)
+    now = int(time.time())
+    db.execute('INSERT INTO kanban_cards (id,title,status,assignee,priority,created_at,updated_at)'
+               ' VALUES (?,?,?,?,?,?,?)', (card_id, f'teszt {card_id}', status, 'boni', priority, now, now))
+    db.commit()
+    db.close()
+
+
+def comment(card_id, text, extra=()):
+    d = tempfile.mkdtemp(prefix='kartya-m-')
+    cf = os.path.join(d, 'c.txt')
+    with open(cf, 'w', encoding='utf-8') as f:
+        f.write(text)
+    env = dict(os.environ)
+    env['KARTYA_DB'] = DB_PATH
+    env['CLAUDECLAW_ROOT'] = SANDBOX_ROOT
+    return subprocess.run(
+        [sys.executable, SCRIPT, '--id', card_id, '--comment-file', cf, '--author', 'Boni', *extra],
+        capture_output=True, text=True, env=env, timeout=30)
+
+
+def card(card_id):
+    db = sqlite3.connect(DB_PATH)
+    r = db.execute('SELECT status,priority FROM kanban_cards WHERE id=?', (card_id,)).fetchone()
+    db.close()
+    return r
+
+
+def title(card_id):
+    db = sqlite3.connect(DB_PATH)
+    r = db.execute('SELECT title FROM kanban_cards WHERE id=?', (card_id,)).fetchone()
+    db.close()
+    return r[0] if r else None
+
+
+def comments(card_id):
+    db = sqlite3.connect(DB_PATH)
+    r = db.execute('SELECT content FROM kanban_comments WHERE card_id=? ORDER BY id', (card_id,)).fetchall()
+    db.close()
+    return [x[0] for x in r]
+
+
+def main():
+    global DB_PATH
+    fd, DB_PATH = tempfile.mkstemp(suffix='.db', prefix='kartya-m-')
+    os.close(fd); os.remove(DB_PATH)
+    fresh_db(DB_PATH)
+
+    # 1. A LELET MAGA: --status komment-modban tenylegesen mozgat.
+    seed('MOZGA906', 'planned')
+    p = comment('MOZGA906', 'Kartya MOZGA906: a vevo valaszara var.', ('--status', 'waiting'))
+    check('1 lefutott', p.returncode == 0, p.stdout + p.stderr)
+    check('1 a statusz TENYLEG waiting lett', card('MOZGA906')[0] == 'waiting',
+          f'kapott: {card("MOZGA906")}')
+    check('1 a komment is beirt', any('vevo valaszara var' in c for c in comments('MOZGA906')))
+    check('1 a kimenet kimondja a mozgatast', 'MEZOMOZGATAS OK' in p.stdout, p.stdout)
+    check('1 nyom-komment a mozgatasrol', any('Mezomozgatas' in c for c in comments('MOZGA906')))
+
+    # 2. --priority ugyanezen az uton, es a ketto egyutt is.
+    seed('MOZGB906', 'planned', 'normal')
+    p = comment('MOZGB906', 'Kartya MOZGB906: surgos lett.', ('--status', 'in_progress', '--priority', 'high'))
+    check('2 lefutott', p.returncode == 0, p.stdout + p.stderr)
+    check('2 mindket mezo mozdult', card('MOZGB906') == ('in_progress', 'high'), f'kapott: {card("MOZGB906")}')
+
+    # 3. Nem-adott kapcsolo NEM ir felul (a None-alapertelmezes lenyege).
+    seed('MOZGC906', 'waiting', 'high')
+    p = comment('MOZGC906', 'Kartya MOZGC906: csak komment, mezo nem.')
+    check('3 lefutott', p.returncode == 0, p.stdout + p.stderr)
+    check('3 a mezok valtozatlanok', card('MOZGC906') == ('waiting', 'high'), f'kapott: {card("MOZGC906")}')
+    check('3 nincs mozgatas-nyom', not any('Mezomozgatas' in c for c in comments('MOZGC906')))
+
+    # 4. Mar ezen az erteken all: KIMONDJA, nem hallgat rola (a csendes no-op ugyanaz a hibaosztaly).
+    seed('MOZGD906', 'waiting')
+    p = comment('MOZGD906', 'Kartya MOZGD906: mar waiting.', ('--status', 'waiting'))
+    check('4 lefutott', p.returncode == 0, p.stdout + p.stderr)
+    check('4 kimondja hogy nem mozgat', 'mar ezen az erteken all' in p.stdout, p.stdout)
+
+    # 5. Ervenytelen ertek: megtagadas, es a komment SEM irodik be.
+    seed('MOZGE906', 'planned')
+    p = comment('MOZGE906', 'Kartya MOZGE906: elgepelt statusz.', ('--status', 'varakozik'))
+    check('5 megtagadva', p.returncode != 0)
+    check('5 a statusz valtozatlan', card('MOZGE906')[0] == 'planned')
+    check('5 a komment sem irodott be', comments('MOZGE906') == [], f'kapott: {comments("MOZGE906")}')
+
+    # 6. Nem letezo kartya: a mezomozgatas nem hozhat letre semmit.
+    p = comment('NINCSILYEN906', 'Kartya NINCSILYEN906: nincs ilyen.', ('--status', 'done'))
+    check('6 megtagadva nem letezo kartyara', p.returncode != 0)
+    check('6 nem hozott letre kartyat', card('NINCSILYEN906') is None)
+
+    # 7. A letrehozo ag alapertelmezese valtozatlan (a None-ra allitott default regresszioja).
+    # PROBA-HIGIENIA: a KARTYA_API-t akkor is elteritjuk, ha ez az ag nem kuld -- egy jovobeli
+    # szerkesztes ne tudjon az ELES uzenetsorba irni egy teszt futasabol. (Ez a teszt elso
+    # valtozata pontosan ezt tette: letrehozott egy valodi sort a sorban.)
+    env = dict(os.environ)
+    env['KARTYA_DB'] = DB_PATH
+    env['CLAUDECLAW_ROOT'] = SANDBOX_ROOT
+    env['KARTYA_API'] = 'http://127.0.0.1:1/api/messages'
+    p = subprocess.run([sys.executable, SCRIPT, '--id', 'UJKARTYA906', '--assignee', 'marveen',
+                        '--title', 'uj kartya teszt', '--no-msg'],
+                       capture_output=True, text=True, env=env, timeout=30)
+    check('7 letrehozo ag lefutott', p.returncode == 0, p.stdout + p.stderr)
+    check('7 alapertelmezes planned/normal maradt', card('UJKARTYA906') == ('planned', 'normal'),
+          f'kapott: {card("UJKARTYA906")}')
+
+    # 8. ELLENTMONDAS-KAPU: --no-msg + --msg-file egyszerre. Korabban atcsuszott es MEGIS kuldott.
+    d = tempfile.mkdtemp(prefix='kartya-m3-')
+    mf = os.path.join(d, 'm.txt')
+    open(mf, 'w', encoding='utf-8').write('Kartya ELLENT906: ellentmondo kapcsolok.')
+    p = subprocess.run([sys.executable, SCRIPT, '--id', 'ELLENT906', '--assignee', 'marveen',
+                        '--title', 'ellentmondas teszt', '--msg-file', mf, '--no-msg'],
+                       capture_output=True, text=True, env=env, timeout=30)
+    # A puszta nem-nulla exit itt NEM eleg: a kapu nelkul is elbukna az uzenetkuldesen (a
+    # KARTYA_API elteritve). A megtagadas SZOVEGERE allitunk, kulonben ez a check a helyes
+    # eredmenyt rossz okbol fogadna el.
+    check('8 megtagadva a --no-msg + --msg-file paros',
+          p.returncode != 0 and 'ellentmond' in (p.stdout + p.stderr), p.stdout + p.stderr)
+    check('8 kartyat sem hozott letre', card('ELLENT906') is None)
+
+    # 9. A CIM is mozgathato -- enelkul a flotta-szabaly fele ("cimre az eszkoz --title-je")
+    #    hamis marad, es a kartya-cim javitasa nyers sqlite3-hoz kenyszerit.
+    seed('CIMMOZG906')
+    p = comment('CIMMOZG906', 'Kartya CIMMOZG906: pontositott cim.',
+                ('--title', 'CIMMOZG906: az uj, pontos cim. Gazda: boni, hatarido 2026-09-09.'))
+    check('9 lefutott', p.returncode == 0, p.stdout + p.stderr)
+    check('9 a cim tenyleg valtozott', title('CIMMOZG906').startswith('CIMMOZG906: az uj'),
+          f'kapott: {title("CIMMOZG906")}')
+
+    # 10. A MOZGATAS NEM KERULHETI MEG a 300 karakteres cim-kaput -- kulonben az uj ut pont
+    #     azt a triggert engedne be, ami a letrehozo agon meg van fogva.
+    seed('CIMHOSSZ906')
+    regi = title('CIMHOSSZ906')
+    p = comment('CIMHOSSZ906', 'Kartya CIMHOSSZ906: tul hosszu cim.', ('--title', 'X' * 301))
+    check('10 megtagadva a 300 feletti cim', p.returncode != 0 and '300' in (p.stdout + p.stderr),
+          p.stdout + p.stderr)
+    check('10 a cim valtozatlan', title('CIMHOSSZ906') == regi)
+    check('10 a komment sem irodott be', comments('CIMHOSSZ906') == [])
+
+    # 11. GYOKER-FELOLDAS: hianyzo DB -> MEGTAGADAS, a feloldott utvonal kimondasaval.
+    #     Enelkul az sqlite3.connect letrehozna egy ures fajlt, es a kartya-iras egy arva
+    #     masolatba menne (worktree-alak). Boni merese, msg 20272.
+    ures = tempfile.mkdtemp(prefix='kartya-gyoker-')
+    d = tempfile.mkdtemp(prefix='kartya-m4-')
+    cf = os.path.join(d, 'c.txt')
+    open(cf, 'w', encoding='utf-8').write('Kartya MOZGA906: rossz gyokerrol.')
+    env = dict(os.environ)
+    env.pop('KARTYA_DB', None)
+    env['CLAUDECLAW_ROOT'] = ures
+    env['KARTYA_API'] = 'http://127.0.0.1:1/api/messages'
+    p = subprocess.run([sys.executable, SCRIPT, '--id', 'MOZGA906', '--comment-file', cf,
+                        '--author', 'Boni'], capture_output=True, text=True, env=env, timeout=30)
+    ki = p.stdout + p.stderr
+    check('11 megtagadva a hianyzo DB-nel', p.returncode != 0 and 'nem letezik' in ki, ki)
+    check('11 kimondja a feloldott utvonalat', ures in ki, ki)
+    check('11 NEM hozott letre ures DB-t', not os.path.exists(os.path.join(ures, 'store', 'claudeclaw.db')))
+
+    # 12. Az env SORRENDJE: a KARTYA_DB felulirja a CLAUDECLAW_ROOT-ot (a worktree-futas ki
+    #     tudja mondani, hogy az ELO tablat irja).
+    env2 = dict(env); env2['KARTYA_DB'] = DB_PATH
+    p = subprocess.run([sys.executable, SCRIPT, '--id', 'MOZGA906', '--comment-file', cf,
+                        '--author', 'Boni'], capture_output=True, text=True, env=env2, timeout=30)
+    check('12 a KARTYA_DB gyoz a CLAUDECLAW_ROOT felett', p.returncode == 0, p.stdout + p.stderr)
+
+    # 13. A visszaolvasas MONDJA KI, melyik tarolobol olvasott (Boni kikotese): egy rossz gyoker
+    #     mellett a visszaolvasas onmagaban konzisztens lenne, csak nem az eles tablan.
+    check('13 a visszaolvasas megnevezi a DB-t', DB_PATH in p.stdout, p.stdout)
+
+    os.remove(DB_PATH)
+    if FAILS:
+        sys.stderr.write('\nBUKOTT: ' + ', '.join(FAILS) + '\n')
+        return 1
+    print('\nminden teszt atment')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/kartya-es-ertesites.py
+++ b/scripts/kartya-es-ertesites.py
@@ -1,0 +1,413 @@
+#!/usr/bin/env python3
+"""Kartya felvetele ES a gazdajanak szolo ertesites EGY lepesben.
+
+MIERT: 2026-09-05-en a kanban-audit ot friss kartyat talalt megnevezett flotta-gazdaval,
+amirol soha nem ment uzenet -- negy kozuluk ugyanabban a delelottben az enyem volt. Boni
+lelete: "a kartya-felvetel es az ertesites ket kulon lepes; ha ez ismetlodik, erdemesebb
+osszekotni, mint emlekezni ra."
+
+Amit garantal:
+  - megnevezett flotta-gazdas kartya NEM jon letre ertesites nelkul (a szkript megtagadja);
+  - mindket iras VISSZA VAN OLVASVA (a kartya SELECT-tel, az uzenet a visszakapott id-vel);
+  - a 300 karakteres cim-kaput ELORE jelzi, nem utolag a trigger;
+  - --dry-run: mindent ellenoriz, semmit nem ir.
+
+Hasznalat:
+  kartya-es-ertesites.py --id X905 --assignee boni --title "..." --desc-file /path
+      --msg-file /path [--priority normal] [--status planned] [--dry-run]
+Az onmagunknak (marveen) vagy a gazdanak (szabolcs) szolo kartya ertesites nelkul is mehet:
+ott a --no-msg kapcsolo kell, KIMONDVA.
+
+A KULDO NEVE (KARTYAKULDO906, Boni lelete 20254): az ertesites feladoja a --from, alapertelmezese
+az --author kisbetusitve. Korabban a from HARDCODE 'marveen' volt, tehat az eszkoz MINDEN agens
+ertesiteset a fo-agens neveben kuldte ki -- aki olvasta, a MAS mereset ENGEM idezte. Attribucios
+hiba, nem kenyelmi kerdes: ket napja pont azon dolgozunk, hogy KI mert MIT es MILYEN HATARRAL.
+ONHUROK: ha a felado ES a felelos ugyanaz, az ertesites nem onmagahoz megy, hanem a
+KOORDINATORHOZ (marveen) -- kimondva, a kimeneten es az uzenet elso soraban is.
+
+KOMMENT-ONLY MOD (KARTYAIRASESZKOZ905, 2026-09-05): komment egy MEGLEVO kartyara,
+ERTESITES NELKUL, ugyanazokkal a kapukkal es kotelezo visszaolvasassal:
+  kartya-es-ertesites.py --id X905 --comment-file /path [--author Samu] [--dry-run]
+MEZOMOZGATAS (KARTYASTATUSZ906, Boni lelete 2026-09-06): komment-modban a --title, a --status es a
+--priority MEGLEVO kartyat mozgat, elotte-pillanatkeppel es FUGGETLEN visszaolvasassal:
+  kartya-es-ertesites.py --id X905 --status waiting --comment-file /path --author Boni
+Korabban ez a ket kapcsolo komment-modban SZO NELKUL ELVESZETT: a kimenet OK-t mondott, a kartya
+nem mozdult. A mozgatas SZANDEKOSAN a komment-modhoz van kotve -- statusz nem valtozhat nyom nelkul.
+
+Ket fuggetlen hibaosztalyt zar ugyanez az egy ut: (1) a nyers sqlite3-quoting otodik
+elofordulasa utan a quoting az eszkoz dolga (parameterkotes); (2) a fejlec-idot a
+RENDSZERORA adja (ugyanaz az ertek, mint a created_at), gepelt orat a kapu megtagad --
+2026-09-05-en 17 kommentbol 11-ben tert el a gepelt ora a valodi created_at-tol.
+"""
+import argparse, json, os, re, sqlite3, sys, time, unicodedata, urllib.request
+
+# GYOKER-FELOLDAS: env ELOSZOR, __file__ CSAK tartaleknak, beegetett /Users/... SEHOL.
+# (Boni ket meresebol, msg 20272.) A sorrend nem izles kerdese:
+#   - A beegetett gazda-utvonal tilos, mert a scripts/ SHIPPEL (project_marveen_distribution_
+#     hardcode_rule): egy beegetett ertek miatt a kozossegi napi uzenetek hetekig nem mentek ki.
+#   - A __file__-ELSO sorrend viszont ROSSZ LENNE, mert a kanban DB EGY ELO tarolo, nem
+#     worktree-nkenti. Worktree-ben a modul helyebol szarmaztatott gyoker eltolodik (merve,
+#     #978 review: nyers worktree-futas 42 drop vs. korrigalt 15), es a kartya-iras egy arva
+#     masolatba menne, amit senki nem lat. Ezert az env mondhatja meg, hova irunk.
+ROOT = os.environ.get('CLAUDECLAW_ROOT') or os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+# KARTYA_DB env: teszt-horog (verify-the-guard) es kimondott felulbiralas.
+DB = os.environ.get('KARTYA_DB') or os.path.join(ROOT, 'store', 'claudeclaw.db')
+
+def _db_kapu():
+    """A NEM LETEZO DB a legveszelyesebb alak: az sqlite3.connect LETREHOZNA egy ures fajlt,
+    es a futas 'no such table'-lel halna el -- vagy ami rosszabb, egy MASOLATBA irna. Ezert a
+    hianyzo fajl MEGTAGADAS, a feloldott utvonal kimondasaval."""
+    if not os.path.exists(DB):
+        sys.exit(f'MEGTAGADVA: a kanban DB nem letezik ezen az utvonalon:\n  {DB}\n'
+                 f'(gyoker: {ROOT})\nA kanban EGY elo tarolo, nem worktree-nkenti. Ha innen akarsz\n'
+                 f'irni, mondd ki: CLAUDECLAW_ROOT=<a fo fa> vagy KARTYA_DB=<a db utvonala>.')
+    return DB
+FLEET = {'samu','zara','boni','iris','dani','geri','deeper','qwen','mira','tomi','jumanji','hidli'}
+COORDINATOR = 'marveen'
+# A kanban_cards CHECK-jei. Kapuban is szerepelnek, hogy egy elgepelt ertek olvashato
+# uzenetet adjon, ne nyers sqlite3 IntegrityError-t.
+STATUSZOK = ('planned','in_progress','testing','waiting','done')
+PRIORITASOK = ('low','normal','high','urgent')
+# Ervenyes FELADO-nevek. Elgepelt nev csendben rossz attribuciot irna a sorba, ezert kapu.
+KULDOK = FLEET | {COORDINATOR}
+API = os.environ.get('KARTYA_API', 'http://localhost:3420/api/messages')
+HU = set('áéíóöőúüűÁÉÍÓÖŐÚÜŰ')
+
+def gyanus(t):
+    """Nem-magyar, nem-ASCII BETUK egy egyebkent ASCII szoban (HOMOGLIFKAPU905 D-szabalya)."""
+    out = []
+    for w in t.split():
+        if any(ord(c) > 127 and c not in HU and unicodedata.category(c).startswith('L') for c in w) \
+           and any('a' <= c.lower() <= 'z' for c in w):
+            out.append(' '.join(f'U+{ord(c):04X}' if ord(c) > 127 else c for c in w))
+    return out
+
+# Gepelt ora a szoveg elejen: "[NEV ... 12:3x]" vagy "[NEV 2026-09-05 12:34]" alaku fejlec.
+# A fejlec-idot az eszkoz teszi be a rendszerorabol; a keziratos ora pont az a hibaosztaly,
+# amit ez a mod megszuntet (11/17 elterese egy napon, mind folfele).
+# A "3x"-es perc-alak (pl. "18:3x") a MERT tipikus keziratos forma -- a ket-szamjegyu
+# minta pont ezt engedte at az elso guard-tesztkor (2026-09-05), ezert [\dx].
+TYPED_CLOCK_RX = re.compile(r'^\s*\[[^\]\n]*\d{1,2}:[\dx][\dx][^\]\n]*\]')
+CLOCK_RX = re.compile(r'\d{1,2}:[\dx][\dx]')
+
+def gepelt_ora_fejlec(text):
+    """A gepelt ora a SZERZO-FEJLEC POZICIOJABAN tilos (Zara lelete, 2026-09-05):
+    az elso sorban, az elso ' -- ' ELOTT allo ora fejlec-datalas ("ZARA 16:15 -- ...").
+    A torzsben vagy a ' -- ' utan idezett idopont ("a gazda TG 10:59-kor irta") szabad:
+    az idezo alakot az kulonbozteti meg, hogy az ora ELOTT kisbetus szo all."""
+    first = text.split('\n', 1)[0]
+    if TYPED_CLOCK_RX.match(first):
+        return True
+    head, sep, _ = first.partition(' -- ')
+    if not sep:
+        head, sep, _ = first.partition('--')
+    if not sep:
+        head = first
+    m = CLOCK_RX.search(head)
+    if not m:
+        return False
+    # RAGOZOTT ido = idezet, nem stempli (Geri 19899/1, Marveen 19920/1 dontese): a
+    # "07:40-ES FUTAS" / "10:59-kor" alakban az ora egy esemenyre mutat, a fejlec-stempli
+    # viszont mindig csupasz ("16:15"). Inkabb atengedunk nehany rosszat, mint hogy a
+    # lelet-jelentes szokasos nagybetus alakja bukjon.
+    utana = head[m.end():m.end()+3]
+    if len(utana) >= 2 and utana[0] == '-' and utana[1].isalpha():
+        return False
+    elotte = head[:m.start()].split()
+    for w in elotte:
+        if w[:1].islower():
+            return False
+    # Ha az ora elott kozvetlenul DATUM all, az csak a MAI datummal fejlec-datalas --
+    # a nem-mai datum hatarido/esemeny-idezet ("HATARIDO 2026-09-08 10:00 -- ..."), szabad.
+    datum = None
+    if elotte:
+        u = elotte[-1].strip('([,').rstrip(',')
+        if re.fullmatch(r'\d{4}-\d{2}-\d{2}', u):
+            datum = u
+    if datum is not None and datum != time.strftime('%Y-%m-%d'):
+        return False
+    if sep:
+        return True
+    # Nincs '--': a korpusz-regresszio (KAPUPOZICIO905) szerint a fejlec-datalas itt is el
+    # (Boni kerek zarojeles alakja, Marveen hajnali "MERES 2026-09-05 04:2x ..." stilusa).
+    # Datum nelkuli, '--' nelkuli mondat-kozepi ido szabad; csak a MAI datum + ora paros bukik.
+    return datum is not None
+
+GEPI_FEJLEC_RX = re.compile(r'^\s*\[[^\]\n]*\d{1,2}:\d{2}, rendszerora\]\s*\n?')
+
+def komment_mod(a):
+    """Komment egy MEGLEVO kartyara, ertesites nelkul. Kapuk + kotelezo visszaolvasas."""
+    text = open(a.comment_file, encoding='utf-8').read().strip()
+    if not text:
+        sys.exit('MEGTAGADVA: ures komment-fajl.')
+    # UJRAPROBALKOZAS-ut (Iris lelete, Mira merese, 19912): ha a szoveg egy KORABBI
+    # gepi fejleccel erkezik (bukott iras utani ujrakuldes, vagy a kartyarol visszamasolt
+    # szoveg), a sajat kimenetunkon akadna fenn a kapu. NEM kivetelt teszunk (azt kezzel
+    # rossz oraval is be lehetne gepelni "rendszerora" cimkevel) -- hanem LEVAGJUK es
+    # friss stemplit kap: a regi gepi fejlecben allo ora sosem elhet tovabb.
+    # INVARIANS (Mira merte, 19943): a levagas a TELJES fejlecet viszi, a NEVVEL egyutt --
+    # igy gepi-fejlec-alaku hamisitvannyal MAS NEVEBEN sem lehet irni (a friss stempli a
+    # tenyleges --author-t hordozza). NE "optimalizald" csak az ora-resz levagasara:
+    # azzal ez a nev-vedelem csendben eltunne.
+    levagva = 0
+    while (m := GEPI_FEJLEC_RX.match(text)):
+        text = text[m.end():].lstrip('\n')
+        levagva += 1
+    if levagva:
+        print(f'FIGYELEM: {levagva} korabbi rendszerora-fejlec eltavolitva, friss stemplit kap.')
+    if not text:
+        sys.exit('MEGTAGADVA: a komment csak fejlec(ek)bol allt, torzs nelkul.')
+    if gepelt_ora_fejlec(text):
+        sys.exit('MEGTAGADVA: gepelt ora a szerzo-fejlec poziciojaban (elso sor, a -- elott). Az orat\n'
+                 'az eszkoz teszi be a rendszerorabol -- torold a kezi fejlecet. A torzsben idezett\n'
+                 'idopont (pl. "a gazda 10:59-kor irta") szabad.')
+    if (h := gyanus(text)):
+        sys.exit(f'MEGTAGADVA: vegyes irasrendszeru szo a kommentben: {h[:5]}')
+
+    # MEZOMOZGATAS (KARTYASTATUSZ906, Boni lelete 20271): a --status/--priority korabban
+    # komment-modban SZO NELKUL ELVESZETT. A kimenet OK-t mondott, a kartya nem mozdult, es a
+    # hamis siker iranya rossz volt: a kartya nema maradt a ROSSZ statuszban. A ket lehetseges
+    # javitas kozul (megtagadas vs. mukodo UPDATE) a masodik all, mert a bevezetes ota ervenyes
+    # flotta-szabaly ("statuszra az eszkoz --status kapcsoloja") ezt IGERI -- Boninak nyers
+    # sqlite3-hoz kellett nyulnia, pont ahhoz az uthoz, amit az eszkoz nyugdijazni akart.
+    # A mozgatas SZANDEKOSAN a komment-modhoz kotott: igy statusz sosem valtozik nyom nelkul.
+    # A CIM IS MOZGATHATO (2026-09-06): a flotta-szabaly a cimre IS az eszkozt nevezi meg, es
+    # amig a --title meglevo kartyara nem hatott, a szabaly fele hamis maradt. Ugyanazok a kapuk
+    # allnak ra, mint a letrehozo agon -- kulonben a mozgatas megkerulne a 300 karaktert.
+    if a.title is not None:
+        if len(a.title) > 300:
+            sys.exit(f'MEGTAGADVA: a cim {len(a.title)} karakter (max 300). A trigger levagna es kommentbe tenne.\n'
+                     f'A cim EGY sor legyen (lelet + gazda + hatarido), a reszletek a leirasba.')
+        if (h := gyanus(a.title)):
+            sys.exit(f'MEGTAGADVA: vegyes irasrendszeru szo a cimben: {h[:5]}')
+    if a.status is not None and a.status not in STATUSZOK:
+        sys.exit(f'MEGTAGADVA: ervenytelen statusz ("{a.status}"). Ervenyes: {", ".join(STATUSZOK)}.')
+    if a.priority is not None and a.priority not in PRIORITASOK:
+        sys.exit(f'MEGTAGADVA: ervenytelen prioritas ("{a.priority}"). Ervenyes: {", ".join(PRIORITASOK)}.')
+
+    db = sqlite3.connect(_db_kapu()); db.execute('PRAGMA busy_timeout=8000')
+    card = db.execute('SELECT id,status,assignee,priority,title FROM kanban_cards WHERE id=?', (a.id,)).fetchone()
+    if not card:
+        sys.exit(f'MEGTAGADVA: a(z) {a.id} kartya NEM LETEZIK -- komment-only mod csak meglevo kartyara ir.\n'
+                 f'Uj kartyahoz a letrehozo mod valo (--assignee/--title).')
+    # ELOTTE-PILLANATKEP: enelkul a visszaolvasas nem meres, csak egy ertek felolvasasa.
+    elotte = {'status': card[1], 'priority': card[3], 'title': card[4]}
+    mozgatas = {k: v for k, v in (('status', a.status), ('priority', a.priority), ('title', a.title))
+                if v is not None}
+    valtozik = {k: v for k, v in mozgatas.items() if v != elotte[k]}
+    valtozatlan = {k: v for k, v in mozgatas.items() if v == elotte[k]}
+
+    now = int(time.time())
+    fejlec = f'[{a.author} {time.strftime("%Y-%m-%d %H:%M", time.localtime(now))}, rendszerora]'
+    tartalom = f'{fejlec}\n{text}'
+    if a.dry_run:
+        terv = (', '.join(f'{k}: {str(elotte[k])[:57]} -> {str(v)[:57]}' for k, v in valtozik.items()) or 'nincs')
+        print(f'DRY-RUN OK (komment-mod, DB: {DB}): kartya letezik ({card}), kapuk atmentek.\n'
+              f'  fejlec: {fejlec} | szoveg {len(text)} kar | ertesites: NINCS (komment-only)\n'
+              f'  mezomozgatas: {terv}'
+              + (f' | mar ezen az erteken all: {valtozatlan}' if valtozatlan else ''))
+        return
+
+    cur = db.execute('INSERT INTO kanban_comments (card_id,author,content,created_at) VALUES (?,?,?,?)',
+                     (a.id, a.author, tartalom, now))
+    db.commit()
+    back = db.execute('SELECT id,author,length(content),created_at FROM kanban_comments WHERE rowid=?',
+                      (cur.lastrowid,)).fetchone()
+    if not back:
+        sys.exit('HIBA: a komment nem olvashato vissza -- az iras nem tortent meg.')
+    if back[3] != now:
+        sys.exit(f'HIBA: a visszaolvasott created_at ({back[3]}) nem a fejlec ideje ({now}).')
+    print(f'KOMMENT OK (visszaolvasva innen: {DB}): comment_id={back[0]} author={back[1]} '
+          f'{back[2]} kar, created_at==fejlec-ido. Ertesites: nem ment (komment-only).')
+
+    if valtozatlan:
+        print(f'FIGYELEM: mar ezen az erteken all, nem mozgatom: '
+              + ', '.join(f'{k}={v}' for k, v in valtozatlan.items()))
+    if not valtozik:
+        if mozgatas:
+            print('MEZOMOZGATAS: nincs teendo (minden kimondott ertek mar ez volt).')
+        return
+    sets = ', '.join(f'{k}=?' for k in valtozik)
+    cur = db.execute(f'UPDATE kanban_cards SET {sets}, updated_at=? WHERE id=?',
+                     (*valtozik.values(), now, a.id))
+    db.commit()
+    if cur.rowcount != 1:
+        sys.exit(f'HIBA: a mezomozgatas {cur.rowcount} sort erintett (1 helyett) -- a komment MAR BEIRT.')
+    # FUGGETLEN visszaolvasas: uj SELECT, nem a cursor allitasa. A 0-talalatos UPDATE
+    # es a sikeres UPDATE kulonben megkulonboztethetetlen lenne.
+    utana = db.execute('SELECT status,priority,title FROM kanban_cards WHERE id=?', (a.id,)).fetchone()
+    kapott = {'status': utana[0], 'priority': utana[1], 'title': utana[2]}
+    for k, v in valtozik.items():
+        if kapott[k] != v:
+            sys.exit(f'HIBA: a(z) {k} visszaolvasva "{kapott[k]}", nem a kert "{v}". Az iras NEM ert celba.')
+    def rov(v):
+        v = str(v)
+        return v if len(v) <= 60 else v[:57] + '...'
+    print(f'MEZOMOZGATAS OK (fuggetlenul visszaolvasva innen: {DB}): '
+          + ', '.join(f'{k}: {rov(elotte[k])} -> {rov(kapott[k])}' for k in valtozik))
+    # A MOZGATAS NYOMA A KARTYAN: a komment szovege Bonie, ez a sor a gepe. Enelkul a
+    # tabla olvasoja latja az uj statuszt, de nem latja, hogy KI es MIKOR mozgatta.
+    db.execute('INSERT INTO kanban_comments (card_id,author,content,created_at) VALUES (?,?,?,?)',
+               (a.id, 'kartya-es-ertesites',
+                '[kartya-es-ertesites.py] Mezomozgatas a fenti komment mellett ('
+                + ', '.join(f'{k}: {rov(elotte[k])} -> {rov(kapott[k])}' for k in valtozik)
+                + f'), kerte: {a.author}. Fuggetlenul visszaolvasva.', now))
+    db.commit()
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument('--id', required=True); p.add_argument('--assignee')
+    p.add_argument('--title'); p.add_argument('--desc-file')
+    p.add_argument('--msg-file'); p.add_argument('--priority', default=None)
+    # Az alapertelmezes SZANDEKOSAN None (nem 'planned'/'normal'): csak igy lehet
+    # megkulonboztetni a KIMONDOTT erteket a nem-adottol. A letrehozo ag lentebb tolti fel.
+    p.add_argument('--status', default=None); p.add_argument('--no-msg', action='store_true')
+    p.add_argument('--comment-file', help='KOMMENT-ONLY mod: komment meglevo kartyara, ertesites nelkul')
+    p.add_argument('--author', default='Marveen', help='komment-mod: a komment szerzoje')
+    p.add_argument('--from', dest='from_agent', default=None,
+                   help='az ertesites feladoja (alapertelmezes: az --author kisbetusitve)')
+    p.add_argument('--dry-run', action='store_true')
+    a = p.parse_args()
+
+    if a.comment_file:
+        if a.assignee or a.msg_file or a.desc_file:
+            sys.exit('MEGTAGADVA: a --comment-file nem keverheto a letrehozo mod kapcsoloival\n'
+                     '(--assignee/--desc-file/--msg-file) -- egy futas egy muvelet.\n'
+                     'A --title/--status/--priority viszont MOZGATJA a meglevo kartyat.')
+        komment_mod(a)
+        return
+    if not a.assignee or not a.title:
+        sys.exit('MEGTAGADVA: letrehozo modhoz --assignee es --title kell (komment-modhoz --comment-file).')
+
+    a.status = a.status or 'planned'
+    a.priority = a.priority or 'normal'
+    if a.status not in STATUSZOK:
+        sys.exit(f'MEGTAGADVA: ervenytelen statusz ("{a.status}"). Ervenyes: {", ".join(STATUSZOK)}.')
+    if a.priority not in PRIORITASOK:
+        sys.exit(f'MEGTAGADVA: ervenytelen prioritas ("{a.priority}"). Ervenyes: {", ".join(PRIORITASOK)}.')
+
+    who = a.assignee.strip().lower()
+    # A FELADO: kimondva (--from), vagy a szerzobol. Az alapertelmezes az --author kisbetusitve,
+    # tehat a korabbi viselkedes (--author nelkul: 'marveen') valtozatlan marad.
+    frm = (a.from_agent or a.author).strip().lower()
+    if frm not in KULDOK:
+        sys.exit(f'MEGTAGADVA: ismeretlen felado ("{frm}"). Ervenyes: {", ".join(sorted(KULDOK))}.\n'
+                 f'Ha az --author nem agens-nev (pl. "Marveen (Boni lelete)"), add meg kimondva: --from <agens>.')
+    desc = open(a.desc_file, encoding='utf-8').read() if a.desc_file else ''
+    msg = open(a.msg_file, encoding='utf-8').read() if a.msg_file else ''
+
+    # 1. KAPU: flotta-gazda ertesites nelkul -> megtagadva
+    if who in FLEET and not msg and not a.no_msg:
+        sys.exit(f'MEGTAGADVA: "{who}" flotta-agens, es nincs --msg-file. Egy megnevezett gazdas kartya,\n'
+                 f'amirol a gazdaja nem tud, ugyanolyan nema, mintha nem letezne. Vagy adj uzenetet,\n'
+                 f'vagy mondd ki a --no-msg kapcsoloval, hogy szandekosan nem ertesitesz.')
+    if a.no_msg and who in FLEET:
+        print(f'FIGYELEM: --no-msg egy flotta-gazdas ({who}) kartyanal. Ez szandekos kihagyas.')
+    # ELLENTMONDAS-KAPU (sajat teszt lelete, 2026-09-06): `--no-msg` + `--msg-file` egyutt
+    # korabban ATCSUSZOTT, es az uzenet MEGIS kiment -- vagyis a kimondott "ne kuldj" nem hatott.
+    # Ugyanaz a hibaosztaly, mint Boni --status-lelete: egy kapcsolo, ami nem azt teszi, amit igér.
+    # Nem valasztunk helyette: megtagadjuk, mert a ket szandek kozul nem talalhato ki, melyik az igazi.
+    if a.no_msg and a.msg_file:
+        sys.exit('MEGTAGADVA: --no-msg ES --msg-file egyszerre -- a ketto ellentmond egymasnak.\n'
+                 'Vagy uzenetet kuldesz (--msg-file), vagy kimondva nem (--no-msg), de nem mindkettot.')
+
+    # 2. cim-kapu ELORE
+    if len(a.title) > 300:
+        sys.exit(f'MEGTAGADVA: a cim {len(a.title)} karakter (max 300). A trigger levagna es kommentbe tenne.\n'
+                 f'A cim EGY sor legyen (lelet + gazda + hatarido), a reszletek a leirasba.')
+
+    # 2b. AZ UZENET NEVEZZE MEG A KARTYAT (2026-09-05, az eszkoz ELSO eles hasznalata bukott el rajta).
+    # Az ORSZEMROUTING905 uzenete kiment es meg is erkezett, de a szovege SEHOL nem irta le a kartya
+    # azonositojat -- ezert (a) a cimzett nem tudja osszekotni a kartyaval, es (b) a kanban-audit
+    # kikuldes-detektora KIKULDETLENNEK olvassa, mert az ID-re illeszt. Elo-ellenorzes, tehat a
+    # visszautasitas meg semmit nem irt.
+    if msg and a.id not in msg:
+        sys.exit(f'MEGTAGADVA: az uzenet szovege sehol nem nevezi meg a kartyat ({a.id}).\n'
+                 f'Enelkul a cimzett nem tudja osszekotni a kettot, es az audit kikuldetlennek olvassa.\n'
+                 f'Ird bele az azonositot a szovegbe (pl. "Kartya: {a.id}").')
+
+    # 3. homoglifa-szures a sajat szovegemen
+    for cimke, szoveg in (('cim', a.title), ('leiras', desc), ('uzenet', msg)):
+        if (h := gyanus(szoveg)):
+            sys.exit(f'MEGTAGADVA: vegyes irasrendszeru szo a(z) {cimke}-ban: {h[:5]}')
+
+    if a.dry_run:
+        _db_kapu()
+        print(f'DRY-RUN OK (DB: {DB}): minden ellenorzes atment.\n  id={a.id} gazda={who} statusz={a.status} '
+              f'prio={a.priority}\n  cim {len(a.title)} kar | leiras {len(desc)} kar | uzenet {len(msg)} kar')
+        return
+
+    # 4. kartya + VISSZAOLVASAS
+    now = int(time.time())
+    db = sqlite3.connect(_db_kapu()); db.execute('PRAGMA busy_timeout=8000')
+    if db.execute('SELECT 1 FROM kanban_cards WHERE id=?', (a.id,)).fetchone():
+        sys.exit(f'MEGTAGADVA: a(z) {a.id} kartya MAR LETEZIK.')
+    db.execute('''INSERT INTO kanban_cards (id,title,description,status,assignee,priority,sort_order,created_at,updated_at)
+                  VALUES (?,?,?,?,?,?,0,?,?)''', (a.id, a.title, desc, a.status, who, a.priority, now, now))
+    db.commit()
+    back = db.execute('SELECT id,status,assignee,length(title) FROM kanban_cards WHERE id=?', (a.id,)).fetchone()
+    if not back: sys.exit('HIBA: a kartya nem olvashato vissza -- az iras nem tortent meg.')
+    print(f'KARTYA OK (visszaolvasva innen: {DB}): {back}')
+
+    # 5. uzenet + VISSZAOLVASAS
+    if not msg:
+        print('uzenet: kihagyva (--no-msg)'); return
+    # ONHUROK (Boni 20254): a sajat magara osztott kartya ertesitese visszaert a keszitohoz, es egy
+    # fordulojaba kerult, mire kiderult, hogy a sajat szoveget kapta vissza. Nem elhagyjuk az uzenetet
+    # (a kartya akkor nema lenne), hanem a KOORDINATORHOZ iranyitjuk -- kimondva.
+    cimzett = who
+    if frm == who:
+        if who == COORDINATOR:
+            print(f'FIGYELEM: a felado es a felelos is a koordinator ({who}) -- nincs hova atiranyitani, '
+                  f'az uzenet magahoz megy.')
+        else:
+            cimzett = COORDINATOR
+            msg = (f'[ATIRANYITVA: {frm} a sajat magara osztott {a.id} kartyajarol ertesit; '
+                   f'onhurok helyett a koordinatorhoz megy.]\n{msg}')
+            print(f'ATIRANYITVA: felado == felelos ({who}) -- az ertesites a koordinatorhoz '
+                  f'({COORDINATOR}) megy, nem onmagahoz.')
+
+    # A token a gyokerbol jon, tehat ugyanaz a feloldas vonatkozik ra. KARTYA_TOKEN: teszt-horog
+    # es kimondott felulbiralas, ugyanabban az alakban, mint a KARTYA_DB/KARTYA_API.
+    tokpath = os.path.join(ROOT, 'store', '.dashboard-token')
+    tok = os.environ.get('KARTYA_TOKEN')
+    if tok is None:
+        if not os.path.exists(tokpath):
+            sys.exit(f'A KARTYA LETREJOTT, DE AZ UZENET NEM MENT KI: nincs dashboard-token itt:\n'
+                     f'  {tokpath}\n(gyoker: {ROOT}). Mondd ki: CLAUDECLAW_ROOT=<a fo fa> vagy KARTYA_TOKEN=<token>.\n'
+                     f'Kuldd el kezzel az uzenetet, kulonben a kartya nema marad.')
+        tok = open(tokpath).read().strip()
+    req = urllib.request.Request(API,
+        data=json.dumps({'from': frm, 'to': cimzett, 'content': msg}).encode(),
+        headers={'Content-Type': 'application/json', 'Authorization': 'Bearer ' + tok}, method='POST')
+    try:
+        r = json.load(urllib.request.urlopen(req))
+    except Exception as e:
+        sys.exit(f'A KARTYA LETREJOTT, DE AZ UZENET NEM MENT KI: {e}\n'
+                 f'Kuldd el kezzel, kulonben a kartya nema marad.')
+    mid = r.get('id')
+    if not mid: sys.exit(f'A KARTYA LETREJOTT, de az uzenet-valasz nem ad id-t: {str(r)[:200]}')
+    row = db.execute('SELECT id,from_agent,to_agent,status FROM agent_messages WHERE id=?', (mid,)).fetchone()
+    if not row:
+        sys.exit(f'A KARTYA LETREJOTT, de a {mid} uzenet-sor NEM OLVASHATO VISSZA.')
+    # A visszaolvasas a FELADOT is meri: pont ez a mezo allt korabban hardcode-olva.
+    if row[1] != frm or row[2] != cimzett:
+        sys.exit(f'HIBA: a sor nem azt hordozza, amit kuldtunk. Vart: {frm} -> {cimzett}; '
+                 f'kapott: {row[1]} -> {row[2]}. Az ertesites ROSSZ NEVEN all.')
+    print(f'UZENET OK (visszaolvasva a sorbol, felado is): {row}')
+
+    # NYOM A KARTYAN: melyik uton keszult, es melyik uzenet tartozik hozza.
+    # Boni lelete (2026-09-05): a kikuldes-detektor VEGYES populaciot mer -- a kozvetlenul
+    # felvett es az eszkozzel felvett kartyakat egyutt. Enelkul a jovo heti szam nem
+    # valaszthato szet "az eszkoz hasznalt-e" es "kevesebb kartya keszult" kozott.
+    db.execute('INSERT INTO kanban_comments (card_id,author,content,created_at) VALUES (?,?,?,?)',
+               (a.id, 'kartya-es-ertesites',
+                f'[kartya-es-ertesites.py] A kartya es az ertesites EGY lepesben keszult. '
+                f'Ertesites: msg {mid}, {frm} -> {cimzett}'
+                + (' (ONHUROK helyett a koordinatorhoz iranyitva).' if cimzett != who else '.')
+                + ' Mindket iras visszaolvasva.', now))
+    db.commit()
+    print(f'NYOM OK: kartya-komment a keszites utjarol (msg {mid})')
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## What

The card+notification tool every agent is required to use (`scripts/kartya-es-ertesites.py`) existed only as an **untracked file on the owner's machine**. A tree reset or reinstall would have taken it, and today's fixes with it. This brings it in, plus two test suites.

## Three silent failures, each found by an agent *using* the tool

| # | Was | Now |
|---|-----|-----|
| 1 | notification sender hardcoded `from: 'marveen'` -- every agent's card notification went out under the main agent's name | `--from`, defaulting to `--author` lowercased; unknown sender refused; the readback now measures `from_agent`; self-loop routes to the coordinator instead of back to its own author |
| 2 | `--status`/`--priority` **silently dropped** in comment mode -- output said OK, card never moved | comment mode moves `--title`/`--status`/`--priority` with a before-snapshot and an **independent re-SELECT**; already-at-that-value is stated, not hidden |
| 3 | `--no-msg` + `--msg-file` slipped through and **sent anyway** | the contradicting pair is refused |

For #2 the direction of the false success is the bad one: the card stays silent in the *wrong* status while the tool reports success. The move is deliberately tied to comment mode, so a status cannot change without a trace.

## Root resolution: env first, `__file__` only as fallback

The file carried `ROOT = '/Users/marvin/ClaudeClaw'`, which cannot ship -- `scripts/` is part of the product, and a baked-in install value once kept the daily community messages from going out for weeks.

But `__file__`-**first** would be worse here: the kanban DB is **one live store, not per-worktree**, and a worktree shifts a module-derived root (measured on #978: 42 drops raw vs 15 corrected). A card written from a worktree must reach the live board, not an orphan copy.

So: `CLAUDECLAW_ROOT` env → `__file__`-derived root → no baked path anywhere. **The real protection is fail-closed, not the ordering:** a missing DB is refused with the resolved path printed, because `sqlite3.connect` would otherwise create an empty file and write into it. Every readback line now names the store it read back from -- against a wrong root the readback would be self-consistent but off the live board.

## Evidence

Two suites, **38 assertions**, isolated DB + a stub of the messages API. **Mutation control on nine independent axes**, each reverted to the pre-fix shape -- all fail, all pass when restored:

- sender hardcode (7 assertions fell) · self-loop redirect (4) · sender gate (3)
- field-move UPDATE (6) · value validation (*the comment was already written before the invalid value*) · contradiction gate (2) · `None` defaults (2)
- title move (1) · title gate on the move path (3)
- DB gate (3) · `__file__`-first ordering (13) · path disclosure (1)

Both suites pass **from a worktree**, which is the shape CI runs in.

Both suites pin `CLAUDECLAW_ROOT` to a sandbox for every run: a mutation control that breaks path resolution would otherwise reach the live board -- which is exactly what happened once today, leaving a test card there that had to be removed by hand.

## Review note

I am the author, so this has had no second pair of eyes. The mutation controls are the evidence, not my report of them -- please re-run them rather than trusting the table above.

Card: KARTYAKULDO906. Findings: Boni (msg 20254, 20271, 20272), whose two measurements settled the root-resolution question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)