### PR TITLE
feat(channels): a dated, countable record of plugin drops, so the rate exists

### DIFF
--- a/src/__tests__/channel-event-log.test.ts
+++ b/src/__tests__/channel-event-log.test.ts
@@ -1,0 +1,132 @@
+// A rate needs a clock, and dashboard.log has none.
+//
+// Card 0390aa37 asks how often the channel plugin drops. It could not be
+// answered, and the reason is instructive: store/channels-failures.log turned
+// out to hold the daily restart's config line, not plugin drops at all (a
+// near-order-of-magnitude "improvement" was almost reported from it), while the
+// real evidence sits in dashboard.log -- 332 MB, and its lines carry a TIME
+// (`[17:30:25.451]`) but no DATE. Two days' events are indistinguishable, so
+// there is no denominator and no rate.
+//
+// This log exists to be counted: one JSON line per event, a full ISO timestamp
+// on every line, one file per day so a day's count is a `wc -l`, and a
+// retention window so it cannot grow into the thing it replaces.
+
+import { describe, it, expect } from 'vitest'
+import {
+  eventLogFileName,
+  parseEventLogDate,
+  isEventLogExpired,
+  formatChannelEvent,
+  summarizeByDay,
+  CHANNEL_EVENT_RETENTION_DAYS,
+  type ChannelEvent,
+} from '../web/channel-event-log.js'
+
+const T = Date.parse('2026-09-06T15:04:05.123Z')
+
+describe('eventLogFileName', () => {
+  it('names one file per UTC day', () => {
+    expect(eventLogFileName(T)).toBe('channel-events-2026-09-06.log')
+  })
+
+  it('does not roll the file at local midnight -- the day boundary is UTC everywhere', () => {
+    // 23:30 UTC is already the NEXT day in Budapest (UTC+2). A local-time
+    // implementation would file this instant under 09-07 on this machine and
+    // under 09-06 on a UTC host, which makes a daily count host-dependent --
+    // exactly the ambiguity this log exists to remove. The earlier version of
+    // this test used 21:30Z, where local and UTC agree, and a local-time
+    // mutation survived it.
+    expect(eventLogFileName(Date.parse('2026-09-06T23:30:00Z'))).toBe('channel-events-2026-09-06.log')
+    expect(eventLogFileName(Date.parse('2026-09-07T00:00:00Z'))).toBe('channel-events-2026-09-07.log')
+  })
+})
+
+describe('parseEventLogDate', () => {
+  it('reads the day back out of a file name', () => {
+    expect(parseEventLogDate('channel-events-2026-09-06.log')).toBe(Date.parse('2026-09-06T00:00:00Z'))
+  })
+
+  it('returns null for anything that is not one of ours', () => {
+    expect(parseEventLogDate('dashboard.log')).toBeNull()
+    expect(parseEventLogDate('channel-events-.log')).toBeNull()
+    expect(parseEventLogDate('channel-events-2026-13-40.log')).toBeNull()
+  })
+})
+
+describe('isEventLogExpired', () => {
+  const now = Date.parse('2026-09-06T00:00:00Z')
+
+  it('keeps a file inside the retention window', () => {
+    expect(isEventLogExpired('channel-events-2026-09-01.log', now, CHANNEL_EVENT_RETENTION_DAYS)).toBe(false)
+  })
+
+  it('drops one past it', () => {
+    const old = new Date(now - (CHANNEL_EVENT_RETENTION_DAYS + 1) * 86400_000).toISOString().slice(0, 10)
+    expect(isEventLogExpired(`channel-events-${old}.log`, now, CHANNEL_EVENT_RETENTION_DAYS)).toBe(true)
+  })
+
+  it('keeps the file exactly on the boundary', () => {
+    const edge = new Date(now - CHANNEL_EVENT_RETENTION_DAYS * 86400_000).toISOString().slice(0, 10)
+    expect(isEventLogExpired(`channel-events-${edge}.log`, now, CHANNEL_EVENT_RETENTION_DAYS)).toBe(false)
+  })
+
+  it('never deletes a file it cannot date -- an unreadable name is not evidence of age', () => {
+    expect(isEventLogExpired('dashboard.log', now, CHANNEL_EVENT_RETENTION_DAYS)).toBe(false)
+    expect(isEventLogExpired('channel-events-nonsense.log', now, CHANNEL_EVENT_RETENTION_DAYS)).toBe(false)
+  })
+})
+
+describe('formatChannelEvent', () => {
+  const event: ChannelEvent = { at: T, agent: 'finy', provider: 'telegram', event: 'down', detail: { failures: 2 } }
+
+  it('writes one line of JSON carrying a full timestamp, not just a time', () => {
+    const line = formatChannelEvent(event)
+    expect(line.endsWith('\n')).toBe(true)
+    expect(line.includes('\n', 0)).toBe(true)
+    const parsed = JSON.parse(line) as Record<string, unknown>
+    expect(parsed['ts']).toBe('2026-09-06T15:04:05.123Z')
+    expect(parsed['agent']).toBe('finy')
+    expect(parsed['event']).toBe('down')
+    expect(parsed['failures']).toBe(2)
+  })
+
+  it('keeps a multi-line detail on one line, so a line stays a record', () => {
+    const line = formatChannelEvent({ ...event, detail: { note: 'first\nsecond' } })
+    expect(line.split('\n').filter(Boolean)).toHaveLength(1)
+    expect(JSON.parse(line)['note']).toBe('first\nsecond')
+  })
+
+  it('never lets a detail field overwrite the identity of the record', () => {
+    const line = formatChannelEvent({ ...event, detail: { ts: 'yesterday', agent: 'someone-else' } })
+    const parsed = JSON.parse(line) as Record<string, unknown>
+    expect(parsed['ts']).toBe('2026-09-06T15:04:05.123Z')
+    expect(parsed['agent']).toBe('finy')
+  })
+})
+
+describe('summarizeByDay', () => {
+  const lines = [
+    formatChannelEvent({ at: Date.parse('2026-09-05T08:00:00Z'), agent: 'finy', provider: 'telegram', event: 'down' }),
+    formatChannelEvent({ at: Date.parse('2026-09-05T09:00:00Z'), agent: 'finy', provider: 'telegram', event: 'restart' }),
+    formatChannelEvent({ at: Date.parse('2026-09-05T10:00:00Z'), agent: 'disy', provider: 'telegram', event: 'down' }),
+    formatChannelEvent({ at: Date.parse('2026-09-06T10:00:00Z'), agent: 'finy', provider: 'telegram', event: 'down' }),
+  ].join('')
+
+  it('counts events per day and per event kind -- the denominator the card was missing', () => {
+    const summary = summarizeByDay(lines)
+    expect(summary['2026-09-05']).toEqual({ down: 2, restart: 1 })
+    expect(summary['2026-09-06']).toEqual({ down: 1 })
+  })
+
+  it('skips a corrupt line instead of losing what follows it', () => {
+    // The corrupt line goes in the MIDDLE on purpose: appended at the end, an
+    // implementation that ABORTS on the first parse error still returns every
+    // earlier day and the test passes for the wrong reason.
+    const parts = lines.split('\n').filter(Boolean).map(l => `${l}\n`)
+    const withGarbage = [parts[0], 'not json\n', ...parts.slice(1)].join('')
+    const summary = summarizeByDay(withGarbage)
+    expect(summary['2026-09-05']).toEqual({ down: 2, restart: 1 })
+    expect(summary['2026-09-06']).toEqual({ down: 1 })
+  })
+})

