### PR TITLE
feat(messages): let the closer decide whether the ack is worth a turn

### DIFF
--- a/REBUILD_PROMPT_V3.md
+++ b/REBUILD_PROMPT_V3.md
@@ -362,7 +362,7 @@ Az utemezett feladatok a `~/.claude/scheduled-tasks/` mappaban elnek, SKILL.md +
 |---------|---------|--------|
 | `/api/messages` | POST | Uzenet kuldese (from, to, content) |
 | `/api/messages` | GET | Uzenetek listazasa (?agent=, ?status=pending, ?limit=) |
-| `/api/messages/:id` | PUT | Uzenet statusz frissites (status: done/failed, result) |
+| `/api/messages/:id` | PUT | Uzenet statusz frissites (status: done/failed, result, notify) -- `notify: false` eseten NEM keletkezik `[Eredmeny]` visszajelzes a kuldonek (delegalt feladatnal hasznos, bejovo jelentesnel felesleges); elhagyva a mai viselkedes marad |
 
 ### MCP Konnektorok
 

--- a/src/__tests__/completion-notification.test.ts
+++ b/src/__tests__/completion-notification.test.ts
@@ -1,11 +1,14 @@
 import { describe, it, expect, beforeAll } from 'vitest'
+import { EventEmitter } from 'node:events'
 import {
   initDatabase, createAgentMessage,
   markMessageDone, markMessageFailed, getAgentMessage, listAgentMessages,
+  getPendingMessages,
   COMPLETION_REPORT_PREFIX,
 } from '../db.js'
-import { shouldNotifyDelegator } from '../web/routes/messages.js'
+import { shouldNotifyDelegator, tryHandleMessages } from '../web/routes/messages.js'
 import { MAIN_AGENT_ID } from '../config.js'
+import type { RouteContext } from '../web/routes/types.js'
 
 // Contract tests for the completion-notification feature.
 //
@@ -117,5 +120,104 @@ describe('shouldNotifyDelegator', () => {
 
   it('rejects an empty sender rather than treating it as an agent', () => {
     expect(shouldNotifyDelegator('', 'dex', 'orphan')).toBe(false)
+  })
+})
+
+// Route-level tests for the `notify` flag on PUT /api/messages/:id.
+//
+// These drive the ACTUAL handler instead of re-implementing its decision, because the
+// claim under test is a SIDE EFFECT of the route: whether closing a message adds a row
+// to agent_messages. The measurement is the delegator's pending mailbox -- the ack is
+// the only thing that lands there, since the original message is addressed the other
+// way. Every case carries its own control probe: the same close WITHOUT the flag.
+//
+// MAIN_AGENT_ID is the delegator for the same reason as in the suite above: isKnownAgent
+// resolves agent directories, and a CI checkout has none.
+async function putStatus(id: number, body: unknown): Promise<{ statusCode: number; json: any }> {
+  const req = new EventEmitter() as unknown as RouteContext['req']
+  ;(req as unknown as { headers: Record<string, string> }).headers = {}
+  const state = { statusCode: 0, body: '' }
+  const res = {
+    writeHead(code: number) { state.statusCode = code; return res },
+    end(data?: unknown) { state.body = String(data ?? '') },
+    setHeader() {},
+  } as unknown as RouteContext['res']
+  process.nextTick(() => {
+    ;(req as unknown as EventEmitter).emit('data', Buffer.from(JSON.stringify(body)))
+    ;(req as unknown as EventEmitter).emit('end')
+  })
+  const handled = await tryHandleMessages({
+    req, res, path: `/api/messages/${id}`, method: 'PUT',
+    url: new URL(`http://localhost/api/messages/${id}`), fedPeer: null,
+  })
+  expect(handled).toBe(true)
+  return { statusCode: state.statusCode || 200, json: state.body ? JSON.parse(state.body) : null }
+}
+
+// Acks land in the delegator's pending mailbox; count them there.
+function ackCount(): number {
+  return getPendingMessages(MAIN_AGENT_ID)
+    .filter((m) => m.content.startsWith(COMPLETION_REPORT_PREFIX)).length
+}
+
+describe('PUT /api/messages/:id -- notify flag', () => {
+  it('omitting notify still creates the ack (control probe: the default is unchanged)', async () => {
+    const msg = createAgentMessage(MAIN_AGENT_ID, 'dex', 'Delegated task')
+    const before = ackCount()
+    const r = await putStatus(msg.id, { status: 'done', result: 'PR opened' })
+    expect(r.statusCode).toBe(200)
+    expect(ackCount() - before).toBe(1)
+  })
+
+  it('notify:false closes the message but creates NO new row', async () => {
+    const msg = createAgentMessage(MAIN_AGENT_ID, 'dex', 'Incoming report, nothing to ack')
+    const before = ackCount()
+    const beforeTotal = listAgentMessages(500).length
+    const r = await putStatus(msg.id, { status: 'done', notify: false })
+    expect(r.statusCode).toBe(200)
+    expect(r.json).toEqual({ ok: true })
+    // The close itself must still happen: its point is to stop the inbox-wakeup from
+    // re-waking the recipient, so suppressing the ack cannot cost the status transition.
+    expect(getAgentMessage(msg.id)!.status).toBe('done')
+    expect(ackCount() - before).toBe(0)
+    expect(listAgentMessages(500).length - beforeTotal).toBe(0)
+  })
+
+  it('notify:true is the default spelled out, not an override of the guards', async () => {
+    const implicitBefore = ackCount()
+    const implicit = createAgentMessage(MAIN_AGENT_ID, 'dex', 'Delegated task')
+    await putStatus(implicit.id, { status: 'failed', result: 'Network error' })
+    const implicitDelta = ackCount() - implicitBefore
+
+    const explicitBefore = ackCount()
+    const explicit = createAgentMessage(MAIN_AGENT_ID, 'dex', 'Delegated task')
+    await putStatus(explicit.id, { status: 'failed', notify: true, result: 'Network error' })
+    expect(ackCount() - explicitBefore).toBe(implicitDelta)
+
+    // A sender shouldNotifyDelegator refuses (the undeliverable `system`) stays refused
+    // with notify:true -- the flag can save a turn, it cannot buy one.
+    const fromSystem = createAgentMessage('system', MAIN_AGENT_ID, "[session-stuck] Agent 'polip' ...")
+    const beforeSystem = listAgentMessages(500).length
+    await putStatus(fromSystem.id, { status: 'done', notify: true, result: 'handled' })
+    expect(listAgentMessages(500).length - beforeSystem).toBe(0)
+  })
+
+  it('rejects a non-boolean notify with 400 and leaves the message untouched', async () => {
+    const msg = createAgentMessage(MAIN_AGENT_ID, 'dex', 'Delegated task')
+    const before = ackCount()
+    const r = await putStatus(msg.id, { status: 'done', notify: 'false' })
+    expect(r.statusCode).toBe(400)
+    expect(r.json.error).toMatch(/boolean/i)
+    // No half-applied close: the guard sits before the status write.
+    expect(getAgentMessage(msg.id)!.status).toBe('pending')
+    expect(ackCount() - before).toBe(0)
+  })
+
+  it('notify:null is treated as absent (default), not as false', async () => {
+    const msg = createAgentMessage(MAIN_AGENT_ID, 'dex', 'Delegated task')
+    const before = ackCount()
+    const r = await putStatus(msg.id, { status: 'done', notify: null, result: 'ok' })
+    expect(r.statusCode).toBe(200)
+    expect(ackCount() - before).toBe(1)
   })
 })

