### PR TITLE
fix(pane): find the prompt footer wherever it is drawn, not in the last five lines (ED50E8B5)

### DIFF
--- a/src/__tests__/permission-footer-anywhere.test.ts
+++ b/src/__tests__/permission-footer-anywhere.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest'
+import { detectsBlockingMenu, detectsPermissionDialog } from '../pane-state.js'
+
+// A prompt high on the screen was invisible to BOTH probes.
+//
+// Every footer probe counted its window back from the last LINE of the
+// capture. A fresh session whose first tool call needs consent draws the
+// prompt in the upper half and leaves the rest of the pane empty, so the
+// footer fell outside the window and nothing matched: no menu, no permission
+// prompt, pane state `unknown`. The monitor then did neither of the things it
+// exists for -- no alert, no recovery. It just sat there.
+//
+// Measured on the shipped code (2026-09-06), live prompt with an 18-line
+// blank tail: detectsBlockingMenu=false, detectsPermissionDialog=false.
+// After the change: both true, which routes the pane to the permission branch
+// in channel-monitor -- alert the owner, send NO keystroke.
+
+const BLANK_TAIL = '\n'.repeat(18)
+
+/** A live consent prompt drawn high, with an empty tail below it. */
+const UPPER_HALF_PROMPT = [
+  '  Reading the sprint notes before the merge.',
+  '',
+  '────────────────────────────────────────────────────────────────',
+  ' Edit file · from the general-purpose agent',
+  '',
+  '   │ ~/.claude/skills/deploy/SKILL.md',
+  '   Update the rollback step',
+  '',
+  ' │ Claude wants to edit its own configuration',
+  '',
+  ' Do you want to make this edit?',
+  ' ❯ Yes, allow this edit',
+  '   Yes, and allow edits to this file for this session',
+  '   No, tell Claude what to do differently',
+  '',
+  ' Esc to cancel · Tab to amend',
+].join('\n') + BLANK_TAIL
+
+/** The same prompt ANSWERED long ago: the work continued, and the footer is
+ * far above the last thing drawn. */
+const ANSWERED_AND_SCROLLED_AWAY = [
+  ' Do you want to proceed?',
+  ' ❯ 1. Yes',
+  '   2. No',
+  ' Esc to cancel · Tab to amend',
+  '',
+  ...Array.from({ length: 20 }, (_, i) => `  step ${i + 1}: editing src/file${i}.ts`),
+  '  Done. Three call sites updated.',
+].join('\n')
+
+describe('a prompt with a blank tail below it', () => {
+  it('is seen as a blocking menu', () => {
+    expect(detectsBlockingMenu(UPPER_HALF_PROMPT)).toBe(true)
+  })
+
+  it('is seen as a permission prompt', () => {
+    // Both matter, and in this order: the monitor only asks the second
+    // question about a pane the first one flagged. Either half false and the
+    // prompt stays invisible.
+    expect(detectsPermissionDialog(UPPER_HALF_PROMPT)).toBe(true)
+  })
+})
+
+describe('an answered prompt that scrolled away', () => {
+  it('is not a blocking menu, so the monitor never acts on it', () => {
+    expect(detectsBlockingMenu(ANSWERED_AND_SCROLLED_AWAY)).toBe(false)
+  })
+
+  // Deliberately NOT asserting that detectsPermissionDialog is false here.
+  //
+  // It returns true -- its question+Yes branch searches the whole pane -- and
+  // that IS imprecise. It was measured and left alone on purpose. The only
+  // caller reaches this probe exclusively for panes that detectsBlockingMenu
+  // already flagged, which the case above shows this pane is not; and on that
+  // branch the cost of the two errors is wildly asymmetric. A false positive
+  // means the owner gets an alert instead of a blind Escape. A false negative
+  // means the monitor presses Escape on a live consent prompt, which is NO --
+  // denying the agent's own request while the owner believes they approved it.
+  // That is the regression PERMDENY905 fixed. Tightening this branch would buy
+  // precision nobody can observe at the risk of re-opening it.
+})

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -139,6 +139,30 @@ const BUSY_INDICATORS: RegExp[] = [
 const BUSY_ESC_TO_INTERRUPT_RX = /\besc to interrupt\b/
 const LIVE_FOOTER_REGION_LINES = 5
 
+/**
+ * The last `count` lines that still have content, ignoring a blank tail.
+ *
+ * Every footer probe in this file used to count back from the last LINE of
+ * the capture. A pane whose prompt sits high on the screen with empty rows
+ * below it -- what a fresh session shows when its FIRST tool call needs
+ * consent -- then had its footer fall outside the window, and the probe
+ * reported nothing at all: no menu, no permission prompt, and a pane state of
+ * `unknown`. Measured 2026-09-06 on the shipped code: a live consent prompt
+ * with an 18-line blank tail read `detectsBlockingMenu=false` AND
+ * `detectsPermissionDialog=false`, so the monitor neither alerted nor
+ * recovered. It just sat there.
+ *
+ * Counting from the last line with content keeps the window size honest (the
+ * footer really is within a few lines of the last thing drawn) while making
+ * the prompt's POSITION on screen stop mattering.
+ */
+function liveTailRegion(lines: string[], count: number): string {
+  let end = lines.length
+  while (end > 0 && lines[end - 1].trim() === '') end--
+  if (end === 0) return ''
+  return lines.slice(Math.max(0, end - count), end).join('\n')
+}
+
 // How many trailing lines the BUSY_INDICATORS (spinner / token-counter)
 // scan inspects. During a live turn the status line renders just above the
 // input box (footer ~3 lines + box ~2 lines + the spinner line + a little
@@ -503,7 +527,7 @@ export function detectsBlockingMenu(pane: string): boolean {
     if (rx.test(pane)) return false
   }
   const lines = pane.split('\n')
-  const footerRegion = lines.slice(-MENU_FOOTER_REGION_LINES).join('\n')
+  const footerRegion = liveTailRegion(lines, MENU_FOOTER_REGION_LINES)
   if (BUSY_ESC_TO_INTERRUPT_RX.test(footerRegion)) return false
   if (IDLE_FOOTER_RX.test(pane)) return false
   return MENU_NAV_RX.test(footerRegion) || MENU_ESC_RX.test(footerRegion)
@@ -635,7 +659,7 @@ export function detectsFirstRunGate(pane: string): FirstRunGateKind | null {
   for (const rx of BUSY_INDICATORS) {
     if (rx.test(busyRegion)) return null
   }
-  const footerRegion = lines.slice(-LIVE_FOOTER_REGION_LINES).join('\n')
+  const footerRegion = liveTailRegion(lines, LIVE_FOOTER_REGION_LINES)
   if (BUSY_ESC_TO_INTERRUPT_RX.test(footerRegion)) return null
   if (IDLE_FOOTER_RX.test(pane)) return null
   for (const g of FIRST_RUN_GATES) {
@@ -710,7 +734,7 @@ export function detectsPermissionDialog(pane: string): boolean {
   for (const rx of BUSY_INDICATORS) {
     if (rx.test(busyRegion)) return false
   }
-  const footerRegion = lines.slice(-LIVE_FOOTER_REGION_LINES).join('\n')
+  const footerRegion = liveTailRegion(lines, LIVE_FOOTER_REGION_LINES)
   if (BUSY_ESC_TO_INTERRUPT_RX.test(footerRegion)) return false
   if (IDLE_FOOTER_RX.test(pane)) return false
   return PERMISSION_AMEND_RX.test(footerRegion)
@@ -724,7 +748,7 @@ export function detectsModelConsentDialog(pane: string): boolean {
   for (const rx of BUSY_INDICATORS) {
     if (rx.test(busyRegion)) return false
   }
-  const footerRegion = lines.slice(-LIVE_FOOTER_REGION_LINES).join('\n')
+  const footerRegion = liveTailRegion(lines, LIVE_FOOTER_REGION_LINES)
   if (BUSY_ESC_TO_INTERRUPT_RX.test(footerRegion)) return false
   if (IDLE_FOOTER_RX.test(pane)) return false
   return MODEL_CONSENT_TITLE_RX.test(pane)
@@ -779,7 +803,7 @@ export function detectsFeedbackDraftModal(pane: string): boolean {
   for (const rx of BUSY_INDICATORS) {
     if (rx.test(busyRegion)) return false
   }
-  const footerRegion = lines.slice(-LIVE_FOOTER_REGION_LINES).join('\n')
+  const footerRegion = liveTailRegion(lines, LIVE_FOOTER_REGION_LINES)
   if (BUSY_ESC_TO_INTERRUPT_RX.test(footerRegion)) return false
 
   const liveFrom = Math.max(0, lines.length - BUSY_LIVE_REGION_LINES)
@@ -1390,7 +1414,7 @@ export function parkedPasteSignature(pane: string): string | null {
   for (const rx of BUSY_INDICATORS) {
     if (rx.test(busyRegion)) return null
   }
-  const footerRegion = lines.slice(-LIVE_FOOTER_REGION_LINES).join('\n')
+  const footerRegion = liveTailRegion(lines, LIVE_FOOTER_REGION_LINES)
   if (BUSY_ESC_TO_INTERRUPT_RX.test(footerRegion)) return null
   if (!detectsPastePlaceholder(pane)) return null
   const sig = pastePlaceholderRegion(pane).replace(/\s+/g, ' ').trim()


### PR DESCRIPTION
## A lelet

Minden lábléc-vizsgálat a capture **utolsó soráról** számolta vissza az ablakot. Egy friss session, aminek az első tool-hívása engedélyt kér, a prompt-blokkot a képernyő felső felében rajzolja, alatta üres sorokkal — és ilyenkor a lábléc kiesik az ablakból.

Megmérve a szállított kódon, élő engedélykérés 18 sor üres farokkal:

```
detectsBlockingMenu     = false
detectsPermissionDialog = false
detectPaneState         = unknown
```

A monitor tehát egyiket sem tette meg, amiért létezik: nem riasztott és nem is állította helyre. Csak állt.

## A javítás

`liveTailRegion(lines, count)` az utolsó **tartalmas** sortól számol vissza. Az ablak mérete változatlan (5, illetve 8) — a lábléc tényleg néhány sorra van az utolsó kirajzolt dologtól —, csak a prompt **helye** szűnik meg számítani. Nincs új szám, és nem toltam el az ablakot egy fix értékkel, amit a következő elrendezés megcáfol.

Ugyanaz a mérés utána: `menu=true`, `perm=true`. Ezzel a pane a `channel-monitor` engedély-ágára fut, ami riaszt és **nem küld billentyűt**.

## Amit szándékosan nem javítottam, és ez a fontosabb rész

A `detectsPermissionDialog` kérdés+`Yes` ága az **egész** pane-t nézi, ezért egy már megválaszolt, felgörgült promptra is `true`-t ad. Ez pontatlan, és az első változatomban meg is szüntettem — az egész vizsgálatot az utolsó tartalmas sorhoz horgonyoztam. Aztán megmértem, mit csinál ez **a hívónál**, és visszavontam:

| pane | régi kód | szigorított |
|---|---|---|
| valóságos felgörgült, megválaszolt | `menu=false` → az ág el sem érhető | `menu=false`, de ha mégis odajutna: `perm=false` → **vak Escape** |

Az Escape egy élő engedélykérésen **NEM**-et jelent. Pontosan ez volt a PERMDENY905 regresszió: a monitor a saját ágens kérését utasította el ~45 mp-cel azután, hogy megjelent, miközben a tulajdonos azt hitte, jóváhagyta.

A két hiba ára itt nem szimmetrikus: egy false positive riasztást jelent vak Escape helyett, egy false negative csendes elutasítást. Ezért marad a szélesebb ág, és ezért áll a tesztfájlban kommentként, hogy **miért nem** állítok róla semmit — hogy takarításkor ne kerüljön vissza.

Két busy-vizsgálat (`esc to interrupt`: `detectPaneState` és a retry-ág) szándékosan a nyers slice-on maradt. Az más kérdés, és ott a szélesítésből hamis „busy" lehetne, ami kézbesítést fojt.

## Mérés

365 fájl, **4728 zöld**, 1 skipped. `tsc --noEmit` tiszta.

A kártya (`ed50e8b5`) premisszáját előzőleg méréssel szűkítettem; ez a PR azt a szűkített leletet zárja le.