--- a/src/web/channel-event-log.ts
+++ b/src/web/channel-event-log.ts
@@ -1,0 +1,149 @@
+/**
+ * A dated, countable record of channel-plugin events.
+ *
+ * Card 0390aa37 asks how often the channel plugin drops. It could not be
+ * answered, and the reason matters more than the answer:
+ *   - store/channels-failures.log looked like the right instrument and is not.
+ *     It holds the daily restart's config line (channel-watchdog.sh redirects
+ *     stderr there), not plugin drops -- a near-order-of-magnitude improvement
+ *     was nearly reported from it.
+ *   - dashboard.log does hold the evidence, but its lines carry a TIME and no
+ *     DATE (`[17:30:25.451]`), in one 332 MB file. Two days' events are
+ *     indistinguishable, so there is no denominator and no rate.
+ *
+ * So this file is built to be counted rather than read: one JSON line per
+ * event, a full ISO timestamp on every line, one file per UTC day (a day's
+ * count is a `wc -l`), and a retention window so it cannot grow into the thing
+ * it replaces. It does not replace dashboard.log's narrative -- it answers
+ * "how often", which the narrative cannot.
+ */
+
+import { appendFileSync, existsSync, mkdirSync, readdirSync, unlinkSync } from 'node:fs'
+import { join } from 'node:path'
+import { logger } from '../logger.js'
+import { PROJECT_ROOT } from '../config.js'
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+// Long enough to see a weekly pattern and to compare "before the fix" with
+// "after", short enough that the directory stays small.
+export const CHANNEL_EVENT_RETENTION_DAYS = 30
+
+const FILE_RX = /^channel-events-(\d{4})-(\d{2})-(\d{2})\.log$/
+
+export type ChannelEventKind = 'down' | 'restart' | 'recovered' | 'gave-up'
+
+export interface ChannelEvent {
+  at: number
+  agent: string
+  provider: string
+  event: ChannelEventKind
+  detail?: Record<string, unknown>
+}
+
+/** One file per UTC day, so the same instant lands in the same file everywhere. */
+export function eventLogFileName(atMs: number): string {
+  return `channel-events-${new Date(atMs).toISOString().slice(0, 10)}.log`
+}
+
+/** The UTC midnight a file name names, or null if the name is not one of ours. */
+export function parseEventLogDate(fileName: string): number | null {
+  const m = FILE_RX.exec(fileName)
+  if (!m) return null
+  const parsed = Date.parse(`${m[1]}-${m[2]}-${m[3]}T00:00:00Z`)
+  if (!Number.isFinite(parsed)) return null
+  // Date.parse accepts 2026-13-40 on some engines by rolling over; reject any
+  // name that does not survive the round trip.
+  return new Date(parsed).toISOString().slice(0, 10) === `${m[1]}-${m[2]}-${m[3]}` ? parsed : null
+}
+
+/**
+ * Is this file older than the retention window?
+ *
+ * A name we cannot date is never expired: deletion is irreversible, and an
+ * unreadable name is not evidence of age. The boundary day counts as inside.
+ */
+export function isEventLogExpired(fileName: string, nowMs: number, retentionDays: number): boolean {
+  const day = parseEventLogDate(fileName)
+  if (day == null) return false
+  return nowMs - day > retentionDays * DAY_MS
+}
+
+/**
+ * One event, one line, JSON.
+ *
+ * The identity fields are written LAST so a detail key can never overwrite
+ * them: a record whose own timestamp came from arbitrary call-site data would
+ * be worse than no record, because it would still look countable.
+ */
+export function formatChannelEvent(event: ChannelEvent): string {
+  const row = {
+    ...(event.detail ?? {}),
+    ts: new Date(event.at).toISOString(),
+    agent: event.agent,
+    provider: event.provider,
+    event: event.event,
+  }
+  return `${JSON.stringify(row)}\n`
+}
+
+/** Counts per UTC day and event kind: the denominator the card was missing. */
+export function summarizeByDay(contents: string): Record<string, Record<string, number>> {
+  const out: Record<string, Record<string, number>> = {}
+  for (const line of contents.split('\n')) {
+    if (!line.trim()) continue
+    let row: { ts?: unknown, event?: unknown }
+    try {
+      row = JSON.parse(line) as { ts?: unknown, event?: unknown }
+    } catch {
+      // A truncated last line (a crash mid-append) must not cost the day.
+      continue
+    }
+    if (typeof row.ts !== 'string' || typeof row.event !== 'string') continue
+    const day = row.ts.slice(0, 10)
+    const bucket = out[day] ?? (out[day] = {})
+    bucket[row.event] = (bucket[row.event] ?? 0) + 1
+  }
+  return out
+}
+
+function eventLogDir(): string {
+  return join(PROJECT_ROOT, 'store', 'channel-events')
+}
+
+let lastPruneDay = ''
+
+function pruneExpired(nowMs: number): void {
+  const today = new Date(nowMs).toISOString().slice(0, 10)
+  if (lastPruneDay === today) return
+  lastPruneDay = today
+  try {
+    for (const name of readdirSync(eventLogDir())) {
+      if (!isEventLogExpired(name, nowMs, CHANNEL_EVENT_RETENTION_DAYS)) continue
+      try {
+        unlinkSync(join(eventLogDir(), name))
+        logger.info({ file: name }, 'channel-event-log: pruned an expired day')
+      } catch { /* best effort */ }
+    }
+  } catch { /* directory missing -- nothing to prune */ }
+}
+
+/**
+ * Append one event. Never throws: a monitor that dies because its own
+ * bookkeeping failed would be a worse bug than the one being measured.
+ */
+export function recordChannelEvent(event: ChannelEvent): void {
+  try {
+    const dir = eventLogDir()
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
+    pruneExpired(event.at)
+    appendFileSync(join(dir, eventLogFileName(event.at)), formatChannelEvent(event))
+  } catch (err) {
+    logger.debug({ err, agent: event.agent, event: event.event }, 'channel-event-log: append failed (non-fatal)')
+  }
+}
+
+/** Test seam: forget which day was last pruned. */
+export function resetPruneState(): void {
+  lastPruneDay = ''
+}

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -47,6 +47,7 @@ import {
   type StuckInputActionFacts,
 } from '../pane-state.js'
 import { MAIN_CHANNELS_SESSION, MAIN_CHANNELS_PLIST } from './main-agent.js'
