### PR TITLE
fix(egress): deny the shell URL-fetch verbs on every agent, not just WebFetch

### DIFF
--- a/docs/security-hardening.md
+++ b/docs/security-hardening.md
@@ -26,3 +26,54 @@ Override an intentional rewrite of a protected branch:
 ```bash
 ALLOW_FORCE_PUSH=1 git push ...
 ```
+
+# Bash egress deny rules
+
+`scripts/hooks/egress-gate.mjs` compares a URL against the allowlist, but it is
+wired as a `PreToolUse` hook with matcher `WebFetch` **only**. Bash was never
+ungated (`outgoing-copy-gate.py` and `email-approval-gate.py` on the main agent,
+`email-send-gate.mjs` and `self-pace-gate.mjs` on sub-agents) but none of those
+gates looks at the destination host, so a shell `curl` never met the allowlist.
+The realistic threat is not a malicious agent: it is a fetched page telling an
+agent to run a `curl`, which is why the quarantine-reader exists in the first
+place.
+
+## What it does
+
+`BASH_EGRESS_DENY` in `src/web/agent-scaffold.ts` is the single source of truth
+for a small `permissions.deny` list that lands in **every** agent's
+`settings.json`:
+
+- on spawn, via `writeAgentSettingsFromProfile()`,
+- on server startup, via `ensureBashEgressDeny()` (existing fleet, main agent
+  included),
+- on scaffold, via `templates/settings.json.template` (so the next agent created
+  starts gated -- a parity test keeps the template and the constant in step).
+
+Denied: `curl` to an `https://` URL, and `wget` / `nc` / `ncat` / `telnet`
+outright. A `deny` rule is checked **before** the
+`--dangerously-skip-permissions` bypass, so it binds on permissive profiles too.
+Sanctioned tooling that speaks HTTPS on its own account (`git`, `gh`, `npm`) is
+deliberately untouched: denying it would break the release path without closing
+anything an agent could not do through it anyway.
+
+The sanctioned route for external content is unchanged: the quarantine-reader
+sub-agent, through `WebFetch`, where the domain check already runs. A host being
+on the egress allowlist does not open it to the shell.
+
+## Limits, stated out loud
+
+This is a deny list, not a sandbox.
+
+- **The localhost exception is why only `https://` is denied for `curl`.** The
+  rule language has no negation and `deny` always beats `allow`, so "any
+  `http://` host except localhost" cannot be expressed. A `*http://*` rule would
+  also match `http://localhost:3420/...` and mute the whole fleet (memory,
+  kanban, message queue, approvals all ride that URL).
+- Still open, by construction: plain-http external fetches, an interpreter
+  one-liner (`python3 -c`, `node -e`), and a URL hidden in a shell variable.
+  Closing those needs a Bash `PreToolUse` hook that parses the command.
+- Known collateral: an internal POST whose **double-quoted** payload quotes an
+  `https://` URL matches the `curl` rule. Single-quoted payloads do not (the
+  permission engine excludes single-quoted content). Use single quotes or
+  `-d @file` for such a call.

--- a/docs/security-hardening.md
+++ b/docs/security-hardening.md
@@ -45,8 +45,8 @@ for a small `permissions.deny` list that lands in **every** agent's
 `settings.json`:
 
 - on spawn, via `writeAgentSettingsFromProfile()`,
-- on server startup, via `ensureBashEgressDeny()` (existing fleet, main agent
-  included),
+- on server startup, via `ensureBashEgressDeny()` (existing fleet, and the main
+  agent -- see the scope note below),
 - on scaffold, via `templates/settings.json.template` (so the next agent created
   starts gated -- a parity test keeps the template and the constant in step).
 
@@ -60,6 +60,34 @@ anything an agent could not do through it anyway.
 The sanctioned route for external content is unchanged: the quarantine-reader
 sub-agent, through `WebFetch`, where the domain check already runs. A host being
 on the egress allowlist does not open it to the shell.
+
+## Where the main agent's copy goes
+
+The main agent's nominal settings path is the shared user root
+(`~/.claude/settings.json`) -- and that same file is the operator's own
+interactive Claude Code sessions. The owner's decision (2026-09-07) was that
+their own shell stays unrestricted while the fleet stays gated, which makes the
+shared file unusable in both directions: writing there restricts the operator,
+removing it from there un-gates the main agent, which is the one agent that
+reads untrusted web content on the owner's behalf.
+
+Measured way out: when the install gives the main agent a config dir of its own
+(`MAIN_AGENT_CONFIG_DIR`, or the provisioned isolated dir behind
+`MAIN_AGENT_ISOLATED_CONFIG`), that dir's `settings.json` is the agent's user
+scope and the operator's shell does not read it. `bashEgressDenyTargetPath()`
+sends the rules there. The separation survives restarts: the provisioner
+rebuilds that file from the shared one on every start but keeps keys the shared
+file never mentions, and `permissions` is such a key.
+
+When the main agent runs on the shared root there is no scope that covers it
+without covering the operator, so **nothing is written** and the startup log
+says so. Giving the main agent its own config dir is the fix; picking a side
+quietly is not this code's call.
+
+A user-scope `settings.json` is read when a session starts and is not re-read
+while it runs (the project scope is -- both measured 2026-09-07). A newly
+written rule therefore binds the main agent from its next restart, not
+immediately.
 
 ## Limits, stated out loud
 

--- a/docs/security-hardening.md
+++ b/docs/security-hardening.md
@@ -84,10 +84,27 @@ without covering the operator, so **nothing is written** and the startup log
 says so. Giving the main agent its own config dir is the fix; picking a side
 quietly is not this code's call.
 
