### PR TITLE
fix(pane): the routing probes were still blind to a pane drawn high

### DIFF
--- a/src/__tests__/pane-busy-blank-tail.test.ts
+++ b/src/__tests__/pane-busy-blank-tail.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest'
+import { detectPaneState, shouldRetrySubmit } from '../pane-state.js'
+
+// A RUNNING turn read as idle, because the pane had empty rows below it.
+//
+// #1205 fixed this shape for the prompt probes: every footer window counted back
+// from the last LINE of the capture, so a pane drawn high with a blank tail pushed
+// the footer out of the window. It converted the six probes that answer "is a
+// prompt on screen". It did not convert the two windows in detectPaneState, nor
+// the two in shouldRetrySubmit -- the functions that decide whether a pane may be
+// written to.
+//
+// Measured 2026-09-06 on a real `tmux capture-pane` of a busy fleet agent: with an
+// 18-line blank tail appended, detectPaneState flipped busy -> idle. The direction
+// is the costly one. An idle verdict is a licence to deliver, so the router would
+// have pushed a message into a live turn, which is the queue-interleaving this
+// monitor exists to prevent.
+//
+// Both windows have to move together. `esc to interrupt` sits on the footer line,
+// but the spinner ("✽ Metamorphosing… (2m 0s · ...)") is drawn several lines above
+// it, inside the wider busy window and outside the narrow footer one -- so a fix to
+// only one of them still misses whichever shape lands in the other.
+
+/** Faithful to a real capture: spinner high, footer last, nothing after it. */
+const BUSY_PANE = [
+  '  Reading the sprint notes before the merge.',
+  '',
+  '✽ Metamorphosing… (2m 0s · ↓ 6.4k tokens · still thinking with high effort)',
+  '  ⎿  Tip: Use /btw to ask a quick side question without interrupting Claude\'s',
+  '     current work',
+  '',
+  '───────────────────────────────────────────────────────────────── Samu ─',
+  '❯ ',
+  '────────────────────────────────────────────────────────────────────────',
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle) · esc to interrupt · ← for ag…',
+].join('\n')
+
+const BLANK_TAIL = '\n'.repeat(18)
+
+describe('a busy pane with a blank tail below it', () => {
+  it('is still busy, exactly as it is without the tail', () => {
+    // The control probe is the same pane untailed: without it a green assertion
+    // would not distinguish "the tail is handled" from "this fixture never read busy".
+    expect(detectPaneState(BUSY_PANE)).toBe('busy')
+    expect(detectPaneState(BUSY_PANE + BLANK_TAIL)).toBe('busy')
+  })
+
+  it('suppresses a retry submit that would otherwise fire', () => {
+    // The assertion has to be discriminating, and `expect(false)` on BUSY_PANE is not:
+    // shouldRetrySubmit returns false there for several reasons at once, so reverting
+    // the window would not move it. Measured -- that first version of this test
+    // survived the mutation, which is the same decorative-assertion class the busy
+    // check itself is about.
+    //
+    // This pane instead takes the retry's path 1: a pending-paste placeholder in the
+    // input box, which returns true UNLESS the busy check stops it first. So the busy
+    // verdict is the only thing standing between a live turn and a clear-and-resend.
+    const hint = 'a payload hint long enough to clear the minimum'
+    const busyWithPlaceholder = [
+      '  Reading the sprint notes before the merge.',
+      '',
+      '✽ Brewing… (52s · ↓ 2.6k tokens)',
+      '',
+      '────────────────────────────────────────────────────────────────────────',
+      '❯ [Pasted text #1 +214 lines]',
+      '────────────────────────────────────────────────────────────────────────',
+      '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+    ].join('\n')
+
+    // Control: the same pane with the spinner removed DOES retry, which is what makes
+    // the two assertions below mean something.
+    expect(shouldRetrySubmit(busyWithPlaceholder.replace('✽ Brewing… (52s · ↓ 2.6k tokens)', ''), hint)).toBe(true)
+
+    expect(shouldRetrySubmit(busyWithPlaceholder, hint)).toBe(false)
+    expect(shouldRetrySubmit(busyWithPlaceholder + BLANK_TAIL, hint)).toBe(false)
+  })
+
+  it('suppresses the same retry when the footer carries the signal instead', () => {
+    // The retry has TWO live windows and they catch different shapes, so each needs
+    // its own input class. Without this case, reverting the footer window alone left
+    // the suite green -- the fixture above answers only for the spinner window.
+    //
+    // This is the shape of the real capture: no spinner line matched, and
+    // `esc to interrupt` sitting on the footer line as the only evidence of a turn.
+    const hint = 'a payload hint long enough to clear the minimum'
+    const footerOnly = [
+      '  Reading the sprint notes before the merge.',
+      '',
+      '────────────────────────────────────────────────────────────────────────',
+      '❯ [Pasted text #1 +214 lines]',
+      '────────────────────────────────────────────────────────────────────────',
+      '  ⏵⏵ bypass permissions on (shift+tab to cycle) · esc to interrupt · ← for ag…',
+    ].join('\n')
+
+    expect(shouldRetrySubmit(footerOnly.replace(' · esc to interrupt · ← for ag…', ''), hint)).toBe(true)
+    expect(shouldRetrySubmit(footerOnly, hint)).toBe(false)
+    expect(shouldRetrySubmit(footerOnly + BLANK_TAIL, hint)).toBe(false)
+  })
+
+  it('stays busy when only the spinner carries the signal', () => {
+    // Both windows have to move, not just the footer one. Here the footer carries
+    // no `esc to interrupt`, so the verdict rests on the spinner line drawn several
+    // rows higher -- inside the wider busy window, outside the narrow footer one.
+    //
+    // The spinner form here is the sub-minute one, `(52s · ↓ 2.6k tokens)`, and that
+    // is deliberate. The real capture this fixture came from read
+    // `(2m 0s · ↓ 6.4k tokens · still thinking with high effort)`, which BUSY_INDICATORS
+    // does not match at all: the pattern requires `\(\s*\d+s` and a minute-form
+    // duration puts `2m ` in between. That is a separate defect from the blank tail,
+    // it is filed on its own, and it is not what this test measures -- using the
+    // unmatched form here would have made this assertion pass for the wrong reason.
+    const spinnerOnly = BUSY_PANE
+      .replace('✽ Metamorphosing… (2m 0s · ↓ 6.4k tokens · still thinking with high effort)',
+               '✽ Brewing… (52s · ↓ 2.6k tokens)')
+      .replace(' · esc to interrupt · ← for ag…', '')
+    expect(spinnerOnly).not.toContain('esc to interrupt')
+    expect(detectPaneState(spinnerOnly)).toBe('busy')
+    expect(detectPaneState(spinnerOnly + BLANK_TAIL)).toBe('busy')
+  })
+})

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -894,7 +894,14 @@ export function detectPaneState(
   // Spinner / token-counter busy signals, scoped to the live bottom region.
   // Whole-pane scanning let a completed turn's stale token-counter line pin
   // an idle session busy (see BUSY_LIVE_REGION_LINES).
-  const busyRegion = paneLines.slice(-BUSY_LIVE_REGION_LINES).join('\n')
+  // liveTailRegion, not slice(-N): a pane drawn high with empty rows below it --
+  // what tmux capture-pane returns whenever the content is shorter than the pane --
+  // pushed BOTH live windows off the footer, and this function then read a running
+  // turn as idle. Measured 2026-09-06 on a real capture of a busy fleet agent: with
+  // an 18-line blank tail appended, detectPaneState went busy -> idle, and the router
+  // would have delivered into a live turn. #1205 fixed this shape for the prompt
+  // probes; these two windows are the same shape in the function that routes.
+  const busyRegion = liveTailRegion(paneLines, BUSY_LIVE_REGION_LINES)
   for (const rx of BUSY_INDICATORS) {
     if (rx.test(busyRegion)) return 'busy'
   }
@@ -903,7 +910,7 @@ export function detectPaneState(
   // Checking the whole pane would let a scrollback quote of the phrase
   // (e.g. in a watchdog report or a log analysis) permanently classify
   // an idle session as busy.
-  const footerRegion = paneLines.slice(-LIVE_FOOTER_REGION_LINES).join('\n')
+  const footerRegion = liveTailRegion(paneLines, LIVE_FOOTER_REGION_LINES)
   if (BUSY_ESC_TO_INTERRUPT_RX.test(footerRegion)) return 'busy'
 
   // Pending-paste placeholder check runs BEFORE the idle-footer gate. The
@@ -1131,12 +1138,12 @@ export function shouldRetrySubmit(
   // Busy pane: the turn is mid-flight, no retry needed. Region-scoped (same
   // as detectPaneState) so a stale token-counter line does not suppress a
   // legitimate retry on an idle pane.
-  const retryBusyRegion = retryPaneLines.slice(-BUSY_LIVE_REGION_LINES).join('\n')
+  const retryBusyRegion = liveTailRegion(retryPaneLines, BUSY_LIVE_REGION_LINES)
   for (const rx of BUSY_INDICATORS) {
     if (rx.test(retryBusyRegion)) return false
   }
   // Footer-region `esc to interrupt` check (same scoping as detectPaneState).
-  const retryFooterRegion = retryPaneLines.slice(-LIVE_FOOTER_REGION_LINES).join('\n')
+  const retryFooterRegion = liveTailRegion(retryPaneLines, LIVE_FOOTER_REGION_LINES)
   if (BUSY_ESC_TO_INTERRUPT_RX.test(retryFooterRegion)) return false
 
   // Path 1: placeholder is unambiguous, retry regardless of hint -- and it is


### PR DESCRIPTION
Follow-up to #1205. `liveTailRegion` is the right shape; this walks it to the call sites that were left behind, which happen to be the ones that decide whether a pane may be written to.

## The finding

#1205 converted six probes that answer *is a prompt on screen*. It left four windows untouched: both in `detectPaneState`, both in `shouldRetrySubmit`.

Measured on a real `tmux capture-pane` of a busy fleet agent (2026-09-06), appending an 18-line blank tail:

```
farok NELKUL : state=busy   esc@busyRegion(12)=true  esc@footerRegion(5)=true
ures FAROKKAL: state=idle   esc@busyRegion(12)=false esc@footerRegion(5)=false
```

The direction is the costly one. An idle verdict is a licence to deliver, so the router pushes a message into a live turn. That is exactly the interleaving the pane monitor exists to prevent, and a blank tail is not exotic: `capture-pane` returns one whenever the content is shorter than the pane.

## Both windows in each function, and why

The two windows catch different shapes. `esc to interrupt` lands on the footer line; a spinner lands several rows higher, inside the wider busy window and outside the narrow footer one. Converting one and not the other leaves whichever shape falls in the other window still blind. Each of the four is pinned by its own input class in the new suite.

## Mutation control

234 assertions green. Five axes, each reverted to the pre-fix shape, every restore byte-identical:

| axis | assertions that fail |
|---|---|
| `detectPaneState` footer window reverted | 1 |
| `detectPaneState` busy window reverted | 1 |
| `shouldRetrySubmit` busy window reverted | 1 |
| `shouldRetrySubmit` footer window reverted | 1 |
| `liveTailRegion` stops trimming the tail | 6 (including #1205's own two) |

Two of those axes only became discriminating after the suite was fixed, and that is worth stating plainly. The first version of the retry test asserted `false` on a busy pane -- but `shouldRetrySubmit` returns `false` there for several independent reasons, so reverting the window did not move it. It survived the mutation. The test now drives the retry down its placeholder path, where the busy verdict is the only thing standing between a live turn and a clear-and-resend, and it carries a control probe showing the retry *does* fire once the busy signal is removed. The footer axis needed a second input class for the same reason.

## Found while measuring, filed separately: `PANESPINPERC906`

`BUSY_INDICATORS` does not match a minute-form duration. The real capture read:

```
✽ Metamorphosing… (2m 0s · ↓ 6.4k tokens · still thinking with high effort)
```

Both patterns require `\(\s*\d+s`, and `(2m 0s` puts `2m ` between the paren and the seconds. So **any turn past sixty seconds loses its spinner signal entirely** and the busy verdict rests on `esc to interrupt` in the footer alone -- which is precisely why the blank-tail gap above mattered as much as it did.

That is a separate defect with a wider blast radius (it changes how broadly we read panes as busy, fleet-wide), so it gets its own change and its own mutation control rather than riding along here. The fixture in this PR deliberately uses the sub-minute form `(52s · ↓ 2.6k tokens)`, so this suite cannot pass for the wrong reason.