### PR TITLE
harden(channels): name every resolve_main_model failure, search node's install paths (WTTAKARIT906)

### DIFF
--- a/scripts/__tests__/channels-main-model.test.sh
+++ b/scripts/__tests__/channels-main-model.test.sh
@@ -91,6 +91,45 @@ migr_fallback "claude-opus-5[1m]"
 expect_model ".env override beats the distribution-default fallback" \
   'MAIN_AGENT_MODEL=claude-sonnet-5' '' 'claude-sonnet-5'
 
+
+# MODELMIGRATE806 review (Marveen): the third link's failure must be NAMED to
+# the failure log, never a silent empty -- the jq-gap's sibling. Missing dist
+# (channels started before a rebuild) is the realistic case.
+migr_missing_dist_is_logged() {
+  local root got log
+  root="$(mktemp -d)"; mkdir -p "$root/scripts" "$root/store"   # NO dist/ dir
+  cp "$SRC" "$root/scripts/channels.sh"
+  got="$(bash "$root/scripts/channels.sh" --resolve-main-model 2>/dev/null | head -1)"
+  log="$(cat "$root/store/channels-failures.log" 2>/dev/null)"
+  rm -rf "$root"
+  if [ -z "$got" ] && printf '%s' "$log" | grep -q "dist/config-registry.js missing"; then
+    pass "missing dist -> empty BUT a named log line (not a silent empty)"
+  else
+    fail "missing dist logs a named failure" "empty + 'dist...missing' log" "got=[$got] log=[$log]"
+  fi
+}
+migr_missing_dist_is_logged
+
+# The fallback resolves the default on a jq-FREE PATH (the WSL/Debian case the
+# whole chain exists for): node present, jq absent. The bin carries every tool
+# channels.sh touches EXCEPT jq -- note dirname, which the script needs early
+# for INSTALL_DIR (leaving it out silently broke this test's first cut).
+migr_fallback_jq_free() {
+  local root got node bin
+  node="$(command -v node)"; [ -z "$node" ] && { pass "node absent on test host; skip"; return; }
+  root="$(mktemp -d)"; mkdir -p "$root/scripts" "$root/dist" "$root/store"
+  cp "$SRC" "$root/scripts/channels.sh"
+  printf 'exports.DISTRIBUTION_DEFAULT_AGENT_MODEL="claude-opus-5[1m]";\n' > "$root/dist/config-registry.js"
+  bin="$(mktemp -d)"
+  for t in bash sh cat rm mkdir cp printf head tail grep sed cut tr wc ls env dirname basename expr mktemp python3; do
+    p="/bin/$t"; [ -x "$p" ] || p="/usr/bin/$t"; [ -x "$p" ] && ln -sf "$p" "$bin/$t"
+  done
+  ln -sf "$node" "$bin/node"   # node present, jq deliberately absent
+  got="$(PATH="$bin" bash "$root/scripts/channels.sh" --resolve-main-model 2>/dev/null | head -1)"
+  rm -rf "$root" "$bin"
+  if [ "$got" = "claude-opus-5[1m]" ]; then pass "distribution-default fallback resolves on a jq-free PATH (node present)"; else fail "jq-free fallback" "claude-opus-5[1m]" "$got"; fi
+}
+migr_fallback_jq_free
 # THE SHIPPED-DEFAULT CONTRACT (MODELDRIFT807, 2026-08-07): a fresh install
 # CLONES the repo, so the .claude/settings.json a customer gets is the TRACKED
 # file itself -- NO installer copies the template (or anything else) over it

