### PR TITLE
fix(pane-state): a turn past one minute lost its spinner busy signal

### DIFF
--- a/src/__tests__/pane-state.test.ts
+++ b/src/__tests__/pane-state.test.ts
@@ -612,6 +612,14 @@ describe('detectPaneState', () => {
     // "Accomplishing… (Ns · ↓ N tokens)" frame lingered well above the idle
     // input box. The token-counter scan is region-scoped, so a counter that
     // has scrolled out of the live bottom region must not pin the pane busy.
+    //
+    // NOTE (2026-09-06): this fixture's counter is MINUTE-shaped ("3m 8s"), a
+    // shape the counter regex could not match until the TURN_ELAPSED fix. Until
+    // then the test passed for the wrong reason -- no region scoping required,
+    // because nothing matched anywhere -- which is why a mutation that widened
+    // the busy scan to the whole pane left the whole suite green. It is a real
+    // scope test only from this commit on; the sibling test below pins the
+    // other side of the same boundary.
     const staleCounter = [
       '✶ Accomplishing… (3m 8s · ↓ 9.3k tokens)',
       '⏺ Done: rebuilt and restarted the dashboard.',
@@ -2303,5 +2311,87 @@ describe('parkedPasteSignature (stuck [Pasted text #N] recovery)', () => {
     ].join('\n')
     expect(stuckInputSignature(auraShape)).toBeNull()
     expect(parkedPasteSignature(auraShape)).not.toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// PANESPINPERC906 -- a turn longer than a minute must still read as busy.
+//
+// Claude Code stops rendering a flat second count at 60s and switches to
+// "1m 16s". Both busy regexes required `\d+s` directly after the paren, so
+// from the 60th second of every turn the spinner/token-counter signal went
+// silent and only the footer's `esc to interrupt` was left. That footer is
+// exactly the signal these patterns exist to backstop: between a submit and
+// the next spinner frame it is briefly absent, and a scheduler tick landing
+// in that window reads 'idle' and injects a prompt into a working pane.
+//
+// The minute-form fixture below is a verbatim capture from a live fleet pane
+// (marveen-channels, 2026-09-06 17:31), not a retyped lookalike.
+// ---------------------------------------------------------------------------
+describe('detectPaneState: minute- and hour-shaped turn durations', () => {
+  const liveTurn = (statusLine: string) =>
+    [
+      '⏺ Reading the router source to find the delivery loop.',
+      '',
+      statusLine,
+      SEP,
+      '❯ ',
+      SEP,
+      '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+    ].join('\n')
+
+  it('reads a minute-shaped token counter as busy (verbatim live capture)', () => {
+    expect(detectPaneState(liveTurn('✻ (1m 16s · ↓ 4.0k tokens)'))).toBe('busy')
+  })
+
+  it('reads a minute-shaped labelled spinner frame as busy', () => {
+    expect(detectPaneState(liveTurn('✢ Combobulating… (2m 0s · ↓ 9.3k tokens)'))).toBe('busy')
+  })
+
+  it('reads an hour-shaped counter as busy', () => {
+    // Defensive, not measured: no fleet turn ran an hour. Pinned so the shape
+    // is a decision in the code rather than an accident of the regex.
+    expect(detectPaneState(liveTurn('✻ (1h 4m 2s · ↓ 210k tokens)'))).toBe('busy')
+  })
+
+  it('still reads the seconds-only shape as busy', () => {
+    // The widened pattern must not lose the shape it already covered.
+    expect(detectPaneState(liveTurn('✻ (52s · ↓ 2.6k tokens)'))).toBe('busy')
+  })
+
+  it('does NOT read a minute-shaped duration without the ↓-tokens tail as busy', () => {
+    // Prose control. "Thinking… (2m 3s)" can appear in reply text; the `· ↓N`
+    // chrome tail is what separates a rendered spinner from quoted prose, and
+    // widening the duration must not weaken that.
+    expect(detectPaneState(liveTurn('  Thinking… (2m 3s) about the schema'))).toBe('idle')
+  })
+
+  it('does NOT read a minute-shaped counter above the live region as busy', () => {
+    // The other side of the boundary pinned by the 2026-06-30 stale-counter
+    // test: same minute shape, but scrolled out of BUSY_LIVE_REGION_LINES.
+    // Together the two tests make the busy-scan SCOPE measurable -- widening
+    // the scan to the whole pane now turns this red instead of staying green.
+    const stale = [
+      '✻ Accomplishing… (1m 16s · ↓ 4.0k tokens)',
+      '⏺ Done: restarted the dashboard.',
+      '⏺ Verified the endpoints.',
+      '⏺ Trailing scrollback line one.',
+      '⏺ Trailing scrollback line two.',
+      '⏺ Trailing scrollback line three.',
+      '⏺ Trailing scrollback line four.',
+      '⏺ Trailing scrollback line five.',
+      '',
+      SEP,
+      '❯ ',
+      SEP,
+      '  ⏵⏵ bypass permissions on (shift+tab to cycle)',
+    ].join('\n')
+    expect(detectPaneState(stale)).toBe('idle')
+  })
+
+  it('blocks a prompt to a pane in a minute-long turn', () => {
+    // The verdict is what the scheduler acts on: isReadyForPrompt is the call
+    // site that decides whether a prompt gets injected.
+    expect(isReadyForPrompt(liveTurn('✻ (1m 16s · ↓ 4.0k tokens)'))).toBe(false)
   })
 })

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -103,6 +103,33 @@ const IDLE_FOOTER_RX = /(?:[A-Za-z][\w-]* ){1,3}on(?: \(shift\+tab to cycle\)| �
 // prevent prose-quoting false positives. A future Claude Code release
 // that renames the spinner labels will miss the label regex but still
 // be caught by the tokens pattern.
+
+// Elapsed-time shape inside the turn marker. Claude Code does NOT render a
+// flat second count once a turn passes a minute: it switches to `1m 16s`, and
+// the seconds-only pattern that used to sit in both regexes below simply
+// stopped matching there. Measured on a live fleet pane 2026-09-06:
+//
+//   seconds form   "(52s · ↓ 2.6k tokens)"     -> matched before and still does
+//   minute form    "(1m 16s · ↓ 4.0k tokens)"  -> did NOT match before this fix
+//
+// The minute form above is the verbatim capture from a busy fleet pane, not a
+// retyped lookalike.
+//
+// The gap was not cosmetic. These patterns exist to cover the frame-level
+// window where the footer has not yet re-rendered `· esc to interrupt`, so
+// for the whole of a turn longer than 60 seconds the pane had ONE busy signal
+// instead of two -- and a long turn is exactly when a mis-detected 'idle'
+// costs the most (a prompt injected into a working pane).
+//
+// The hour segment is defensive, not measured: no live pane in the fleet ran
+// long enough to render one. It widens nothing dangerous, because every use
+// still requires the `· ↓N` chrome tail that prose cannot produce.
+//
+// One fragment, one definition: both patterns below and all eight busy-scan
+// call sites read the same shape, so the next rendering change is a one-line
+// edit rather than a hunt for copies.
+const TURN_ELAPSED = String.raw`(?:\d+h\s*)?(?:\d+m\s*)?\d+s`
+
 const BUSY_INDICATORS: RegExp[] = [
   // NOTE: /\besc to interrupt\b/ is NOT in this list.
   // It is checked separately via BUSY_ESC_TO_INTERRUPT_RX scoped to the
@@ -120,13 +147,15 @@ const BUSY_INDICATORS: RegExp[] = [
   // 2026-06-30). The live spinner/token line renders just above the input
   // box during a real turn, so the bottom-region scope still catches it.
   //
-  // Tokens-down-arrow counter: "(52s · ↓ 2.6k tokens ..."
-  /\(\s*\d+s\s*·\s*↓\s*\d/,
+  // Tokens-down-arrow counter: "(52s · ↓ 2.6k tokens ...", "(1m 16s · ↓ 4.0k tokens)"
+  new RegExp(String.raw`\(\s*${TURN_ELAPSED}\s*·\s*↓\s*\d`),
   // Known spinner labels paired with the turn-scoped `(Ns · ↓` tail on
   // the same line. The tail requirement kills the "Thinking…" prose
   // false positive. Non-exhaustive by design; the bare tokens pattern
   // above is the authoritative fallback.
-  /\b(?:Combobulating|Beaming|Thinking|Pondering|Reticulating|Configuring|Noodling|Ruminating|Percolating|Cogitating|Deliberating|Contemplating|Musing|Brewing|Synthesizing|Distilling|Refining|Simmering|Crafting|Formulating|Consulting|Unfurling|Unspooling|Unraveling)…\s*\(\s*\d+s\s*·\s*↓/,
+  new RegExp(
+    String.raw`\b(?:Combobulating|Beaming|Thinking|Pondering|Reticulating|Configuring|Noodling|Ruminating|Percolating|Cogitating|Deliberating|Contemplating|Musing|Brewing|Synthesizing|Distilling|Refining|Simmering|Crafting|Formulating|Consulting|Unfurling|Unspooling|Unraveling)…\s*\(\s*${TURN_ELAPSED}\s*·\s*↓`,
+  ),
 ]
 
 // `esc to interrupt` is a footer-region-only busy signal: Claude Code


### PR DESCRIPTION
## What was wrong

Claude Code renders the elapsed time inside the turn marker as a flat second count only up to 60 seconds. Past that it switches to `1m 16s`. Both busy regexes in `BUSY_INDICATORS` required `\d+s` immediately after the paren, so from the 60th second of every turn they stopped matching.

Measured on a live pane before the fix (marveen-channels, 2026-09-06 17:31):

| shape | matched before |
|---|---|
| `(52s · ↓ 2.6k tokens)` | yes |
| `(1m 16s · ↓ 4.0k tokens)` | **no** |

The test fixture is that capture verbatim, not a retyped lookalike.

## Why it is not cosmetic

These patterns exist as the backstop for the footer. Between a submit and the next spinner frame the footer briefly renders without `esc to interrupt`, and a scheduler tick landing in that window used to read `idle` and inject a prompt into a working pane. With the counter silent, a turn over a minute had ONE busy signal instead of two, and a long turn is exactly when a mis-detected `idle` costs the most.

## The change

One shared fragment (`TURN_ELAPSED`) instead of a literal in each regex. Both patterns feed eight busy-scan call sites, so the next rendering change is a one-line edit rather than a hunt for copies. The hour segment is defensive and labelled as such: no fleet turn ran long enough to render one, and it stays safe because every use still requires the `· ↓N` chrome tail that prose cannot produce.

## Mutation control

Reverting `TURN_ELAPSED` to the old `\d+s` reddens exactly the four new positive tests (minute, labelled minute, hour, `isReadyForPrompt`) and nothing else, so they measure this fix rather than something nearby.

## Scope, and a correction to how it was previously described

Samu's #1212 verify reported that widening the busy scan to the whole pane left the suite green. Measured here on both trees:

- **pre-fix tree**, scope mutation: reddens only the two `esc to interrupt` footer tests. The FOOTER scope was already pinned; the TOKEN-COUNTER scope was not pinned at all.
- **this branch**, same mutation: additionally reddens the 2026-06-30 stale-counter test plus a new sibling that pins the minute shape INSIDE the live region as busy.

The cause is this same bug. That 2026-06-30 test used a MINUTE-shaped fixture (`3m 8s`), which nothing could match, so it passed without the region scoping doing any work. It is a real scope test only from this commit on.

## Verification

- full suite 4836 passed, 1 skipped; `npm run typecheck` clean
- run from a git worktree under `$HOME`, not the live install

## Review note

`src/pane-state.ts` is in the recovery stack and I am the author, so this needs an independent second pair of eyes before merge. Assigned to Samu.