### PR TITLE
feat(channels): measure the intake, because a deaf channel raises no event

### DIFF
--- a/src/__tests__/channel-intake-monitor.test.ts
+++ b/src/__tests__/channel-intake-monitor.test.ts
@@ -1,0 +1,194 @@
+// A dead inbound pipe produces no event: nothing arrives, nothing errors, and
+// the pane keeps rendering a connected plugin. Finy was deaf for five days in
+// July 2026 and every existing check was satisfied the whole time.
+//
+// These tests pin the two positive signals that DO exist while the channel is
+// deaf, so the detection never rests on an absence again:
+//   1. getWebhookInfo.pending_update_count > 0 -- updates queued upstream that
+//      nobody is fetching. Proof, not suspicion.
+//   2. getMe answering ok:false -- the token itself is gone.
+// Inbound silence alone stays a suspicion and must never alert on its own: an
+// agent with nothing to do is legitimately silent for days.
+
+import { describe, it, expect } from 'vitest'
+import {
+  parseIntakeProbe,
+  decideIntakeVerdict,
+  type IntakeProbe,
+  type IntakeObservation,
+} from '../web/channel-intake-monitor.js'
+
+const DAY_MS = 24 * 60 * 60 * 1000
+const SILENCE_MS = 2 * DAY_MS
+const NOW = 1_760_000_000_000
+
+function probe(over: Partial<IntakeProbe> = {}): IntakeProbe {
+  return { reachable: true, tokenOk: true, pendingUpdates: 0, webhookUrl: '', lastErrorMessage: null, ...over }
+}
+
+describe('parseIntakeProbe', () => {
+  it('reads the pending update count out of a healthy getWebhookInfo body', () => {
+    const r = parseIntakeProbe(200, {
+      ok: true,
+      result: { url: '', pending_update_count: 7, last_error_message: 'wrong response' },
+    })
+    expect(r).toEqual({
+      reachable: true,
+      tokenOk: true,
+      pendingUpdates: 7,
+      webhookUrl: '',
+      lastErrorMessage: 'wrong response',
+    })
+  })
+
+  it('parses the exact body a healthy live bot returned on 2026-09-06', () => {
+    // Verbatim from getWebhookInfo against a running fleet agent's token.
+    const r = parseIntakeProbe(200, {
+      ok: true,
+      result: { url: '', has_custom_certificate: false, pending_update_count: 0 },
+    })
+    expect(r.tokenOk).toBe(true)
+    expect(r.pendingUpdates).toBe(0)
+    expect(r.lastErrorMessage).toBeNull()
+  })
+
+  it('marks the token invalid when Telegram rejects it', () => {
+    const r = parseIntakeProbe(401, { ok: false, error_code: 401, description: 'Unauthorized' })
+    expect(r.tokenOk).toBe(false)
+    expect(r.reachable).toBe(true)
+    expect(r.pendingUpdates).toBeNull()
+  })
+
+  it('reports unreachable (not token-invalid) when the HTTP call itself failed', () => {
+    const r = parseIntakeProbe(0, null)
+    expect(r.reachable).toBe(false)
+    expect(r.tokenOk).toBe(true)
+    expect(r.pendingUpdates).toBeNull()
+  })
+})
+
+describe('decideIntakeVerdict', () => {
+  it('stays silent while the channel is quiet but the intake is clean', () => {
+    const d = decideIntakeVerdict({
+      probe: probe(),
+      prev: null,
+      lastInboundAt: NOW - 5 * DAY_MS,
+      now: NOW,
+      silenceThresholdMs: SILENCE_MS,
+    })
+    expect(d.verdict).toBe('quiet')
+    expect(d.alert).toBe(false)
+  })
+
+  it('says ok when inbound arrived inside the silence window', () => {
+    const d = decideIntakeVerdict({
+      probe: probe(),
+      prev: null,
+      lastInboundAt: NOW - 60_000,
+      now: NOW,
+      silenceThresholdMs: SILENCE_MS,
+    })
+    expect(d.verdict).toBe('ok')
+    expect(d.alert).toBe(false)
+  })
+
+  it('does not alert on a single backlog reading -- one tick can catch a burst mid-fetch', () => {
+    const d = decideIntakeVerdict({
+      probe: probe({ pendingUpdates: 3 }),
+      prev: null,
+      lastInboundAt: NOW - 5 * DAY_MS,
+      now: NOW,
+      silenceThresholdMs: SILENCE_MS,
+    })
+    expect(d.verdict).toBe('backlog-suspected')
+    expect(d.alert).toBe(false)
+  })
+
+  it('alerts when the backlog is still there on the next tick and has not shrunk', () => {
+    const prev: IntakeObservation = { at: NOW - 5 * 60_000, pendingUpdates: 3 }
+    const d = decideIntakeVerdict({
+      probe: probe({ pendingUpdates: 4 }),
+      prev,
+      lastInboundAt: NOW - 5 * DAY_MS,
+      now: NOW,
+      silenceThresholdMs: SILENCE_MS,
+    })
+    expect(d.verdict).toBe('deaf-backlog')
+    expect(d.alert).toBe(true)
+  })
+
+  it('alerts on a persistent backlog even when inbound is recent -- deafness is not a silence question', () => {
+    const prev: IntakeObservation = { at: NOW - 5 * 60_000, pendingUpdates: 2 }
+    const d = decideIntakeVerdict({
+      probe: probe({ pendingUpdates: 2 }),
+      prev,
+      lastInboundAt: NOW - 60_000,
+      now: NOW,
+      silenceThresholdMs: SILENCE_MS,
+    })
+    expect(d.verdict).toBe('deaf-backlog')
+    expect(d.alert).toBe(true)
+  })
+
+  it('clears the suspicion when the poller drained the queue between ticks', () => {
+    const prev: IntakeObservation = { at: NOW - 5 * 60_000, pendingUpdates: 9 }
+    const d = decideIntakeVerdict({
+      probe: probe({ pendingUpdates: 2 }),
+      prev,
+      lastInboundAt: NOW - 60_000,
+      now: NOW,
+      silenceThresholdMs: SILENCE_MS,
+    })
+    expect(d.verdict).toBe('draining')
+    expect(d.alert).toBe(false)
+  })
+
+  it('does not confirm a backlog from two readings taken in the same moment', () => {
+    const prev: IntakeObservation = { at: NOW - 1_000, pendingUpdates: 3 }
+    const d = decideIntakeVerdict({
+      probe: probe({ pendingUpdates: 3 }),
+      prev,
+      lastInboundAt: NOW - 60_000,
+      now: NOW,
+      silenceThresholdMs: SILENCE_MS,
+    })
+    expect(d.verdict).toBe('backlog-suspected')
+    expect(d.alert).toBe(false)
+  })
+
+  it('alerts when the token stopped working', () => {
+    const d = decideIntakeVerdict({
+      probe: probe({ tokenOk: false, pendingUpdates: null }),
+      prev: null,
+      lastInboundAt: NOW - 60_000,
+      now: NOW,
+      silenceThresholdMs: SILENCE_MS,
+    })
+    expect(d.verdict).toBe('token-invalid')
+    expect(d.alert).toBe(true)
+  })
+
+  it('never alerts when our own side could not reach Telegram', () => {
+    const d = decideIntakeVerdict({
+      probe: probe({ reachable: false, pendingUpdates: null }),
+      prev: null,
+      lastInboundAt: NOW - 9 * DAY_MS,
+      now: NOW,
+      silenceThresholdMs: SILENCE_MS,
+    })
+    expect(d.verdict).toBe('unreachable')
+    expect(d.alert).toBe(false)
+  })
+
+  it('reports a missing ingestion timestamp as unknown, never as proven silence', () => {
+    const d = decideIntakeVerdict({
+      probe: probe(),
+      prev: null,
+      lastInboundAt: null,
+      now: NOW,
+      silenceThresholdMs: SILENCE_MS,
+    })
+    expect(d.verdict).toBe('unknown-inbound')
+    expect(d.alert).toBe(false)
+  })
+})