-A user-scope `settings.json` is read when a session starts and is not re-read
-while it runs (the project scope is -- both measured 2026-09-07). A newly
-written rule therefore binds the main agent from its next restart, not
-immediately.
+## The trap for whoever measures this next
+
+The two scopes do not behave the same way, and the difference is invisible until
+it misleads you (both measured 2026-09-07):
+
+- The **project scope** (`<cwd>/.claude/settings.json` and `settings.local.json`)
+  is re-read while a session runs. A rule written there fires immediately, which
+  makes it a fine live test bench: drop a narrow, unique rule in, probe it, then
+  delete the file.
+- The **user scope** (the `settings.json` in the session's `CLAUDE_CONFIG_DIR`)
+  is read when the session STARTS and is not re-read afterwards. A rule written
+  there while the session runs does nothing at all.
+
+So a probe that works perfectly on the project scope reports a confident
+"allowed" on the user scope, and the honest-looking conclusion -- "the rule does
+not work" -- is wrong. What it means is "this session has not read it yet".
+Measure a user-scope rule from a session that started AFTER the write, or after
+the next restart.
+
+The same asymmetry is why a newly written rule binds the main agent from its
+next restart rather than immediately.
 
 ## Limits, stated out loud
 

--- a/scripts/hooks/egress-gate.mjs
+++ b/scripts/hooks/egress-gate.mjs
@@ -32,10 +32,17 @@
 // The log is separate from the main Marveen log so operators can grep it
 // independently: `tail -f store/egress-blocked.log`
 //
-// Scope: this guard covers the Claude Code WebFetch tool only. It does NOT
-// intercept WebSearch, curl/Bash network calls, or MCP-server outbound
-// requests. Those channels are out of scope for this hook mechanism and require
-// separate controls if needed.
+// Scope: this guard covers the Claude Code WebFetch tool only -- it is wired
+// with matcher "WebFetch" and sees no other tool. It does NOT intercept
+// WebSearch or MCP-server outbound requests.
+//
+// The SHELL half is a separate control: BASH_EGRESS_DENY in
+// src/web/agent-scaffold.ts puts a small permissions.deny list on every agent
+// (curl to https://, plus wget/nc/ncat/telnet outright), because a fetched page
+// telling an agent to run a curl would otherwise walk straight past this file.
+// That list is a deny list, not a sandbox, and its limits are written down in
+// docs/security-hardening.md. The two halves are deliberately separate: this
+// one decides on a URL, that one on a command string.
 
 import { readFileSync, appendFileSync, mkdirSync } from 'node:fs'
 import { realpathSync } from 'node:fs'

--- a/src/__tests__/bash-egress-deny.test.ts
+++ b/src/__tests__/bash-egress-deny.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { BASH_EGRESS_DENY, mergeBashEgressDeny } from '../web/agent-scaffold.js'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+
+// How Claude Code matches a Bash permission rule, measured against the shipped
+// 2.1.263 binary and confirmed live in a running session on 2026-09-07:
+//
+//   - A rule body containing `*` is compiled to an ANCHORED full-match regex,
+//     `*` -> `.*`, with the `s` flag. (A body ending in `:*` is the legacy
+//     prefix form instead; none of our rules use it.)
+//   - Deny is evaluated per sub-command: a compound `cd x && curl ...` is split
+//     first, so a rule anchored at `curl ` still fires on the second half.
+//   - Deny is checked BEFORE the --dangerously-skip-permissions bypass, so the
+//     rules bind on permissive fleet profiles too.
+//
+// This helper models the FIRST rule only -- the anchored regex -- because that
+// is what decides whether a rule is written correctly. It deliberately does NOT
+// model the engine's quote handling. Measured, and recorded here so nobody has
+// to rediscover it: a `-d '...https://...'` payload in SINGLE quotes is NOT
+// matched, while the same payload in DOUBLE quotes IS. The corpus below is
+// written so its verdicts do not depend on that difference, except for the one
+// case that pins it.
+function ruleMatches(rule: string, command: string): boolean {
+  const body = rule.replace(/^Bash\(/, '').replace(/\)$/, '')
+  const re = new RegExp(`^${body.split('*').map((p) => p.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('.*')}$`, 's')
+  return re.test(command)
+}
+
+// Deny is evaluated per sub-command, so the corpus is matched the same way.
+function denied(command: string): boolean {
+  const parts = command.split(/\s*(?:&&|\|\||;|\|)\s*/).map((p) => p.trim()).filter(Boolean)
+  return [command.trim(), ...parts].some((c) => BASH_EGRESS_DENY.some((r) => ruleMatches(r, c)))
+}
+
+// The fleet's own internal traffic. Every one of these is a real shape from the
+// agents' CLAUDE.md / skills: memory, kanban, daily log, message queue,
+// approvals, the local Ollama server. If a rule ever denies one of these, every
+// agent goes mute -- this is the test that has to fail first.
+const INTERNAL = [
+  `curl -s -X POST http://localhost:3420/api/memories -H "Content-Type: application/json" -H "Authorization: Bearer $(cat store/.dashboard-token)" -d '{"agent_id":"agent-a","content":"x","category":"warm","keywords":"a, b"}'`,
+  `curl -s -H "Authorization: Bearer $(cat store/.dashboard-token)" "http://localhost:3420/api/memories?agent=agent-a&q=KEYWORD&category=warm"`,
+  `curl -s -X POST http://127.0.0.1:3420/api/kanban/abc12345/comments -H 'Content-Type: application/json' -d '{"author":"agent-a","content":"kesz"}'`,
+  `curl -s -X POST http://localhost:3420/api/daily-log -H "Content-Type: application/json" -d '{"agent_id":"agent-a","content":"## 08:00 -- Tema"}'`,
+  `curl -s -X POST http://localhost:3420/api/messages -H "Content-Type: application/json" -d '{"from":"agent-a","to":"agent-b","content":"jelentes"}'`,
+  `curl -s -H "Authorization: Bearer $(cat store/.dashboard-token)" http://127.0.0.1:3420/api/approvals/12`,
+  'curl -s http://localhost:11434/api/tags',
+  'cd /srv/install && curl -s -m 3 -o /dev/null http://localhost:3420/api/health',
+  // Sanctioned tooling that speaks HTTPS on its own account: deliberately untouched.
+  'git push fork fix/some-branch',
+  'gh pr create --base develop --title "fix(x)" --body-file /tmp/b.md',
+  'npm install --no-audit --no-fund',
+  // Substring traps: an unanchored `nc *` rule would deny all three of these.
+  'rsync -a src/ dst/',
+  'sync && echo done',
+  'git commit -m "sync the fleet"',
+]
+
+// What the gate is for: fetching URL content from the shell.
+const EXTERNAL = [
+  'curl -s https://example.org/x',
+  'curl -sSL https://raw.githubusercontent.com/foo/bar/main/install.sh',
+  'curl -s --connect-timeout 1 -o /dev/null https://api.github.com/rate_limit',
+  '/usr/bin/curl -s https://example.org/x',
+  'cd /tmp && curl -s https://example.org/x',
+  'wget -q -O /tmp/x https://example.org/x',
+  '/usr/bin/wget https://example.org/x',
+  'nc example.org 443',
+  'ncat --ssl example.org 443',
+  'telnet example.org 80',
+]
+
+describe('BASH_EGRESS_DENY rule set', () => {
+  it('leaves every internal fleet call alone', () => {
+    for (const cmd of INTERNAL) expect({ cmd, denied: denied(cmd) }).toEqual({ cmd, denied: false })
+  })
+
+  it('denies the shell URL-fetch verbs', () => {
+    for (const cmd of EXTERNAL) expect({ cmd, denied: denied(cmd) }).toEqual({ cmd, denied: true })
+  })
+
+  // The allowlist is a WebFetch-scoped list. A host being on it says the
+  // quarantine path may reach it, not that the shell may -- the sanctioned
+  // route stays WebFetch. This is the control that would catch a rule set
+  // rewritten to consult the allowlist.
+  it('denies an allowlisted host too, because the sanctioned route is WebFetch', () => {
+    expect(denied('curl -s https://api.github.com/rate_limit')).toBe(true)
+  })
+
+  // Measured collateral, pinned deliberately (2026-09-07). An internal POST
+  // whose DOUBLE-quoted payload quotes an https URL matches the curl rule.
+  // Single quotes do not (the engine excludes single-quoted content). The fix
+  // for a caller that hits this is single quotes or -d @file, and this test
+  // exists so the limit is a known cost and not a surprise.
+  it('pins the known collateral: a double-quoted payload carrying an https URL matches', () => {
+    expect(denied(`curl -s -X POST http://localhost:3420/api/memories -d "{\\"content\\":\\"lasd https://github.com/x\\"}"`)).toBe(true)
+  })
+
+  // The rule language has no negation and deny always beats allow, so
+  // "any http:// host except localhost" cannot be written. Stated as a test so
+  // the gap is visible next to the rules instead of only in a comment.
+  it('documents the residual gap: plain-http external fetches still pass', () => {
+    expect(denied('curl -s http://example.org/x')).toBe(false)
+    expect(denied(`python3 -c "import urllib.request; urllib.request.urlopen('http://example.org/x')"`)).toBe(false)
+  })
+})
+
+describe('mergeBashEgressDeny', () => {
+  it('adds every rule to a settings object that has no permissions block', () => {
+    const settings: Record<string, unknown> = {}
+    expect(mergeBashEgressDeny(settings)).toBe(true)
+    const deny = (settings.permissions as { deny: string[] }).deny
+    for (const rule of BASH_EGRESS_DENY) expect(deny).toContain(rule)
+  })
+
+  it('preserves the operator\'s existing deny entries and their order', () => {
+    const settings: Record<string, unknown> = {
+      permissions: { allow: ['Bash(ls:*)'], deny: ['Bash(sudo:*)', 'Read(/Users/x/.ssh/**)'] },
+    }
+    mergeBashEgressDeny(settings)
+    const perms = settings.permissions as { allow: string[]; deny: string[] }
+    expect(perms.deny.slice(0, 2)).toEqual(['Bash(sudo:*)', 'Read(/Users/x/.ssh/**)'])
+    expect(perms.allow).toEqual(['Bash(ls:*)'])
+    expect(perms.deny).toHaveLength(2 + BASH_EGRESS_DENY.length)
+  })
+
+  it('is idempotent: a second merge changes nothing', () => {
+    const settings: Record<string, unknown> = {}
+    mergeBashEgressDeny(settings)
+    const before = JSON.stringify(settings)
+    expect(mergeBashEgressDeny(settings)).toBe(false)
+    expect(JSON.stringify(settings)).toBe(before)
+  })
+
+  it('does not choke on a malformed permissions value', () => {
+    const settings: Record<string, unknown> = { permissions: 'nonsense' }
+    expect(mergeBashEgressDeny(settings)).toBe(true)
+    expect((settings.permissions as { deny: string[] }).deny).toEqual(BASH_EGRESS_DENY)
+  })
+})
+
+// A freshly scaffolded agent gets its first settings.json straight from the
+// template, before any profile write or startup migration runs. If the template
+// and the constant drift, the NEXT agent created starts without the gate --
+// which is exactly how the fleet ended up with two agents carrying a partial
+// curl deny and eight carrying none.
+describe('template parity', () => {
+  it('templates/settings.json.template carries exactly the same rules', () => {
+    const tpl = JSON.parse(readFileSync(join(ROOT, 'templates', 'settings.json.template'), 'utf-8'))
+    expect(tpl.permissions?.deny).toEqual(BASH_EGRESS_DENY)
+  })
+})

--- a/src/__tests__/bash-egress-deny.test.ts
+++ b/src/__tests__/bash-egress-deny.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect } from 'vitest'
-import { readFileSync } from 'node:fs'
+import { readFileSync, writeFileSync, mkdtempSync, existsSync, rmSync } from 'node:fs'
+import { tmpdir, homedir } from 'node:os'
 import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { BASH_EGRESS_DENY, mergeBashEgressDeny } from '../web/agent-scaffold.js'
