### PR TITLE
feat(dashboard): a session that exists is not an agent that answers

### DIFF
--- a/src/__tests__/pane-liveness.test.ts
+++ b/src/__tests__/pane-liveness.test.ts
@@ -1,0 +1,84 @@
+// A tmux session that still exists is not proof that an agent lives in it.
+// When the Claude CLI exits, tmux keeps the session alive with a bare shell
+// prompt in the pane: list-sessions still lists it, so runState says 'running'
+// and the dashboard shows a perfectly idle agent that will never answer.
+//
+// The positive signal is the pane's FOREGROUND COMMAND. Measured on the live
+// fleet (2026-09-06): every healthy agent pane reports 'claude.exe'; a session
+// with no CLI in it reports its shell ('bash'). These tests pin that reading
+// and, more importantly, pin the conjunction that keeps it honest: a shell
+// reading alone never means dead while the pane still shows work in progress.
+
+import { describe, it, expect } from 'vitest'
+import { classifyPaneLiveness, activityState } from '../web/pane-liveness.js'
+
+const SEP = '─'.repeat(40)
+const IDLE_PANE = ['', SEP, '❯ ', SEP, '  ⏵⏵ bypass permissions on (shift+tab to cycle)'].join('\n')
+const BUSY_PANE = [
+  '✢ Combobulating… (52s · ↓ 2.6k tokens · thinking some more)',
+  '',
+  SEP,
+  '❯ ',
+  SEP,
+  '  ⏵⏵ bypass permissions on (shift+tab to cycle) · esc to interrupt',
+].join('\n')
+
+describe('classifyPaneLiveness', () => {
+  it('reads the measured healthy value as alive', () => {
+    expect(classifyPaneLiveness('claude.exe')).toBe('alive')
+  })
+
+  it('reads every common shell as a dead pane', () => {
+    for (const shell of ['bash', 'zsh', 'sh', 'fish', 'ksh', 'dash', 'tcsh', 'login', '-zsh']) {
+      expect(classifyPaneLiveness(shell)).toBe('dead-shell')
+    }
+  })
+
+  it('is case-insensitive about the command name', () => {
+    expect(classifyPaneLiveness('ZSH')).toBe('dead-shell')
+  })
+
+  it('calls anything else alive -- an unknown foreground process is still a process', () => {
+    expect(classifyPaneLiveness('node')).toBe('alive')
+    expect(classifyPaneLiveness('claude')).toBe('alive')
+  })
+
+  it('reports unknown when tmux gave us nothing', () => {
+    expect(classifyPaneLiveness(null)).toBe('unknown')
+    expect(classifyPaneLiveness('')).toBe('unknown')
+    expect(classifyPaneLiveness('   ')).toBe('unknown')
+  })
+})
+
+describe('activityState', () => {
+  it('a session that is not running is stopped, whatever the pane says', () => {
+    expect(activityState({ running: false, pane: BUSY_PANE, paneCommand: 'claude.exe' })).toBe('stopped')
+  })
+
+  it('names the failure the card was opened for: session alive, CLI gone, pane idle', () => {
+    expect(activityState({ running: true, pane: IDLE_PANE, paneCommand: 'bash' })).toBe('dead')
+  })
+
+  it('does NOT call it dead while the pane still shows work in progress', () => {
+    // 180 samples across six live sessions on 2026-09-06 never showed a child
+    // command, not even during tool calls -- but a working pane outranks the
+    // reading anyway, so no future build can turn a busy agent into a corpse.
+    expect(activityState({ running: true, pane: BUSY_PANE, paneCommand: 'bash' })).toBe('working')
+  })
+
+  it('keeps a live CLI on an empty prompt as idle, not dead', () => {
+    expect(activityState({ running: true, pane: IDLE_PANE, paneCommand: 'claude.exe' })).toBe('idle')
+  })
+
+  it('falls back to idle when tmux could not report a foreground command', () => {
+    expect(activityState({ running: true, pane: IDLE_PANE, paneCommand: null })).toBe('idle')
+  })
+
+  it('reports unknown when there is no pane to read', () => {
+    expect(activityState({ running: true, pane: null, paneCommand: 'claude.exe' })).toBe('unknown')
+  })
+
+  it('calls a dead pane dead even when the leftover shell output reads as unknown', () => {
+    expect(activityState({ running: true, pane: 'zsh: command not found: claudee', paneCommand: 'zsh' })).toBe('dead')
+  })
+})

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -2453,6 +2453,25 @@ export function capturePane(session: string, host: string | null = null): string
   }
 }
 