--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -151,12 +151,40 @@ resolve_main_model() {
   # WITHOUT this fallback they would silently keep the CLI default forever. We do
   # NOT write the value into a per-install file -- that would pin an inherited
   # default and cut those machines off from the NEXT bump. The shipped TS
-  # constant stays the single source of truth; node reads it (node is already a
-  # hard dependency on this launch path, and the read is ~one-time per restart).
-  # The .env override above still wins, so a hand-set model is untouched.
-  if command -v node >/dev/null 2>&1 && [ -f "$INSTALL_DIR/dist/config-registry.js" ]; then
-    node -e 'try { process.stdout.write(String(require(process.argv[1]).DISTRIBUTION_DEFAULT_AGENT_MODEL || "")) } catch (e) {}' "$INSTALL_DIR/dist/config-registry.js" 2>/dev/null
+  # constant stays the single source of truth; node reads it (~one-time per
+  # restart). The .env override above still wins, so a hand-set model is untouched.
+  #
+  # EVERY failure here is NAMED to store/channels-failures.log, never a silent
+  # empty (Marveen review, the jq-gap's sibling): a missing node, a missing/stale
+  # dist (channels can start before the update rebuilds it), or an empty read all
+  # get a log line so the operator sees WHY the model is unset instead of it
+  # looking like nothing was configured.
+  local _fail_log="$INSTALL_DIR/store/channels-failures.log"
+  # Node may not be on the (narrow launchd) PATH at this point; try the standard
+  # install locations too -- the same ones line ~287 adds to PATH -- so this does
+  # not depend on the launcher having widened PATH before this runs.
+  local _node
+  _node="$(command -v node 2>/dev/null || true)"
+  if [ -z "$_node" ]; then
+    for _c in /opt/homebrew/bin/node /usr/local/bin/node "$HOME/.bun/bin/node" "$HOME/.local/bin/node" /home/linuxbrew/.linuxbrew/bin/node; do
+      [ -x "$_c" ] && { _node="$_c"; break; }
+    done
   fi
+  if [ -z "$_node" ]; then
+    echo "resolve_main_model: node not found on PATH or standard locations; main-agent model left UNSET (would run the CLI default)" >>"$_fail_log" 2>/dev/null || true
+    return 0
+  fi
+  if [ ! -f "$INSTALL_DIR/dist/config-registry.js" ]; then
+    echo "resolve_main_model: dist/config-registry.js missing (build not present yet?); main-agent model left UNSET" >>"$_fail_log" 2>/dev/null || true
+    return 0
+  fi
+  local _def
+  _def="$("$_node" -e 'try { process.stdout.write(String(require(process.argv[1]).DISTRIBUTION_DEFAULT_AGENT_MODEL || "")) } catch (e) { process.exit(3) }' "$INSTALL_DIR/dist/config-registry.js" 2>/dev/null)"
+  if [ -z "$_def" ]; then
+    echo "resolve_main_model: read of DISTRIBUTION_DEFAULT_AGENT_MODEL was empty (stale or broken dist/config-registry.js); main-agent model left UNSET" >>"$_fail_log" 2>/dev/null || true
+    return 0
+  fi
+  printf '%s' "$_def"
 }
 
 # Test seam: print the resolved model and exit before any side effect.


### PR DESCRIPTION
## What

Two hardenings to `resolve_main_model()` in `scripts/channels.sh`, both currently ABSENT from develop (recovered from an uncommitted worktree, card WTTAKARIT906):

1. **Every failure is named to `store/channels-failures.log`, never a silent empty.** Today a missing node, a missing/not-yet-built `dist/config-registry.js`, or an empty read all leave the main-agent model UNSET with no trace — the silent-empty class we chased all day. Each now writes a named line.
2. **node search across the usual install paths.** Under launchd the PATH is thin, so `command -v node` can miss a node that is installed — the resolver now looks in the standard locations.

The `#89`/registry contract and the distribution default are unchanged.

## Provenance

MODELMIGRATE806 review (Marveen). Origin worktree was uncommitted; the content is saved on `fix/model-inherited-default` (commit 2476875f) and re-based here onto fresh develop. The develop test file had since replaced the old template-based fixture with the shipped-default contract (MODELDRIFT807) — I kept that, dropped the obsolete template fixture, and added only the two named-log tests.

## Tests

`channels-main-model.test.sh`: 15 passed, 0 failed. The two new tests (`migr_missing_dist_is_logged`, `migr_fallback_jq_free`) verified by mutation: removing the dist-missing log line turns `missing dist logs a named failure` red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
