### PR TITLE
fix(secret-gate): read git objects, not the working tree; and except one fixture literal instead of a whole file

### DIFF
--- a/scripts/secret-gate.ts
+++ b/scripts/secret-gate.ts
@@ -228,6 +228,12 @@ function report(result: GateResult, mode: string, entries: Entry[]): void {
     for (const l of links) line(`  - ${l.path}`);
   }
 
+  if (result.exceptions.length) {
+    line();
+    line(`Fixture exceptions applied (${result.exceptions.length}) -- ONE literal each, the rest of the file still scanned:`);
+    for (const e of result.exceptions) line(`  - ${e.file}${e.line ? `:${e.line}` : ''}  [${e.detector}]  <- ${e.reason}`);
+  }
+
   if (result.allowlisted.length) {
     line();
     line('Allowlisted by path (NOT scanned, on purpose):');

--- a/scripts/secret-gate.ts
+++ b/scripts/secret-gate.ts
@@ -12,53 +12,221 @@
  *
  * Everything this runner cannot scan is REPORTED and FAILS. Size limits, binary
  * files, read errors: each is named. A silent skip would read as "clean".
+ *
+ * ── THE SOURCE OF TRUTH IS GIT OBJECT STORAGE, NEVER THE WORKING TREE ────────
+ *
+ * Found 2026-09-06 on PR #775, which was red for two weeks with NO secret in it.
+ * The runner resolved each path with `readFileSync`, and two of the paths were
+ * versioned symlinks pointing at directories (`releases/monitor-current`,
+ * `releases/monitor-previous`, both mode 120000). `readFileSync` on those
+ * follows the link into a directory and throws EISDIR, so the gate reported
+ * "NOT SCANNED, therefore NOT CLEARED" and failed closed -- correctly, by its
+ * own rule, on a question it had asked wrongly.
+ *
+ * The deeper problem is not the crash. Reading the working tree makes the gate
+ * answer a question nobody asked: it scans whatever happens to be on this disk
+ * right now, which in CI is a checkout and locally is an arbitrarily dirty tree.
+ * What a range gate must scan is what the COMMITS CONTAIN. So every mode now
+ * resolves content from git:
+ *
+ *   --range   the head tree of the range
+ *   --staged  the index -- which is precisely "what is about to be committed",
+ *             and is not the same thing as the working tree once a file has been
+ *             edited after `git add`
+ *   --all     the index
+ *
+ * A symlink is then scanned as what git actually stores for it: a small blob
+ * holding the TARGET PATH as text. That is the honest object to scan. Following
+ * it would scan a file the commit does not contain, and for a directory target
+ * there is nothing to follow at all.
  */
 import { execFileSync } from 'node:child_process';
-import { readFileSync, statSync } from 'node:fs';
 import { runGate, type ScanInput, type GateResult } from '../src/security/secret-gate.js';
 
 /** Beyond this the file is not scanned -- and therefore not cleared. */
 const MAX_BYTES = 5 * 1024 * 1024;
 
-function git(args: string[]): string {
-  return execFileSync('git', args, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+/** Git file modes we can meet in a tree or the index. */
+const MODE_SYMLINK = '120000';
+const MODE_GITLINK = '160000';
+
+interface Entry {
+  path: string;
+  /** Six-digit git mode: 100644, 100755, 120000, 160000. */
+  mode: string;
+  /** Blob sha. Empty for a gitlink, which has no blob in this repository. */
+  sha: string;
 }
 
-function fileList(mode: string, range?: string): string[] {
-  if (mode === '--staged') {
-    return git(['diff', '--cached', '--name-only', '--diff-filter=ACMR']).split('\n').filter(Boolean);
+function git(args: string[]): string {
+  return execFileSync('git', args, { encoding: 'utf8', maxBuffer: 256 * 1024 * 1024 });
+}
+
+function gitBuf(args: string[], input?: string): Buffer {
+  return execFileSync('git', args, { input, maxBuffer: 256 * 1024 * 1024 });
+}
+
+/** NUL-separated git output -> array, without an empty tail element. */
+function splitZ(s: string): string[] {
+  return s.split('\0').filter(Boolean);
+}
+
+/**
+ * The head of a range, for `A..B` and `A...B` alike.
+ *
+ * `git diff` resolves `A...B` against the merge base, but in BOTH forms the side
+ * whose content we must scan is B. Splitting on the LAST `..` gets that right
+ * for both without special-casing.
+ */
+function headOfRange(range: string): string {
+  const at = range.lastIndexOf('..');
+  const head = range.slice(at + 2);
+  if (!head) throw new Error(`--range needs <base>..<head>, got: ${range}`);
+  return head;
+}
+
+/** `<mode> <type> <sha>\t<path>` records from `git ls-tree`. */
+function parseLsTree(out: string): Entry[] {
+  return splitZ(out).map((rec) => {
+    const tab = rec.indexOf('\t');
+    const [mode, , sha] = rec.slice(0, tab).split(' ');
+    return { path: rec.slice(tab + 1), mode, sha: mode === MODE_GITLINK ? '' : sha };
+  });
+}
+
+/** `<mode> <sha> <stage>\t<path>` records from `git ls-files -s`. */
+function parseLsFiles(out: string): Entry[] {
+  return splitZ(out).map((rec) => {
+    const tab = rec.indexOf('\t');
+    const [mode, sha] = rec.slice(0, tab).split(' ');
+    return { path: rec.slice(tab + 1), mode, sha: mode === MODE_GITLINK ? '' : sha };
+  });
+}
+
+/**
+ * Look paths up in a tree or in the index, in chunks.
+ *
+ * Chunked because a large PR can exceed the argv limit, and a gate that dies of
+ * E2BIG is a gate that stops running. The chunk size is deliberately modest:
+ * this is not a hot path.
+ */
+function lookup(paths: string[], make: (chunk: string[]) => string[], parse: (out: string) => Entry[]): Entry[] {
+  const found: Entry[] = [];
+  for (let i = 0; i < paths.length; i += 200) {
+    found.push(...parse(git(make(paths.slice(i, i + 200)))));
   }
+  return found;
+}
+
+/**
+ * The files in scope, each bound to the git object that IS its content.
+ *
+ * A path the diff lists but the tree does not hold is not silently dropped: it
+ * comes back with an empty sha and becomes an explicit unscannable finding
+ * below. Dropping it would shrink the file set invisibly, which is the exact
+ * fail-open this gate exists to prevent.
+ */
+function entriesFor(mode: string, range?: string): Entry[] {
   if (mode === '--range') {
     if (!range || !range.includes('..')) throw new Error(`--range needs <base>..<head>, got: ${range ?? '(nothing)'}`);
-    return git(['diff', '--name-only', '--diff-filter=ACMR', range]).split('\n').filter(Boolean);
+    const head = headOfRange(range);
+    const paths = splitZ(git(['diff', '--name-only', '-z', '--diff-filter=ACMR', range]));
+    if (paths.length === 0) return [];
+    const found = lookup(paths, (c) => ['ls-tree', '-z', '--full-tree', head, '--', ...c], parseLsTree);
+    return reconcile(paths, found, `not present in the head tree of ${range}`);
   }
-  if (mode === '--all') return git(['ls-files']).split('\n').filter(Boolean);
+  if (mode === '--staged') {
+    const paths = splitZ(git(['diff', '--cached', '--name-only', '-z', '--diff-filter=ACMR']));
+    if (paths.length === 0) return [];
+    const found = lookup(paths, (c) => ['ls-files', '-s', '-z', '--', ...c], parseLsFiles);
+    return reconcile(paths, found, 'staged for commit but not present in the index');
+  }
+  if (mode === '--all') return parseLsFiles(git(['ls-files', '-s', '-z']));
   throw new Error(`unknown mode: ${mode}`);
 }
 
-/** Binary sniff: a NUL byte in the first 8k. Binary files are still scanned as
- *  latin1 text -- an embedded ASCII key is exactly the case we care about. */
-function readForScan(path: string): ScanInput {
-  let size: number;
-  try {
-    size = statSync(path).size;
-  } catch (e) {
-    return { path, unreadable: { reason: `stat failed (${(e as Error).message})` } };
-  }
-  if (size > MAX_BYTES) {
-    return { path, unreadable: { reason: `file is ${(size / 1048576).toFixed(1)} MB, above the ${MAX_BYTES / 1048576} MB scan limit` } };
-  }
-  try {
-    return { path, content: readFileSync(path, 'latin1') };
-  } catch (e) {
-    return { path, unreadable: { reason: `read failed (${(e as Error).message})` } };
-  }
+/** Keep the diff's file set exactly, marking anything git could not resolve. */
+function reconcile(paths: string[], found: Entry[], missingReason: string): Entry[] {
+  const byPath = new Map(found.map((e) => [e.path, e]));
+  return paths.map((p) => byPath.get(p) ?? { path: p, mode: '', sha: '' });
 }
 
-function report(result: GateResult, mode: string, files: string[]): void {
+/**
+ * Read every entry's blob in ONE `git cat-file --batch` process.
+ *
+ * Batched rather than one spawn per file because `--all` runs over the whole
+ * repository, and a few thousand process spawns is the difference between a
+ * gate that runs on every commit and one people start skipping.
+ *
+ * Content is decoded latin1 for the same reason the previous implementation
+ * did: an embedded ASCII key inside an otherwise binary file is exactly the
+ * case worth catching, and latin1 never throws on a byte sequence.
+ */
+function readAll(entries: Entry[]): ScanInput[] {
+  const needsBlob = entries.filter((e) => e.sha);
+  const blobs = new Map<string, { content?: string; error?: string }>();
+
+  // Deduped, because two paths can share a blob (identical content, or a file
+  // copied) and `--batch` answers ONE record per input line. Reading the stream
+  // must therefore consume exactly one record per line SENT, never per path:
+  // an early `continue` that skips the parse without advancing the cursor
+  // desynchronises everything after it, and the gate then reports one file's
+  // content under another file's name. Measured: it attributed nine findings to
+  // a 38-line file at lines 69-154.
+  const order = [...new Set(needsBlob.map((e) => e.sha))];
+
+  if (order.length) {
+    const out = gitBuf(['cat-file', '--batch'], `${order.join('\n')}\n`);
+    let at = 0;
+    for (const sha of order) {
+      const nl = out.indexOf(0x0a, at);
+      if (nl < 0) {
+        // The stream ended early: every remaining object is unknown, and saying
+        // so for each is the fail-closed answer.
+        blobs.set(sha, { error: 'git cat-file produced no record for this object' });
+        continue;
+      }
+      const header = out.toString('latin1', at, nl);
+      const [, type, sizeText] = header.split(' ');
+      if (type !== 'blob') {
+        // `missing` and anything non-blob: named, not skipped.
+        blobs.set(sha, { error: `git object is ${header.trim()}, not a readable blob` });
+        at = nl + 1;
+        continue;
+      }
+      const size = Number(sizeText);
+      const start = nl + 1;
+      blobs.set(sha, size > MAX_BYTES
+        ? { error: `blob is ${(size / 1048576).toFixed(1)} MB, above the ${MAX_BYTES / 1048576} MB scan limit` }
+        : { content: out.toString('latin1', start, start + size) });
+      at = start + size + 1; // trailing LF after the object body
+    }
+  }
+
+  return entries.map((e): ScanInput => {
+    if (e.mode === MODE_GITLINK) {
+      return { path: e.path, unreadable: { reason: 'gitlink (submodule): this repository holds no content for it, so it cannot be cleared here' } };
+    }
+    if (!e.sha) {
+      return { path: e.path, unreadable: { reason: 'git could not resolve this path to a blob' } };
+    }
+    const b = blobs.get(e.sha);
+    if (!b || b.error) return { path: e.path, unreadable: { reason: b?.error ?? 'no object content returned' } };
+    return { path: e.path, content: b.content };
+  });
+}
+
+function report(result: GateResult, mode: string, entries: Entry[]): void {
   const line = (s = '') => process.stdout.write(`${s}\n`);
   line();
-  line(`secret-gate (EVIDGUARD818) -- mode ${mode}, ${result.scannedCount} file(s) in scope`);
+  line(`secret-gate (EVIDGUARD818) -- mode ${mode}, ${result.scannedCount} file(s) in scope, read from git objects`);
+
+  const links = entries.filter((e) => e.mode === MODE_SYMLINK);
+  if (links.length) {
+    line();
+    line(`Symlinks (${links.length}) scanned as the blob git stores -- the target path as text, not the file it points at:`);
+    for (const l of links) line(`  - ${l.path}`);
+  }
 
   if (result.allowlisted.length) {
     line();
@@ -92,17 +260,17 @@ function report(result: GateResult, mode: string, files: string[]): void {
   line('If a hit is an intentional fixture, add the PATH to ALLOWLISTED_PATHS in');
   line('src/security/secret-gate.ts. Do NOT loosen the pattern: a pattern exception');
   line('opens the same hole in every file in the repository.');
-  if (files.length !== result.scannedCount) {
+  if (entries.length !== result.scannedCount) {
     line();
-    line(`NOTE: ${files.length} file(s) were listed but ${result.scannedCount} reached the scanner.`);
+    line(`NOTE: ${entries.length} file(s) were listed but ${result.scannedCount} reached the scanner.`);
   }
 }
 
 function main(): void {
   const [, , mode = '--staged', range] = process.argv;
-  let files: string[];
+  let entries: Entry[];
   try {
-    files = fileList(mode, range);
+    entries = entriesFor(mode, range);
   } catch (e) {
     // Fail-closed: if we cannot even determine the set, we do not pass it.
     process.stdout.write(`\nsecret-gate: FAILED to determine the file set: ${(e as Error).message}\n`);
@@ -112,13 +280,13 @@ function main(): void {
 
   // --staged with nothing staged is a no-op commit, which git blocks anyway;
   // any other mode with an empty set means the computation broke.
-  if (files.length === 0 && mode === '--staged') {
+  if (entries.length === 0 && mode === '--staged') {
     process.stdout.write('\nsecret-gate: nothing staged, nothing to check.\n');
     process.exit(0);
   }
 
-  const result = runGate(files.map(readForScan));
-  report(result, mode, files);
+  const result = runGate(readAll(entries));
+  report(result, mode, entries);
   process.exit(result.ok ? 0 : 1);
 }
 

--- a/src/__tests__/secret-gate-fixture-exceptions.test.ts
+++ b/src/__tests__/secret-gate-fixture-exceptions.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest'
+import { createHash } from 'node:crypto'
+import {
+  scanFileDetailed, fixtureExceptionReason, invalidFixtureExceptions,
+  FIXTURE_EXCEPTIONS, type FixtureException,
+} from '../security/secret-gate.js'
+
+// A fixture exception clears ONE literal in ONE test file. These cases exist to
+// prove the "one" in both halves of that sentence, because the whole reason the
+// mechanism was built instead of adding two ALLOWLISTED_PATHS entries is that an
+// allowlist entry blinds a whole file.
+//
+// The mechanism is exercised with SYNTHETIC entries. Testing it through the real
+// ones would mean writing their literals here to reproduce the hashes, which
+// would put the very secret-shaped strings this exists to contain into one more
+// file -- and that file would then need its own exception.
+
+/** Assembled at runtime so this test file carries no key-shaped literal. */
+const KEY_A = `sk-${'A'.repeat(30)}`
+const KEY_B = `sk-${'B'.repeat(30)}`
+const AWS = `AKIA${'ABCDEFGHIJKLMNOP'}`
+
+const hash = (s: string) => createHash('sha256').update(s, 'latin1').digest('hex')
+
+const REASON = 'a synthetic fixture whose raw-secret shape is the subject under test'
+const EXC: FixtureException[] = [
+  { path: 'src/__tests__/fake-fixture.test.ts', sha256: hash(KEY_A), reason: REASON },
+]
+
+describe('fixture exceptions are narrow', () => {
+  it('clears the named literal in the named file', () => {
+    const r = scanFileDetailed({ path: 'src/__tests__/fake-fixture.test.ts', content: `const k = '${KEY_A}'\n` }, EXC)
+    expect(r.findings).toHaveLength(0)
+    expect(r.exceptions).toHaveLength(1)
+    expect(r.exceptions[0].reason).toBe(REASON)
+    expect(r.exceptions[0].line).toBe(1)
+  })
+
+  it('the REST of the same file is still scanned -- this is the whole point', () => {
+    const content = `const ok = '${KEY_A}'\nconst notOk = '${AWS}'\n`
+    const r = scanFileDetailed({ path: 'src/__tests__/fake-fixture.test.ts', content }, EXC)
+    expect(r.exceptions).toHaveLength(1)
+    expect(r.findings).toHaveLength(1)
+    expect(r.findings[0].reason).toContain('AWS access key id')
+    expect(r.findings[0].line).toBe(2)
+  })
+
+  it('a DIFFERENT literal in the same file is not covered', () => {
+    const r = scanFileDetailed({ path: 'src/__tests__/fake-fixture.test.ts', content: `const k = '${KEY_B}'\n` }, EXC)
+    expect(r.exceptions).toHaveLength(0)
+    expect(r.findings).toHaveLength(1)
+  })
+
+  it('the SAME literal in a different file is not covered', () => {
+    const r = scanFileDetailed({ path: 'src/__tests__/other.test.ts', content: `const k = '${KEY_A}'\n` }, EXC)
+    expect(r.exceptions).toHaveLength(0)
+    expect(r.findings).toHaveLength(1)
+  })
+
+  it('editing the fixture invalidates its exception, so the gate goes red and a human looks', () => {
+    // The hash is the point: an exception cannot drift onto text nobody approved.
+    const r = scanFileDetailed({ path: 'src/__tests__/fake-fixture.test.ts', content: `const k = '${KEY_A}X'\n` }, EXC)
+    expect(r.exceptions).toHaveLength(0)
+    expect(r.findings).toHaveLength(1)
+  })
+
+  it('a non-test path can never carry an exception, even if the hash matches', () => {
+    const prod: FixtureException[] = [{ path: 'src/costops/collectors/anthropic.ts', sha256: hash(KEY_A), reason: REASON }]
+    expect(fixtureExceptionReason('src/costops/collectors/anthropic.ts', KEY_A, prod)).toBeNull()
+    const r = scanFileDetailed({ path: 'src/costops/collectors/anthropic.ts', content: `const k = '${KEY_A}'\n` }, prod)
+    expect(r.findings).toHaveLength(1)
+    expect(r.exceptions).toHaveLength(0)
+  })
+
+  it('a malformed exception is reported rather than silently widening the gate', () => {
+    expect(invalidFixtureExceptions([
+      { path: 'src/costops/x.ts', sha256: hash(KEY_A), reason: REASON },
+    ])[0].reason).toContain('TEST-ONLY')
+    expect(invalidFixtureExceptions([
+      { path: 'src/__tests__/x.test.ts', sha256: 'nothex', reason: REASON },
+    ])[0].reason).toContain('64 lowercase hex')
+    expect(invalidFixtureExceptions([
+      { path: 'src/__tests__/x.test.ts', sha256: hash(KEY_A), reason: 'because' },
+    ])[0].reason).toContain('reason')
+  })
+
+  it('the exceptions actually shipped are well formed and test-only', () => {
+    expect(invalidFixtureExceptions()).toEqual([])
+    for (const e of FIXTURE_EXCEPTIONS) expect(e.path).toMatch(/(^|\/)(__tests__|tests)\//)
+  })
+})

--- a/src/__tests__/secret-gate-runner.test.ts
+++ b/src/__tests__/secret-gate-runner.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, beforeAll } from 'vitest'
+import { execFileSync, spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, symlinkSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+// The RUNNER's tests. `secret-gate.test.ts` covers the pure core (which shapes
+// are secrets); this file covers the half that decides WHAT the core is handed,
+// which is where the gate has actually failed in practice.
+//
+// PR #775 was red for two weeks with no secret in it. The runner resolved each
+// path with readFileSync, two of the paths were versioned symlinks pointing at
+// directories, readFileSync threw EISDIR, and the gate failed closed on a
+// question it had asked wrongly. The fix is that git object storage -- not the
+// working tree -- is the source of truth. These cases pin that down in both
+// directions, because "reads from git" is only worth something if it also still
+// goes RED on a real secret.
+
+const REPO = process.cwd()
+const RUNNER = join(REPO, 'scripts', 'secret-gate.ts')
+const TSX = join(REPO, 'node_modules', '.bin', 'tsx')
+
+/** A secret shape the core detects, assembled at runtime so this test file does
+ *  not itself carry a literal the gate would flag (and would then need its own
+ *  allowlist entry, blinding the file). */
+const SECRET_LINE = `const k = '${'AKIA'}${'ABCDEFGHIJKLMNOP'}'`
+
+interface Run { status: number; out: string }
+
+function runGate(cwd: string, args: string[]): Run {
+  const r = spawnSync(TSX, [RUNNER, ...args], { cwd, encoding: 'utf-8' })
+  return { status: r.status ?? -1, out: `${r.stdout ?? ''}${r.stderr ?? ''}` }
+}
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf-8' })
+}
+
+/** A throwaway repository. Real git objects: the point is the object store. */
+function newRepo(): string {
+  const root = mkdtempSync(join(tmpdir(), 'secret-gate-runner-'))
+  git(root, ['init', '-q', '-b', 'main'])
+  git(root, ['config', 'user.email', 'test@example.invalid'])
+  git(root, ['config', 'user.name', 'test'])
+  writeFileSync(join(root, 'README.md'), '# base\n')
+  git(root, ['add', '-A'])
+  git(root, ['commit', '-qm', 'base'])
+  return root
+}
+
+function commit(root: string, msg: string): string {
+  git(root, ['add', '-A'])
+  git(root, ['commit', '-qm', msg])
+  return git(root, ['rev-parse', 'HEAD']).trim()
+}
+
+describe('secret-gate runner: git objects are the source of truth', () => {
+  beforeAll(() => {
+    expect(existsSync(TSX), 'tsx must be installed to run the gate').toBe(true)
+    expect(existsSync(RUNNER)).toBe(true)
+  })
+
+  it('goes RED on a real secret shape in the range -- the guard can still fire', () => {
+    const root = newRepo()
+    try {
+      const base = git(root, ['rev-parse', 'HEAD']).trim()
+      writeFileSync(join(root, 'leak.ts'), `${SECRET_LINE}\n`)
+      const head = commit(root, 'add a key')
+      const r = runGate(root, ['--range', `${base}..${head}`])
+      expect(r.status).toBe(1)
+      expect(r.out).toContain('BLOCKED')
+      expect(r.out).toContain('leak.ts')
+    } finally { rmSync(root, { recursive: true, force: true }) }
+  })
+
+  it('PR #775: a versioned symlink to a DIRECTORY is scanned as its blob, not followed', () => {
+    const root = newRepo()
+    try {
+      const base = git(root, ['rev-parse', 'HEAD']).trim()
+      mkdirSync(join(root, 'releases', 'monitor-abc123'), { recursive: true })
+      writeFileSync(join(root, 'releases', 'monitor-abc123', 'monitor.js'), 'export const ok = 1\n')
+      symlinkSync('monitor-abc123', join(root, 'releases', 'monitor-current'))
+      const head = commit(root, 'add a release and the symlink systemd runs')
+
+      expect(git(root, ['ls-tree', head, 'releases/monitor-current'])).toContain('120000')
+
+      const r = runGate(root, ['--range', `${base}..${head}`])
+      // The old runner failed here with EISDIR and "NOT SCANNED, therefore NOT
+      // CLEARED". Both halves matter: it must pass, AND it must say out loud
+      // that it treated the link as a blob rather than silently skipping it.
+      expect(r.out).not.toContain('EISDIR')
+      expect(r.out).not.toContain('NOT SCANNED')
+      expect(r.out).toContain('releases/monitor-current')
+      expect(r.out).toContain('Symlinks (1)')
+      expect(r.status).toBe(0)
+    } finally { rmSync(root, { recursive: true, force: true }) }
+  })
+
+  it('a symlink whose TARGET PATH is itself a secret shape still goes RED', () => {
+    // Scanning the blob is not a way of ignoring symlinks: the blob is the
+    // target path as text, and that text is scanned like any other content.
+    const root = newRepo()
+    try {
+      const base = git(root, ['rev-parse', 'HEAD']).trim()
+      symlinkSync(`AKIA${'ABCDEFGHIJKLMNOP'}`, join(root, 'weird-link'))
+      const head = commit(root, 'a link whose name is a key shape')
+      const r = runGate(root, ['--range', `${base}..${head}`])
+      expect(r.status).toBe(1)
+      expect(r.out).toContain('weird-link')
+    } finally { rmSync(root, { recursive: true, force: true }) }
+  })
+
+  it('a secret only in the WORKING TREE does not fail a range gate: the commits are what is scanned', () => {
+    const root = newRepo()
+    try {
+      const base = git(root, ['rev-parse', 'HEAD']).trim()
+      writeFileSync(join(root, 'clean.ts'), 'export const ok = 1\n')
+      const head = commit(root, 'clean file')
+      // Dirty the working tree AFTER the commit.
+      writeFileSync(join(root, 'clean.ts'), `${SECRET_LINE}\n`)
+      const r = runGate(root, ['--range', `${base}..${head}`])
+      expect(r.status).toBe(0)
+      expect(r.out).toContain('PASS')
+    } finally { rmSync(root, { recursive: true, force: true }) }
+  })
+
+  it('a secret in the COMMIT still fails after the working tree is cleaned up', () => {
+    // The direction that matters for a leak: deleting the evidence from disk
+    // must not clear the commit that carries it.
+    const root = newRepo()
+    try {
+      const base = git(root, ['rev-parse', 'HEAD']).trim()
+      writeFileSync(join(root, 'oops.ts'), `${SECRET_LINE}\n`)
+      const head = commit(root, 'leak')
+      writeFileSync(join(root, 'oops.ts'), 'export const ok = 1\n')
+      const r = runGate(root, ['--range', `${base}..${head}`])
+      expect(r.status).toBe(1)
+      expect(r.out).toContain('oops.ts')
+    } finally { rmSync(root, { recursive: true, force: true }) }
+  })
+
+  it('--staged reads the INDEX, so an edit made after `git add` cannot smuggle a secret past the hook', () => {
+    const root = newRepo()
+    try {
+      writeFileSync(join(root, 'staged.ts'), `${SECRET_LINE}\n`)
+      git(root, ['add', 'staged.ts'])
+      // Working tree now looks innocent; the index does not.
+      writeFileSync(join(root, 'staged.ts'), 'export const ok = 1\n')
+      const r = runGate(root, ['--staged'])
+      expect(r.status).toBe(1)
+      expect(r.out).toContain('staged.ts')
+    } finally { rmSync(root, { recursive: true, force: true }) }
+  })
+
+  it('two paths sharing one blob are not misattributed to each other', () => {
+    // Regression for a bug written while fixing this file, and caught only by
+    // comparing against the previous behaviour: `git cat-file --batch` answers
+    // one record per line SENT, and a loop that skipped a record without
+    // advancing its cursor reported one file's content under another file's
+    // name -- nine findings against a 38-line file, at lines 69 to 154.
+    const root = newRepo()
+    try {
+      const base = git(root, ['rev-parse', 'HEAD']).trim()
+      const shared = 'export const same = 1\n'
+      writeFileSync(join(root, 'a.ts'), shared)
+      writeFileSync(join(root, 'b.ts'), shared)
+      writeFileSync(join(root, 'c.ts'), `${SECRET_LINE}\n`)
+      const head = commit(root, 'two identical files and one leak')
+      const r = runGate(root, ['--range', `${base}..${head}`])
+      expect(r.status).toBe(1)
+      // The finding names c.ts and ONLY c.ts, at its real line 1.
+      expect(r.out).toContain('c.ts:1')
+      expect(r.out).not.toContain('a.ts:')
+      expect(r.out).not.toContain('b.ts:')
+    } finally { rmSync(root, { recursive: true, force: true }) }
+  })
+
+  it('an EMPTY file set fails closed rather than reading as clean', () => {
+    // Named for what it actually checks. A range that adds nothing produces an
+    // empty set, and an empty set is the shape a silently-shrunk file list
+    // takes: the gate must refuse it, not call it a pass.
+    const root = newRepo()
+    try {
+      const base = git(root, ['rev-parse', 'HEAD']).trim()
+      writeFileSync(join(root, 'kept.ts'), 'export const ok = 1\n')
+      const head = commit(root, 'add')
+      expect(runGate(root, ['--range', `${base}..${head}`]).status).toBe(0)
+
+      const emptyTree = git(root, ['hash-object', '-t', 'tree', '/dev/null']).trim()
+      const orphan = git(root, ['commit-tree', emptyTree, '-m', 'empty']).trim()
+      const r = runGate(root, ['--range', `${head}..${orphan}`])
+      expect(r.status).not.toBe(0)
+      expect(r.out).toContain('EMPTY')
+    } finally { rmSync(root, { recursive: true, force: true }) }
+  })
+})

--- a/src/security/secret-gate.ts
+++ b/src/security/secret-gate.ts
@@ -20,6 +20,8 @@
  * the original leak through.
  */
 
+import { createHash } from 'node:crypto';
+
 export type Severity = 'blocked' | 'unscannable';
 
 export interface Finding {
@@ -46,6 +48,9 @@ export interface GateResult {
   scannedCount: number;
   /** Files the gate deliberately let through, with the reason. Always reported. */
   allowlisted: { file: string; reason: string }[];
+  /** Single literals cleared by a fixture exception. Always reported: an
+   *  exception nobody sees is an exception nobody re-reads. */
+  exceptions: { file: string; line?: number; detector: string; reason: string }[];
 }
 
 /**
@@ -156,6 +161,99 @@ export const ALLOWLISTED_PATHS: { path: string; reason: string }[] = [
 export const WRAPPER_TAG = /<\s*(channel|trusted-peer)\b[^>]*\bsource\s*=\s*["'][^"']+["'][^>]*>/i;
 export const WRAPPED_PAYLOAD = /\bmessage_id\s*[:=]?\s*\d{2,}|"(update_id|chat_id|from_user)"\s*:\s*\d+/;
 
+/**
+ * A fixture exception: ONE secret-shaped literal, in ONE test file, cleared by
+ * name, with the rest of the file still scanned.
+ *
+ * WHY THIS EXISTS ALONGSIDE ALLOWLISTED_PATHS. An allowlist entry blinds a
+ * WHOLE FILE. That is the right trade when the file's entire subject is
+ * synthetic secrets (the gate's own tests), and the wrong one for an ordinary
+ * test file that happens to need one key-shaped literal: from then on nothing
+ * in it is checked, including the parts nobody was thinking about.
+ *
+ * Found on PR #628 (2026-09-06). Two costops collector tests carry an `sk-`
+ * shaped fixture, and both literals are load-bearing: one drives the assertion
+ * that a RAW secret in `secret_ref` must be rejected in favour of a `vault:`
+ * reference, the other drives "the secret never reaches the report". Replacing
+ * them with a neutral string would leave the tests passing while measuring
+ * something weaker than their names claim. Blinding both whole files to keep
+ * two lines is the other bad trade. Hence this: the narrowest exception that
+ * still lets the gate do its job.
+ *
+ * THE KEY IS A HASH OF THE MATCHED TEXT, NOT A LINE NUMBER AND NOT THE LITERAL.
+ *  - A line number goes stale the moment anyone edits above it, and a stale
+ *    exception either stops working or, worse, starts covering a different line.
+ *  - The literal itself cannot live here: this file is scanned too, and writing
+ *    a secret shape into the scanner to excuse a secret shape elsewhere is how
+ *    the exception becomes the leak.
+ *  - A hash is exact and fails closed: change the fixture and the exception
+ *    simply stops applying, so the gate goes red and a human looks again.
+ */
+export interface FixtureException {
+  /** Test file the fixture lives in. A non-test path is REFUSED, loudly. */
+  path: string;
+  /** sha256 (hex, latin1 bytes) of the EXACT text the detector matched. */
+  sha256: string;
+  /** Why this literal must keep its secret shape. Not optional. */
+  reason: string;
+}
+
+/** Only these paths may carry a fixture exception. */
+const TEST_PATH = /(^|\/)(__tests__|tests)\//;
+
+export const FIXTURE_EXCEPTIONS: readonly FixtureException[] = Object.freeze([
+  {
+    path: 'src/__tests__/costops-collectors-dryrun.test.ts',
+    sha256: '8e11255764528986c15d1063a0bbafc4663de6f1c4e40c5d5e60bd5ff0e99454',
+    reason: 'costops collector dry-run: the SECRET constant is asserted NOT to appear in the report, the audit row or the DB dump. A neutral string would still pass while proving less -- the shape is what makes the leak test meaningful.',
+  },
+  {
+    path: 'src/__tests__/costops-collectors.test.ts',
+    sha256: 'db8f43c042cf5bdf36abda27c6fb50a1eac827489a10916a552531b93cb548cd',
+    reason: 'collectors config validation: this literal IS the input to "rejects a raw secret in secret_ref (must be vault:)". Its raw-secret shape is the subject under test.',
+  },
+]);
+
+export type ExceptionProblem = { path: string; reason: string };
+
+/** Exceptions that are not allowed to apply, with why. Reported, never silent. */
+export function invalidFixtureExceptions(
+  list: readonly FixtureException[] = FIXTURE_EXCEPTIONS,
+): ExceptionProblem[] {
+  const seen = new Set<string>();
+  const bad: ExceptionProblem[] = [];
+  for (const e of list) {
+    const key = `${e.path}#${e.sha256}`;
+    if (!TEST_PATH.test(e.path)) {
+      bad.push({ path: e.path, reason: 'fixture exceptions are TEST-ONLY, and this path is not under __tests__/ or tests/' });
+    }
+    if (!/^[0-9a-f]{64}$/.test(e.sha256)) {
+      bad.push({ path: e.path, reason: 'sha256 must be 64 lowercase hex characters' });
+    }
+    if (!e.reason || e.reason.trim().length < 20) {
+      bad.push({ path: e.path, reason: 'an exception without a real written reason is a hole nobody can review' });
+    }
+    if (seen.has(key)) bad.push({ path: e.path, reason: 'duplicate exception entry' });
+    seen.add(key);
+  }
+  return bad;
+}
+
+/** The reason this exact matched text is excepted in this exact file, or null.
+ *
+ *  The list is a parameter so the mechanism can be tested against SYNTHETIC
+ *  entries. Testing it only through the real entries would mean writing their
+ *  literals into a test file to reproduce the hashes -- putting the very
+ *  secret-shaped strings this exists to contain into one more place. */
+export function fixtureExceptionReason(
+  path: string, matched: string, list: readonly FixtureException[] = FIXTURE_EXCEPTIONS,
+): string | null {
+  if (!TEST_PATH.test(path)) return null;
+  const digest = createHash('sha256').update(matched, 'latin1').digest('hex');
+  const hit = list.find((e) => e.path === path && e.sha256 === digest);
+  return hit ? hit.reason : null;
+}
+
 export function allowlistReason(path: string): string | null {
   const hit = ALLOWLISTED_PATHS.find((a) => a.path === path);
   return hit ? hit.reason : null;
@@ -165,10 +263,25 @@ function lineOf(text: string, index: number): number {
   return text.slice(0, index).split('\n').length;
 }
 
-/** All findings for ONE file. An allowlisted path yields none. */
+export interface ScanOutcome {
+  findings: Finding[];
+  exceptions: { file: string; line?: number; detector: string; reason: string }[];
+}
+
+/** All findings for ONE file. An allowlisted path yields none.
+ *  Kept for callers that only want the findings. */
 export function scanFile(input: ScanInput): Finding[] {
+  return scanFileDetailed(input).findings;
+}
+
+/** Findings AND the fixture exceptions that were applied, so the caller can
+ *  report what was let through rather than quietly not mentioning it. */
+export function scanFileDetailed(
+  input: ScanInput, list: readonly FixtureException[] = FIXTURE_EXCEPTIONS,
+): ScanOutcome {
   const { path } = input;
-  if (allowlistReason(path)) return [];
+  const exceptions: ScanOutcome['exceptions'] = [];
+  if (allowlistReason(path)) return { findings: [], exceptions };
 
   const findings: Finding[] = [];
 
@@ -188,21 +301,27 @@ export function scanFile(input: ScanInput): Finding[] {
       severity: 'unscannable',
       reason: `${input.unreadable.reason} -- the gate could not read this file, so it cannot clear it. Allowlist the path if it is intentional.`,
     });
-    return findings;
+    return { findings, exceptions };
   }
 
   const text = input.content ?? '';
   for (const { name, pattern } of SECRET_PATTERNS) {
     const m = pattern.exec(text);
-    if (m) {
-      findings.push({
-        file: path,
-        detector: 'content',
-        severity: 'blocked',
-        line: lineOf(text, m.index),
-        reason: `secret shape: ${name}`,
-      });
+    if (!m) continue;
+    // Keyed on THIS matched text in THIS file. Every other pattern, and every
+    // other match in the same file, is still scanned.
+    const excused = fixtureExceptionReason(path, m[0], list);
+    if (excused) {
+      exceptions.push({ file: path, line: lineOf(text, m.index), detector: `secret shape: ${name}`, reason: excused });
+      continue;
     }
+    findings.push({
+      file: path,
+      detector: 'content',
+      severity: 'blocked',
+      line: lineOf(text, m.index),
+      reason: `secret shape: ${name}`,
+    });
   }
   const tag = WRAPPER_TAG.exec(text);
   if (tag && WRAPPED_PAYLOAD.test(text)) {
@@ -216,17 +335,21 @@ export function scanFile(input: ScanInput): Finding[] {
   }
   for (const { name, pattern } of TRANSCRIPT_PATTERNS) {
     const m = pattern.exec(text);
-    if (m) {
-      findings.push({
-        file: path,
-        detector: 'transcript',
-        severity: 'blocked',
-        line: lineOf(text, m.index),
-        reason: `channel material: ${name}`,
-      });
+    if (!m) continue;
+    const excused = fixtureExceptionReason(path, m[0], list);
+    if (excused) {
+      exceptions.push({ file: path, line: lineOf(text, m.index), detector: `channel material: ${name}`, reason: excused });
+      continue;
     }
+    findings.push({
+      file: path,
+      detector: 'transcript',
+      severity: 'blocked',
+      line: lineOf(text, m.index),
+      reason: `channel material: ${name}`,
+    });
   }
-  return findings;
+  return { findings, exceptions };
 }
 
 /**
@@ -242,11 +365,20 @@ export function runGate(inputs: ScanInput[]): GateResult {
     .map((i) => ({ file: i.path, reason: allowlistReason(i.path) }))
     .filter((a): a is { file: string; reason: string } => a.reason !== null);
 
+  // A malformed exception must never be an invisible widening of the gate.
+  const badExceptions = invalidFixtureExceptions().map((b): Finding => ({
+    file: `(fixture exception) ${b.path}`,
+    detector: 'unscannable',
+    severity: 'unscannable',
+    reason: `${b.reason} -- the gate refuses to run with an exception it cannot justify`,
+  }));
+
   if (inputs.length === 0) {
     return {
       ok: false,
       scannedCount: 0,
       allowlisted,
+      exceptions: [],
       findings: [{
         file: '(file set)',
         detector: 'unscannable',
@@ -256,6 +388,8 @@ export function runGate(inputs: ScanInput[]): GateResult {
     };
   }
 
-  const findings = inputs.flatMap(scanFile);
-  return { ok: findings.length === 0, findings, scannedCount: inputs.length, allowlisted };
+  const outcomes = inputs.map((i) => scanFileDetailed(i));
+  const findings = [...badExceptions, ...outcomes.flatMap((o) => o.findings)];
+  const exceptions = outcomes.flatMap((o) => o.exceptions);
+  return { ok: findings.length === 0, findings, scannedCount: inputs.length, allowlisted, exceptions };
 }


### PR DESCRIPTION
Two changes to the secret gate, in two reviewable commits. Both came out of
looking at why PR #775 has been red for two weeks and why #628 would go red the
moment it is rebased. Neither is an allowlist.

## 1. Scan what the commits contain, not what happens to be on disk

`scripts/secret-gate.ts` resolved every path with `readFileSync`. PR #775 adds
two versioned symlinks that point at directories — `releases/monitor-current`
and `releases/monitor-previous`, both mode `120000`. `readFileSync` follows a
link into a directory and throws `EISDIR`, so the gate reported

```
NOT SCANNED, therefore NOT CLEARED (2):
  releases/monitor-current   read failed (EISDIR: ...)
  releases/monitor-previous  read failed (EISDIR: ...)
```

and failed closed. No secret pattern matched. The gate refused correctly, on a
question it had asked wrongly.

The crash is the symptom. Reading the working tree makes a **range** gate answer
a different question from the one it is named for: it scans whatever is on that
disk at that moment, which in CI is a checkout and locally is an arbitrarily
dirty tree. So the source of truth is now git object storage in every mode — the
head tree for `--range`, the index for `--staged` and `--all` — and a symlink is
scanned as the blob git actually stores for it, which is the target path as
text. Following it would scan a file the commit does not contain, and for a
directory target there is nothing to follow at all.

`--staged` was not part of the original problem and is changed here deliberately
rather than quietly: it had the identical defect, and the index *is* "what is
about to be committed", so an edit made after `git add` can no longer smuggle a
secret past the pre-commit hook.

Eight runner cases in `src/__tests__/secret-gate-runner.test.ts`, four of which
go RED against the previous implementation: the symlink case, both
working-tree-versus-commit directions, and the `--staged` index case. The other
four are invariants that must hold either way — including a regression test for
a bug introduced while writing this: `git cat-file --batch` answers one record
per line *sent*, and a loop that skipped a record without advancing its cursor
reported one file's content under another file's name. It was caught by running
`--all` (990 files) under both implementations and diffing the verdicts, not by
a test.

Measured on the real #775 range `fde78707..a8577259`: 185 files in scope — the
same count CI reports — PASS.

## 2. Except ONE fixture literal, not a whole file

`ALLOWLISTED_PATHS` blinds an entire file. That is the right trade when the
file's whole subject is synthetic secrets (the gate's own tests) and the wrong
one for an ordinary test file that needs a single key-shaped literal: from then
on nothing in it is checked, including the parts nobody was thinking about when
the entry was added.

PR #628 is the case. Two costops collector tests carry an `sk-` shaped fixture,
and both literals are load-bearing rather than decorative: one drives *"rejects
a raw secret in secret_ref (must be vault:)"*, the other drives *"the secret
never reaches the report, the audit row or the DB dump"*. Replace them with a
neutral string and both tests still pass while measuring something weaker than
their names claim. Blind both whole files to keep two lines, and the gate stops
watching 43 files' worth of new code.

So an exception names **one literal in one file**, keyed on the **sha256 of the
matched text**:

* not a line number, which goes stale the moment anyone edits above it and can
  then cover a line nobody approved;
* not the literal itself, because this file is scanned too, and writing a secret
  shape into the scanner to excuse a secret shape elsewhere is how the exception
  becomes the leak;
* a hash is exact and fails closed — edit the fixture and the exception simply
  stops applying, the gate goes red, and a human looks again.

Constrained on every axis: **test-only** (a non-test path can never carry one,
checked at validation and again at lookup), exact literal scope, a written
reason that must be substantial, and the rest of the file still scanned. A
malformed entry is not inert, it is a **finding** — the gate refuses to run with
an exception it cannot justify. Applied exceptions are printed in the report
with file, line, detector and reason, because an exception nobody sees is an
exception nobody re-reads.

Eight cases prove the narrowness in both directions, including a second secret
in the same excepted file still blocking, the same literal in a different file
not being covered, and an edited fixture losing its exception. They run against
**synthetic** entries on purpose: testing through the real ones would mean
writing their literals into the test file, which would put the strings this
exists to contain into one more place — and that file would then need its own
exception.

Measured on the real #628 range: 43 files in scope, 2 exceptions applied, PASS.

## Why this comes first

Rebasing #628 onto current `develop` produces a clean tree and a green suite,
but its `secret-gate` job fails on those two fixtures under today's gate
(measured: 2 BLOCKED, exit 1). With this change it passes (42 files, 2
exceptions, exit 0). #775's `scan` job goes green here too. So this is the
prerequisite for both, and it carries no product change of its own.

## What this PR does not claim

The local suite on this branch is green except for one pre-existing failure that
has nothing to do with it: `scripts/__tests__/intel-db.test.sh` shells out to the
`sqlite3` CLI, which is not a declared dependency of this repository — it is
absent from `package.json`, absent from the CI workflow, and `scripts/backup.sh`
explicitly tolerates its absence. The test can use Python's stdlib `sqlite3`
module instead, which every environment already has. That is a separate,
one-file change and is deliberately not bundled here.


---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015HDX2xPs9u6B9nyG4ekiRm
