### PR TITLE
fix(kanban): the card tool must not let a move drop the ID anchor, and it must move the assignee

### DIFF
--- a/scripts/__tests__/kartya-mezomozgatas.test.py
+++ b/scripts/__tests__/kartya-mezomozgatas.test.py
@@ -354,6 +354,63 @@ def main():
     check('25 a kulso nev SZO SZERINT kerult be', felelos('KULSONEV906') == 'UjSzerzo',
           f'kapott: {felelos("KULSONEV906")}')
 
+    # ---------------------------------------------------------------------------
+    # A #1211 VERIFY KIKOTESE (Samu, 2026-09-06) + a ket teszteletlen hatar.
+    # ---------------------------------------------------------------------------
+
+    # 26. HOMOGLIFA A FELELOS-NEVBEN. A szures a cimre, leirasra, uzenetre es kommentre futott,
+    #     a FELELOSRE nem -- ket kulon agon kellett volna kimondani, es a masodik kimaradt.
+    #     Elo probaval merve a fix elott: MINDKET agon beirodott a tablara.
+    #     A felelos a legrosszabb hely erre: a nev helyesnek LATSZIK, a kartya viszont sajat,
+    #     egy-elemu oszlopba kerul, es a "kinel all a dontes" kerdesre a tabla rosszul valaszol.
+    CIRILL_A = '\u0430'
+    hamis_nev = 's' + CIRILL_A + 'mmu'
+    seed('HOMOGA906', assignee='samu')
+    p = comment('HOMOGA906', 'Kartya HOMOGA906: homoglifas nev.', ('--assignee', hamis_nev, '--assignee-uj'))
+    check('26 megtagadva a homoglifas felelos (mozgato ag)',
+          p.returncode != 0 and 'vegyes irasrendszeru' in (p.stdout + p.stderr), p.stdout + p.stderr)
+    check('26 a felelos valtozatlan', felelos('HOMOGA906') == 'samu', f'kapott: {felelos("HOMOGA906")!r}')
+    check('26 a komment sem irodott be', comments('HOMOGA906') == [])
+
+    # 27. UGYANAZ A LETREHOZO AGON. A kapu a KOZOS feloldasban all, nem a ket hivonal --
+    #     pont ez a megoszlas hasadt el egyszer mar.
+    p = subprocess.run([sys.executable, SCRIPT, '--id', 'HOMOGB906', '--assignee', hamis_nev,
+                        '--title', 'HOMOGB906 homoglifa a letrehozo agon', '--no-msg'],
+                       capture_output=True, text=True, env=env, timeout=30)
+    check('27 megtagadva a homoglifas felelos (letrehozo ag)',
+          p.returncode != 0 and 'vegyes irasrendszeru' in (p.stdout + p.stderr), p.stdout + p.stderr)
+    check('27 kartyat sem hozott letre', card('HOMOGB906') is None)
+
+    # 28. A TISZTA ASCII NEV NEM BUKIK. Kontroll-proba: enelkul a 26/27 attol is zold lenne,
+    #     ha a kapu MINDEN nevet megtagadna.
+    seed('HOMOGC906', assignee='samu')
+    p = comment('HOMOGC906', 'Kartya HOMOGC906: tiszta nev.', ('--assignee', 'TisztaNev', '--assignee-uj'))
+    check('28 a tiszta ASCII nev atmegy', p.returncode == 0, p.stdout + p.stderr)
+    check('28 be is irodott', felelos('HOMOGC906') == 'TisztaNev')
+
+    # 29. A GAZDA-SOR HAZIRENDJE KIMONDVA (nem kapu). A tabla-szabaly szerint a gazdanal csak
+    #     az a kartya all, amit MA el tud donteni; a mozgatas legitim, de ne csusszon oda nyom
+    #     nelkul. FIGYELMEZTETES, nem megtagadas: a dontes-kartya valodi eset.
+    seed('GAZDASOR906', assignee='samu')
+    p = comment('GAZDASOR906', 'Kartya GAZDASOR906: dontes-kartya a gazdanak.', ('--assignee', 'szabolcs'))
+    check('29 lefutott (nem kapu)', p.returncode == 0, p.stdout + p.stderr)
+    check('29 a felelos tenyleg szabolcs lett', felelos('GAZDASOR906') == 'szabolcs')
+    check('29 kimondja a gazda-sor szabalyat', 'MA el tud donteni' in p.stdout, p.stdout)
+
+    # 30. A "MASIK KARTYA MAR ALL EZEN A NEVEN" ELLENORZES ESET-ERZEKENY (Samu tengelye: egy
+    #     case-insensitive mutacio alatt mind a 45 allitas zold maradt, tehat a hatar teszteletlen
+    #     volt). "TisztaNev" all a tablan a 28-bol; a "tisztanev" alak NEM ugyanaz az oszlop.
+    seed('ESETA906', assignee='samu')
+    p = comment('ESETA906', 'Kartya ESETA906: mas kis/nagybetuvel.', ('--assignee', 'tisztanev'))
+    check('30 a mas eset-alak NEM szamit letezonek',
+          p.returncode != 0 and 'nem ismert' in (p.stdout + p.stderr), p.stdout + p.stderr)
+    check('30 a felelos valtozatlan', felelos('ESETA906') == 'samu')
+
+    # 31. A KOZELI-JAVASLAT LISTA tenyleg a LETEZO neveket sorolja (nit, de a megtagadas
+    #     hasznalhatosaga ezen all: enelkul csak azt mondjuk "nem jo", azt nem, hogy mi a jo).
+    check('31 a megtagadas felajanlja a letezo TisztaNev-et', 'TisztaNev' in (p.stdout + p.stderr),
+          p.stdout + p.stderr)
+
     os.remove(DB_PATH)
     if FAILS:
         sys.stderr.write('\nBUKOTT: ' + ', '.join(FAILS) + '\n')

--- a/scripts/__tests__/kartya-mezomozgatas.test.py
+++ b/scripts/__tests__/kartya-mezomozgatas.test.py
@@ -51,13 +51,20 @@ def fresh_db(path):
     db.close()
 
 