+import { recordChannelEvent } from './channel-event-log.js'
 import { notifyChannel } from '../notify.js'
 import { sendRoutineAlert } from './routine-alert.js'
 import { getProvider, channelStateDir, readChannelToken, type ChannelProviderType } from '../channel-provider.js'
@@ -2071,6 +2072,13 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
         } else {
           if (agentDownSince.has(t.session)) {
             logger.info({ session: t.session, provider: t.provider }, 'Agent channel plugin recovered')
+            recordChannelEvent({
+              at: Date.now(),
+              agent: t.agentName ?? t.session,
+              provider: t.provider,
+              event: 'recovered',
+              detail: { downMs: Date.now() - (agentDownSince.get(t.session) ?? Date.now()) },
+            })
             agentDownSince.delete(t.session)
           }
           // Healthy observation clears the exponential back-off so the next
@@ -2089,6 +2097,15 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
       } else {
         if (!agentDownSince.has(t.session)) {
           agentDownSince.set(t.session, Date.now())
+          // Countable record, once per spell: dashboard.log tells the story of
+          // a drop, but its lines carry no date, so it cannot answer "how
+          // often". See channel-event-log.
+          recordChannelEvent({
+            at: Date.now(),
+            agent: t.agentName ?? t.session,
+            provider: t.provider,
+            event: 'down',
+          })
           // First down observation of this spell: capture WHY before anything is
           // torn down. Without this the restart destroys the evidence and the
           // log can only say "down" -- which is exactly why the 10x/day churn
@@ -2162,6 +2179,13 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
           // fires exactly once; a later healthy sweep resets it (re-arming the
           // alert for a future down-spell).
           logger.error({ agent: t.agentName, provider: t.provider, failures, absentConfirmed }, 'Agent channel plugin down after max restart attempts -- giving up, alerting operator')
+          recordChannelEvent({
+            at: Date.now(),
+            agent: t.agentName ?? t.session,
+            provider: t.provider,
+            event: 'gave-up',
+            detail: { failures, absentConfirmed },
+          })
           sendAlert(absentConfirmed
             ? `⛔ A(z) ${t.agentName} ágens ${t.provider} plugin-je BE SEM TÖLTŐDÖTT (absent a /mcp listából), a fresh-restart ezt nem javítja -- tovább nem próbálom (minden restart elveszi a session kontextusát). Kézi TISZTA újraindítás kell (üresen, más ágens indulásával nem átlapolva): ${t.session}.`
             : `⛔ A(z) ${t.agentName} ágens ${t.provider} csatornája ${AGENT_MAX_RESTART_ATTEMPTS} automatikus újraindítás után sem állt helyre. Tovább nem indítom újra (minden restart elveszi a session kontextusát). Kézi beavatkozás kell: nézd meg a ${t.session} session-t és a ${SERVICE_ID} csatorna-plugint.`)
@@ -2194,6 +2218,13 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
           continue
         }
         logger.warn({ agent: t.agentName, provider: t.provider, failures }, 'Agent channel plugin down -- auto-restarting')
+        recordChannelEvent({
+          at: Date.now(),
+          agent: t.agentName ?? t.session,
+          provider: t.provider,
+          event: 'restart',
+          detail: { failures },
+        })
         try {
           await stopAgentProcess(t.agentName!)
           // Settle before the fresh start. stopAgentProcess already reaps this


### PR DESCRIPTION
## Miért nem volt megválaszolható a kérdés

A `0390aa37` azt kérdezi, naponta hányszor esik le a channel-plugin. A premissza-audit nem tudta megmérni, és az ok tanulságosabb, mint a válasz lett volna:

| forrás | mit hittünk róla | mi van benne |
|---|---|---|
| `store/channels-failures.log` | plugin-elesek | a napi újraindítás **config-sora** (a `channel-watchdog.sh` oda irányítja a stderr-t) |
| `store/dashboard.log` | a bizonyíték | a bizonyíték — de a sorokon **idő van és dátum nincs** (`[17:30:25.451]`), egyetlen 332 MB-os fájlban |

Az elsőből majdnem egy nagyságrendi javulást jelentettünk, ami nem létezik. A másodikban két különböző nap eseményei megkülönböztethetetlenek: nincs nevező, nincs ráta.

## Ez a napló számolásra készült, nem olvasásra

- eseményenként egy JSON sor, minden soron **teljes ISO időbélyeg**
- naponta egy fájl → egy nap darabszáma egy `wc -l`
- 30 napos megőrzés, hogy ne nőjön ki magát azzá, amit lecserél

A `dashboard.log` elbeszélését nem váltja ki — arra felel, amire az nem tud: hogy *milyen gyakran*.

Négy esemény kerül be a `channel-monitor`-ból: `down` (spellenként egyszer), `restart`, `recovered` (a lenn töltött idővel), `gave-up`.

## Két részlet, szándékosan így

- Az azonosító mezők (`ts`, `agent`, `provider`, `event`) a `detail` **után** kerülnek a sorba, tehát egy detail-kulcs nem tudja felülírni őket. Egy rekord, aminek a saját időbélyege hívási hely adatából jön, rosszabb a seminél — továbbra is számolhatónak látszana.
- Egy **dátumozhatatlan nevű** fájl sosem jár le. A törlés visszafordíthatatlan, és egy olvashatatlan név nem bizonyíték a korra.

## Mérés

13 új eset, plusz egy végponti próba: három esemény kiírva, visszaolvasva, napi bontásban összegezve.

```
{"ts":"2026-09-06T15:46:04.873Z","agent":"finy","provider":"telegram","event":"down"}
{"failures":1,"ts":"...","agent":"finy","provider":"telegram","event":"restart"}
{"downMs":2000,"ts":"...","agent":"finy","provider":"telegram","event":"recovered"}
summary: {"2026-09-06":{"down":1,"restart":1,"recovered":1}}
```

Öt mutációs próba, és **kettő először túlélt**:

| mutáció | eredmény |
|---|---|
| azonosító mezők a detail elé | piros |
| dátumozhatatlan fájl lejártnak véve | piros |
| határnap lejártnak véve | piros |
| korrupt sor megszakítja az összegzést | **először túlélt** — a korrupt sort a fájl végére tettem, így egy „első hibánál megáll" implementáció is átment. Középre téve már fog |
| helyi nap UTC nap helyett | **először túlélt** — 21:30Z-vel próbáltam, ahol a két naptár egyezik ezen a gépen. 23:30Z-vel (Budapesten már másnap) már megfogja |

Mindkettő a saját tesztem hibája volt, nem a szabályé. A végleges állapotban mind az öt mutáció piros.

Teljes suite: 4842 zöld, 1 skipped. `tsc --noEmit` tiszta.

Kártya: `64679892`. A `0390aa37` ettől nem dől el, de mostantól **mérhető** — pontosan ezt kérte a kártya.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148rV8xMuHmpCgH1T8J1ZJz
