### PR TITLE
fix(kanban): warn the reader that a dispatch may have arrived late

### DIFF
--- a/src/__tests__/kanban-dispatch-instructions.test.ts
+++ b/src/__tests__/kanban-dispatch-instructions.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
+import { execFileSync } from 'node:child_process'
 import { kanbanMoveInstructions } from '../web/routes/kanban.js'
+
+// The one line of the dispatch that is a COMMAND rather than prose.
+const probeLine = (out: string): string | undefined =>
+  out.split('\n').find((l) => l.includes('/api/kanban |'))
 
 // A card dispatched to an agent used to just say "drag it to done" -- but a
 // headless agent cannot drag, and the run left no record on the card. The
@@ -27,6 +32,61 @@ describe('kanbanMoveInstructions', () => {
     const out = kanbanMoveInstructions('abc123', 'cody')
     expect(out).toContain('"status":"done","actor":"cody"')
     expect(out).toContain('"status":"in_progress","actor":"cody"')
+  })
+
+  // The dispatch fires once, when the card enters in_progress, and is correct at
+  // that moment -- but the message rides the normal inter-agent queue and a busy
+  // session may read it a round later, after the work is already done. The guard
+  // cannot live at dispatch time (the card is not `testing` yet when the message
+  // is written), so it has to be IN the message. These assert it is there, that it
+  // is actionable, and that it is read BEFORE the work rather than after it.
+  it('tells the reader to re-check the card status before starting', () => {
+    const out = kanbanMoveInstructions('abc123', 'cody')
+    expect(out).toContain('MIELŐTT NEKIKEZDESZ')
+    expect(out).toContain('testing')
+    expect(out).toContain('NE kezdj bele')
+  })
+
+  it('hands over the status check as a runnable command, not as an instruction to compose', () => {
+    const out = kanbanMoveInstructions('abc123', 'cody')
+    const probe = probeLine(out)
+    expect(probe).toBeDefined()
+    // Same token discipline as every other command in the message: read at run
+    // time, never embedded.
+    expect(probe).toContain('$(cat ')
+    expect(probe).toContain('.dashboard-token')
+  })
+
+  // Text assertions cannot tell a working command from a plausible-looking one,
+  // and this line's whole value is that the reader can paste it. So run the
+  // program it emits: once against a board (the answer must be THIS card's status,
+  // not a neighbour's) and once against the error object the endpoint returns when
+  // the token cannot be read -- the shape that made the first draft die on a
+  // Python TypeError, which is the one answer a pre-flight check must never give.
+  const runProbeProgram = (out: string, stdin: string): string => {
+    const probe = probeLine(out)!
+    const program = probe.slice(probe.indexOf('python3 -c "') + 'python3 -c "'.length).replace(/"\s*$/, '')
+    return execFileSync('python3', ['-c', program], { input: stdin, encoding: 'utf-8' }).trim()
+  }
+
+  it('the emitted program reports THIS card status and survives an error response', () => {
+    const out = kanbanMoveInstructions('abc123', 'cody')
+    const board = JSON.stringify([
+      { id: 'zzz999', status: 'in_progress' },
+      { id: 'abc123', status: 'testing' },
+    ])
+    expect(runProbeProgram(out, board)).toBe('testing')
+    expect(runProbeProgram(out, JSON.stringify([{ id: 'zzz999', status: 'done' }]))).toBe('nincs ilyen kartya')
+    const err = runProbeProgram(out, JSON.stringify({ error: 'Unauthorized' }))
+    expect(err).toContain('Unauthorized')
+    expect(err).not.toContain('Traceback')
+  })
+
+  it('puts the warning BEFORE the completion steps -- it is a pre-flight check', () => {
+    const out = kanbanMoveInstructions('abc123', 'cody')
+    expect(out.indexOf('MIELŐTT NEKIKEZDESZ')).toBeLessThan(out.indexOf('Amikor VÉGEZTÉL'))
+    // And it is the first thing in the block, not buried mid-message.
+    expect(out.startsWith('MIELŐTT NEKIKEZDESZ')).toBe(true)
   })
 
   it('keeps the bearer token out of the message (reads it at run time)', () => {

--- a/src/web/routes/kanban.ts
+++ b/src/web/routes/kanban.ts
@@ -50,7 +50,39 @@ export function kanbanMoveInstructions(id: string, target: string): string {
   // not to the human).
   const isMainAgent = target === MAIN_AGENT_ID
   const escalateTo = isMainAgent ? OWNER_NAME : MAIN_AGENT_ID
+  // FIRST line on purpose: this dispatch is fired ONCE, at the moment the card
+  // enters in_progress, and the status is correct then -- the `dispatched_at`
+  // guard is right and is not what needs fixing. What can slip is DELIVERY: the
+  // message rides the normal inter-agent queue, and a busy session may only read
+  // it after finishing that round, by which time the card has moved on. Observed
+  // on a live install, on more than one card.
+  //
+  // A status check at dispatch time therefore cannot help (the card is not yet
+  // `testing` when the message is written), so the guard has to travel WITH the
+  // message and be re-evaluated by the reader. The wasted round is the mild
+  // outcome; the expensive one is a second attempt producing parallel work on the
+  // same target -- a SECOND test file for one controller, with its own fixture,
+  // maintained in two places. The receiving agent's own rules already forbid that,
+  // but they cannot fire on a task the agent has no reason to think is finished.
+  //
+  // The check is handed over as a runnable command, like every other step here:
+  // an instruction the reader has to compose is one it can skip. There is no
+  // single-card GET endpoint, hence the board fetch plus a one-field extract.
+  //
+  // The isinstance(list) branch is not defensive padding: measured while writing
+  // this, an unreadable token makes the endpoint answer with an error OBJECT, and
+  // iterating that dict yields its KEYS, so the naive one-liner dies on a Python
+  // TypeError. A traceback is the one answer this line must never give -- the
+  // reader would have no status and no idea why, and the likeliest reaction to a
+  // broken pre-flight check is to skip it. Echoing the server's own error keeps it
+  // actionable.
+  const statusProbe =
+    `  curl -s ${auth} ${base}/api/kanban | python3 -c "import sys,json;d=json.load(sys.stdin);print(next((c['status'] for c in d if c.get('id')=='${id}'),'nincs ilyen kartya') if isinstance(d,list) else 'ismeretlen -- a szerver nem kartya-listat adott: '+str(d)[:120])"`
   return [
+    'MIELŐTT NEKIKEZDESZ: nézd meg a kártya AKTUÁLIS státuszát. Ez az üzenet egy foglalt session sorában KÉSHET, és közben a munka elkészülhetett:',
+    statusProbe,
+    'Ha a válasz már "testing" vagy "done", NE kezdj bele -- az üzenet későn ért ide, a munka már áll. Egy második nekifutás párhuzamos, két helyen karbantartott munkát szül (például egy MÁSODIK teszt-fájlt ugyanarra a vezérlőre). Ilyenkor jelezd a delegálódnak, és ne írj kódot.',
+    '',
     'A kártyát in_progress-re húzták. Amikor VÉGEZTÉL, két lépés (mindkettő a kártyára kerül, a web UI-ban látszik):',
     '',
     '1) Írj egy rövid eredmény-összefoglalót kommentként (1-2 mondat: mi lett a vége):',


### PR DESCRIPTION
## A változtatás típusa / Type of change
- [x] Hibajavítás (bugfix)

## Rövid leírás / Summary
HU: A kanban-dispatch EGYSZER tüzel, akkor amikor a kártya `in_progress`-be kerül, és abban a pillanatban a státusz helyes -- a `dispatched_at` őr jó, ez a PR hozzá sem nyúl. Ami csúszhat, az a KÉZBESÍTÉS: az üzenet a szokásos inter-agent soron utazik, és egy foglalt session csak a köre végén olvassa el, mire a kártya már továbbment. Dispatch-időben ezt nem lehet kivédeni (az üzenet írásakor a kártya még nem `testing`), ezért az őrnek AZ ÜZENETTEL kell utaznia, és az olvasónak kell újraértékelnie.

Az elpazarolt kör az enyhébb kimenet. A drágább az, hogy a második nekifutás párhuzamos munkát szül ugyanarra a célra: egy MÁSODIK teszt-fájl ugyanahhoz a vezérlőhöz, saját fixture-rel, két helyen karbantartva. A fogadó ágens saját szabályai ezt már tiltják, de nem tudnak elsülni egy olyan feladaton, amiről az ágensnek semmi oka feltételezni, hogy már kész.

Ezért a dispatch-instrukció mostantól egy pre-flight ellenőrzéssel NYIT, futtatható parancs formájában átadva, mint az üzenet minden más lépése: egy olyan utasítás, amit az olvasónak magának kell összeraknia, kihagyható utasítás. Egy-kártyás GET végpont nincs, ezért a tábla-lekérés plusz egy mezős kiemelés a megoldás. A kiadott program védi a nem-lista választ: méréssel, írás közben derült ki, hogy olvashatatlan tokennél a végpont egy hiba-OBJEKTUMMAL válaszol, és annak a bejárása a KULCSAIT adja vissza, tehát a naiv egysoros Python-traceback-kel halna meg -- ez pont az az egy válasz, amit egy pre-flight ellenőrzés soha nem adhat, mert egy elromlott ellenőrzésre a legvalószínűbb reakció az, hogy kihagyják.

EN: A kanban dispatch fires ONCE, when the card enters `in_progress`, and its status is correct at that moment -- the `dispatched_at` guard is right and is untouched here. What slips is DELIVERY: the message rides the normal inter-agent queue, and a busy session may only read it after finishing its round, by which time the card has moved on. A status check at dispatch time cannot help (the card is not yet `testing` when the message is written), so the guard has to travel WITH the message and be re-evaluated by whoever reads it.

The wasted round is the mild outcome. The expensive one is a second attempt producing parallel work on the same target -- a SECOND test file for one controller, with its own fixture, maintained in two places. The receiving agent's own rules already forbid that, but they cannot fire on a task the agent has no reason to believe is finished.

So the instructions now OPEN with a pre-flight check, handed over as a runnable command like every other step in the message: an instruction the reader has to compose is one it can skip. There is no single-card GET endpoint, hence the board fetch plus a one-field extract. The emitted program guards the non-list response: measured while writing this, an unreadable token makes the endpoint answer with an error OBJECT, and iterating that dict yields its KEYS, so the naive one-liner dies on a Python traceback -- the one answer a pre-flight check must never give, since the likeliest reaction to a broken check is to skip it.

## Kapcsolódó issue / Related issue
Nincs nyitott GitHub issue.

## Ellenőrzőlista / Checklist
- [x] A tesztek a kiadott programot VÉGREHAJTJÁK, nem a szövegét illesztik: egy tábla ellen (a válasz ENNEK a kártyának a státusza legyen, ne a szomszédé), és a hiba-objektum ellen (a szerver saját hibája jelenjen meg, traceback ne).
- [x] Mind a három mutáció (a figyelmeztetés elhagyása, a parancs elhagyása, a nem-lista ág gyengítése) ellenőrizve, hogy a megfelelő tesztet buktatja.
- [x] A pre-flight ellenőrzés a blokk ELEJÉN áll, nem az üzenet közepén elrejtve -- erre külön teszt van.
- [x] Token-fegyelem változatlan: a parancs futásidőben olvassa a tokent, nem ágyazza be.
- [x] `npm run typecheck` (exit 0), `npm test` (366 fájl, 4756 teszt, 0 bukás), `npm run syntax-check` (exit 0) -- mind a naprakész `develop`-ra rebase-elt állapoton futtatva.
- [x] docs/ frissítés: nem szükséges (a változás az ágensnek küldött üzenet szövegében van, felhasználó-látható felület nem érintett).
- [x] Nincs beégetett szenzitív adat.
- [x] Saját, beszédes nevű branch: fix/kanban-dispatch-stale-warning