--- a/src/web.ts
+++ b/src/web.ts
@@ -22,6 +22,7 @@ import { startScheduleRunner } from './web/schedule-runner.js'
 import { startChannelPluginMonitor } from './web/channel-monitor.js'
 import { startInboundProber } from './web/inbound-probe.js'
 import { startChannelHealthMonitor } from './web/channel-health-monitor.js'
+import { startChannelIntakeMonitor } from './web/channel-intake-monitor.js'
 import { startStuckInputWatcher } from './web/stuck-input-watcher.js'
 import { startInboxNudgeWatcher } from './web/inbox-nudge-watcher.js'
 import { startStuckToolCallWatcher } from './web/stuck-tool-call-watcher.js'
@@ -409,6 +410,12 @@ export function startWebServer(port = 3420): http.Server {
   const channelHealthInterval = webOnly ? undefined : startChannelHealthMonitor()
   if (!webOnly) logger.info('Channel MCP health monitor started (60s poll, 45s offset)')
 
+  // The pane-grep above only sees a channel that SAYS it failed. This one asks
+  // Telegram whether anyone is still fetching the agent's updates, which is the
+  // only signal a silently deaf poller leaves behind.
+  const channelIntakeInterval = webOnly ? undefined : startChannelIntakeMonitor(PROJECT_ROOT)
+  if (!webOnly) logger.info('Channel intake monitor started (5min poll, 100s offset)')
+
   // CostOps: reflect the local config's fixed costs into the ledger once at boot + every
   // 10 minutes. Deliberately NOT done inside the GET /api/costs/summary handler -- a read
   // endpoint must not write (was flagged in review); this is the one place that does.
@@ -606,6 +613,7 @@ setInterval(() => { try { sweepExpiredDesktopLock() } catch { /* never kill the 
     workerLivenessCancelled = true
     if (workerLivenessInterval) clearInterval(workerLivenessInterval)
     clearInterval(channelHealthInterval)
+    if (channelIntakeInterval) clearInterval(channelIntakeInterval)
     if (costsSyncInterval) clearInterval(costsSyncInterval)
     clearInterval(stuckInputInterval)
     clearInterval(stuckToolCallInterval)

--- a/src/web/channel-intake-monitor.ts
+++ b/src/web/channel-intake-monitor.ts
@@ -1,0 +1,316 @@
+/**
+ * Channel intake monitor: measures whether a channel's inbound side is still
+ * being consumed, using a signal that EXISTS while the channel is deaf.
+ *
+ * Why this is not covered by what we already run:
+ *   - channel-health-monitor greps the pane for `✘ failed`. A plugin whose
+ *     poll loop stopped while the process stayed alive renders nothing.
+ *   - channel-poller-reap and channel-conflict-probe answer "is someone else
+ *     holding the getUpdates slot", and only once the monitor already believes
+ *     the channel is down.
+ *   - inbound-probe is the gold standard, but it covers the MAIN channels
+ *     session only (one transcript dir, one telethon prober account), and it
+ *     is gated on an operator allowlisting that prober.
+ * Finy sat deaf for five days in July 2026 with all of the above green. The
+ * absence of inbound is not an event, so nothing fired.
+ *
+ * The positive signal used here is getWebhookInfo.pending_update_count: the
+ * number of updates Telegram is holding that NOBODY has fetched. A live poller
+ * keeps it at zero; a dead poll loop lets it grow the moment anyone writes to
+ * the bot. It costs one HTTP call, contends with nothing, and -- unlike a
+ * getUpdates probe -- cannot itself cause the deafness it is looking for
+ * (grammy gives up permanently after 8 consecutive 409s, and a healthy poller
+ * answered 409 to 2 of 5 hand-run getUpdates probes on 2026-09-06).
+ *
+ * Inbound silence is carried alongside as context only. An agent with nothing
+ * to do is legitimately silent for days, so silence never alerts on its own.
+ */
+
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { homedir } from 'node:os'
+import { logger } from '../logger.js'
+import { MAIN_AGENT_ID } from '../config.js'
+import { agentDir, listAgentNames } from './agent-config.js'
+import { isAgentRunning } from './agent-process.js'
+import { readLastIngestionTimestamp } from './inbound-probe.js'
+import { sendRoutineAlert } from './routine-alert.js'
+
+const MINUTE_MS = 60 * 1000
+const DAY_MS = 24 * 60 * 60 * 1000
+
+// Silence long enough that a working agent would normally have heard something,
+// short enough to still be actionable. Only ever downgrades an alert to a log
+// line -- see decideIntakeVerdict.
+export const INTAKE_SILENCE_THRESHOLD_MS = 2 * DAY_MS
+
+// Two readings taken this close together describe one moment, not a trend.
+export const BACKLOG_CONFIRM_MIN_GAP_MS = 3 * MINUTE_MS
+
+// The channel is either deaf or it is not; repeating hourly buries the first
+// message (see routine-alert). Matches the fleet's 3h re-alert cadence.
+export const INTAKE_ALERT_COOLDOWN_MS = 3 * 60 * MINUTE_MS
+
+const CHECK_INTERVAL_MS = 5 * MINUTE_MS
+const INITIAL_DELAY_MS = 100 * 1000
+const PROBE_TIMEOUT_MS = 8_000
+
+export interface IntakeProbe {
+  /** false only when OUR side failed to complete the call (network, timeout). */
+  reachable: boolean
+  /** false when Telegram answered but rejected the token. */
+  tokenOk: boolean
+  /** Updates queued upstream that nobody has fetched; null when unknown. */
+  pendingUpdates: number | null
+  webhookUrl: string | null
+  lastErrorMessage: string | null
+}
+
+export interface IntakeObservation {
+  at: number
+  pendingUpdates: number
+}
+
+export type IntakeVerdict =
+  | 'ok'
+  | 'quiet'
+  | 'unknown-inbound'
+  | 'draining'
+  | 'backlog-suspected'
+  | 'deaf-backlog'
+  | 'token-invalid'
+  | 'unreachable'
+
+export interface IntakeDecision {
+  verdict: IntakeVerdict
+  alert: boolean
+}
+
+interface TelegramWebhookInfoBody {
+  ok?: boolean
+  description?: string
+  result?: {
+    url?: string
+    pending_update_count?: number
+    last_error_message?: string
+  }
+}
+
+/**
+ * Turn one getWebhookInfo response into a probe reading.
+ *
+ * `status === 0` is the caller's marker for "the HTTP call never completed",
+ * which must NOT be read as a bad token: our own network being down would
+ * otherwise page the owner about every agent at once.
+ */
+export function parseIntakeProbe(status: number, body: unknown): IntakeProbe {
+  if (status === 0) {
+    return { reachable: false, tokenOk: true, pendingUpdates: null, webhookUrl: null, lastErrorMessage: null }
+  }
+  const parsed = (body ?? {}) as TelegramWebhookInfoBody
+  if (status !== 200 || parsed.ok !== true || !parsed.result) {
+    return {
+      reachable: true,
+      tokenOk: false,
+      pendingUpdates: null,
+      webhookUrl: null,
+      lastErrorMessage: parsed.description ?? null,
+    }
+  }
+  const pending = parsed.result.pending_update_count
+  return {
+    reachable: true,
+    tokenOk: true,
+    pendingUpdates: typeof pending === 'number' ? pending : null,
+    webhookUrl: parsed.result.url ?? null,
+    lastErrorMessage: parsed.result.last_error_message ?? null,
+  }
+}
+
+/**
+ * Pure verdict for one agent's channel intake.
+ *
+ * Alerting cases (both are positive evidence):
+ *   - `token-invalid`: Telegram answered and refused the token.
+ *   - `deaf-backlog`: updates were queued upstream at two readings far enough
+ *     apart to be a trend, and the queue did not shrink between them. A live
+ *     poller drains in milliseconds, so a queue that survives minutes means
+ *     nobody is fetching.
+ *
+ * Everything else is logged only. `quiet` in particular is a suspicion, not a
+ * finding: silence is also what a correctly working idle agent looks like.
+ */
+export function decideIntakeVerdict(opts: {
+  probe: IntakeProbe
+  prev: IntakeObservation | null
+  lastInboundAt: number | null
+  now: number
+  silenceThresholdMs: number
+}): IntakeDecision {
+  const { probe, prev, lastInboundAt, now, silenceThresholdMs } = opts
+
+  if (!probe.reachable) return { verdict: 'unreachable', alert: false }
+  if (!probe.tokenOk) return { verdict: 'token-invalid', alert: true }
+
+  const pending = probe.pendingUpdates ?? 0
+  if (pending > 0) {
+    const confirmed =
+      prev != null &&
+      prev.pendingUpdates > 0 &&
+      now - prev.at >= BACKLOG_CONFIRM_MIN_GAP_MS
+    if (!confirmed) return { verdict: 'backlog-suspected', alert: false }
+    if (pending < prev.pendingUpdates) return { verdict: 'draining', alert: false }
+    return { verdict: 'deaf-backlog', alert: true }
+  }
+
+  // No ingestion timestamp is missing evidence, not evidence of silence: the
+  // transcript scan reads the newest JSONL's tail, and an agent whose newest
+  // session is a worker or a scheduled run shows no channel line at all. Saying
+  // "silent forever" there would be an unmeasured claim on every tick.
+  if (lastInboundAt == null) return { verdict: 'unknown-inbound', alert: false }
+  if (now - lastInboundAt >= silenceThresholdMs) return { verdict: 'quiet', alert: false }
+  return { verdict: 'ok', alert: false }
+}
+
+export function formatIntakeAlert(agentName: string, decision: IntakeDecision, probe: IntakeProbe, silentForMs: number | null): string {
+  const silence =
+    silentForMs == null ? 'nem érkezett bejövő üzenet, amióta figyeljük'
+    : `${Math.floor(silentForMs / DAY_MS)} napja nem érkezett bejövő üzenet`
+  if (decision.verdict === 'token-invalid') {
+    return `🔇 ${agentName}: a Telegram elutasította a bot tokent (${probe.lastErrorMessage ?? 'nincs indoklás'}). A csatorna nem tud fogadni. ${silence}.`
+  }
+  return `🔇 ${agentName}: ${probe.pendingUpdates} bejövő üzenet áll a Telegram sorában, és senki nem veszi le. A plugin fut, de a poll-ciklusa halott. ${silence}.`
+}
+
+// ---------------------------------------------------------------------------
+// Runtime
+// ---------------------------------------------------------------------------
+
+const lastObservation = new Map<string, IntakeObservation>()
+const lastQuietLogAt = new Map<string, number>()
+
+// A quiet channel is a standing condition, not an event; repeating it every
+// tick would bury the lines that matter in dashboard.log.
+const QUIET_LOG_INTERVAL_MS = 6 * 60 * MINUTE_MS
+
+/** Test seam: reset the per-agent backlog history. */
+export function resetIntakeObservations(): void {
+  lastObservation.clear()
+  lastQuietLogAt.clear()
+}
+
+/**
+ * The main agent's channel lives under the global ~/.claude install; every
+ * sub-agent has its own copy under its agent dir (mirrors telegram.ts).
+ */
+export function channelEnvPathFor(agentName: string): string {
+  const root = agentName === MAIN_AGENT_ID ? homedir() : agentDir(agentName)
+  return join(root, '.claude', 'channels', 'telegram', '.env')
+}
+
+function readTelegramToken(agentName: string): string | null {
+  const envPath = channelEnvPathFor(agentName)
+  if (!existsSync(envPath)) return null
+  try {
+    const match = readFileSync(envPath, 'utf-8').match(/^\s*TELEGRAM_BOT_TOKEN=(.+)$/m)
+    return match?.[1]?.trim() || null
+  } catch {
+    return null
+  }
+}
+
+/** Transcript dir Claude Code uses for a cwd: every '/' replaced with '-'. */
+export function transcriptDirFor(agentName: string, projectRoot: string): string {
+  const cwd = agentName === MAIN_AGENT_ID ? projectRoot : agentDir(agentName)
+  return join(process.env['HOME'] ?? homedir(), '.claude', 'projects', cwd.replace(/\//g, '-'))
+}
+
+async function probeIntake(token: string): Promise<IntakeProbe> {
+  try {
+    const res = await fetch(`https://api.telegram.org/bot${token}/getWebhookInfo`, {
+      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+    })
+    let body: unknown = null
+    try {
+      body = await res.json()
+    } catch {
+      // Telegram always answers JSON; a proxy in between might not.
+    }
+    return parseIntakeProbe(res.status, body)
+  } catch {
+    return parseIntakeProbe(0, null)
+  }
+}
+
+async function checkAgentIntake(agentName: string, projectRoot: string): Promise<void> {
+  const token = readTelegramToken(agentName)
+  if (!token) return
+
+  const probe = await probeIntake(token)
+  const now = Date.now()
+  const lastInboundAt = readLastIngestionTimestamp(transcriptDirFor(agentName, projectRoot))
+  const decision = decideIntakeVerdict({
+    probe,
+    prev: lastObservation.get(agentName) ?? null,
+    lastInboundAt,
+    now,
+    silenceThresholdMs: INTAKE_SILENCE_THRESHOLD_MS,
+  })
+
+  if (probe.pendingUpdates != null) {
+    lastObservation.set(agentName, { at: now, pendingUpdates: probe.pendingUpdates })
+  }
+
+  const silentForMs = lastInboundAt == null ? null : now - lastInboundAt
+  // Never log message bodies -- only counts and timestamps (see inbound-probe).
+  logger.debug(
+    { agent: agentName, verdict: decision.verdict, pending: probe.pendingUpdates, silentForMs },
+    'channel-intake-monitor: probe',
+  )
+
+  if (decision.verdict === 'quiet') {
+    const loggedAt = lastQuietLogAt.get(agentName) ?? 0
+    if (now - loggedAt >= QUIET_LOG_INTERVAL_MS) {
+      lastQuietLogAt.set(agentName, now)
+      logger.info(
+        { agent: agentName, silentForMs },
+        'channel-intake-monitor: no inbound for a long while, but the intake is clean (not an alert on its own)',
+      )
+    }
+    return
+  }
+  if (!decision.alert) return
+
+  logger.warn(
+    { agent: agentName, verdict: decision.verdict, pending: probe.pendingUpdates, silentForMs },
+    'channel-intake-monitor: channel intake is dead',
+  )
+  sendRoutineAlert(
+    `channel-intake:${agentName}:${decision.verdict}`,
+    formatIntakeAlert(agentName, decision, probe, silentForMs),
+    { cooldownMs: INTAKE_ALERT_COOLDOWN_MS },
+  )
+}
+
+export function startChannelIntakeMonitor(projectRoot: string): NodeJS.Timeout {
+  async function check(): Promise<void> {
+    const names = [MAIN_AGENT_ID, ...listAgentNames().filter(n => n !== MAIN_AGENT_ID)]
+    for (const name of names) {
+      // A stopped agent has no poller by design; that is not deafness.
+      if (name !== MAIN_AGENT_ID && !isAgentRunning(name)) {
+        lastObservation.delete(name)
+        continue
+      }
+      try {
+        await checkAgentIntake(name, projectRoot)
+      } catch (err) {
+        logger.debug({ err, agent: name }, 'channel-intake-monitor: check error')
+      }
+    }
+  }
+
+  // Offset past channel-monitor (30s) and channel-health-monitor (45s) so the
+  // three do not share a tick.
+  setTimeout(() => void check(), INITIAL_DELAY_MS)
+  return setInterval(() => void check(), CHECK_INTERVAL_MS)
+}


### PR DESCRIPTION
## Mit old meg

Finy öt napig süket volt 2026 júliusában, és közben minden ellenőrzés zöld maradt. A hibamód szerkezeti: **a nem-érkező üzenet nem esemény**, tehát nincs mire riasztani.

Amink eddig volt, és miért nem fogta meg:

- `channel-health-monitor` a pane-ben keresi a `✘ failed` jelölőt. Az a plugin, aminek a poll-ciklusa leállt, de a processze él, semmit nem ír ki.
- `channel-conflict-probe` + `channel-poller-reap` arra felel, hogy ki tartja a getUpdates slotot, és csak akkor fut le, ha a monitor már down-nak hiszi a csatornát.
- `inbound-probe` a gold standard, de csak a FŐ channels sessionre néz (egy transzkript-könyvtár, egy telethon prober), és a prober kézi allowlistelésén áll. A sub-agentekre nem terjed ki.

## Mit mér

`getWebhookInfo.pending_update_count`: hány frissítést tart a Telegram, amit **senki nem vesz le**. Élő poller mellett nulla; halott poll-ciklus mellett nőni kezd, amint bárki ír a botnak. Ez pozitív jel, nem hiány.

**Miért nem getUpdates-szel** (mért, nem feltételezett): 2026-09-06-án kézzel, egy egészséges, futó agent tokenjén 5 próbából 2 adott 409-et és 3 adott 200-at. Vagyis a 200 önmagában nem bizonyít süketséget. Ráadásul a plugin (`server.ts`, grammy) 8 egymást követő 409 után **véglegesen kilép** a poll-ciklusból, tehát a mérés maga okozhatná a keresett hibát. A `getWebhookInfo` semmivel nem versenyez.

## Riasztási szabály

Riasztás csak bizonyítékra megy:

| verdikt | jelentés | riaszt |
|---|---|---|
| `token-invalid` | a Telegram válaszolt, és elutasította a tokent | igen |
| `deaf-backlog` | két, legalább 3 perccel eltolt mérésben is állt a sor, és nem csökkent | igen |
| `backlog-suspected` | egyetlen mérés lát sort (lehet burst közbeni pillanat) | nem |
| `draining` | a sor csökkent két mérés között, a poller dolgozik | nem |
| `quiet` | a küszöbön túl nincs bejövő, de az intake tiszta | nem, csak napló (6 óránként) |
| `unknown-inbound` | nincs ingestion-időbélyeg, nincs mérésünk | nem |
| `unreachable` | a mi oldalunk nem érte el a Telegramot | nem |

A bejövő csend csak kontextus, sosem riaszt magában: egy dolgozni nem kapott agent jogosan néma napokig. A `unknown-inbound` külön verdikt, mert a transzkript-olvasás a legfrissebb JSONL utolsó 256 KB-ját nézi, és egy worker- vagy ütemezett session tetején nincs channel-sor. Ilyenkor "hiányzó mérés", nem "megmért örök csend".

Riasztás `sendRoutineAlert`-en, 3 órás cooldownnal, agentenként és verdiktenként külön kulccsal.

## Ütemezés

5 perces tick, 100 s indulási eltolással (a channel-monitor 30 s és a channel-health-monitor 45 s mellé). Csak futó, Telegram-csatornás agenteket próbál; leállított agentnél nincs poller, az nem süketség.

## Mérések

- Élő `getWebhookInfo` három futó flotta-agent tokenjén: `pending_update_count: 0`, `url: ""`. A parse + döntés valós válaszon is lefutott (`verdict: ok`), revokált token szimulálva `token-invalid` + riasztás.
- Négy mutációs próba a döntéslogikán, mind piros lett: confirm-gap elhagyása, `quiet` riasztásra állítása, `unreachable` `token-invalid`-nak véve, csökkenő sor figyelmen kívül hagyása. Tehát a tesztek tényleg fognak, nem csak fordítási hibán pirosak.
- Teljes suite: 367 fájl, 4766 teszt zöld, 1 skipped. `tsc --noEmit` tiszta.

## Kártya

`b910043d` 1. és 2. pontja. A 3. pont (a watchdog "feladtam" állapotának láthatósága) külön kártyán van: `a664f9b2` -- ez a PR nem nyúl hozzá.

## Amit szándékosan NEM tartalmaz

- Nincs dashboard-felület a verdikthez. A jelzés riasztás + `dashboard.log`.
- Csak Telegram. A Slack/Discord/Google Chat providereknek nincs ekvivalens "hány frissítés áll a sorban" végpontja ugyanezen az áron; külön munka.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148rV8xMuHmpCgH1T8J1ZJz