+import { BASH_EGRESS_DENY, mergeBashEgressDeny, bashEgressDenyTargetPath, ensureBashEgressDeny } from '../web/agent-scaffold.js'
+import { MAIN_AGENT_ID } from '../config.js'
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
 
@@ -151,5 +153,70 @@ describe('template parity', () => {
   it('templates/settings.json.template carries exactly the same rules', () => {
     const tpl = JSON.parse(readFileSync(join(ROOT, 'templates', 'settings.json.template'), 'utf-8'))
     expect(tpl.permissions?.deny).toEqual(BASH_EGRESS_DENY)
+  })
+})
+
+// WHERE the main agent's rules are written is the whole point of the second
+// round. The shared user root is also the operator's own interactive shell, and
+// the operator asked to stay out of the rule while the fleet stays in it. So
+// the main agent is covered ONLY through a config dir of its own, and when
+// there is none this must write nothing at all rather than pick a side.
+describe('bashEgressDenyTargetPath', () => {
+  it('sends a sub-agent to its own settings.json', () => {
+    const p = bashEgressDenyTargetPath('some-agent', null)
+    expect(p).toContain(join('some-agent', '.claude', 'settings.json'))
+  })
+
+  it('sends the main agent to ITS OWN config dir when it has one', () => {
+    expect(bashEgressDenyTargetPath(MAIN_AGENT_ID, '/somewhere/.channels-config'))
+      .toBe(join('/somewhere/.channels-config', 'settings.json'))
+  })
+
+  it('returns null for the main agent on the shared root -- never the operator\'s file', () => {
+    expect(bashEgressDenyTargetPath(MAIN_AGENT_ID, null)).toBe(null)
+  })
+
+  // The regression that would invert the guard: writing to the shared root
+  // restricts the operator's own shell and still leaves the main agent open on
+  // an install where it has a config dir of its own.
+  it('never targets the shared home settings for the main agent', () => {
+    const shared = join(homedir(), '.claude', 'settings.json')
+    expect(bashEgressDenyTargetPath(MAIN_AGENT_ID, null)).not.toBe(shared)
+    expect(bashEgressDenyTargetPath(MAIN_AGENT_ID, '/somewhere/.channels-config')).not.toBe(shared)
+  })
+})
+
+describe('ensureBashEgressDeny for the main agent', () => {
+  it('writes the rules into the config dir it was given', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'marveen-egress-'))
+    try {
+      expect(ensureBashEgressDeny(MAIN_AGENT_ID, dir)).toBe(true)
+      const written = JSON.parse(readFileSync(join(dir, 'settings.json'), 'utf-8'))
+      expect(written.permissions.deny).toEqual(BASH_EGRESS_DENY)
+      // Idempotent: a second boot must not append the same rules again.
+      expect(ensureBashEgressDeny(MAIN_AGENT_ID, dir)).toBe(false)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('keeps the config dir\'s other keys -- the file is rebuilt on every start and only its own keys survive', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'marveen-egress-'))
+    try {
+      writeFileSync(join(dir, 'settings.json'), JSON.stringify({ hooks: { PreCompact: [] }, enabledPlugins: { x: true } }))
+      ensureBashEgressDeny(MAIN_AGENT_ID, dir)
+      const written = JSON.parse(readFileSync(join(dir, 'settings.json'), 'utf-8'))
+      expect(Object.keys(written).sort()).toEqual(['enabledPlugins', 'hooks', 'permissions'])
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('writes NOTHING when there is no separate config dir', () => {
+    const shared = join(homedir(), '.claude', 'settings.json')
+    const before = existsSync(shared) ? readFileSync(shared, 'utf-8') : null
+    expect(ensureBashEgressDeny(MAIN_AGENT_ID, null)).toBe(false)
+    const after = existsSync(shared) ? readFileSync(shared, 'utf-8') : null
+    expect(after).toBe(before)
   })
 })

--- a/src/__tests__/main-agent-isolated-config.test.ts
+++ b/src/__tests__/main-agent-isolated-config.test.ts
@@ -105,6 +105,26 @@ describe('ensureMainAgentIsolatedConfigDir', () => {
     expect(after.model).toBe('agent-only-model')
   })
 