+/**
+ * Foreground command of a session's first pane (`claude.exe` on a healthy agent,
+ * the shell name once the CLI has exited). Feeds classifyPaneLiveness so the
+ * dashboard can tell a dead session from an idle one -- `tmux list-sessions`
+ * cannot, it lists the leftover shell exactly like a live agent.
+ *
+ * Returns null on any failure: an unreadable pane must degrade to "unknown",
+ * never to a false death sentence.
+ */
+export function paneCurrentCommand(session: string, host: string | null = null): string | null {
+  try {
+    const out = captureTmux(host, ['list-panes', '-t', session, '-F', '#{pane_current_command}'])
+    const first = out.split('\n').map(line => line.trim()).find(line => line.length > 0)
+    return first ?? null
+  } catch {
+    return null
+  }
+}
+
 // Capture a pane for STUCK-INPUT detection, with the editor's dim "ghost
 // suggestion" autocomplete removed. Captures WITH colour (`-e`) and strips the
 // SGR-2 (dim) ghost + all ANSI, so a hint shown in an empty input box is never

--- a/src/web/pane-liveness.ts
+++ b/src/web/pane-liveness.ts
@@ -1,0 +1,62 @@
+/**
+ * Is anything actually alive in this tmux session?
+ *
+ * `agentRunState` answers one question -- does the session name appear in
+ * `tmux list-sessions` -- and reports 'running' when it does. tmux keeps a
+ * session alive after the Claude CLI inside it exits: the pane falls back to a
+ * bare shell prompt. From the outside that is indistinguishable from a healthy,
+ * idle agent, so the dashboard shows 'idle' for an agent that will never answer
+ * again, and the operator finds out by accident.
+ *
+ * The signal that survives the CLI's death is the pane's FOREGROUND COMMAND.
+ * Measured across the live fleet on 2026-09-06: every healthy agent pane
+ * reported `claude.exe`; a session with no CLI in it reported its shell.
+ *
+ * The reading is deliberately paired with the pane state instead of trusted on
+ * its own. `pane_current_command` follows whatever process currently owns the
+ * pane's terminal, so a transient child could read as a shell for a moment. A
+ * pane that still shows work in progress therefore outranks it: 'dead' is only
+ * reported when the shell reading AND a non-working pane agree.
+ */
+
+import { detectPaneState } from '../pane-state.js'
+
+export type PaneLiveness = 'alive' | 'dead-shell' | 'unknown'
+
+export type ActivityState = 'stopped' | 'dead' | 'working' | 'idle' | 'unknown' | 'error'
+
+// A login shell arrives as '-zsh'; tmux reports the basename, so no paths here.
+const SHELL_COMMANDS = new Set([
+  'bash', 'zsh', 'sh', 'fish', 'ksh', 'dash', 'tcsh', 'csh', 'login',
+])
+
+export function classifyPaneLiveness(paneCommand: string | null): PaneLiveness {
+  const name = (paneCommand ?? '').trim().toLowerCase().replace(/^-/, '')
+  if (!name) return 'unknown'
+  return SHELL_COMMANDS.has(name) ? 'dead-shell' : 'alive'
+}
+
+/**
+ * The dashboard's live per-agent label, as one pure decision.
+ *
+ * Order matters: a stopped session is stopped; a pane that shows work in
+ * progress is working even if the foreground command looked like a shell; only
+ * then does the shell reading turn 'idle'/'unknown' into 'dead'.
+ */
+export function activityState(opts: {
+  running: boolean
+  pane: string | null
+  paneCommand: string | null
+}): ActivityState {
+  const { running, pane, paneCommand } = opts
+  if (!running) return 'stopped'
+
+  const liveness = classifyPaneLiveness(paneCommand)
+  const paneState = pane === null ? null : detectPaneState(pane)
+
+  if (paneState === 'busy' || paneState === 'typing') return 'working'
+  if (liveness === 'dead-shell') return 'dead'
+  if (paneState === null) return 'unknown'
+  if (paneState === 'idle') return 'idle'
+  return paneState // 'unknown' | 'error'
+}

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -103,6 +103,7 @@ import {
   agentSessionName,
   sendPromptToSession,
   capturePane,
+  paneCurrentCommand,
   delay,
 } from '../agent-process.js'
 import { addDesiredAgent, removeDesiredAgent } from '../agent-desired-state.js'
