### PR TITLE
fix(watchdog): giving up on an agent must not mean going quiet about it

### DIFF
--- a/src/__tests__/agent-restart-policy.test.ts
+++ b/src/__tests__/agent-restart-policy.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { shouldAutoRestartDownAgent, effectiveRestartGraceMs, parseEtimeToSeconds, decideDownAgentAction } from '../web/agent-restart-policy.js'
+import { shouldAutoRestartDownAgent, effectiveRestartGraceMs, parseEtimeToSeconds, decideDownAgentAction, GIVE_UP_REALERT_MS } from '../web/agent-restart-policy.js'
 
 const STARTUP = 180_000
 const RESTART = 90_000
@@ -287,9 +287,18 @@ describe('decideDownAgentAction', () => {
     expect(decideDownAgentAction({ ...restartable, consecutiveFailures: MAX }, MAX)).toBe('alert')
   })
 
-  it("skips (silent) once the counter has been ticked past the cap", () => {
-    expect(decideDownAgentAction({ ...restartable, consecutiveFailures: MAX + 1 }, MAX)).toBe('skip')
-    expect(decideDownAgentAction({ ...restartable, consecutiveFailures: MAX + 9 }, MAX)).toBe('skip')
+  // CONTRACT CHANGE (card a664f9b2): past the cap this used to be silent for
+  // the rest of the spell, and the spell had no end -- the counter is only
+  // cleared by a healthy observation, which needs a restart, which the counter
+  // itself prevents. Finy sat there for five days on one alert. It now repeats
+  // on a cadence; silence holds only INSIDE that cadence.
+  it("stays silent past the cap only until the re-alert interval is due", () => {
+    expect(decideDownAgentAction({ ...restartable, consecutiveFailures: MAX + 1, msSinceGiveUpAlert: 60_000 }, MAX)).toBe('skip')
+    expect(decideDownAgentAction({ ...restartable, consecutiveFailures: MAX + 9, msSinceGiveUpAlert: 60_000 }, MAX)).toBe('skip')
+  })
+
+  it("speaks again once the re-alert interval has elapsed", () => {
+    expect(decideDownAgentAction({ ...restartable, consecutiveFailures: MAX + 1, msSinceGiveUpAlert: GIVE_UP_REALERT_MS }, MAX)).toBe('alert')
   })
 
   it("skips (does not restart) within back-off even under the cap", () => {
@@ -326,8 +335,10 @@ describe('decideDownAgentAction', () => {
       // After that restart ticked the counter to 1, the next confirmed-absent
       // sweep escalates instead of nuking the agent's context again.
       expect(decideDownAgentAction({ ...restartable, consecutiveFailures: 1 }, ABSENT_MAX)).toBe('alert')
-      // And stays silent thereafter.
-      expect(decideDownAgentAction({ ...restartable, consecutiveFailures: 2 }, ABSENT_MAX)).toBe('skip')
+      // And stays silent thereafter -- until the re-alert interval is due, at
+      // which point the standing "I have given up" fact is repeated.
+      expect(decideDownAgentAction({ ...restartable, consecutiveFailures: 2, msSinceGiveUpAlert: 60_000 }, ABSENT_MAX)).toBe('skip')
+      expect(decideDownAgentAction({ ...restartable, consecutiveFailures: 2, msSinceGiveUpAlert: GIVE_UP_REALERT_MS }, ABSENT_MAX)).toBe('alert')
     })
 
     it("still honours the startup grace on the first attempt", () => {

--- a/src/__tests__/give-up-realert.test.ts
+++ b/src/__tests__/give-up-realert.test.ts
@@ -1,0 +1,128 @@
+// Giving up must not mean going quiet.
+//
+// When the watchdog hits the restart cap it alerts once and then returns 'skip'
+// for ever: the counter only resets when the plugin is seen healthy, and that
+// observation never comes because nothing restarts it any more. Finy sat in
+// exactly that state from 2026-07-09, one alert and then five days of silence,
+// with the dashboard showing 'running' the whole time. The self-sustaining
+// deadlock is the bug -- a plugin nobody will retry and nobody will mention.
+//
+// Two changes are pinned here:
+//   1. the give-up state re-announces itself on a cadence while it lasts, and
+//   2. a persisted failure count goes stale, so a frozen counter cannot outlive
+//      the incident that produced it.
+
+import { describe, it, expect } from 'vitest'
+import {
+  decideDownAgentAction,
+  isFailureCountStale,
+  GIVE_UP_REALERT_MS,
+  AGENT_FAILURE_COUNT_TTL_MS,
+} from '../web/agent-restart-policy.js'
+
+const MAX = 5
+const HOUR = 60 * 60 * 1000
+
+// Inputs that would otherwise produce a restart, so every verdict below is
+// decided by the cap logic and nothing else.
+function base(over: Record<string, unknown> = {}) {
+  return {
+    processAgeMs: 10 * 60 * 1000,
+    msSinceLastRestart: 10 * 60 * 1000,
+    startupGraceMs: 60_000,
+    restartGraceMs: 90_000,
+    msDown: 10 * 60 * 1000,
+    downConfirmMs: 60_000,
+    ...over,
+  }
+}
+
+describe('decideDownAgentAction past the restart cap', () => {
+  it('still alerts once when the cap is first reached', () => {
+    expect(decideDownAgentAction(base({ consecutiveFailures: MAX }), MAX)).toBe('alert')
+  })
+
+  it('stays quiet right after that alert', () => {
+    const d = decideDownAgentAction(
+      base({ consecutiveFailures: MAX + 1, msSinceGiveUpAlert: 60_000 }),
+      MAX,
+    )
+    expect(d).toBe('skip')
+  })
+
+  it('speaks again once the re-alert interval has passed', () => {
+    const d = decideDownAgentAction(
+      base({ consecutiveFailures: MAX + 1, msSinceGiveUpAlert: GIVE_UP_REALERT_MS }),
+      MAX,
+    )
+    expect(d).toBe('alert')
+  })
+
+  it('keeps speaking on every later interval, not just the second time', () => {
+    const d = decideDownAgentAction(
+      base({ consecutiveFailures: MAX + 9, msSinceGiveUpAlert: 5 * GIVE_UP_REALERT_MS }),
+      MAX,
+    )
+    expect(d).toBe('alert')
+  })
+
+  it('treats a missing alert timestamp as due -- an unknown last-alert must not buy silence', () => {
+    const d = decideDownAgentAction(
+      base({ consecutiveFailures: MAX + 1, msSinceGiveUpAlert: null }),
+      MAX,
+    )
+    expect(d).toBe('alert')
+  })
+
+  it('re-alerts on the caller-supplied interval when one is given', () => {
+    const input = base({ consecutiveFailures: MAX + 1, msSinceGiveUpAlert: 2 * HOUR, giveUpRealertMs: HOUR })
+    expect(decideDownAgentAction(input, MAX)).toBe('alert')
+    const notYet = base({ consecutiveFailures: MAX + 1, msSinceGiveUpAlert: 30 * 60 * 1000, giveUpRealertMs: HOUR })
+    expect(decideDownAgentAction(notYet, MAX)).toBe('skip')
+  })
+
+  it('leaves the under-cap paths untouched', () => {
+    expect(decideDownAgentAction(base({ consecutiveFailures: 0 }), MAX)).toBe('restart')
+    expect(decideDownAgentAction(base({ consecutiveFailures: 1, msDown: 0, downConfirmMs: 60_000 }), MAX)).toBe('skip')
+  })
+
+  it('never reaches the give-up branch when the cap is disabled', () => {
+    // maxRestartAttempts 0 turns the cap off entirely, so a high failure count
+    // is governed by the exponential back-off instead -- 99 failures means a
+    // grace window far longer than the elapsed time, hence 'skip'. What matters
+    // here is that it is never 'alert': with no cap there is nothing to give up
+    // on, so the re-alert cadence must not fire either.
+    expect(decideDownAgentAction(base({ consecutiveFailures: 99, msSinceGiveUpAlert: null }), 0)).toBe('skip')
+    expect(decideDownAgentAction(base({ consecutiveFailures: 0 }), 0)).toBe('restart')
+  })
+})
+
+describe('isFailureCountStale', () => {
+  const NOW = 1_760_000_000_000
+
+  it('keeps a count that was written inside the window', () => {
+    expect(isFailureCountStale(NOW - HOUR, NOW, AGENT_FAILURE_COUNT_TTL_MS)).toBe(false)
+  })
+
+  it('drops a count nothing has touched for longer than the window', () => {
+    expect(isFailureCountStale(NOW - AGENT_FAILURE_COUNT_TTL_MS - 1, NOW, AGENT_FAILURE_COUNT_TTL_MS)).toBe(true)
+  })
+
+  it('treats the boundary as still fresh', () => {
+    expect(isFailureCountStale(NOW - AGENT_FAILURE_COUNT_TTL_MS, NOW, AGENT_FAILURE_COUNT_TTL_MS)).toBe(false)
+  })
+
+  it('keeps the count when the file time is unreadable -- unknown age is not proof of staleness', () => {
+    expect(isFailureCountStale(null, NOW, AGENT_FAILURE_COUNT_TTL_MS)).toBe(false)
+    expect(isFailureCountStale(Number.NaN, NOW, AGENT_FAILURE_COUNT_TTL_MS)).toBe(false)
+  })
+
+  it('keeps a count whose timestamp is in the future (clock skew), rather than resetting the watchdog', () => {
+    // Far enough ahead to exceed the window in absolute terms: a rule written
+    // as |now - mtime| > ttl would call this stale, and a restored backup or a
+    // corrected clock would silently re-arm restarts on a plugin already given
+    // up on. Staleness is about AGE, which is one-directional.
+    expect(isFailureCountStale(NOW + AGENT_FAILURE_COUNT_TTL_MS + HOUR, NOW, AGENT_FAILURE_COUNT_TTL_MS)).toBe(false)
+    expect(isFailureCountStale(NOW + HOUR, NOW, AGENT_FAILURE_COUNT_TTL_MS)).toBe(false)
+  })
+})

--- a/src/web/agent-restart-policy.ts
+++ b/src/web/agent-restart-policy.ts
@@ -58,6 +58,14 @@ export interface AgentRestartDecisionInput {
   // decision escalates to the operator ('alert-busy') rather than deferring for
   // ever OR killing the work. Omitted = defer indefinitely while busy.
   busyDeferMaxMs?: number
+  // Time since the operator was last told this agent had been given up on, in
+  // milliseconds. null/omitted means "no alert on record", which counts as due:
+  // an unknown last-alert must never buy silence, because the state this
+  // measures is an agent nobody is going to restart.
+  msSinceGiveUpAlert?: number | null
+  // How often the give-up state re-announces itself while it lasts. Omitted
+  // uses GIVE_UP_REALERT_MS.
+  giveUpRealertMs?: number
 }
 
 // The restart grace after applying exponential back-off for repeated failed
@@ -110,6 +118,50 @@ export type DownAgentAction = 'restart' | 'alert' | 'alert-busy' | 'skip'
 // operator instead, turning a silent infinite loop into one actionable ping.
 export const AGENT_MAX_RESTART_ATTEMPTS = 5
 
+// How often the watchdog repeats "I have given up on this agent" while the
+// give-up state lasts.
+//
+// The old behaviour was one alert per down-spell, and the comment on
+// decideDownAgentAction said so plainly -- but the counter that ends the spell
+// is only reset when the plugin is observed healthy, and nothing restarts it
+// any more, so the spell has no natural end. Finy spent five days there on a
+// single 2026-07-09 alert. One message about a permanently deaf agent is a
+// message that will be scrolled past.
+//
+// Three hours, matching the fleet's other "stopped / dead" re-alert cadence
+// (the owner asked for a few hours rather than tens of minutes: often enough to
+// stay visible, rare enough to stay signal). The card that asked for this
+// suggested six; three is the cadence the rest of the fleet settled on since.
+export const GIVE_UP_REALERT_MS = 3 * 60 * 60 * 1000
+
+// A persisted failure count older than this is treated as 0 on load.
+//
+// The count lives in store/.agent-failures-<agent> so a dashboard restart does
+// not forgive a plugin that has already been given up on. The cost of that
+// durability was a counter that could sit above the cap for ever: the only
+// thing that clears it is a healthy observation, which requires a restart,
+// which the count itself prevents. A TTL breaks the loop from the other side --
+// after a day with nothing written to it, the watchdog is allowed to try again.
+export const AGENT_FAILURE_COUNT_TTL_MS = 24 * 60 * 60 * 1000
+
+/**
+ * Is a persisted failure count too old to still describe the present?
+ *
+ * `mtimeMs` is when the count was last written; null or NaN means we could not
+ * read it. Unknown age is NOT proof of staleness, so it keeps the count: the
+ * durable-counter behaviour is the safe default, and only positive evidence of
+ * age may override it. A timestamp in the future (clock skew, a restored
+ * backup) is likewise not evidence.
+ */
+export function isFailureCountStale(
+  mtimeMs: number | null | undefined,
+  nowMs: number,
+  ttlMs: number,
+): boolean {
+  if (mtimeMs == null || !Number.isFinite(mtimeMs)) return false
+  return nowMs - (mtimeMs as number) > ttlMs
+}
+
 // Decide what to do about a sub-agent whose channel plugin is observed down.
 // Wraps shouldAutoRestartDownAgent with a consecutive-failure cap so the
 // watchdog escalates to a human instead of churning the session indefinitely:
@@ -133,7 +185,16 @@ export function decideDownAgentAction(
     ? Math.floor(input.consecutiveFailures as number)
     : 0
   if (maxRestartAttempts > 0 && failures >= maxRestartAttempts) {
-    return failures === maxRestartAttempts ? 'alert' : 'skip'
+    if (failures === maxRestartAttempts) return 'alert'
+    // Past the cap the watchdog has stopped acting, so the only thing that can
+    // still change is the operator's knowledge. Repeat on a cadence rather than
+    // falling silent for the rest of the spell -- there is no other end to it.
+    const realertMs = Number.isFinite(input.giveUpRealertMs) && (input.giveUpRealertMs as number) > 0
+      ? (input.giveUpRealertMs as number)
+      : GIVE_UP_REALERT_MS
+    const sinceAlert = input.msSinceGiveUpAlert
+    if (sinceAlert == null || !Number.isFinite(sinceAlert)) return 'alert'
+    return (sinceAlert as number) >= realertMs ? 'alert' : 'skip'
   }
   // Confirmation window: one down sample is a suspicion, not a verdict.
   const msDown = Number.isFinite(input.msDown) ? (input.msDown as number) : 0

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -52,7 +52,14 @@ import { sendRoutineAlert } from './routine-alert.js'
 import { getProvider, channelStateDir, readChannelToken, type ChannelProviderType } from '../channel-provider.js'
 import { attemptChannelMcpReconnect } from './channel-mcp-reconnect.js'
 import { readLastIngestionTimestamp, TRANSCRIPT_DIR } from './inbound-probe.js'
-import { decideDownAgentAction, AGENT_MAX_RESTART_ATTEMPTS, parseEtimeToSeconds } from './agent-restart-policy.js'
+import {
+  decideDownAgentAction,
+  AGENT_MAX_RESTART_ATTEMPTS,
+  AGENT_FAILURE_COUNT_TTL_MS,
+  GIVE_UP_REALERT_MS,
+  isFailureCountStale,
+  parseEtimeToSeconds,
+} from './agent-restart-policy.js'
 // getClaudePidForSession + hasChannelPluginAlive live in the shared liveness
 // module so the standalone channel-coordinator reuses the exact same probe.
 import { getClaudePidForSession, hasChannelPluginAlive, probeChannelPluginLiveness, classifyRespawnStampAdvance } from '../channel-coordinator/liveness.js'
@@ -142,13 +149,61 @@ function agentFailuresPath(agentName: string): string {
   return join(PROJECT_ROOT, 'store', `.agent-failures-${agentName}`)
 }
 
+function giveUpAlertPath(agentName: string): string {
+  return join(PROJECT_ROOT, 'store', `.agent-giveup-alert-${agentName}`)
+}
+
 function loadPersistedAgentFailures(agentName: string): number {
+  const path = agentFailuresPath(agentName)
   try {
-    const n = parseInt(readFileSync(agentFailuresPath(agentName), 'utf-8').trim(), 10)
-    return Number.isFinite(n) && n >= 0 ? n : 0
+    const n = parseInt(readFileSync(path, 'utf-8').trim(), 10)
+    if (!Number.isFinite(n) || n < 0) return 0
+    if (n === 0) return 0
+    // A count nobody has written to for a day describes an incident that is
+    // over, or one whose own persistence is what keeps it alive: past the cap
+    // nothing restarts the plugin, so nothing can ever observe it healthy and
+    // clear the count. Finy's sat at 6 from 2026-07-09 for five days. Ageing
+    // it out lets the watchdog try again instead of honouring a frozen verdict.
+    let mtimeMs: number | null = null
+    try {
+      mtimeMs = statSync(path).mtimeMs
+    } catch {
+      mtimeMs = null
+    }
+    if (isFailureCountStale(mtimeMs, Date.now(), AGENT_FAILURE_COUNT_TTL_MS)) {
+      logger.info(
+        { agent: agentName, failures: n, ageHours: mtimeMs != null ? Math.round((Date.now() - mtimeMs) / 3600000) : null },
+        'channel-monitor: persisted restart failure count is stale -- starting the agent with a clean slate',
+      )
+      return 0
+    }
+    return n
   } catch {
     return 0
   }
+}
+
+function loadGiveUpAlertAt(agentName: string): number | null {
+  try {
+    const n = parseInt(readFileSync(giveUpAlertPath(agentName), 'utf-8').trim(), 10)
+    return Number.isFinite(n) && n > 0 ? n : null
+  } catch {
+    return null
+  }
+}
+
+function saveGiveUpAlertAt(agentName: string, atMs: number): void {
+  try {
+    writeFileSync(giveUpAlertPath(agentName), String(atMs))
+  } catch (err) {
+    logger.debug({ err, agentName }, 'Failed to persist give-up alert timestamp (non-fatal)')
+  }
+}
+
+function clearGiveUpAlertAt(agentName: string): void {
+  try {
+    writeFileSync(giveUpAlertPath(agentName), '0')
+  } catch { /* best effort */ }
 }
 
 function savePersistedAgentFailures(agentName: string, count: number): void {
@@ -2077,6 +2132,10 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
           // down-spell starts again at the base grace.
           agentRestartFailures.delete(t.agentName!)
           clearPersistedAgentFailures(t.agentName!)
+          // The re-alert clock belongs to the spell, not to the agent: a future
+          // give-up must announce itself immediately rather than inheriting the
+          // cadence of the last one.
+          clearGiveUpAlertAt(t.agentName!)
           agentBusyDeferAlerted.delete(t.session)
           // Retire any stale absent verdict too, so a future down-spell starts
           // with the full restart budget rather than the absent-capped one.
@@ -2134,6 +2193,11 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
           downConfirmMs: AGENT_DOWN_CONFIRM_MS,
           agentBusy,
           busyDeferMaxMs: AGENT_BUSY_DEFER_MAX_MS,
+          msSinceGiveUpAlert: (() => {
+            const at = loadGiveUpAlertAt(t.agentName!)
+            return at != null ? Date.now() - at : null
+          })(),
+          giveUpRealertMs: GIVE_UP_REALERT_MS,
         }, maxRestartAttempts)
         if (action === 'alert-busy') {
           // The channel has been down past the deferral cap while the agent kept
@@ -2158,15 +2222,29 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
         if (action === 'alert') {
           // The cap is reached: restarting is not bringing the plugin back, and
           // each restart costs the agent its whole session context. Stop the
-          // loop and hand it to a human. Tick the counter past the cap so this
-          // fires exactly once; a later healthy sweep resets it (re-arming the
-          // alert for a future down-spell).
-          logger.error({ agent: t.agentName, provider: t.provider, failures, absentConfirmed }, 'Agent channel plugin down after max restart attempts -- giving up, alerting operator')
+          // loop and hand it to a human -- and keep saying so. The counter that
+          // would end this spell is only cleared by a healthy observation, and
+          // nothing restarts the plugin any more, so silence here lasts until
+          // someone happens to look. Finy's did for five days.
+          const isRepeat = failures > maxRestartAttempts
+          const downSinceMs = agentDownSince.get(t.session)
+          const spellHours = downSinceMs != null ? Math.round((Date.now() - downSinceMs) / 3600000) : null
+          logger.error({ agent: t.agentName, provider: t.provider, failures, absentConfirmed, isRepeat, spellHours }, 'Agent channel plugin down after max restart attempts -- giving up, alerting operator')
+          const stillPrefix = isRepeat
+            ? `⛔ MÉG MINDIG: a(z) ${t.agentName} ágens ${t.provider} csatornája halott, és nem próbálom újraindítani. `
+            : ''
           sendAlert(absentConfirmed
-            ? `⛔ A(z) ${t.agentName} ágens ${t.provider} plugin-je BE SEM TÖLTŐDÖTT (absent a /mcp listából), a fresh-restart ezt nem javítja -- tovább nem próbálom (minden restart elveszi a session kontextusát). Kézi TISZTA újraindítás kell (üresen, más ágens indulásával nem átlapolva): ${t.session}.`
-            : `⛔ A(z) ${t.agentName} ágens ${t.provider} csatornája ${AGENT_MAX_RESTART_ATTEMPTS} automatikus újraindítás után sem állt helyre. Tovább nem indítom újra (minden restart elveszi a session kontextusát). Kézi beavatkozás kell: nézd meg a ${t.session} session-t és a ${SERVICE_ID} csatorna-plugint.`)
-          agentRestartFailures.set(t.agentName!, failures + 1)
-          savePersistedAgentFailures(t.agentName!, failures + 1)
+            ? `${stillPrefix}⛔ A(z) ${t.agentName} ágens ${t.provider} plugin-je BE SEM TÖLTŐDÖTT (absent a /mcp listából), a fresh-restart ezt nem javítja -- tovább nem próbálom (minden restart elveszi a session kontextusát). Kézi TISZTA újraindítás kell (üresen, más ágens indulásával nem átlapolva): ${t.session}.`
+            : `${stillPrefix}⛔ A(z) ${t.agentName} ágens ${t.provider} csatornája ${AGENT_MAX_RESTART_ATTEMPTS} automatikus újraindítás után sem állt helyre. Tovább nem indítom újra (minden restart elveszi a session kontextusát). Kézi beavatkozás kell: nézd meg a ${t.session} session-t és a ${SERVICE_ID} csatorna-plugint.`)
+          // Only the FIRST alert of a spell ticks the counter past the cap.
+          // Later ones are the same standing fact repeated on a cadence, and
+          // incrementing there would inflate a number the operator reads as
+          // "restart attempts".
+          if (failures === maxRestartAttempts) {
+            agentRestartFailures.set(t.agentName!, failures + 1)
+            savePersistedAgentFailures(t.agentName!, failures + 1)
+          }
+          saveGiveUpAlertAt(t.agentName!, Date.now())
           agentDownSince.delete(t.session)
           agentBusyDeferAlerted.delete(t.session)
           continue


### PR DESCRIPTION
## Az önfenntartó holtpont

Amikor a watchdog eléri a restart-plafont, egyszer riaszt, majd a spell hátralévő részében `skip`-et ad. A spellnek viszont **nincs természetes vége**: a számlálót csak egy egészséges plugin-észlelés nullázza, az pedig restartot igényel — amit épp a számláló tilt.

Finy 2026-07-09-én kapott egy riasztást, és öt napig nem kapott többet. A dashboard végig `running`-ot mutatott.

## Két oldalról töröm meg

*1. A feladott állapot újramondja magát.* A plafon fölött a döntés már nem némul el, hanem **3 órás ritmusban** ismétel. A másodiktól kezdve a szöveg `MÉG MINDIG` prefixet kap — egy álló állapot ismétlése más hír, mint egy új esemény.

A ritmus a flotta többi „leállt/halott" jelzéséhez igazodik (a tulajdonos pár órás kadenciát kért, nem tízpercest). A kártya hatot javasolt, de az a döntés előtt született.

Az időbélyeg lemezre kerül (`store/.agent-giveup-alert-<agent>`), tehát egy dashboard-újraindulás nem indítja újra a ritmust; a plugin helyreállásakor törlődik, így a következő feladás azonnal megszólal, nem örökli az előzőét.

*2. A befagyott számláló elévül.* A perzisztált érték 24 óra után 0-ként olvasódik be (`isFailureCountStale` + a fájl `mtime`-ja). Ez a másik oldalról nyitja a holtpontot. Ismeretlen fájlkor **nem** elévültség (marad a számláló), és a jövőbe mutató időbélyeg sem az — az elévülés kor kérdése, ami egyirányú.

A plafon fölötti ismételt riasztás **nem** növeli tovább a számlálót: csak az első riasztás ticket, a többi ugyanannak az álló ténynek az ismétlése.

## Szerződés-változás, két meglévő teszt igazítva

Az `agent-restart-policy.test.ts` két esete pontosan a régi „néma a plafon fölött" viselkedést rögzítette. Nem azért írtam át őket, hogy zöldek legyenek, hanem mert **épp az a viselkedés a kártya tárgya**; az új alak azt rögzíti, hogy a csend csak a ritmuson belül áll.

## Mérés

13 új eset a döntésre és az elévülésre. Négy mutációs próba:

| mutáció | bukó tesztek |
|---|---|
| a plafon fölötti csend visszaállítása | 6 |
| ismeretlen utolsó-riasztás csendre váltva | 1 |
| ismeretlen fájlkor elévültnek véve | 1 |
| jövőbe mutató időbélyeg elévültnek véve | 1 |

Az utolsó **először túlélte** a próbát: a tesztem egy órával a jövőben állt, ami a 24 órás ablakon belül van, tehát nem különböztette meg a két szabályt. A határra kitolva már fog — a mutáció mutatta meg, hogy az eredeti teszt a saját állítását nem hordozta.

Teljes suite: 4843 zöld, 1 skipped. `tsc --noEmit` tiszta.

## Hatókör

A kártya (`a664f9b2`) első és harmadik kérése. A második — a `runState` tükrözze a feladást — **nincs benne**: az a router és a scheduler delivery-kapuját érinti, külön kockázat. A természetes helye a #1213 aktivitás-címkéje, ami még merge-re vár.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148rV8xMuHmpCgH1T8J1ZJz