+  // The Bash egress deny (BASH_EGRESS_DENY) is written into THIS file rather
+  // than the shared root, so the operator's own shell stays out of it while the
+  // main agent stays in. That only holds if a permissions block survives the
+  // rewrite this function performs on every start -- and it survives only
+  // because the shared file never mentions `permissions`. Asserted on the real
+  // provisioner, not inferred from the merge code, so the guarantee the egress
+  // change rests on is executed rather than believed.
+  it('keeps a permissions block the shared file never mentions (Bash egress deny target)', () => {
+    const dir = ensureMainAgentIsolatedConfigDir(undefined, 'linux')!
+    const own = join(dir, 'settings.json')
+    writeFileSync(own, JSON.stringify({
+      permissions: { deny: ['Bash(curl *https://*)', 'Bash(wget *)'] },
+    }, null, 2) + '\n')
+
+    ensureMainAgentIsolatedConfigDir(undefined, 'linux')
+
+    const after = JSON.parse(readFileSync(own, 'utf-8')) as Record<string, unknown>
+    expect((after.permissions as { deny: string[] }).deny).toEqual(['Bash(curl *https://*)', 'Bash(wget *)'])
+  })
+
   it('lets the shared file win for every key it DOES define', () => {
     writeFileSync(join(HOME, '.claude', 'settings.json'), JSON.stringify({ model: 'shared-model' }))
     const dir = ensureMainAgentIsolatedConfigDir(undefined, 'linux')!

--- a/src/web.ts
+++ b/src/web.ts
@@ -13,7 +13,7 @@ import { isBlockedCrossOriginWrite, originMatchesServedHost } from './web/csrf-o
 import { json } from './web/http-helpers.js'
 import { detectLanIp } from './web/network-info.js'
 import { AGENTS_BASE_DIR, listAgentNames, listAllAgentNames } from './web/agent-config.js'
-import { ensureAgentHooks, ensureAgentStalenessHook, ensureAgentProvenanceHook, ensureEgressGate, ensureGovernanceGateCommands, ensureTelegramCopyGate, ensureQuarantineReader, watchEgressAllowlistForReaderRender, ensureDefaultScheduledTasks, agentSettingsPath, ensureAutonomySection, ensureSkillsPathTrapSection, ensureSystemDirectiveAuthSection } from './web/agent-scaffold.js'
+import { ensureAgentHooks, ensureAgentStalenessHook, ensureAgentProvenanceHook, ensureEgressGate, ensureBashEgressDeny, ensureGovernanceGateCommands, ensureTelegramCopyGate, ensureQuarantineReader, watchEgressAllowlistForReaderRender, ensureDefaultScheduledTasks, agentSettingsPath, ensureAutonomySection, ensureSkillsPathTrapSection, ensureSystemDirectiveAuthSection } from './web/agent-scaffold.js'
 import { shouldRegisterHooks, pruneStaleHooksFromSettingsFile } from './web/hook-registration-guard.js'
 import { refreshMarveenBotUsername } from './web/telegram.js'
 import { startMessageRouter } from './web/message-router.js'
@@ -543,6 +543,7 @@ setInterval(() => { try { sweepExpiredDesktopLock() } catch { /* never kill the 
       const stalePatched: string[] = []
       const provPatched: string[] = []
       const egressPatched: string[] = []
+      const bashEgressPatched: string[] = []
       const govPatched: string[] = []
       const copyGatePatched: string[] = []
       const pruned: string[] = []
@@ -564,6 +565,7 @@ setInterval(() => { try { sweepExpiredDesktopLock() } catch { /* never kill the 
         if (ensureAgentStalenessHook(agentName)) stalePatched.push(agentName)
         if (ensureAgentProvenanceHook(agentName)) provPatched.push(agentName)
         if (ensureEgressGate(agentName)) egressPatched.push(agentName)
+        if (ensureBashEgressDeny(agentName)) bashEgressPatched.push(agentName)
         if (ensureGovernanceGateCommands(agentName)) govPatched.push(agentName)
         if (ensureTelegramCopyGate(agentName)) copyGatePatched.push(agentName)
         ensureQuarantineReader(agentName)
@@ -582,6 +584,7 @@ setInterval(() => { try { sweepExpiredDesktopLock() } catch { /* never kill the 
       if (stalePatched.length) logger.info({ patched: stalePatched }, 'staleness-guard UserPromptSubmit hook backfilled into agent settings.json')
       if (provPatched.length) logger.info({ patched: provPatched }, 'provenance-gate UserPromptSubmit hook backfilled into agent settings.json')
       if (egressPatched.length) logger.info({ patched: egressPatched }, 'egress-gate WebFetch hook backfilled into agent settings.json')
+      if (bashEgressPatched.length) logger.info({ patched: bashEgressPatched }, 'Bash egress deny rules backfilled into agent settings.json (permissions.deny)')
       if (govPatched.length) logger.info({ patched: govPatched }, 'governance gate hook commands upgraded to absolute node path in agent settings.json')
       if (copyGatePatched.length) logger.info({ patched: copyGatePatched }, 'outgoing-copy-gate wired onto the Telegram send tools in agent settings.json (GATECOPY828)')
     } catch (err) {

--- a/src/web.ts
+++ b/src/web.ts
@@ -15,6 +15,7 @@ import { detectLanIp } from './web/network-info.js'
 import { AGENTS_BASE_DIR, listAgentNames, listAllAgentNames } from './web/agent-config.js'
 import { ensureAgentHooks, ensureAgentStalenessHook, ensureAgentProvenanceHook, ensureEgressGate, ensureBashEgressDeny, ensureGovernanceGateCommands, ensureTelegramCopyGate, ensureQuarantineReader, watchEgressAllowlistForReaderRender, ensureDefaultScheduledTasks, agentSettingsPath, ensureAutonomySection, ensureSkillsPathTrapSection, ensureSystemDirectiveAuthSection } from './web/agent-scaffold.js'
 import { shouldRegisterHooks, pruneStaleHooksFromSettingsFile } from './web/hook-registration-guard.js'
+import { mainAgentConfigDirIfSeparate } from './web/agent-process.js'
 import { refreshMarveenBotUsername } from './web/telegram.js'
 import { startMessageRouter } from './web/message-router.js'
 import { startUpdateChecker } from './web/update-checker.js'
@@ -544,6 +545,7 @@ setInterval(() => { try { sweepExpiredDesktopLock() } catch { /* never kill the 
       const provPatched: string[] = []
       const egressPatched: string[] = []
       const bashEgressPatched: string[] = []
+      const bashEgressUncovered: string[] = []
       const govPatched: string[] = []
       const copyGatePatched: string[] = []
       const pruned: string[] = []
@@ -565,7 +567,15 @@ setInterval(() => { try { sweepExpiredDesktopLock() } catch { /* never kill the 
         if (ensureAgentStalenessHook(agentName)) stalePatched.push(agentName)
         if (ensureAgentProvenanceHook(agentName)) provPatched.push(agentName)
         if (ensureEgressGate(agentName)) egressPatched.push(agentName)
-        if (ensureBashEgressDeny(agentName)) bashEgressPatched.push(agentName)
+        // The Bash egress deny needs the main agent's OWN config dir: its
+        // nominal settings path is the shared ~/.claude, which is also the
+        // operator's own interactive shell, and the operator asked to stay out
+        // of the rule while the fleet stays in it. Null -> no separate scope
+        // exists on this install, so nothing is written and it is reported
+        // rather than decided quietly.
+        const bashDenyDir = agentName === MAIN_AGENT_ID ? mainAgentConfigDirIfSeparate() : null
+        if (agentName === MAIN_AGENT_ID && !bashDenyDir) bashEgressUncovered.push(agentName)
+        else if (ensureBashEgressDeny(agentName, bashDenyDir)) bashEgressPatched.push(agentName)
         if (ensureGovernanceGateCommands(agentName)) govPatched.push(agentName)
         if (ensureTelegramCopyGate(agentName)) copyGatePatched.push(agentName)
         ensureQuarantineReader(agentName)
@@ -585,6 +595,8 @@ setInterval(() => { try { sweepExpiredDesktopLock() } catch { /* never kill the 
       if (provPatched.length) logger.info({ patched: provPatched }, 'provenance-gate UserPromptSubmit hook backfilled into agent settings.json')
       if (egressPatched.length) logger.info({ patched: egressPatched }, 'egress-gate WebFetch hook backfilled into agent settings.json')
       if (bashEgressPatched.length) logger.info({ patched: bashEgressPatched }, 'Bash egress deny rules backfilled into agent settings.json (permissions.deny)')
+      if (bashEgressUncovered.length) logger.warn({ agents: bashEgressUncovered },
+        'Bash egress deny NOT applied to the main agent: it runs on the shared user config root, which is also the operator\'s own shell. Give it a config dir of its own (MAIN_AGENT_ISOLATED_CONFIG / MAIN_AGENT_CONFIG_DIR) to cover it without covering the operator.')
       if (govPatched.length) logger.info({ patched: govPatched }, 'governance gate hook commands upgraded to absolute node path in agent settings.json')
       if (copyGatePatched.length) logger.info({ patched: copyGatePatched }, 'outgoing-copy-gate wired onto the Telegram send tools in agent settings.json (GATECOPY828)')
     } catch (err) {

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -375,6 +375,27 @@ export function ensureMainAgentIsolatedConfigDir(
   )
 }
 
+// READ-ONLY sibling of the two resolvers above: which config dir will the main
+// agent actually use, without provisioning anything. `null` means the shared
+// ~/.claude root, i.e. the same file the operator's own interactive sessions
+// read -- and a caller that must not touch the operator's shell has to treat
+// that as "no place of my own to write" rather than falling back to it.
+//
+// Same gates as ensureMainAgentIsolatedConfigDir (explicit dir wins; otherwise
+// the setting AND the fleet token AND the dir actually existing), deliberately
+// without its side effects, so a boot-time migration can ask the question
+// before the launcher has run.
+export function mainAgentConfigDirIfSeparate(): string | null {
+  const explicit = resolveMainAgentConfigDir()
+  if (explicit) return explicit
+  let enabled = false
+  try { enabled = String(getEffectiveSettingValue('MAIN_AGENT_ISOLATED_CONFIG')) === '1' } catch { return null }
+  if (!enabled) return null
+  if (!hasFleetOauthToken()) return null
+  const dir = join(PROJECT_ROOT, '.channels-config')
+  return existsSync(dir) ? dir : null
+}
+
 // CHANNEL_PLUGINS_EXTRA -- the co-listen plugins channels.sh appends to
 // --channels so ONE main session can serve several providers at once (e.g.
 // Telegram primary + Discord). Same .env key channels.sh parses, read here so

--- a/src/web/agent-scaffold.ts
+++ b/src/web/agent-scaffold.ts
@@ -774,14 +774,53 @@ export function mergeBashEgressDeny(settings: Record<string, unknown>): boolean 
   return true
 }
 
+// WHICH FILE the egress deny is written to -- the part that is not obvious, so
+// it is a pure function with its own tests.
+//
+// A sub-agent is simple: its own settings.json.
+//
+// The MAIN agent is not, and getting it wrong inverts the whole guard. Its
+// settings path is the shared ~/.claude/settings.json, and that file is ALSO
+// the owner's own interactive sessions. The owner decided (2026-09-07) that
+// their own shell must stay unrestricted while the fleet stays gated, so the
+// shared file is off limits: writing there would restrict the owner, and
+// deleting from there would un-gate the main agent -- which is the one agent
+// that reads untrusted web content on the owner's behalf.
+//
+// The way out is measured, not assumed: when the install gives the main agent a
+// config dir of its own (an explicit one, or the provisioned isolated dir), the
+// agent reads ITS settings.json as the user scope and the owner's shell does
+// not. The two are genuinely separate files -- and the separation survives
+// restarts, because the provisioner rebuilds that file from the shared one but
+// keeps keys the shared file never mentions, and `permissions` is exactly such
+// a key.
+//
+// Returns null when the main agent runs on the shared root: there is no scope
+// that covers it without covering the owner, so this writes NOTHING and the
+// caller reports it. A silent fallback either way would be a decision this code
+// is not entitled to make.
+export function bashEgressDenyTargetPath(name: string, mainAgentConfigDir: string | null): string | null {
+  if (name !== MAIN_AGENT_ID) return agentSettingsPath(name)
+  return mainAgentConfigDir ? join(mainAgentConfigDir, 'settings.json') : null
+}
+
 // Idempotent migration for the EXISTING fleet: writeAgentSettingsFromProfile
-// only rewrites a sub-agent's settings on spawn, and the main agent's
-// ~/.claude/settings.json is not written by it at all. Called at server startup
-// alongside ensureEgressGate so the rules reach every agent -- main included,
-// because the main agent is hijackable through fetched content exactly like a
-// sub-agent. Returns true if the file was updated.
-export function ensureBashEgressDeny(name: string): boolean {
-  const settingsPath = agentSettingsPath(name)
+// only rewrites a sub-agent's settings on spawn, and the main agent's settings
+// are not written by it at all. Called at server startup alongside
+// ensureEgressGate so the rules reach every agent -- the main one included,
+// because it is hijackable through fetched content exactly like a sub-agent.
+//
+// `mainAgentConfigDir` is the main agent's own config dir, or null when it runs
+// on the shared root; it is ignored for sub-agents. Returns true if a file was
+// written, false if nothing was needed OR there was no place to write it.
+//
+// NOTE the scope loads at session start: a user-scope settings.json is read
+// when the session boots and is NOT re-read while it runs (the project scope
+// is -- measured 2026-09-07, both directions). So a freshly written rule binds
+// the main agent from its next restart, not immediately.
+export function ensureBashEgressDeny(name: string, mainAgentConfigDir: string | null = null): boolean {
+  const settingsPath = bashEgressDenyTargetPath(name, mainAgentConfigDir)
+  if (!settingsPath) return false
   let settings: Record<string, unknown> = {}
   if (existsSync(settingsPath)) {
     try { settings = JSON.parse(readFileSync(settingsPath, 'utf-8')) } catch { return false }

--- a/src/web/agent-scaffold.ts
+++ b/src/web/agent-scaffold.ts
@@ -559,6 +559,10 @@ export function writeAgentSettingsFromProfile(name: string, profile: ProfileTemp
   // the Bash escape routes a name-deny cannot reach. (2026-06-26 autonom-kor fix.)
   if (agentGetsGovernanceGates(name)) denyList.push(...SELF_PACE_TOOL_DENY)
 
+  // Egress deny: applied to EVERY profile, not just the gated ones. This
+  // function replaces permissions wholesale on each spawn, so without it a
+  // respawn would silently drop what ensureBashEgressDeny() merged in.
+  denyList.push(...BASH_EGRESS_DENY)
   existing.permissions = {
     allow: profile.filesystem.allow.map(p => resolveProfilePlaceholders(p, ctx)),
     deny: denyList,
@@ -689,6 +693,104 @@ export function injectEmailSendGate(existing: Record<string, unknown>, threadRep
 // closed, enforced even under --dangerously-skip-permissions). The Bash escape
 // routes are covered by the self-pace-gate hook, which a name-deny cannot reach.
 const SELF_PACE_TOOL_DENY = ['ScheduleWakeup', 'CronCreate', 'CronDelete', 'CronList', 'RemoteTrigger']
+
+// Bash egress deny rules -- the shell half of the outbound-traffic gate.
+//
+// WHY THIS EXISTS: egress-gate.mjs is wired as a PreToolUse hook with
+// matcher "WebFetch" ONLY. Nothing compared a shell command against the
+// allowlist, so the sanctioned inbound path (quarantine-reader -> WebFetch ->
+// domain check) sat next to an unchecked outbound one (`curl https://...`).
+// The realistic threat is not a malicious agent: it is a page an agent fetched
+// telling it to curl something -- which is the very reason the quarantine
+// reader exists. Measured 2026-09-07 after another fleet agent reported the
+// gap and did not use it.
+//
+// PRECISION, because the earlier wording overstated it: Bash was never
+// ungated. outgoing-copy-gate.py + email-approval-gate.py (main agent) and
+// email-send-gate.mjs + self-pace-gate.mjs (sub-agents) already sit on it.
+// None of them looks at the DESTINATION HOST. What was missing is an EGRESS
+// gate on Bash, not a gate.
+//
+// WHAT THIS IS: a deny list, not a sandbox. It stops the URL-fetch verbs a
+// misled-but-compliant agent reaches for. Sanctioned tooling that speaks HTTPS
+// on its own (git, gh, npm) is deliberately untouched -- denying those would
+// break the fleet's own release path without closing anything, since an agent
+// that wanted to exfiltrate could still use them.
+//
+// RULE SEMANTICS (measured against the shipped Claude Code 2.1.263 binary, and
+// confirmed live in a running session): a rule containing `*` is compiled to an
+// ANCHORED full-match regex where `*` becomes `.*`. Deny is evaluated per
+// sub-command (a `cd x && curl ...` compound is split first), env-var
+// assignments are stripped before matching, an `xargs <cmd>` variant is tried
+// too, and deny is checked BEFORE the --dangerously-skip-permissions bypass --
+// so these rules bind even on permissive profiles.
+//
+// Consequences of that anchoring, and why the list looks the way it does:
+//   - `curl *https://*` cannot be written as `*curl *https://*` for free: a
+//     leading `*` also matches inside a word. `*nc *` would deny `rsync -a x y`
+//     ("...nc " is a suffix of "rsync "). Hence `nc *` (anchored) plus an
+//     explicit `*/nc *` for absolute-path invocations.
+//   - THE LOCALHOST EXCEPTION IS THE REASON ONLY https:// IS DENIED FOR curl.
+//     There is no negation in the rule language and `deny` always beats
+//     `allow`, so "any http:// host except localhost" is NOT expressible: a
+//     `*http://*` rule would also match the dashboard's own
+//     `http://localhost:<WEB_PORT>/` calls and mute the entire fleet (memory,
+//     kanban, message queue, approvals all ride that URL). The residual gap is
+//     stated out loud rather than papered over:
+//     plain-http external fetches, an interpreter one-liner (python3 -c,
+//     node -e), and a URL hidden in a shell variable all still pass. Closing
+//     those needs a Bash PreToolUse hook that parses the command, which is a
+//     separate and larger decision.
+export const BASH_EGRESS_DENY = [
+  // curl: the https:// form only -- see the localhost note above.
+  'Bash(curl *https://*)',
+  'Bash(*/curl *https://*)',
+  // wget / nc / ncat / telnet have no internal use in this install, so they are
+  // denied whole; no localhost carve-out is needed and none is possible.
+  'Bash(wget *)',
+  'Bash(*/wget *)',
+  'Bash(nc *)',
+  'Bash(*/nc *)',
+  'Bash(ncat *)',
+  'Bash(*/ncat *)',
+  'Bash(telnet *)',
+  'Bash(*/telnet *)',
+]
+
+// Idempotently merge the egress deny rules into a settings object's
+// permissions.deny. Pure (no I/O) so both the rule set and the merge behaviour
+// are unit-testable; ensureBashEgressDeny() below is the filesystem wrapper.
+// Existing entries are preserved and their order kept: an operator's own deny
+// rule must never be dropped by a migration. Returns true if anything changed.
+export function mergeBashEgressDeny(settings: Record<string, unknown>): boolean {
+  const perms = (settings.permissions && typeof settings.permissions === 'object' && !Array.isArray(settings.permissions))
+    ? settings.permissions as Record<string, unknown>
+    : {}
+  const deny = Array.isArray(perms.deny) ? [...(perms.deny as unknown[])] : []
+  const missing = BASH_EGRESS_DENY.filter((rule) => !deny.includes(rule))
+  if (missing.length === 0) return false
+  perms.deny = [...deny, ...missing]
+  settings.permissions = perms
+  return true
+}
+
+// Idempotent migration for the EXISTING fleet: writeAgentSettingsFromProfile
+// only rewrites a sub-agent's settings on spawn, and the main agent's
+// ~/.claude/settings.json is not written by it at all. Called at server startup
+// alongside ensureEgressGate so the rules reach every agent -- main included,
+// because the main agent is hijackable through fetched content exactly like a
+// sub-agent. Returns true if the file was updated.
+export function ensureBashEgressDeny(name: string): boolean {
+  const settingsPath = agentSettingsPath(name)
+  let settings: Record<string, unknown> = {}
+  if (existsSync(settingsPath)) {
+    try { settings = JSON.parse(readFileSync(settingsPath, 'utf-8')) } catch { return false }
+  }
+  if (!mergeBashEgressDeny(settings)) return false
+  if (name !== MAIN_AGENT_ID) mkdirSync(join(agentDir(name), '.claude'), { recursive: true })
+  atomicWriteFileSync(settingsPath, JSON.stringify(settings, null, 2))
+  return true
+}
 
 // Which agents are subject to the self-pace gate: every agent EXCEPT the main
 // agent (same name-agnostic main-exempt rule as the email gate). Pure + exported

--- a/templates/settings.json.template
+++ b/templates/settings.json.template
@@ -3,6 +3,20 @@
     "telegram@claude-plugins-official": true
   },
   "effortLevel": "high",
+  "permissions": {
+    "deny": [
+      "Bash(curl *https://*)",
+      "Bash(*/curl *https://*)",
+      "Bash(wget *)",
+      "Bash(*/wget *)",
+      "Bash(nc *)",
+      "Bash(*/nc *)",
+      "Bash(ncat *)",
+      "Bash(*/ncat *)",
+      "Bash(telnet *)",
+      "Bash(*/telnet *)"
+    ]
+  },
   "hooks": {
     "PreCompact": [
       {


### PR DESCRIPTION
## A változtatás típusa / Type of change
- [x] Hibajavítás (bugfix)

## Rövid leírás / Summary
HU: Az egress-kapu (`scripts/hooks/egress-gate.mjs`) `PreToolUse` hookként CSAK a `WebFetch`
matcherre van bekötve, így egyetlen shell-parancs sem került soha összevetésre a domain-listával.
A Bash nem volt kapu nélkül (`outgoing-copy-gate.py` + `email-approval-gate.py` a fő ágensen,
`email-send-gate.mjs` + `self-pace-gate.mjs` a flotta-ágenseken), de egyik sem nézi a CÉLHOSTOT --
vagyis a Bash-en nem volt EGRESS-kapu. A fenyegetés nem a rosszindulatú ágens, hanem egy letöltött,
untrusted oldal, amely curl-re utasítja az ágenst; pontosan ezért létezik a quarantine-reader.

A javítás egy `permissions.deny` lista (`BASH_EGRESS_DENY`, `src/web/agent-scaffold.ts`), amely
HÁROM úton ér el MINDEN ágenst: `writeAgentSettingsFromProfile()` induláskor, `ensureBashEgressDeny()`
a szerver bootnál (meglévő flotta + fő ágens), és `templates/settings.json.template` scaffoldnál --
a template és a konstans egyezését teszt őrzi. Ez azért fontos, mert a korábbi részleges kísérlet
két ágensig jutott, a többi kapu nélkül maradt; ugyanaz ne ismétlődjön.

A `curl`-nél CSAK a `https://` alak tiltott. A szabálynyelvben nincs tagadás és a `deny` mindig veri
az `allow`-t, ezért a "bármely `http://` host, kivéve a localhost" NEM kifejezhető: egy tágabb
szabály a dashboard saját hívásait is elkapná, és az egész flotta elnémulna. A maradék rések és az
egy mért mellékhatás nincs elhallgatva: `docs/security-hardening.md`-ben le vannak írva és teszt
rögzíti őket.

EN: The egress gate is wired as a `PreToolUse` hook with matcher `WebFetch` only, so no shell
command was ever compared against the allowlist. Bash was never ungated -- `outgoing-copy-gate.py`
and `email-approval-gate.py` on the main agent, `email-send-gate.mjs` and `self-pace-gate.mjs` on
fleet agents -- but none of those looks at the destination host: what was missing is an EGRESS gate
on Bash, not a gate. The realistic threat is a fetched, untrusted page instructing an agent to run a
curl, which is exactly why the quarantine-reader exists.

`BASH_EGRESS_DENY` in `src/web/agent-scaffold.ts` is now the single source of truth for a small
`permissions.deny` list that reaches every agent three ways: on spawn, at server startup (existing
fleet and the main agent included), and at scaffold time via the settings template, with a parity
test keeping template and constant in step.

Only `https://` is denied for `curl`: the rule language has no negation and `deny` always beats
`allow`, so "any `http://` host except localhost" is not expressible, and a wider rule would also
match the dashboard's own calls and mute the whole fleet. The residual gaps and the one measured
collateral are documented in `docs/security-hardening.md` and pinned by tests rather than left
implicit.

### Mit tilt / What is denied
`curl` egy `https://` URL-re, valamint `wget` / `nc` / `ncat` / `telnet` teljesen (ezeknek nincs
belső használatuk). A `git`, `gh`, `npm` szándékosan érintetlen: ezek szentesített eszközök, a
tiltásuk a kiszállítási utat törné el anélkül, hogy bármit lezárna.

`curl` to an `https://` URL, plus `wget` / `nc` / `ncat` / `telnet` outright (no internal use).
`git`, `gh` and `npm` are deliberately untouched: sanctioned tooling whose denial would break the
release path without closing anything.

### A három kontroll / The three controls
Élő méréssel, futó session-ben (2026-09-07), a szabályok ideiglenes `settings.local.json`-ban:

| Próba / Probe | Elvárt / Expected | Mért / Measured |
|---|---|---|
| `curl` a helyi dashboard API-ra (GET + POST, Bearer tokennel) | átmegy / passes | `http_code=200` és `404` -- LEFUTOTT |
| `curl -s --connect-timeout 1 https://<nem listás host>/x` | bukik / denied | `Permission to use Bash ... has been denied.` |
| `curl -s https://api.github.com/rate_limit` (WebFetch-allowlisten RAJTA VAN) | bukik / denied | `Permission to use Bash ... has been denied.` |

A harmadik a lényegi kontroll: attól, hogy egy host rajta van a WebFetch-listán, a shell még nem
mehet oda -- a szentesített út a `WebFetch`. Ha ez átmenne, a kapu nem azt csinálná, amit hiszünk.

The third is the control that matters: a host being on the WebFetch allowlist does not open it to
the shell -- the sanctioned route stays `WebFetch`.

### Mért határok / Measured limits
- **Sima `http://` külső letöltés átmegy** (mérve: `rc=28` timeout, tehát lefutott). Nem
  kifejezhető szabály, lásd fent.
- **Interpreter-egysoros átmegy** (`python3 -c` urllib: a kérés elment).
- **Ismert mellékhatás:** egy belső POST, amelynek **dupla idézőjeles** payloadja `https://` URL-t
  idéz, illeszkedik a curl-szabályra. **Egyszeres idézőjelnél nem** (a jogosultság-motor kihagyja az
  egyszeres idézőjeles tartalmat). Megoldás: egyszeres idézőjel vagy `-d @fájl`.
- Plain-http external fetches and interpreter one-liners still pass; a double-quoted payload quoting
  an `https://` URL matches the curl rule while a single-quoted one does not.

### Szabály-szemantika, mérve / Rule semantics, measured
A shipped Claude Code binárisból kiolvasva és élőben visszaigazolva: a `*`-ot tartalmazó szabály
HORGONYZOTT teljes-illeszkedésű regexre fordul (`*` -> `.*`); a `deny` AL-PARANCSONKÉNT értékelődik
(a `cd x && curl ...` szét van bontva); és a `deny` a `--dangerously-skip-permissions` bypass ELŐTT
dönt, tehát a megengedő profilokon is köt. Ezért nem `*curl *https://*` az alak: a vezető `*` szó
közben is illeszkedne, és egy `*nc *` szabály a `rsync -a x y`-t is megtiltaná.

## Kapcsolódó issue / Related issue
Nincs nyitott GitHub issue -- kanban #1305.

## Ellenőrzőlista / Checklist
- [x] `npm run typecheck` zöld.
- [x] `npm test` zöld: 373 fájl, 4839 teszt (1 skipped).
- [x] `npm run syntax-check` zöld.
- [x] Új teszt: `src/__tests__/bash-egress-deny.test.ts` (10 eset) -- a flotta belső hívásai NEM
      tilthatók, a külső letöltő igék igen, az allowlistás host is bukik shellből, és a maradék rés
      is rögzítve van, hogy látható maradjon.
- [x] Idempotencia és a meglévő `deny` bejegyzések megőrzése tesztelve (`mergeBashEgressDeny`).
- [x] Template-konstans paritás tesztelve, hogy a KÖVETKEZŐ létrehozott ágens se induljon kapu nélkül.
- [x] docs/ frissítés: `docs/security-hardening.md` új szekció a korlátokkal együtt.
- [x] Nincs beégetett szenzitív adat.
- [x] Saját, beszédes nevű branch: fix/bash-egress-deny-rules

## A fo agens hatokore / Where the main agent's copy goes

> **A fo agens fedettsege FELTETELES.** Csak ott all fenn, ahol a telepites a fo agensnek SAJAT config
> konyvtarat ad. Ha a fo agens a kozos user-gyokeren fut, ez a valtozat NEM fedi le -- tudatosan, mert
> ott nincs olyan scope, ami ot fedi es a tulajdonos sajat shelljet nem. A kod ilyenkor semmit nem ir,
> es a boot-log kimondja.
>
> **The main agent's coverage is CONDITIONAL**: it holds only where the install gives the main agent a
> config dir of its own. On an install where it runs on the shared user root this change does NOT cover
> it -- deliberately, because no scope there covers the agent without covering the operator. Nothing is
> written and startup says so.

HU: Az elso korben ez nyitott kerdes volt, es a tulajdonos ugy dontott, hogy a SAJAT interaktiv
munkamenetei maradjanak ki a tiltas alol, a flottara viszont valtozatlanul alljon. A trivialis
megoldas (a fo agens kihagyasa a migraciobol) TOBBET nyitott volna ki, mint amit kertek: a fo agens
settings-utvonala a KOZOS user-gyoker, ami egyszerre a tulajdonos sajat shellje ES az az agens,
amelyik az o neveben untrusted webtartalmat olvas. Onnan torolni annyi, mint az agenst kinyitni;
ott hagyni annyi, mint a tulajdonost korlatozni. Egy fajl nem tud mindket dolgot.

MERVE, nem feltetelezve: ha a telepites a fo agensnek SAJAT config konyvtarat ad (explicit dir, vagy
a provisionalt izolalt dir), akkor annak a `settings.json`-ja a fo agens user-scope-ja, es a
tulajdonos shellje NEM olvassa. Ket kulon fajl. A szetvalast ugy igazoltam, hogy egy egyedi,
artalmatlan szabalyt irtam az egyikbe, es egy masik config dir alatt futo munkamenet valtozatlanul
lefuttatta ugyanazt a parancsot. A szetvalas RESTARTOT is tulel: a provisioner minden indulaskor
ujraepiti azt a fajlt a kozosbol, de a csak-ott-letezo kulcsokat megtartja -- es a `permissions`
pontosan ilyen kulcs (a kozos fajlnak nincs `permissions` blokkja).

Ha a fo agens a kozos gyokeren fut, akkor NINCS olyan scope, ami ot fedi es a tulajdonost nem --
ilyenkor a kod SEMMIT nem ir, es a boot-log ezt kimondja. A megoldas ott a fo agens sajat config
konyvtara; helyette csendben valasztani nem ennek a kodnak a dolga.

EN: The owner asked to keep their own interactive shell out of the rule while the fleet stays gated.
Dropping the main agent from the migration would have opened more than was asked: its settings path
is the shared user root, which is both the operator's shell and the agent that reads untrusted web
content on their behalf. When the install gives the main agent a config dir of its own, that dir's
`settings.json` is its user scope and the operator's shell does not read it -- verified by writing a
unique harmless rule into one and watching a session on the other stay unaffected. The separation
survives restarts, because the provisioner keeps keys the shared file never mentions and
`permissions` is such a key. On the shared root nothing is written and startup says so.

`bashEgressDenyTargetPath()` is a pure function with its own tests, because getting this wrong
inverts the guard silently.

### Egy mert idozitesi tulajdonsag / One measured timing property
A user-scope `settings.json` a munkamenet INDULASAKOR olvasodik be, es futas kozben NEM toltodik
ujra -- a projekt-scope viszont igen (mindketto merve). Egy frissen kiirt szabaly tehat a fo agenst
a KOVETKEZO restartjatol koti, nem azonnal. Ezert a "fo agensbol megtagadva" kontrollt a kovetkezo
restart utan kell lefuttatni; addig nem allitom bizonyitottnak.

A user-scope settings file is read at session start and not re-read while the session runs (the
project scope is). A newly written rule therefore binds the main agent from its next restart, so the
"denied in the main agent" control is due after that restart and is not claimed as proven before it.

### A CSAPDA a kovetkezo meronek / The trap for whoever measures this next
A ket scope NEM egyformán viselkedik, es a kulonbseg addig lathatatlan, amig felre nem vezet:
a PROJEKT-scope menet kozben ujratoltodik (oda irt szabaly azonnal tuzel), a USER-scope viszont
csak a session INDULASAKOR olvasodik be. Ezert egy olyan proba, ami a projekt-scope-on tokeletesen
mukodik, a user-scope-on magabiztos "atment"-et jelent -- es az ebbol levont, tisztessegesnek latszo
kovetkeztetes ("a szabaly nem mukodik") HIBAS: a session csak meg nem olvasta. Ez itt egy merest mar
felrevitt, ezert bekerult a `docs/security-hardening.md`-be is, nem csak ide.

The project scope is re-read while a session runs; the user scope is read only at session start. A
probe that works on the first reports a confident "allowed" on the second, and the honest-looking
conclusion -- "the rule does not work" -- is wrong. Documented in
`docs/security-hardening.md` so the next measurement does not pay for it again.

### Mi MERT es mi MEG NEM / What is measured and what is not
MERT: a cel-utvonal soha nem a kozos user-gyoker (regresszios teszt). MERT: egy config dir szabalya
nem erinti a masik config dir alatt futo munkamenetet (elo proba, egyedi TEST-NET mintaval, utana
backupbol visszaallitva). MERT: a `permissions` blokk tulel egy provisioner-ujraepitest -- ez most a
VALODI provisionerre futtatott teszt allitasa (ketszer meghivva), nem a merge-kod elolvasasa; valodi
folyamat-restart elotti/utani osszevetes NEM tortent. MERT: a sub-agensek cel-utvonala es szabalyai
valtozatlanok (paritas-teszt + zold suite).
MEG NEM MERT: hogy a fo agens sajat munkamenetebol a kulso `curl https://` tenylegesen megtagadasra
kerul. Ez a kovetkezo restartja utan merheto, es addig nincs bizonyitottnak allitva.

MEASURED: the target path is never the shared user root (regression test); a rule in one config dir
does not reach a session on another (live probe, unique TEST-NET pattern, restored from backup
afterwards); a permissions block survives a provisioner rebuild (asserted against the real
provisioner, called twice -- NOT a before/after comparison across a real process restart); sub-agent
targets and rules are unchanged (parity test + green suite).
NOT YET MEASURED: that an external `curl https://` is actually denied from the main agent's own
session. That is measurable after its next restart and is not claimed as proven before then.

### A flotta vedelme valtozatlan / The fleet's protection is unchanged
A sub-agensek ugyanazt a cel-utvonalat es ugyanazokat a szabalyokat kapjak, a template-paritas teszt
all. Regresszio-teszt kimondja, hogy a fo agens cel-utvonala SOHA nem a kozos user-gyoker.