@@ -110,6 +111,7 @@ import { RemoteStatusCache } from '../remote-status-cache.js'
 import type { AgentRunState } from '../ssh-tmux.js'
 import { readActiveModelFromProjectDir, readContextTokensFromProjectDir } from '../active-model.js'
 import { detectPaneState, detectPermissionMode } from '../../pane-state.js'
+import { activityState } from '../pane-liveness.js'
 import { checkAgentPutFields, checkConfigPutFields, AGENT_PUT_WRITABLE_FIELDS } from '../agent-put-fields.js'
 import { detectReauthNeeded } from '../reauth-detect.js'
 import { readAutoRestartConfig, writeAutoRestartConfig } from '../auto-restart-store.js'
@@ -682,14 +684,16 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
   // fleet, not just sub-agents. Restored after #226 dropped this route while the
   // frontend kept calling /api/agents/activity (which then 404'd the panel).
   if (path === '/api/agents/activity' && method === 'GET') {
-    const label = (running: boolean, pane: string | null): string => {
-      if (!running) return 'stopped'
-      if (pane === null) return 'unknown'
-      const s = detectPaneState(pane)
-      if (s === 'busy' || s === 'typing') return 'working'
-      if (s === 'idle') return 'idle'
-      return s // 'unknown' | 'error'
-    }
+    // A session that still exists is not an agent that still answers: when the
+    // CLI exits, tmux leaves a bare shell in the pane and the old label read
+    // that as a perfectly healthy 'idle'. activityState pairs the pane text
+    // with the pane's foreground command so that corpse is named 'dead'.
+    //
+    // The command is read for LOCAL sessions only. A remote agent would need a
+    // second ssh round-trip per 3s poll; it keeps the previous behaviour
+    // (paneCommand null => never 'dead') rather than paying that on every tick.
+    const label = (running: boolean, pane: string | null, paneCommand: string | null = null): string =>
+      activityState({ running, pane, paneCommand })
     const tailOf = (pane: string | null): string[] =>
       pane === null
         ? []
@@ -713,11 +717,12 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     {
       const mainPane = capturePane(MAIN_CHANNELS_SESSION)
       const running = mainPane !== null
+      const mainPaneCommand = running ? paneCurrentCommand(MAIN_CHANNELS_SESSION) : null
       entries.push({
         name: MAIN_AGENT_ID,
         isMain: true,
         running,
-        state: label(running, mainPane),
+        state: label(running, mainPane, mainPaneCommand),
         mode: modeOf(running, mainPane),
         tail: tailOf(mainPane),
       })
@@ -735,7 +740,8 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
           ? remotePaneCache.getOrRefresh(name, Date.now(), () => capturePane(agentSessionName(name), host), null)
           : capturePane(agentSessionName(name))
       }
-      const state = runState === 'unreachable' ? 'unreachable' : label(running, pane)
+      const paneCommand = running && !host ? paneCurrentCommand(agentSessionName(name)) : null
+      const state = runState === 'unreachable' ? 'unreachable' : label(running, pane, paneCommand)
       entries.push({ name, isMain: false, running, state, mode: modeOf(running, pane), tail: tailOf(pane) })
     }
 