-def seed(card_id, status='planned', priority='normal'):
+def seed(card_id, status='planned', priority='normal', assignee='boni'):
     db = sqlite3.connect(DB_PATH)
     now = int(time.time())
     db.execute('INSERT INTO kanban_cards (id,title,status,assignee,priority,created_at,updated_at)'
-               ' VALUES (?,?,?,?,?,?,?)', (card_id, f'teszt {card_id}', status, 'boni', priority, now, now))
+               ' VALUES (?,?,?,?,?,?,?)', (card_id, f'teszt {card_id}', status, assignee, priority, now, now))
     db.commit()
     db.close()
+
+
+def felelos(card_id):
+    db = sqlite3.connect(DB_PATH)
+    r = db.execute('SELECT assignee FROM kanban_cards WHERE id=?', (card_id,)).fetchone()
+    db.close()
+    return r[0] if r else None
 
 
 def comment(card_id, text, extra=()):
@@ -150,7 +157,7 @@ def main():
     env['CLAUDECLAW_ROOT'] = SANDBOX_ROOT
     env['KARTYA_API'] = 'http://127.0.0.1:1/api/messages'
     p = subprocess.run([sys.executable, SCRIPT, '--id', 'UJKARTYA906', '--assignee', 'marveen',
-                        '--title', 'uj kartya teszt', '--no-msg'],
+                        '--title', 'UJKARTYA906 uj kartya teszt', '--no-msg'],
                        capture_output=True, text=True, env=env, timeout=30)
     check('7 letrehozo ag lefutott', p.returncode == 0, p.stdout + p.stderr)
     check('7 alapertelmezes planned/normal maradt', card('UJKARTYA906') == ('planned', 'normal'),
@@ -217,6 +224,135 @@ def main():
     # 13. A visszaolvasas MONDJA KI, melyik tarolobol olvasott (Boni kikotese): egy rossz gyoker
     #     mellett a visszaolvasas onmagaban konzisztens lenne, csak nem az eles tablan.
     check('13 a visszaolvasas megnevezi a DB-t', DB_PATH in p.stdout, p.stdout)
+
+    # ---------------------------------------------------------------------------
+    # KARTYAKULDO906 FOLLOW-UP (2026-09-06): negy tetel a #1204 merge utan.
+    # ---------------------------------------------------------------------------
+
+    # 14. FELELOS-MOZGATAS (4. tetel). A lelet sajat hasznalatbol: a CONNMKT906-ot le kellett
+    #     vennem a gazda sorarol, es az eszkoz nem tudta -- nyers sqlite3-hoz kellett nyulni,
+    #     pont ahhoz az uthoz, amit nyugdijazni akar.
+    seed('FELELOSA906', assignee='szabolcs')
+    p = comment('FELELOSA906', 'Kartya FELELOSA906: a dontes visszakerul a vegrehajtohoz.',
+                ('--assignee', 'samu'))
+    check('14 lefutott', p.returncode == 0, p.stdout + p.stderr)
+    check('14 a felelos TENYLEG samu lett', felelos('FELELOSA906') == 'samu', f'kapott: {felelos("FELELOSA906")}')
+    check('14 a kimenet kimondja a mozgatast', 'MEZOMOZGATAS OK' in p.stdout, p.stdout)
+    check('14 a nyom-komment nevezi a felelos-valtast',
+          any('assignee' in c and 'szabolcs' in c and 'samu' in c
+              for c in comments('FELELOSA906')), f'kapott: {comments("FELELOSA906")}')
+
+    # 15. A KEVERES-KAPUT ki kellett engedni az --assignee-hoz. Ha ez visszazarul, a 14. teszt
+    #     bukik -- de a --desc-file/--msg-file TOVABBRA IS tiltott komment-modban.
+    d = tempfile.mkdtemp(prefix='kartya-m5-')
+    df = os.path.join(d, 'd.txt'); open(df, 'w', encoding='utf-8').write('leiras')
+    seed('KEVER906')
+    p = comment('KEVER906', 'Kartya KEVER906: keveres.', ('--desc-file', df))
+    check('15 a --desc-file tovabbra is tiltott komment-modban',
+          p.returncode != 0 and 'nem keverheto' in (p.stdout + p.stderr), p.stdout + p.stderr)
+
+    # 16. ISMERETLEN NEV, amin MASIK kartya sem all: megtagadas. A felelos-oszlop NEM zart halmaz
+    #     (merve: 40 kulonbozo ertek), ezert nem nev-halmazt kapuzunk, hanem azt, hogy a nev
+    #     letezik-e mar a tablan. Egy elgepeles kulonben sajat, egy-elemu oszlopot nyit.
+    seed('FELELOSB906', assignee='samu')
+    p = comment('FELELOSB906', 'Kartya FELELOSB906: elgepelt nev.', ('--assignee', 'samuu'))
+    check('16 megtagadva az ismeretlen nev', p.returncode != 0 and 'nem ismert' in (p.stdout + p.stderr),
+          p.stdout + p.stderr)
+    check('16 a felelos valtozatlan', felelos('FELELOSB906') == 'samu')
+    check('16 a komment SEM irodott be', comments('FELELOSB906') == [], f'kapott: {comments("FELELOSB906")}')
+    check('16 felajanlja a hasonlo LETEZO nevet', 'samu' in p.stdout + p.stderr)
+
+    # 17. UGYANAZ A NEV, KIMONDVA (--assignee-uj): atmegy, es a KIS/NAGYBETU SZO SZERINT marad.
+    #     A tablan a kulso GitHub-nevek vegyes alakban allnak (Vlbbtabs, KratoBal); a feltetel
+    #     nelkuli .lower() mas ertekre irna, mint ami a tablan van.
+    seed('FELELOSC906', assignee='samu')
+    p = comment('FELELOSC906', 'Kartya FELELOSC906: uj kulso szerzo.', ('--assignee', 'UjSzerzo', '--assignee-uj'))
+    check('17 lefutott a kimondott uj nevvel', p.returncode == 0, p.stdout + p.stderr)
+    check('17 a nev SZO SZERINT maradt', felelos('FELELOSC906') == 'UjSzerzo', f'kapott: {felelos("FELELOSC906")}')
+
+    # 18. ISMERETLEN, DE A TABLAN MAR LETEZO nev: flag nelkul is atmegy (a 17. hozta letre).
+    seed('FELELOSD906', assignee='samu')
+    p = comment('FELELOSD906', 'Kartya FELELOSD906: ugyanaz a kulso szerzo.', ('--assignee', 'UjSzerzo'))
+    check('18 letezo kulso nev flag nelkul is atmegy', p.returncode == 0, p.stdout + p.stderr)
+    check('18 a felelos tenyleg atallt', felelos('FELELOSD906') == 'UjSzerzo')
+
+    # 19. FLOTTA-NEV kisbetusites: "Samu" -> "samu", tehat a mar-ezen-az-erteken ag sul el,
+    #     nem egy latszolagos mozgatas.
+    seed('FELELOSE906', assignee='samu')
+    p = comment('FELELOSE906', 'Kartya FELELOSE906: ugyanaz nagybetuvel.', ('--assignee', 'Samu'))
+    check('19 lefutott', p.returncode == 0, p.stdout + p.stderr)
+    check('19 kimondja hogy mar ezen az erteken all', 'mar ezen az erteken all' in p.stdout, p.stdout)
+    check('19 nem keletkezett mozgatas-nyom',
+          not any('Mezomozgatas' in c for c in comments('FELELOSE906')), f'{comments("FELELOSE906")}')
+
+    # 20. ID-HORGONY a CIM-MOZGATASON (1. tetel, Boni). A 411 kartyas migracio azon allt vagy
+    #     bukott, hogy az ID ott van-e a cimben; egy cim-mozgatas csendben leveheti.
+    seed('HORGONY906')
+    regi = title('HORGONY906')
+    p = comment('HORGONY906', 'Kartya HORGONY906: horgony nelkuli uj cim.',
+                ('--title', 'Valami egeszen mas cim, azonosito nelkul.'))
+    check('20 megtagadva a horgony nelkuli cim',
+          p.returncode != 0 and 'nem tartalmazza a kartya sajat ID' in (p.stdout + p.stderr), p.stdout + p.stderr)
+    check('20 a cim valtozatlan', title('HORGONY906') == regi)
+    check('20 a komment SEM irodott be', comments('HORGONY906') == [])
+
+    # 21. A KAPU NORMALIZAL, es ez nem kenyelmi kerdes: a nyers `id not in title` a tabla bevett
+    #     PR-kartya-konvenciojat tagadna meg (id PR1195, cim "PR #1195 (...)"). Merve az utolso het
+    #     354 kartyajan: nyers 52 elutasitas (14,7%), normalizalt 13 (3,7%).
+    seed('PR1195')
+    p = comment('PR1195', 'Kartya PR1195: a bevett PR-cim-alak.',
+                ('--title', 'PR #1195 (Samu): copy-gate -- az edit_message is a kapun belul.'))
+    check('21 a "PR #1195" alak ATMEGY a PR1195 id-hez', p.returncode == 0, p.stdout + p.stderr)
+    check('21 a cim tenyleg valtozott', title('PR1195').startswith('PR #1195'), f'kapott: {title("PR1195")}')
+
+    # 22. UGYANAZ A KAPU A LETREHOZO AGON. Ha csak a mozgatason allna, a horgony nelkuli cim
+    #     egyszeruen a letrehozaskor kerulne be, es a kapu semmit nem vedene.
+    env = dict(os.environ)
+    env['KARTYA_DB'] = DB_PATH; env['CLAUDECLAW_ROOT'] = SANDBOX_ROOT
+    env['KARTYA_API'] = 'http://127.0.0.1:1/api/messages'
+    p = subprocess.run([sys.executable, SCRIPT, '--id', 'HORGONYUJ906', '--assignee', 'marveen',
+                        '--title', 'cim azonosito nelkul', '--no-msg'],
+                       capture_output=True, text=True, env=env, timeout=30)
+    check('22 a letrehozo ag is megtagadja a horgony nelkuli cimet',
+          p.returncode != 0 and 'nem tartalmazza a kartya sajat ID' in (p.stdout + p.stderr), p.stdout + p.stderr)
+    check('22 kartyat sem hozott letre', card('HORGONYUJ906') is None)
+
+    # 23. A LETEZO-DE-URES DB (2. tetel, Samu lelete a #1204 verifyben): korabban ATMENT a kapun
+    #     (az csak os.path.exists-t nezett), es nyers Python-tracebacket adott a szep MEGTAGADVA
+    #     helyett. Nem hamis siker volt, de hasznalhatatlan hibauzenet.
+    ures_db = os.path.join(tempfile.mkdtemp(prefix='kartya-uresdb-'), 'ures.db')
+    open(ures_db, 'wb').close()
+    d = tempfile.mkdtemp(prefix='kartya-m6-')
+    cf = os.path.join(d, 'c.txt'); open(cf, 'w', encoding='utf-8').write('Kartya MOZGA906: ures DB-re.')
+    env2 = dict(env); env2['KARTYA_DB'] = ures_db
+    p = subprocess.run([sys.executable, SCRIPT, '--id', 'MOZGA906', '--comment-file', cf, '--author', 'Boni'],
+                       capture_output=True, text=True, env=env2, timeout=30)
+    ki = p.stdout + p.stderr
+    check('23 megtagadva a letezo-de-ures DB', p.returncode != 0 and 'MEGTAGADVA' in ki, ki)
+    check('23 NEM nyers traceback', 'Traceback' not in ki, ki)
+    # A puszta 'kanban_cards' elofordulas NEM megkulonbozteto: a kapu NELKULI valtozat
+    # tracebackje is tartalmazza ("no such table: kanban_cards"). A MEGTAGADVA-sorra allitunk.
+    check('23 a MEGTAGADVA-uzenet nevezi meg a hianyzo tablat',
+          any('MEGTAGADVA' in l or 'kanban_cards tabla' in l
+              for l in ki.splitlines() if 'kanban_cards' in l), ki)
+
+    # 24. Az --assignee-uj a LETREHOZO agon ertelmetlen -- egy nem hato kapcsolo pont az a
+    #     hibaosztaly, amit ez az eszkoz ket kore zar (a --status csendes elvesztese).
+    p = subprocess.run([sys.executable, SCRIPT, '--id', 'UJFLAG906', '--assignee', 'marveen',
+                        '--title', 'UJFLAG906 teszt', '--no-msg', '--assignee-uj'],
+                       capture_output=True, text=True, env=env, timeout=30)
+    check('24 megtagadva az --assignee-uj a letrehozo agon',
+          p.returncode != 0 and 'csak komment-modban' in (p.stdout + p.stderr), p.stdout + p.stderr)
+    check('24 kartyat sem hozott letre', card('UJFLAG906') is None)
+
+    # 25. A LETREHOZO AG IS MEGORZI a kulso nev kis/nagybetujet (a kozos feloldas kovetkezmenye).
+    #     Korabban a feltetel nelkuli .lower() mas erteket irt volna, mint ami a tablan all.
+    p = subprocess.run([sys.executable, SCRIPT, '--id', 'KULSONEV906', '--assignee', 'UjSzerzo',
+                        '--title', 'KULSONEV906 kulso szerzo kartyaja', '--no-msg'],
+                       capture_output=True, text=True, env=env, timeout=30)
+    check('25 a letrehozo ag lefutott', p.returncode == 0, p.stdout + p.stderr)
+    check('25 a kulso nev SZO SZERINT kerult be', felelos('KULSONEV906') == 'UjSzerzo',
+          f'kapott: {felelos("KULSONEV906")}')
 
     os.remove(DB_PATH)
     if FAILS:

--- a/scripts/kartya-es-ertesites.py
+++ b/scripts/kartya-es-ertesites.py
@@ -97,7 +97,15 @@ ISMERT_FELELOSOK = FLEET | {COORDINATOR, GAZDA}
 
 
 def _felelos_feloldas(nyers):
-    """A felelos KANONIKUS alakja. Flotta/gazda nev -> kisbetus (ez a tabla bevett alakja).
+    """A felelos KANONIKUS alakja, ES a rea vonatkozo kapuk EGY helyen.
+
+    A KAPU AZERT ITT ALL, ES NEM A KET HIVONAL (Samu lelete a #1211 verifyben): a homoglifa-
+    szures a cimre, a leirasra, az uzenetre es a kommentre futott, a FELELOSRE nem, mert ket
+    kulon agon kellett volna kimondani -- es a masodikat elfelejtettem. Elo probaval merve:
+    egy cirill a-t tartalmazo nev MINDKET agon beirodott a tablara. Egy megoszlo kapu pontosan
+    igy hasad el, ezert a kozos feloldas kapuz, es minden jovobeli ag ingyen megkapja.
+
+    A KANONIKUS ALAK: flotta/gazda nev -> kisbetus (ez a tabla bevett alakja).
     MINDEN MAS nev SZO SZERINT marad.
 
     MERVE (2026-09-06, elo tabla): a nem-flotta felelosok kulso GitHub-nevek, es TOBB VEGYES
@@ -106,6 +114,23 @@ def _felelos_feloldas(nyers):
     tool-lal felvett kartya kulon oszlopba kerult volna ugyanattol a szerzotol. A kisbetusites
     ezert a FLOTTA-nevekre szol, ahol az a bevett alak, es nem a tablatol idegen normalizalas."""
     nev = nyers.strip()
+    if not nev:
+        sys.exit('MEGTAGADVA: ures felelos-nev.')
+    # HOMOGLIFA: a felelos-mezo a legrosszabb hely egy lathatatlan betucserere -- a nev
+    # HELYESNEK LATSZIK, a kartya viszont sajat, egy-elemu oszlopba kerul, es a "kinel all
+    # a dontes" kerdesre a tabla csendben rosszul valaszol. Ugyanaz a szures, mint a cimen.
+    if (h := gyanus(nev)):
+        sys.exit(f'MEGTAGADVA: vegyes irasrendszeru betu a felelos-nevben: {h[:5]}\n'
+                 f'A nev helyesnek LATSZIK, de nem az, amit a tabla tobbi kartyaja hordoz.\n'
+                 f'Gepeld ujra a nevet, ne masold be.')
+    if nev.lower() == GAZDA:
+        # NEM kapu, hanem a hazirend kimondasa (gazda-keres, 2026-09-04): a gazda soran CSAK
+        # az a kartya all, amit MA EL TUD DONTENI -- egy mondatban feltehato kerdes, ket
+        # kimenettel. Nem tiltjuk, mert a dontes-kartya legitim; de nyom nelkul ne csusszon oda.
+        print(f'FIGYELEM: a felelos "{GAZDA}" lesz. A tabla-szabaly szerint a gazda soran csak az\n'
+              f'a kartya all, amit MA el tud donteni: egy mondatban feltehato kerdes, KET kimenettel,\n'
+              f'es a valasz ma is szamit. Ha elobb MERNI vagy KESZITENI kell valamit, a kartya a\n'
+              f'vegrehajtoe marad, es a fo-agens viszi a gazda ele kotegben.')
     return nev.lower() if nev.lower() in ISMERT_FELELOSOK else nev
 
 
@@ -266,8 +291,6 @@ def komment_mod(a):
     uj_felelos = None
     if a.assignee is not None:
         uj_felelos = _felelos_feloldas(a.assignee)
-        if not uj_felelos:
-            sys.exit('MEGTAGADVA: ures felelos-nev.')
         if uj_felelos != elotte['assignee'] and uj_felelos not in ISMERT_FELELOSOK and not a.assignee_uj:
             # TIPUS-KAPU, NEM NEV-HALMAZ (Marveen merese, 2026-09-06): a felelos-oszlop NEM zart
             # halmaz -- 40 kulonbozo ertek all rajta, tobbsegukben kulso GitHub-nevek. Egy zart
@@ -395,8 +418,6 @@ def main():
     # UGYANAZ A KANONIKUS ALAK, mint a mozgato agon -- kulonben a ket ut ugyanarra a nevre
     # KET KULONBOZO erteket irna a tablara.
     who = _felelos_feloldas(a.assignee)
-    if not who:
-        sys.exit('MEGTAGADVA: ures felelos-nev.')
     # A FELADO: kimondva (--from), vagy a szerzobol. Az alapertelmezes az --author kisbetusitve,
     # tehat a korabbi viselkedes (--author nelkul: 'marveen') valtozatlan marad.
     frm = (a.from_agent or a.author).strip().lower()

--- a/scripts/kartya-es-ertesites.py
+++ b/scripts/kartya-es-ertesites.py
@@ -28,11 +28,20 @@ KOORDINATORHOZ (marveen) -- kimondva, a kimeneten es az uzenet elso soraban is.
 KOMMENT-ONLY MOD (KARTYAIRASESZKOZ905, 2026-09-05): komment egy MEGLEVO kartyara,
 ERTESITES NELKUL, ugyanazokkal a kapukkal es kotelezo visszaolvasassal:
   kartya-es-ertesites.py --id X905 --comment-file /path [--author Samu] [--dry-run]
-MEZOMOZGATAS (KARTYASTATUSZ906, Boni lelete 2026-09-06): komment-modban a --title, a --status es a
---priority MEGLEVO kartyat mozgat, elotte-pillanatkeppel es FUGGETLEN visszaolvasassal:
+MEZOMOZGATAS (KARTYASTATUSZ906, Boni lelete 2026-09-06): komment-modban a lenti mezok MEGLEVO
+kartyat mozgatnak, elotte-pillanatkeppel es FUGGETLEN visszaolvasassal:
   kartya-es-ertesites.py --id X905 --status waiting --comment-file /path --author Boni
-Korabban ez a ket kapcsolo komment-modban SZO NELKUL ELVESZETT: a kimenet OK-t mondott, a kartya
-nem mozdult. A mozgatas SZANDEKOSAN a komment-modhoz van kotve -- statusz nem valtozhat nyom nelkul.
+
+  A MOZGATHATO MEZOK TELJES LISTAJA (ez az egyetlen hely, ahol fel van sorolva):
+    --title      a kartya cime      (300 karakteres kapu + ID-horgony kapu)
+    --status     planned | in_progress | testing | waiting | done
+    --priority   low | normal | high | urgent
+    --assignee   a felelos          (KARTYAKULDO906 4. tetel, 2026-09-06)
+
+Korabban a --status es a --priority komment-modban SZO NELKUL ELVESZETT: a kimenet OK-t mondott, a
+kartya nem mozdult. A mozgatas SZANDEKOSAN a komment-modhoz van kotve -- egyik mezo sem valtozhat
+nyom nelkul. A FELELOS kulon indoka (Marveen, sajat hasznalatbol): a felelos-mezo a tablankon nem
+cimke, hanem azt mondja meg, KINEL all a dontes -- a mozgatasa allapot-valtoztatas, nem adminisztracio.
 
 Ket fuggetlen hibaosztalyt zar ugyanez az egy ut: (1) a nyers sqlite3-quoting otodik
 elofordulasa utan a quoting az eszkoz dolga (parameterkotes); (2) a fejlec-idot a
@@ -56,14 +65,73 @@ DB = os.environ.get('KARTYA_DB') or os.path.join(ROOT, 'store', 'claudeclaw.db')
 def _db_kapu():
     """A NEM LETEZO DB a legveszelyesebb alak: az sqlite3.connect LETREHOZNA egy ures fajlt,
     es a futas 'no such table'-lel halna el -- vagy ami rosszabb, egy MASOLATBA irna. Ezert a
-    hianyzo fajl MEGTAGADAS, a feloldott utvonal kimondasaval."""
+    hianyzo fajl MEGTAGADAS, a feloldott utvonal kimondasaval.
+
+    SAMU LELETE a #1204 verifyben: a kapu CSAK a letezest nezte, ezert egy LETEZO-de-ures
+    (0 byte, vagy kanban_cards nelkuli) fajl ATMENT rajta, es a futas nyers Python-tracebacket
+    adott a szep MEGTAGADVA helyett. Nem volt hamis siker es rossz helyre sem irt -- de a
+    hibauzenet volt hasznalhatatlan. Ezert a kapu MOST A TABLAT IS MEGNEZI."""
     if not os.path.exists(DB):
         sys.exit(f'MEGTAGADVA: a kanban DB nem letezik ezen az utvonalon:\n  {DB}\n'
                  f'(gyoker: {ROOT})\nA kanban EGY elo tarolo, nem worktree-nkenti. Ha innen akarsz\n'
                  f'irni, mondd ki: CLAUDECLAW_ROOT=<a fo fa> vagy KARTYA_DB=<a db utvonala>.')
+    try:
+        db = sqlite3.connect(f'file:{DB}?mode=ro', uri=True)
+        van = db.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='kanban_cards'").fetchone()
+        db.close()
+    except sqlite3.Error as e:
+        sys.exit(f'MEGTAGADVA: a fajl letezik, de nem olvashato kanban DB-kent:\n  {DB}\n'
+                 f'(gyoker: {ROOT})\nsqlite: {e}')
+    if not van:
+        sys.exit(f'MEGTAGADVA: a fajl letezik, de NINCS BENNE kanban_cards tabla:\n  {DB}\n'
+                 f'(gyoker: {ROOT})\nEz jellemzoen egy korabbi rossz ut-feloldas hagyta ott. Mondd ki:\n'
+                 f'CLAUDECLAW_ROOT=<a fo fa> vagy KARTYA_DB=<a db utvonala>.')
     return DB
 FLEET = {'samu','zara','boni','iris','dani','geri','deeper','qwen','mira','tomi','jumanji','hidli'}
 COORDINATOR = 'marveen'
+GAZDA = 'szabolcs'
+# Ismert FELELOS-nevek. NEM zart halmaz: a tablan 2026-09-06-an 40 kulonbozo felelos allt, es a
+# tobbsegi nem-flotta ertek kulso GitHub-felhasznalonev (PR-kartyak szerzoi). Ezert a nem-ismert
+# nev nem automatikusan hiba -- lasd _felelos_feloldas.
+ISMERT_FELELOSOK = FLEET | {COORDINATOR, GAZDA}
+
+
+def _felelos_feloldas(nyers):
+    """A felelos KANONIKUS alakja. Flotta/gazda nev -> kisbetus (ez a tabla bevett alakja).
+    MINDEN MAS nev SZO SZERINT marad.
+
+    MERVE (2026-09-06, elo tabla): a nem-flotta felelosok kulso GitHub-nevek, es TOBB VEGYES
+    KISBETUS-NAGYBETUS alakban allnak (Vlbbtabs, KratoBal, PCha0s, palvolgyidigital). A korabbi
+    feltetel nelkuli .lower() ezeket MAS ertekke alakitotta, mint ami a tablan all -- vagyis a
+    tool-lal felvett kartya kulon oszlopba kerult volna ugyanattol a szerzotol. A kisbetusites
+    ezert a FLOTTA-nevekre szol, ahol az a bevett alak, es nem a tablatol idegen normalizalas."""
+    nev = nyers.strip()
+    return nev.lower() if nev.lower() in ISMERT_FELELOSOK else nev
+
+
+def _horgony(s):
+    """Osszehasonlitasi alak az ID-horgonyhoz: csak betuk/szamok, nagybetusen."""
+    return re.sub(r'[^0-9A-Za-z]', '', s).upper()
+
+
+def _horgony_kapu(card_id, cim):
+    """A CIM TARTALMAZZA A KARTYA SAJAT ID-JET (Boni lelete, KARTYAKULDO906 1. tetel).
+
+    MIERT KAPU: nalunk a cim-horgony az ID -- a 2026-08-24-i 411 kartyas migracio azon allt vagy
+    bukott, hogy az ID ott van-e a cimben; aminek nem volt horgonya, az kezi bucket lett. Egy
+    cim-mozgatas csendben leveheti a horgonyt, es a kovetkezo migracio fizeti meg.
+
+    MIERT NORMALIZALT, ES NEM NYERS `id not in title` (Marveen merese, 2026-09-06): a nyers alak a
+    tabla BEVETT PR-kartya-konvenciojat tagadna meg -- az id `PR1195`, a cim "PR #1195 (...)", tehat
+    a horgony OTT VAN, csak szokozzel es kettoskereszttel. Az utolso het 354 kartyajan merve: a nyers
+    feltetel 52-t (14,7%) utasitana el, a normalizalt 13-at (3,7%) -- es ez a 13 tulnyomoreszt pont a
+    celzott hiba (hex-ID a DB-ben, tole fuggetlen szemantikus horgony a cimben)."""
+    if _horgony(card_id) not in _horgony(cim):
+        sys.exit(f'MEGTAGADVA: a cim nem tartalmazza a kartya sajat ID-jet ({card_id}).\n'
+                 f'  cim:        {cim[:120]}\n'
+                 f'  osszevetve: "{_horgony(card_id)}" nincs benne ebben: "{_horgony(cim)[:120]}"\n'
+                 f'A cim-horgony nalunk az ID: ami horgony nelkul marad, az a kovetkezo migracioban\n'
+                 f'kezi bucket lesz. Az irasjelek nem szamitanak ("PR #1195" jo a PR1195 id-hez).')
 # A kanban_cards CHECK-jei. Kapuban is szerepelnek, hogy egy elgepelt ertek olvashato
 # uzenetet adjon, ne nyers sqlite3 IntegrityError-t.
 STATUSZOK = ('planned','in_progress','testing','waiting','done')
@@ -180,6 +248,7 @@ def komment_mod(a):
                      f'A cim EGY sor legyen (lelet + gazda + hatarido), a reszletek a leirasba.')
         if (h := gyanus(a.title)):
             sys.exit(f'MEGTAGADVA: vegyes irasrendszeru szo a cimben: {h[:5]}')
+        _horgony_kapu(a.id, a.title)
     if a.status is not None and a.status not in STATUSZOK:
         sys.exit(f'MEGTAGADVA: ervenytelen statusz ("{a.status}"). Ervenyes: {", ".join(STATUSZOK)}.')
     if a.priority is not None and a.priority not in PRIORITASOK:
@@ -191,8 +260,38 @@ def komment_mod(a):
         sys.exit(f'MEGTAGADVA: a(z) {a.id} kartya NEM LETEZIK -- komment-only mod csak meglevo kartyara ir.\n'
                  f'Uj kartyahoz a letrehozo mod valo (--assignee/--title).')
     # ELOTTE-PILLANATKEP: enelkul a visszaolvasas nem meres, csak egy ertek felolvasasa.
-    elotte = {'status': card[1], 'priority': card[3], 'title': card[4]}
-    mozgatas = {k: v for k, v in (('status', a.status), ('priority', a.priority), ('title', a.title))
+    elotte = {'status': card[1], 'priority': card[3], 'title': card[4], 'assignee': card[2]}
+    # A FELELOS FELOLDASA a kartya ismereteben: a kanonikus alakot hasonlitjuk az elotte-erteknek,
+    # kulonben egy "Samu" -> "samu" no-op valodi mozgatasnak latszana.
+    uj_felelos = None
+    if a.assignee is not None:
+        uj_felelos = _felelos_feloldas(a.assignee)
+        if not uj_felelos:
+            sys.exit('MEGTAGADVA: ures felelos-nev.')
+        if uj_felelos != elotte['assignee'] and uj_felelos not in ISMERT_FELELOSOK and not a.assignee_uj:
+            # TIPUS-KAPU, NEM NEV-HALMAZ (Marveen merese, 2026-09-06): a felelos-oszlop NEM zart
+            # halmaz -- 40 kulonbozo ertek all rajta, tobbsegukben kulso GitHub-nevek. Egy zart
+            # halmazu kapu ezert a legitim mozgatasok tobbseget tagadna meg. Amit viszont meg
+            # tudunk merni: all-e MAR MASIK kartya pontosan ezen a neven. Ha nem, az tipikusan
+            # elgepeles, ami csendben egy sajat, egy-elemu oszlopba viszi a kartyat.
+            # ISMERT HATAR: ARCHIVALT kartya is szamit. Igy egy regi elgepeles onmagat
+            # legitimalja (merve: a tablan 44 archivalt kartya all "Samu" es 2 a
+            # "Marveen+Samu+Zara" erteken). Szandekos: a szigoritas a legitim, regota hasznalt
+            # kulso neveket is elutasitana, ami gyakoribb eset, mint a regi elgepeles ujra-
+            # felhasznalasa. A kapu celja az UJ elgepeles kiszurese, nem a tortenet takaritasa.
+            masik = db.execute('SELECT COUNT(*) FROM kanban_cards WHERE assignee=? AND id<>?',
+                               (uj_felelos, a.id)).fetchone()[0]
+            if not masik:
+                kozeli = [r[0] for r in db.execute(
+                    'SELECT DISTINCT assignee FROM kanban_cards WHERE assignee IS NOT NULL'
+                    ' AND lower(assignee) LIKE ? ORDER BY assignee LIMIT 5',
+                    ('%' + uj_felelos.lower()[:4] + '%',)).fetchall()]
+                sys.exit(f'MEGTAGADVA: "{uj_felelos}" nem ismert flotta-nev, es MASIK kartya sem all rajta.\n'
+                         f'Ez tipikusan elgepeles, ami sajat, egy-elemu oszlopba viszi a kartyat.\n'
+                         + (f'Hasonlo, MAR LETEZO nevek: {", ".join(kozeli)}\n' if kozeli else '')
+                         + 'Ha tenyleg uj nev (pl. uj kulso PR-szerzo), mondd ki: --assignee-uj.')
+    mozgatas = {k: v for k, v in (('status', a.status), ('priority', a.priority), ('title', a.title),
+                                  ('assignee', uj_felelos))
                 if v is not None}
     valtozik = {k: v for k, v in mozgatas.items() if v != elotte[k]}
     valtozatlan = {k: v for k, v in mozgatas.items() if v == elotte[k]}
@@ -235,8 +334,8 @@ def komment_mod(a):
         sys.exit(f'HIBA: a mezomozgatas {cur.rowcount} sort erintett (1 helyett) -- a komment MAR BEIRT.')
     # FUGGETLEN visszaolvasas: uj SELECT, nem a cursor allitasa. A 0-talalatos UPDATE
     # es a sikeres UPDATE kulonben megkulonboztethetetlen lenne.
-    utana = db.execute('SELECT status,priority,title FROM kanban_cards WHERE id=?', (a.id,)).fetchone()
-    kapott = {'status': utana[0], 'priority': utana[1], 'title': utana[2]}
+    utana = db.execute('SELECT status,priority,title,assignee FROM kanban_cards WHERE id=?', (a.id,)).fetchone()
+    kapott = {'status': utana[0], 'priority': utana[1], 'title': utana[2], 'assignee': utana[3]}
     for k, v in valtozik.items():
         if kapott[k] != v:
             sys.exit(f'HIBA: a(z) {k} visszaolvasva "{kapott[k]}", nem a kert "{v}". Az iras NEM ert celba.')
@@ -263,6 +362,8 @@ def main():
     # megkulonboztetni a KIMONDOTT erteket a nem-adottol. A letrehozo ag lentebb tolti fel.
     p.add_argument('--status', default=None); p.add_argument('--no-msg', action='store_true')
     p.add_argument('--comment-file', help='KOMMENT-ONLY mod: komment meglevo kartyara, ertesites nelkul')
+    p.add_argument('--assignee-uj', action='store_true', dest='assignee_uj',
+                   help='komment-mod: kimondva uj (a tablan meg nem szereplo) felelos-nev')
     p.add_argument('--author', default='Marveen', help='komment-mod: a komment szerzoje')
     p.add_argument('--from', dest='from_agent', default=None,
                    help='az ertesites feladoja (alapertelmezes: az --author kisbetusitve)')
@@ -270,12 +371,17 @@ def main():
     a = p.parse_args()
 
     if a.comment_file:
-        if a.assignee or a.msg_file or a.desc_file:
+        # A KEVERES-KAPUT KI KELL ENGEDNI az uj mezohoz, kulonben az uj kod ELERHETETLEN, es a
+        # bovites "kesz"-nek latszik ugy, hogy soha nem fut le (Boni kikotese a cim-bovitesnel).
+        if a.msg_file or a.desc_file:
             sys.exit('MEGTAGADVA: a --comment-file nem keverheto a letrehozo mod kapcsoloival\n'
-                     '(--assignee/--desc-file/--msg-file) -- egy futas egy muvelet.\n'
-                     'A --title/--status/--priority viszont MOZGATJA a meglevo kartyat.')
+                     '(--desc-file/--msg-file) -- egy futas egy muvelet.\n'
+                     'A --title/--status/--priority/--assignee viszont MOZGATJA a meglevo kartyat.')
         komment_mod(a)
         return
+    if a.assignee_uj:
+        sys.exit('MEGTAGADVA: az --assignee-uj csak komment-modban (mezomozgatas) ertelmes.\n'
+                 'A letrehozo ag a kimondott felelos-nevet szo szerint elfogadja.')
     if not a.assignee or not a.title:
         sys.exit('MEGTAGADVA: letrehozo modhoz --assignee es --title kell (komment-modhoz --comment-file).')
 
@@ -286,7 +392,11 @@ def main():
     if a.priority not in PRIORITASOK:
         sys.exit(f'MEGTAGADVA: ervenytelen prioritas ("{a.priority}"). Ervenyes: {", ".join(PRIORITASOK)}.')
 
-    who = a.assignee.strip().lower()
+    # UGYANAZ A KANONIKUS ALAK, mint a mozgato agon -- kulonben a ket ut ugyanarra a nevre
+    # KET KULONBOZO erteket irna a tablara.
+    who = _felelos_feloldas(a.assignee)
+    if not who:
+        sys.exit('MEGTAGADVA: ures felelos-nev.')
     # A FELADO: kimondva (--from), vagy a szerzobol. Az alapertelmezes az --author kisbetusitve,
     # tehat a korabbi viselkedes (--author nelkul: 'marveen') valtozatlan marad.
     frm = (a.from_agent or a.author).strip().lower()
@@ -315,6 +425,9 @@ def main():
     if len(a.title) > 300:
         sys.exit(f'MEGTAGADVA: a cim {len(a.title)} karakter (max 300). A trigger levagna es kommentbe tenne.\n'
                  f'A cim EGY sor legyen (lelet + gazda + hatarido), a reszletek a leirasba.')
+    # 2a. ID-HORGONY: ugyanaz a kapu, mint a cim-mozgatason. Ha csak a mozgatasra allna, a
+    # horgony nelkuli cim egyszeruen a LETREHOZASKOR kerulne be, es a kapu semmit nem vedene.
+    _horgony_kapu(a.id, a.title)
 
     # 2b. AZ UZENET NEVEZZE MEG A KARTYAT (2026-09-05, az eszkoz ELSO eles hasznalata bukott el rajta).
     # Az ORSZEMROUTING905 uzenete kiment es meg is erkezett, de a szovege SEHOL nem irta le a kartya


### PR DESCRIPTION
Follow-up to #1204, the four items recorded on `KARTYAKULDO906` plus one the measurement found. Two of the four are **not** the shape the card specified, and both times the live board is the reason.

## What changed

**1. ID anchor gate, on both branches.** The title carries the card's own ID. The 2026-08-24 migration of 411 cards stood or fell on it, and whatever had no anchor became a manual bucket. Until now neither the create branch nor the title move required it, so a move could quietly strip it.

Not the literal `if a.id not in a.title` from the card. Measured against the live board, that form refuses the established PR-card convention (id `PR1195`, title `PR #1195 (...)` -- the anchor is present, just written with a space and a hash):

| gate | refused, last 354 cards |
|---|---|
| raw `id not in title` | 52 (14.7%) |
| normalized (letters and digits, uppercased) | 13 (3.7%) |

The remaining 13 are mostly the defect Boni was aiming at: a hex DB id with an unrelated semantic anchor in the title (`D520CB4A` titled `SCHEDGATERES904 ...`).

**2. The DB gate checks the table, not just the file** (Samu's non-blocking finding in the #1204 verify). An existing-but-empty file passed the old gate and the run died with a raw traceback instead of the readable refusal.

**3. The movable fields are listed in one place** in the docstring.

**4. `--assignee` moves an existing card**, with the same gates as the other fields: before-snapshot, independent readback, machine trace comment. The finding is from my own use -- taking `CONNMKT906` off the owner's row needed raw sqlite3, the path this tool exists to retire. On our board the assignee is not a label, it says who holds the decision, so moving it is a state change.

Not the "valid name set" the card proposed. Measured: the column holds 40 distinct values, most of them external GitHub usernames. A closed set would refuse most legitimate moves. The gate asks instead whether another card already carries that exact name; if none does it refuses and names the near matches, and `--assignee-uj` states a genuinely new name out loud.

**5. Found while measuring.** The create branch lowercased every assignee unconditionally, so a card filed for an external author was written under a value different from the one already on the board (`Vlbbtabs`, `KratoBal`, `PCha0s`). Both branches now share one resolution: fleet and owner names lowercase, every other name verbatim. The live board still shows what this cost: `samu` on 1086 cards and `Samu` on 44, the latter all archived.

## Evidence

45 assertions on an isolated DB (`scripts/__tests__/kartya-mezomozgatas.test.py`), plus the unchanged sender suite, both green. Eight mutation axes of my own choosing, each gate removed in turn:

| axis | assertions that fail | restore identical |
|---|---|---|
| A) anchor gate off, title move | 3 | yes |
| B) anchor gate off, create branch | 2 | yes |
| C) anchor gate raw, no normalization | 2 | yes |
| D) assignee dropped from the moved fields | 7 | yes |
| E) mixing gate re-closed on `--assignee` | 12 | yes |
| F) DB table check off | 3 | yes |
| G) unconditional `.lower()` restored | 3 | yes |
| H) "another card already carries it" check off | 3 | yes |

Axis F also proved one assertion was not discriminating: the traceback happens to contain `kanban_cards` too, so it passed with and without the gate. It now asserts on the refusal line, and fails under the mutation.

Live-data probe on an isolated copy of the board (dry-run, nothing written, copy verified unchanged): the anchor refusal, the assignee move plan, and the typo refusal all behave on real rows.

## Two house-rule questions, deliberately not built

Both are policy, not technique, so they are for the reviewer rather than for me:

1. **Should a move to `szabolcs` warn?** The board rule says only a card the owner can decide today stands on the owner's row. The tool could say so on an assignee move. It does not today.
2. **Should the create branch get the same "name already on the board" gate?** It does not have it, because a new external PR author is the dominant create path and the gate would fire on every one of them. The asymmetry is deliberate but debatable.

## Known limit, stated

The "another card already carries it" check counts archived cards, so an old typo legitimizes itself (`Marveen+Samu+Zara` sits on 2 archived cards). Chosen deliberately: excluding archived rows would refuse long-used external names, which is the more common case than reusing an old typo. The gate is aimed at new typos, not at cleaning history.

Card: `KARTYAKULDO906`