--- a/src/web/routes/messages.ts
+++ b/src/web/routes/messages.ts
@@ -279,7 +279,30 @@ export async function tryHandleMessages(ctx: RouteContext): Promise<boolean> {
   if (msgUpdateMatch && method === 'PUT') {
     const id = parseInt(msgUpdateMatch[1], 10)
     const body = await readBody(req)
-    const { status: newStatus, result } = JSON.parse(body.toString()) as { status: string; result?: string }
+    const { status: newStatus, result, notify } = JSON.parse(body.toString()) as
+      { status: string; result?: string; notify?: boolean }
+
+    // `notify` lets the CLOSER decide whether the reverse [Eredmény] message is
+    // worth an agent turn at the other end. The two cases share this one code
+    // path and cannot be told apart from here:
+    //   - closing a DELEGATED task   -> the delegator is waiting, the ack IS the result;
+    //   - closing an INCOMING report -> the sender already knows it sent it, and the ack
+    //     (typically the 52-char "(nincs eredmény)" form) only lengthens the very queue
+    //     whose delay made the report late. Measured on a live install: several such acks
+    //     sat queued behind an agent whose delivery was already lagging, so closing the
+    //     reports made the queue that the reports arrive in longer still.
+    // Absent (or null) keeps today's behavior, so no existing caller changes.
+    // Rejected BEFORE the status write, not coerced: a truthy `"false"` string would send
+    // exactly the notification the caller asked to skip, and a half-applied close (status
+    // written, unwanted ack sent) is worse than an actionable error the caller can retry
+    // -- the same reason the GET list handler rejects unknown query params.
+    if (notify !== undefined && notify !== null && typeof notify !== 'boolean') {
+      json(res, {
+        error: 'notify must be a boolean',
+        hint: 'omit it for the default (notify the sender), or send JSON true/false -- not a string',
+      }, 400)
+      return true
+    }
 
     let ok = false
     if (newStatus === 'done') ok = markMessageDone(id, result)
@@ -294,7 +317,10 @@ export async function tryHandleMessages(ctx: RouteContext): Promise<boolean> {
       // Notify the delegator: create a reverse message from executor → delegator so
       // they learn the result without polling. See shouldNotifyDelegator for which
       // senders are skipped and why.
-      if (done && shouldNotifyDelegator(done.from_agent, done.to_agent, done.content)) {
+      // `notify: false` suppresses it; `notify: true` is only the default spelled out --
+      // it does NOT override shouldNotifyDelegator, whose guards stop undeliverable and
+      // ping-pong acks, not merely expensive ones.
+      if (done && notify !== false && shouldNotifyDelegator(done.from_agent, done.to_agent, done.content)) {
         // A vagas NE legyen nema, ES legyen KOVETHETO: lasd resultSummary().
         const summary = resultSummary(id, result)
         createAgentMessage(


### PR DESCRIPTION
## A változtatás típusa / Type of change
- [x] Új funkció (feature / new feature)

## Rövid leírás / Summary
HU: Egy inter-agent üzenet lezárása eddig MINDIG visszaküldött egy `[Eredmény]` üzenetet a küldőnek. Delegált feladatnál ez maga az eredmény; bejövő jelentésnél viszont zaj, mert a küldő tudja, hogy elküldte, és az üres eredmény egy rövid "(nincs eredmény)" szöveggé rendereldik, ami mégis egy teljes agent-kört fogyaszt a címzettnél. A két eset ugyanazon a kódúton megy, és a kezelőn belülről nem különböztethető meg, ezért a `PUT /api/messages/:id` mostantól elfogad egy opcionális `notify` mezőt:

- elhagyva (vagy `null`): a mai viselkedés marad, tehát egyetlen meglévő hívó sem változik;
- `notify: false`: kimarad a visszajelzés, de a státusz-írás megtörténik -- a lezárás maga az, ami megállítja az inbox-wakeup ismételt ébresztését, azt nem szabad elveszíteni;
- `notify: true`: csak kimondja az alapértelmezést, NEM írja felül a `shouldNotifyDelegator` őreit (kézbesíthetetlen és ping-pong visszajelzés továbbra is tiltott).

Nem-boolean érték 400-zal elutasítva, MÉG a státusz-írás előtt: egy igaz értékű `"false"` string pont azt az értesítést küldené el, amit a hívó ki akart hagyni, a félig végrehajtott lezárás (státusz kiírva, kéretlen visszajelzés elküldve) pedig rosszabb, mint egy újrapróbálható hiba.

EN: Closing an inter-agent message always posted a reverse `[Eredmény]` message back to its sender. For a DELEGATED task that ack is the result; for an INCOMING report it is noise -- the sender already knows it sent it, and an empty result renders as a short "(nincs eredmény)" that still costs the recipient a full agent turn. Both cases share one code path and cannot be told apart inside the handler, so `PUT /api/messages/:id` now takes an optional `notify` field:

- omitted (or `null`): today's behavior, so no existing caller changes;
- `notify: false`: skips the ack but still writes the status -- the close itself is what stops the inbox-wakeup from re-waking the recipient, and that must not be lost;
- `notify: true`: only spells out the default; it does NOT override `shouldNotifyDelegator`, whose guards keep stopping undeliverable and ping-pong acks.

A non-boolean is rejected with 400 BEFORE the status write: coercing a truthy `"false"` string would send exactly the notification the caller asked to skip, and a half-applied close (status written, unwanted ack sent) is worse than an actionable error the caller can retry.

## Kapcsolódó issue / Related issue
Nincs nyitott GitHub issue.

## Ellenőrzőlista / Checklist
- [x] A route-szintű tesztek a VALÓDI kezelőt hajtják meg, és a mellékhatást mérik (keletkezik-e új sor az `agent_messages` táblában a delegáló postaládájában), nem a döntést implementálják újra. Minden eset mellett ott a kontroll-próba: ugyanaz a lezárás a flag NÉLKÜL.
- [x] Mindkét mutáció (a `notify !== false` őr elhagyása, illetve a nem-boolean elutasítás elhagyása) ellenőrizve, hogy a megfelelő tesztet buktatja.
- [x] Visszafelé kompatibilis: a `notify` nélkül hívó meglévő kliensek viselkedése bitre azonos.
- [x] `npm run typecheck` (exit 0), `npm test` (366 fájl, 4757 teszt, 0 bukás), `npm run syntax-check` (exit 0) -- mind a naprakész `develop`-ra rebase-elt állapoton futtatva.
- [x] docs/ frissítés: a `REBUILD_PROMPT_V3.md` API-táblájában a `PUT /api/messages/:id` sor megkapta a `notify` mezőt.
- [x] Nincs beégetett szenzitív adat.
- [x] Saját, beszédes nevű branch: fix/message-close-notify-flag