--- a/web/app.js
+++ b/web/app.js
@@ -687,6 +687,7 @@ if (document.readyState !== 'loading') {
 const ACTIVITY_STATE_META = {
   working: { label: () => t('activity.state.working'), cls: 'act-working', tip: 'Élő állapot (a tmux pane tartalmából, 3 másodpercenként): éppen dolgozik / gondolkodik.' },
   idle: { label: () => t('activity.state.idle'), cls: 'act-idle', tip: 'Élő állapot (3 másodpercenként): fut, de épp nem csinál semmit.' },
+  dead: { label: () => t('activity.state.dead'), cls: 'act-dead', tip: 'A tmux session él, de nincs benne Claude CLI: a pane egy shell promptra esett vissza. Ez nem várakozás, ez halott ágens -- indítsd újra.' },
   unknown: { label: () => t('activity.state.unknown'), cls: 'act-unknown', tip: 'Élő állapot: nem sikerült megállapítani a session pane tartalmából.' },
   error: { label: () => t('activity.state.error'), cls: 'act-error', tip: 'Élő állapot: hiba látszik az ágens session paneljén.' },
   stopped: { label: () => t('activity.state.stopped'), cls: 'act-stopped', tip: 'Élő állapot: az ágens session nem fut.' },

--- a/web/lang/en.js
+++ b/web/lang/en.js
@@ -333,6 +333,7 @@ window._i18n.en = {
   'agents.card.not_running':     'session not running',
   'activity.state.working':      'working',
   'activity.state.idle':         'idle',
+  'activity.state.dead':         'dead',
   'activity.state.unknown':      'unknown',
   'activity.state.error':        'error',
   'activity.state.stopped':      'stopped',

--- a/web/lang/hu.js
+++ b/web/lang/hu.js
@@ -475,6 +475,7 @@ window._i18n.hu = {
   'activity.tooltip.mode':       'Jogosultsági mód: {mode}. Ebben a módban az ágens megáll és jóváhagyásra vár, mielőtt eszközt hívna -- ha senki nem figyeli, órákig állhat úgy, hogy közben tétlennek látszik.',
   'activity.state.working':      'dolgozik',
   'activity.state.idle':         'várakozik',
+  'activity.state.dead':         'halott',
   'activity.state.unknown':      'ismeretlen',
   'activity.state.error':        'hiba',
   'activity.state.stopped':      'leállt',

--- a/web/style.css
+++ b/web/style.css
@@ -1485,6 +1485,7 @@ main.kanban-active { padding-left: 16px; padding-right: 16px; }
 .agents-grid[data-card-mode="activity"] .agent-card.act-working { border-left-color: #22c55e; }
 .agents-grid[data-card-mode="activity"] .agent-card.act-idle    { border-left-color: #9ca3af; }
 .agents-grid[data-card-mode="activity"] .agent-card.act-error   { border-left-color: #ef4444; }
+.agents-grid[data-card-mode="activity"] .agent-card.act-dead    { border-left-color: #b91c1c; }
 .agents-grid[data-card-mode="activity"] .agent-card.act-unknown { border-left-color: #eab308; }
 .agents-grid[data-card-mode="activity"] .agent-card.act-stopped { border-left-color: #6b7280; opacity: 0.7; }
 /* A stopped agent has no session to open, so its card is not clickable -- same
@@ -6522,6 +6523,7 @@ main.kanban-active { padding-left: 16px; padding-right: 16px; }
 .activity-card.act-working { border-left-color: #22c55e; }
 .activity-card.act-idle    { border-left-color: #9ca3af; }
 .activity-card.act-error   { border-left-color: #ef4444; }
+.activity-card.act-dead    { border-left-color: #b91c1c; }
 .activity-card.act-unknown { border-left-color: #eab308; }
 .activity-card.act-stopped { border-left-color: #6b7280; opacity: 0.7; }
 .activity-card.act-clickable { cursor: pointer; transition: background 0.15s, box-shadow 0.15s; }
@@ -6548,6 +6550,7 @@ main.kanban-active { padding-left: 16px; padding-right: 16px; }
 }
 .activity-badge.act-idle    { background: rgba(156,163,175,0.18); color: #6b7280; }
 .activity-badge.act-error   { background: rgba(239,68,68,0.15); color: #dc2626; }
+.activity-badge.act-dead    { background: rgba(185,28,28,0.18); color: #b91c1c; font-weight: 600; }
 .activity-badge.act-unknown { background: rgba(234,179,8,0.18); color: #ca8a04; }
 .activity-badge.act-stopped { background: rgba(107,114,128,0.15); color: #6b7280; }
 


### PR DESCRIPTION
## A hibamód

Ha a Claude CLI kilép, a tmux session **ettől még él**: a pane visszaesik egy csupasz shell promptra. A `tmux list-sessions` ugyanúgy listázza, tehát `agentRunState` `running`-ot mond, a dashboard pedig „várakozik" címkét tesz egy ágensre, ami soha többé nem válaszol. A kiesett ágens eddig csak véletlenül derült ki.

A kártya (`e4776dfb`) három állapotot kért: dolgozik / él de nincs dolga / halott. A premissza-audit szűkítése szerint az első kettő már megvolt (`/api/agents/activity` `label()` a `detectPaneState` alapján). A harmadik hiányzott — ez a PR azt teszi hozzá.

## A jel

A pane **foreground parancsa** az, ami túléli a CLI halálát.

Mérés a teljes élő flottán, 2026-09-06: 180 minta hat sessionön, 60 másodpercen át, 2 másodperces mintavétellel. Minden egészséges agent pane `claude.exe`-t jelentett, kivétel nélkül — **tool-hívás közben is** (az `agent-devy` mintái közben `npm ci` és `vitest` futott a saját sessionömben). A jel tehát nem billen át gyerekfolyamatra.

Végponti próba ugyanaznap: egy szándékosan üres tmux session (csak `zsh`) `dead`-nek olvasódik, míg két élő ágens `working` illetve `idle` marad:

```
devy-liveness-probe    cmd=zsh          liveness=dead-shell  state=dead
agent-devy             cmd=claude.exe   liveness=alive       state=working
agent-disy             cmd=claude.exe   liveness=alive       state=idle
```

## Amitől nem lesz hamis halott

A parancs-olvasás nem áll magában: **a dolgozó pane felülírja**. Ha a pane még munkát mutat (spinner / token-számláló), az `working` marad akkor is, ha a foreground parancs shellnek látszik. A mérés szerint ez ma nem fordul elő, de így egyetlen jövőbeli Claude Code build sem tud egy dolgozó ágenst hullává minősíteni.

Sorrend: `stopped` → `working` (pane-elsőbbség) → `dead` (shell-olvasás) → `idle` / `unknown` / `error`.

## Hatókör

- **A `runState` változatlan** (`running` | `stopped` | `unreachable`). A router és a scheduler delivery-kapuja arra épül; ha az is finomodik, az külön kártya és külön kockázat. Itt csak az aktivitás-címke bővül.
- A foreground parancsot **csak lokális** sessionre kérdezzük le. Egy távoli ágensnél ez 3 másodpercenként további ssh kört jelentene; ott a régi viselkedés marad (`paneCommand` null, tehát sosem `dead`).
- Frontend: új `dead` állapot a közös állapot-szótárban (`ACTIVITY_STATE_META`), HU/EN fordítás, saját badge- és kártyaszín (sötétvörös, elkülönítve a sárga `error`-tól), tooltip ami megmondja mi a teendő (újraindítás).

## Ellenőrzés

- 12 új teszt, köztük a mért `claude.exe` érték és a dolgozó-pane elsőbbség.
- Három mutációs próba, mind piros lett: shell-olvasás kihagyása (4 bukó), a `dead` ág a `busy` ág elé emelése (1 bukó), hiányzó parancs halottnak véve (2 bukó). A tesztek tehát fognak, nem csak fordítási hibán pirosak.
- Teljes suite: 368 fájl, 4776 teszt zöld, 1 skipped. `tsc --noEmit` tiszta, `npm run syntax-check` tiszta.

## Kapcsolódás

Ugyanaz a tő, mint a #1210 (néma csatorna: a nem-érkező üzenet nem esemény) és az `a664f9b2` (a watchdog „feladtam" állapota örök és láthatatlan). Mindhárom ugyanazt a mintát javítja: a rendszer zöldet mutat, mert a hiba nem termel eseményt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148rV8xMuHmpCgH1T8J1ZJz
