### PR TITLE
feat(scheduler): record when a task run ENDS, not only when it fires

### DIFF
--- a/src/__tests__/schedule-task-timeout.test.ts
+++ b/src/__tests__/schedule-task-timeout.test.ts
@@ -55,19 +55,19 @@ describe('decideTaskTimeout: idle clear', () => {
   it('clears immediately when the pane is idle (task completed before timeout)', () => {
     const entry = makeEntry({ injectedAt: 0 })
     const now = GRACE + 1000
-    expect(decideTaskTimeout(entry, 'idle', now, BASE_OPTS)).toBe('clear')
+    expect(decideTaskTimeout(entry, 'idle', now, BASE_OPTS)).toBe('done')
   })
 
   it('clears even before the grace period if somehow idle', () => {
     const entry = makeEntry({ injectedAt: 0 })
     const now = GRACE - 5000
-    expect(decideTaskTimeout(entry, 'idle', now, BASE_OPTS)).toBe('clear')
+    expect(decideTaskTimeout(entry, 'idle', now, BASE_OPTS)).toBe('done')
   })
 
   it('clears when idle even after the timeout has elapsed', () => {
     const entry = makeEntry({ injectedAt: 0 })
     const now = TIMEOUT + 1000
-    expect(decideTaskTimeout(entry, 'idle', now, BASE_OPTS)).toBe('clear')
+    expect(decideTaskTimeout(entry, 'idle', now, BASE_OPTS)).toBe('done')
   })
 })
 
@@ -105,7 +105,7 @@ describe('decideTaskTimeout: one-shot alert flag', () => {
   it('still clears when idle even after alerted', () => {
     const entry = makeEntry({ injectedAt: 0, alerted: true })
     const now = TIMEOUT + 60_000
-    expect(decideTaskTimeout(entry, 'idle', now, BASE_OPTS)).toBe('clear')
+    expect(decideTaskTimeout(entry, 'idle', now, BASE_OPTS)).toBe('done')
   })
 })
 
@@ -129,16 +129,16 @@ describe('decideTaskTimeout: injection that never started a turn', () => {
     expect(decideTaskTimeout(entry, 'idle', now, BASE_OPTS)).toBe('hold')
   })
 
-  it('clears instead of losing once a turn has been observed', () => {
+  it('reports done instead of lost once a turn has been observed', () => {
     const entry = makeEntry({ injectedAt: 0, sawTurn: true })
     const now = GRACE + 1
-    expect(decideTaskTimeout(entry, 'idle', now, BASE_OPTS)).toBe('clear')
+    expect(decideTaskTimeout(entry, 'idle', now, BASE_OPTS)).toBe('done')
   })
 
   it('still evicts at max tracking age rather than reporting lost', () => {
     const entry = makeEntry({ injectedAt: 0, sawTurn: false })
     const now = MAX_TRACK + 1
-    expect(decideTaskTimeout(entry, 'idle', now, BASE_OPTS)).toBe('clear')
+    expect(decideTaskTimeout(entry, 'idle', now, BASE_OPTS)).toBe('abandoned')
   })
 
   it('does not report lost while the pane is busy -- that is the alert path', () => {
@@ -182,20 +182,26 @@ describe('decideTaskTimeout: stage-2 owner escalation', () => {
     expect(decideTaskTimeout(entry, 'busy', now, BASE_OPTS)).toBe('hold')
   })
 
-  it('still clears when idle even after escalation', () => {
+  it('still ends when idle even after escalation, and it ends as done', () => {
+    // Upstream wrote this as 'clear'. Since the done/abandoned split that value
+    // no longer exists: an idle pane with a turn seen is a FINISHED run, so the
+    // honest assertion is 'done'. Changing it is the point of the split, not a
+    // concession to it.
     const entry = makeEntry({ injectedAt: 0, alerted: true, ownerAlerted: true })
     const now = TIMEOUT + OWNER_EXTRA + 60_000
-    expect(decideTaskTimeout(entry, 'idle', now, BASE_OPTS)).toBe('clear')
+    expect(decideTaskTimeout(entry, 'idle', now, BASE_OPTS)).toBe('done')
   })
 
   it('maxTrackMs eviction still wins over escalate for a task configured near the ceiling', () => {
     // Known, accepted limitation (see decideTaskTimeout's doc comment):
-    // clear (maxTrackMs) is checked before alert/escalate, so a task whose
+    // abandoned (maxTrackMs) is checked before alert/escalate, so a task whose
     // timeoutMs + ownerExtraMs together exceed maxTrackMs never escalates.
+    // Upstream called this 'clear'; after the split, giving up on a still-busy
+    // task is 'abandoned' -- explicitly NOT 'done', because we never saw it end.
     const entry = makeEntry({ injectedAt: 0, alerted: true })
     const nearCeilingOpts = { graceMs: GRACE, timeoutMs: MAX_TRACK - 1000, maxTrackMs: MAX_TRACK, ownerExtraMs: OWNER_EXTRA }
     const now = MAX_TRACK + 1
-    expect(decideTaskTimeout(entry, 'busy', now, nearCeilingOpts)).toBe('clear')
+    expect(decideTaskTimeout(entry, 'busy', now, nearCeilingOpts)).toBe('abandoned')
   })
 })
 
@@ -227,13 +233,30 @@ describe('decideTaskTimeout: max tracking age', () => {
   it('evicts the entry regardless of pane state after maxTrackMs', () => {
     const entry = makeEntry({ injectedAt: 0, alerted: true })
     const now = MAX_TRACK + 1
-    expect(decideTaskTimeout(entry, 'busy', now, BASE_OPTS)).toBe('clear')
+    expect(decideTaskTimeout(entry, 'busy', now, BASE_OPTS)).toBe('abandoned')
   })
 
   it('evicts even if the pane is unknown at max age', () => {
     const entry = makeEntry({ injectedAt: 0 })
     const now = MAX_TRACK + 1
-    expect(decideTaskTimeout(entry, 'unknown', now, BASE_OPTS)).toBe('clear')
+    expect(decideTaskTimeout(entry, 'unknown', now, BASE_OPTS)).toBe('abandoned')
+  })
+
+  // The load-bearing half of the 2026-08-26 split. Ageing out is NOT success:
+  // the session was still busy when we stopped watching. If both cases kept
+  // returning one value, recording completions would silently stamp 'done' on
+  // every task that ran past six hours -- worse than recording nothing, because
+  // it would look like evidence.
+  it('a busy session at max age is abandoned, NOT done', () => {
+    const entry = makeEntry({ injectedAt: 0, alerted: true })
+    const decision = decideTaskTimeout(entry, 'busy', MAX_TRACK + 1, BASE_OPTS)
+    expect(decision).toBe('abandoned')
+    expect(decision).not.toBe('done')
+  })
+
+  it('an idle session that saw a turn is done, and max age cannot mask it as such', () => {
+    const finished = makeEntry({ injectedAt: 0, sawTurn: true })
+    expect(decideTaskTimeout(finished, 'idle', GRACE + 1000, BASE_OPTS)).toBe('done')
   })
 })
 

--- a/src/__tests__/task-run-completion.test.ts
+++ b/src/__tests__/task-run-completion.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+// Completion bookkeeping for scheduled task runs (2026-08-26).
+//
+// Before this change `task_runs` only ever recorded how a run was DISPATCHED.
+// On a live install that produced 3269 'fired' rows, 113 'skipped', and zero
+// completions -- so "still running" and "finished twenty minutes ago" were the
+// same row, and the stuck-task alert had nothing to compare against.
+//
+// The signal was never missing. The post-fire watchdog decides, every 15 s,
+// whether the target session has gone idle after a turn -- which is exactly
+// "the run finished". It just deleted the map entry instead of writing it down.
+//
+// These are source-level guards: the db functions need a real SQLite handle and
+// the suite refuses to run against a live install, so the behaviour that can be
+// pinned here without I/O is the CONTRACT -- that the two ending kinds stay
+// distinct, that a run is closed exactly where it is known to have ended, and
+// that a restart cannot leave rows open for ever.
+
+const SRC = join(__dirname, '..')
+const DB_SRC = readFileSync(join(SRC, 'db.ts'), 'utf-8')
+const RUNNER_SRC = readFileSync(join(SRC, 'web', 'schedule-runner.ts'), 'utf-8')
+const COMMAND_SRC = readFileSync(join(SRC, 'web', 'command-task.ts'), 'utf-8')
+
+describe('task_runs schema: completion columns are additive', () => {
+  it('adds completed_at and outcome without touching status', () => {
+    expect(DB_SRC).toMatch(/ALTER TABLE task_runs ADD COLUMN completed_at INTEGER/)
+    expect(DB_SRC).toMatch(/ALTER TABLE task_runs ADD COLUMN outcome TEXT/)
+    // status keeps its original meaning and default; rewriting it would
+    // invalidate every historical row and every existing query.
+    expect(DB_SRC).toMatch(/ALTER TABLE task_runs ADD COLUMN status TEXT NOT NULL DEFAULT 'fired'/)
+  })
+
+  it('indexes the open-run lookup the restart reconcile depends on', () => {
+    expect(DB_SRC).toMatch(/idx_task_runs_open ON task_runs\(completed_at, ts\)/)
+  })
+})
+
+describe('appendTaskRun returns an id', () => {
+  it('hands back lastInsertRowid so a run can be closed later', () => {
+    expect(DB_SRC).toMatch(/export function appendTaskRun\([^)]*\): number/)
+    expect(DB_SRC).toMatch(/return Number\(info\.lastInsertRowid\)/)
+  })
+})
+
+describe('markTaskRunCompleted is first-writer-wins', () => {
+  it('refuses to overwrite an already-closed run', () => {
+    // Without the completed_at IS NULL guard a reconcile racing a live sweep
+    // could turn a real 'done' into 'interrupted' -- corrupting the very data
+    // the change exists to produce.
+    expect(DB_SRC).toMatch(/UPDATE task_runs SET completed_at = \?, outcome = \? WHERE id = \? AND completed_at IS NULL/)
+  })
+})
+
+describe('the two ending kinds stay distinct', () => {
+  it('done and abandoned are separate decisions, and clear is gone', () => {
+    expect(RUNNER_SRC).toMatch(/export type TaskTimeoutDecision = 'done' \| 'abandoned' \| 'alert' \| 'escalate' \| 'hold' \| 'lost'/)
+    // 'clear' merged success with giving-up. If it comes back, completions
+    // become unreliable in the one direction that matters. Comment lines are
+    // excluded on purpose: the file keeps the historical note explaining what
+    // 'clear' used to mean, and that prose is worth more than a tidier regex.
+    const codeLines = RUNNER_SRC.split('\n').filter(l => !l.trim().startsWith('//'))
+    expect(codeLines.join('\n')).not.toMatch(/return 'clear'/)
+  })
+
+  it('max tracking age returns abandoned; idle-after-a-turn returns done', () => {
+    expect(RUNNER_SRC).toMatch(/if \(elapsed >= opts\.maxTrackMs\) return 'abandoned'/)
+    expect(RUNNER_SRC).toMatch(/if \(entry\.sawTurn\) return 'done'/)
+  })
+})
+
+describe('every run that opens also closes', () => {
+  it('the sweep closes the row it opened, for both ending kinds', () => {
+    expect(RUNNER_SRC).toMatch(/decision === 'done' \|\| decision === 'abandoned'/)
+    expect(RUNNER_SRC).toMatch(/markTaskRunCompleted\(entry\.runId, decision, now\)/)
+  })
+
+  it('the lost path closes the original row too, not just appends a lost one', () => {
+    // Otherwise the injection's own row stays open for ever next to its 'lost'
+    // sibling, which is the same leak in a different shape.
+    expect(RUNNER_SRC).toMatch(/markTaskRunCompleted\(entry\.runId, 'lost', now\)/)
+  })
+
+  it('synchronous command tasks close immediately -- the pane watchdog never sees them', () => {
+    expect(COMMAND_SRC).toMatch(/markTaskRunCompleted\(runId, "done"\)/)
+  })
+
+  it('a restart cannot leave rows open for ever', () => {
+    expect(RUNNER_SRC).toMatch(/reconcileOpenTaskRuns\(TASK_FIRE_MAX_TRACK_MS\)/)
+    expect(DB_SRC).toMatch(/outcome = 'interrupted'/)
+    // 'interrupted', not 'done': after a restart we genuinely do not know.
+    expect(DB_SRC).not.toMatch(/outcome = 'done'\s*\n\s*WHERE completed_at IS NULL/)
+  })
+})
+
+describe('bookkeeping never blocks the task', () => {
+  it('a failed completion write is logged, not thrown', () => {
+    expect(RUNNER_SRC).toMatch(/Failed to record task-run completion/)
+  })
+})
+
+describe('the alert can finally say what normal looks like', () => {
+  it('the stuck-task alert quotes the median of this task own completed runs', () => {
+    expect(DB_SRC).toMatch(/export function getTaskRunMedianDurationMs/)
+    expect(RUNNER_SRC).toMatch(/getTaskRunMedianDurationMs\(entry\.taskName\)/)
+    expect(RUNNER_SRC).toMatch(/korábbi befejezett futások mediánja/)
+  })
+
+  it('stays silent about the median until there is enough history', () => {
+    expect(DB_SRC).toMatch(/if \(ds\.length < minSamples\) return null/)
+  })
+})
+
+describe('history exposes the ending, so a finished run stops looking stuck', () => {
+  it('listTaskRunHistory returns completed_at, outcome and duration', () => {
+    expect(DB_SRC).toMatch(/completed_at: number \| null/)
+    expect(DB_SRC).toMatch(/outcome: string \| null/)
+    expect(DB_SRC).toMatch(/duration_ms: completedAt != null \? completedAt - row\.ts : null/)
+  })
+})

--- a/src/db.ts
+++ b/src/db.ts
@@ -684,6 +684,21 @@ export function initDatabase(dbPathOverride?: string): void {
   db.exec(`CREATE INDEX IF NOT EXISTS idx_task_runs_ts ON task_runs(ts)`)
   // Migration: add status column to task_runs (introduced 2026-06-13)
   try { db.exec(`ALTER TABLE task_runs ADD COLUMN status TEXT NOT NULL DEFAULT 'fired'`) } catch { /* already present */ }
+  // Migration: completion bookkeeping (introduced 2026-08-26).
+  //
+  // `status` records how the DISPATCH went (fired / skipped / lost / ...) and is
+  // stamped once, at injection time. It was the only column, so a run that had
+  // been delivered and a run that had finished looked identical for ever --
+  // 3269 'fired' rows on this install, zero completions. These two columns
+  // record how the run ENDED, and are written by the post-fire watchdog sweep
+  // that already computes exactly that and then threw the answer away.
+  //
+  // Deliberately additive: `status` keeps its meaning, so every existing query
+  // and the historical rows stay valid. A NULL completed_at means "not closed",
+  // which is the honest reading for every row written before this migration.
+  try { db.exec(`ALTER TABLE task_runs ADD COLUMN completed_at INTEGER`) } catch { /* already present */ }
+  try { db.exec(`ALTER TABLE task_runs ADD COLUMN outcome TEXT`) } catch { /* already present */ }
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_task_runs_open ON task_runs(completed_at, ts)`)
 
   // --- Pending Scheduled Task Retries ---
   // Busy-skipped scheduled tasks used to live in an in-memory Map. On a
@@ -2891,21 +2906,92 @@ export function getAgentConversationThreads(): AgentThread[] {
 
 export interface TaskRunEntry { name: string; agent: string; ts: number; status: string }
 
-export interface TaskRunHistoryEntry { ts: number; status: string; tokens_est: number | null }
+export interface TaskRunHistoryEntry {
+  ts: number
+  status: string
+  tokens_est: number | null
+  // Completion bookkeeping (2026-08-26). null = the run was never closed:
+  // either it is still in flight, or it predates this migration. The UI must
+  // render that as 'unknown', NOT as 'still running' -- the two are different
+  // claims and conflating them is how a finished task kept looking stuck.
+  completed_at: number | null
+  outcome: string | null
+  duration_ms: number | null
+}
 
 const TASK_RUN_TTL_MS = 30 * 24 * 60 * 60 * 1000
 
-export function appendTaskRun(name: string, agent: string, status = 'fired'): void {
+/**
+ * Record that a run was dispatched. Returns the row id so the caller can close
+ * the run later with markTaskRunCompleted -- without it there is no way to
+ * attach an ending to a beginning, which is why completions were never written.
+ */
+export function appendTaskRun(name: string, agent: string, status = 'fired'): number {
   const now = Date.now()
-  db.prepare('INSERT INTO task_runs (name, agent, ts, status) VALUES (?, ?, ?, ?)').run(name, agent, now, status)
+  const info = db.prepare('INSERT INTO task_runs (name, agent, ts, status) VALUES (?, ?, ?, ?)').run(name, agent, now, status)
   // Opportunistic TTL prune: cheap indexed DELETE, keeps the table bounded.
   db.prepare('DELETE FROM task_runs WHERE ts < ?').run(now - TASK_RUN_TTL_MS)
+  return Number(info.lastInsertRowid)
+}
+
+/** How a run ENDED. Distinct from `status`, which is how it was dispatched. */
+export type TaskRunOutcome = 'done' | 'abandoned' | 'lost' | 'interrupted'
+
+/**
+ * Close a run. Idempotent by design: the WHERE clause refuses to overwrite an
+ * already-closed row, so a duplicate sweep (or a reconcile racing a live sweep)
+ * cannot turn a 'done' into an 'abandoned'. First writer wins.
+ */
+export function markTaskRunCompleted(runId: number, outcome: TaskRunOutcome, completedAt = Date.now()): boolean {
+  const info = db.prepare(
+    'UPDATE task_runs SET completed_at = ?, outcome = ? WHERE id = ? AND completed_at IS NULL'
+  ).run(completedAt, outcome, runId)
+  return info.changes > 0
+}
+
+/**
+ * Close runs that a restart orphaned.
+ *
+ * The watchdog's in-flight map lives in memory, so a dashboard restart loses
+ * every open run it was tracking and those rows would stay open for ever --
+ * re-introducing the exact "cannot tell running from finished" problem this
+ * change removes, just in a smaller window. Rows older than maxAgeMs with no
+ * completed_at are closed as 'interrupted': we genuinely do not know whether
+ * they finished, and saying so is more useful than either optimistic 'done'
+ * or alarming 'abandoned'.
+ */
+export function reconcileOpenTaskRuns(maxAgeMs: number, now = Date.now()): number {
+  const info = db.prepare(
+    `UPDATE task_runs SET completed_at = ?, outcome = 'interrupted'
+     WHERE completed_at IS NULL AND ts < ? AND status IN ('fired', 'fired_late')`
+  ).run(now, now - maxAgeMs)
+  return info.changes
+}
+
+/**
+ * Median wall-clock duration of the recent COMPLETED runs of a task, in ms.
+ * Returns null until there is enough history to be meaningful.
+ *
+ * This is what turns the stuck-task alert from a bare threshold into a
+ * judgement the operator can make: "running 5 min, typically finishes in 40 s"
+ * says something; "running 5 min" alone does not.
+ */
+export function getTaskRunMedianDurationMs(name: string, minSamples = 5, limit = 50): number | null {
+  const rows = db.prepare(
+    `SELECT (completed_at - ts) AS d FROM task_runs
+     WHERE name = ? AND outcome = 'done' AND completed_at IS NOT NULL
+     ORDER BY ts DESC LIMIT ?`
+  ).all(name, limit) as { d: number }[]
+  const ds = rows.map(r => r.d).filter(d => Number.isFinite(d) && d >= 0).sort((a, b) => a - b)
+  if (ds.length < minSamples) return null
+  const mid = Math.floor(ds.length / 2)
+  return ds.length % 2 === 0 ? Math.round((ds[mid - 1] + ds[mid]) / 2) : ds[mid]
 }
 
 export function listTaskRunHistory(name: string, limit: number): TaskRunHistoryEntry[] {
   const rows = db.prepare(
-    'SELECT ts, status, agent FROM task_runs WHERE name = ? ORDER BY ts DESC LIMIT ?'
-  ).all(name, limit) as { ts: number; status: string; agent: string }[]
+    'SELECT ts, status, agent, completed_at, outcome FROM task_runs WHERE name = ? ORDER BY ts DESC LIMIT ?'
+  ).all(name, limit) as { ts: number; status: string; agent: string; completed_at: number | null; outcome: string | null }[]
 
   // token_usage.timestamp is in seconds; task_runs.ts is in ms -- divide by 1000
   const tokenStmt = db.prepare(
@@ -2919,7 +3005,15 @@ export function listTaskRunHistory(name: string, limit: number): TaskRunHistoryE
     const newerTs = i > 0 ? rows[i - 1].ts : undefined
     const windowEnd = newerTs !== undefined ? Math.min(row.ts + 3600000, newerTs) : row.ts + 3600000
     const tokenRow = tokenStmt.get(row.agent, Math.floor(row.ts / 1000), Math.floor(windowEnd / 1000)) as { total: number }
-    return { ts: row.ts, status: row.status, tokens_est: tokenRow.total > 0 ? tokenRow.total : null }
+    const completedAt = row.completed_at ?? null
+    return {
+      ts: row.ts,
+      status: row.status,
+      tokens_est: tokenRow.total > 0 ? tokenRow.total : null,
+      completed_at: completedAt,
+      outcome: row.outcome ?? null,
+      duration_ms: completedAt != null ? completedAt - row.ts : null,
+    }
   })
 }
 

--- a/src/web/command-task.ts
+++ b/src/web/command-task.ts
@@ -6,7 +6,7 @@ import { resolveOwnerChatId } from "../owner-chat.js"
 import { atomicWriteFileSync } from "./atomic-write.js"
 import { logger } from "../logger.js"
 import { sendTelegramMessage } from "./telegram.js"
-import { appendTaskRun } from "../db.js"
+import { appendTaskRun, markTaskRunCompleted } from "../db.js"
 import type { ScheduledTask } from "./scheduled-tasks-io.js"
 
 // command-type scheduled tasks run a raw shell command directly (no LLM
@@ -91,7 +91,14 @@ export function runCommandTask(task: ScheduledTask, now: number): void {
   const { next, action } = evaluateCommandResult(map[task.name], ok, failThreshold, now)
   map[task.name] = next
   persist()
-  try { appendTaskRun(task.name, task.agent || "system") } catch { /* non-fatal */ }
+  // A command task is synchronous: by the time runCommand returns, the run IS
+  // over. Close it here rather than leaving it to the pane watchdog, which
+  // never sees these -- they are not injected into a session at all, so without
+  // this they would be the one class of run that stays open for ever.
+  try {
+    const runId = appendTaskRun(task.name, task.agent || "system")
+    markTaskRunCompleted(runId, "done")
+  } catch { /* non-fatal */ }
   logger.info({ task: task.name, ok, detail, fails: next.fails, action }, "command task ran")
 
   if (action === "none") return

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -15,6 +15,9 @@ import {
 import { resolveOwnerChatId, configuredOwnerChatFor } from '../owner-chat.js'
 import {
   appendTaskRun,
+  markTaskRunCompleted,
+  reconcileOpenTaskRuns,
+  getTaskRunMedianDurationMs,
   listPendingTaskRetries,
   deletePendingTaskRetry,
   updatePendingTaskRetry,
@@ -142,6 +145,10 @@ export interface TaskInflightEntry {
   // during the sweep so an edit to the schedule mid-run cannot move the
   // goalposts under an already-running injection.
   timeoutMs: number
+  // task_runs row id of the dispatch that opened this entry, so the sweep can
+  // close the SAME row it started. null only if the insert failed (non-fatal by
+  // design -- bookkeeping must never block a task from running).
+  runId: number | null
 }
 
 // How long a fired task may stay busy before the watchdog calls it stuck.
@@ -173,7 +180,21 @@ export function resolveStuckTimeoutMs(
 // Active task/heartbeat injections keyed by `${taskName}@${agentName}`.
 const taskInflightMap = new Map<string, TaskInflightEntry>()
 
-export type TaskTimeoutDecision = 'clear' | 'alert' | 'escalate' | 'hold' | 'lost'
+// 'done'      -- the pane went idle after a turn was seen: the run FINISHED.
+// 'abandoned' -- max tracking age reached; we stop watching without knowing.
+// 'alert'     -- still busy past the threshold; one-shot operator alert.
+// 'hold'      -- no conclusion this tick.
+// 'lost'      -- the session took the keystrokes but never started a turn.
+//
+// 'done' and 'abandoned' were one value ('clear') until 2026-08-26. They are
+// opposites -- one is success, the other is giving up -- and merging them meant
+// the only moment the system KNEW a task had finished was spent deleting a map
+// entry. Splitting them is what makes a completion recordable at all.
+// 'escalate' -- stage 2: the main agent was already told and the session is
+//                STILL busy after the extra owner window; alert the owner
+//                directly. Added upstream after this branch forked, so the
+//                rebase has to keep it alongside the done/abandoned split.
+export type TaskTimeoutDecision = 'done' | 'abandoned' | 'alert' | 'escalate' | 'hold' | 'lost'
 
 // Pure: decide what the watchdog should do for a single in-flight entry this
 // tick. Exported so it can be unit-tested without tmux I/O.
@@ -231,9 +252,9 @@ export function decideTaskTimeout(
   opts: { graceMs: number; timeoutMs: number; maxTrackMs: number; ownerExtraMs: number },
 ): TaskTimeoutDecision {
   const elapsed = now - entry.injectedAt
-  if (elapsed >= opts.maxTrackMs) return 'clear'
+  if (elapsed >= opts.maxTrackMs) return 'abandoned'
   if (paneState === 'idle') {
-    if (entry.sawTurn) return 'clear'
+    if (entry.sawTurn) return 'done'
     // Idle, and nothing ever showed the prompt being picked up. Inside the
     // grace window that is just the normal pre-turn lag, so hold; past it the
     // delivery is gone.
@@ -888,14 +909,16 @@ async function attemptFireTask(
     // history) surfaces exactly which tasks were missed and had to be
     // caught up, without any new alert/polling path that could race other
     // running tasks. Read-only w.r.t. everything else in this function.
+    // Bookkeeping id for the run we are about to open; the watchdog closes it.
+    let firedRunId: number | null = null
     if (lateCatchUpMs != null) {
-      appendTaskRun(task.name, agentName, 'fired_late')
+      firedRunId = appendTaskRun(task.name, agentName, 'fired_late')
       logger.warn(
         { task: task.name, agent: agentName, session, lateCatchUpMinutes: Math.round(lateCatchUpMs / 60000) },
         'Scheduled task fired via restart catch-up window -- missed its normal tick',
       )
     } else {
-      appendTaskRun(task.name, agentName, 'fired')
+      firedRunId = appendTaskRun(task.name, agentName, 'fired')
     }
     logger.info({ task: task.name, agent: agentName, session }, 'Scheduled task fired')
 
@@ -929,6 +952,7 @@ async function attemptFireTask(
       // amplification running unnoticed since 2026-08-27.
       configDir: agentName === MAIN_AGENT_ID ? undefined : (resolveAgentConfigDirForRead(agentName) ?? undefined),
       timeoutMs: resolveStuckTimeoutMs(task),
+      runId: firedRunId,
     })
 
     // Post-send verify: if the agent started a new turn during our chunk
@@ -1351,8 +1375,20 @@ function sendTaskTimeoutAlert(entry: TaskInflightEntry, elapsedMs: number): void
   // judge: a long-running analysis task that legitimately needs more time is
   // then one config line away, instead of a recurring 3am mystery.
   const thresholdMinutes = Math.round(entry.timeoutMs / 60000)
+  // "Running 5 minutes" is not actionable on its own; "running 5 minutes, normally
+  // finishes in 40 s" is. The median comes from this task's own completed runs,
+  // which only exist because completions are now recorded.
+  const medianMs = (() => {
+    try { return getTaskRunMedianDurationMs(entry.taskName) } catch { return null }
+  })()
+  const typical = medianMs == null
+    ? null
+    : medianMs < 60_000
+      ? `${Math.round(medianMs / 1000)} másodperc`
+      : `${Math.round(medianMs / 60_000)} perc`
   const text = [
     `[${BOT_NAME} scheduler] A(z) "${entry.taskName}" (${entry.agentName}) ütemezett feladat ${ageMinutes} perce fut -- lehetséges beakadás. A(z) fő-agent mar ertesitve volt errol, de nem oldodott meg.`,
+    ...(typical ? [`Ez a feladat általában ${typical} alatt lefut (a korábbi befejezett futások mediánja).`] : []),
     `A riasztási küszöb ennél a feladatnál ${thresholdMinutes} perc; ha ez a feladat jogosan fut ennél tovább, allitsd a task-config.json "stuckAfterMinutes" mezojet.`,
     'Az ágensben megtekintheted; a dashboard /Ütemezések oldalán visszavonható ha kell.',
   ].join('\n')
@@ -1372,6 +1408,19 @@ function sendTaskTimeoutAlert(entry: TaskInflightEntry, elapsedMs: number): void
 export const SCHEDULE_TICK_MS = 15_000
 
 export function startScheduleRunner(): NodeJS.Timeout {
+  // Close runs that the previous process was still watching when it stopped.
+  // taskInflightMap is in memory, so a restart loses every open entry and those
+  // rows would stay open for ever -- the same "cannot tell running from
+  // finished" hole this bookkeeping exists to close, just in a smaller window.
+  // They are recorded as 'interrupted', not 'done': we do not know whether they
+  // finished, and saying so beats guessing either way.
+  try {
+    const closed = reconcileOpenTaskRuns(TASK_FIRE_MAX_TRACK_MS)
+    if (closed > 0) logger.info({ closed }, 'Closed task runs orphaned by a restart (outcome=interrupted)')
+  } catch (err) {
+    logger.warn({ err }, 'task-run restart reconcile failed (non-fatal)')
+  }
+
   // Reload the persisted last-run times so a restart inside a task's catch-up
   // window does not re-fire an already-run task.
   loadScheduleLastRun()
@@ -1479,7 +1528,25 @@ export function startScheduleRunner(): NodeJS.Timeout {
         maxTrackMs: TASK_FIRE_MAX_TRACK_MS,
         ownerExtraMs: OWNER_ESCALATION_EXTRA_MS,
       })
-      if (decision === 'clear') {
+      if (decision === 'done' || decision === 'abandoned') {
+        // The one moment the system knows how the run ended. Before 2026-08-26
+        // this branch only deleted the map entry, so the knowledge died here and
+        // task_runs kept every row open for ever.
+        if (entry.runId != null) {
+          try {
+            markTaskRunCompleted(entry.runId, decision, now)
+          } catch (err) {
+            // Bookkeeping must never take down the sweep: the next tick still
+            // needs to watch the remaining entries.
+            logger.warn({ err, task: entry.taskName, runId: entry.runId }, 'Failed to record task-run completion')
+          }
+        }
+        if (decision === 'abandoned') {
+          logger.info(
+            { task: entry.taskName, agent: entry.agentName, elapsedMs: now - entry.injectedAt },
+            'Task-run tracking aged out before the session went idle -- recorded as abandoned, NOT as completed',
+          )
+        }
         taskInflightMap.delete(key)
       } else if (decision === 'alert') {
         sendTaskInflightMainAgentNotice(entry, now - entry.injectedAt)
@@ -1498,6 +1565,11 @@ export function startScheduleRunner(): NodeJS.Timeout {
           { task: entry.taskName, agent: entry.agentName, session: entry.session, elapsedMs: now - entry.injectedAt },
           'Scheduled injection never started a turn (session accepted the keystrokes but stayed idle) -- recording as lost and re-queueing',
         )
+        // Close the run this injection opened before recording the loss, so the
+        // original row does not stay open for ever alongside its own 'lost' row.
+        if (entry.runId != null) {
+          try { markTaskRunCompleted(entry.runId, 'lost', now) } catch { /* non-fatal */ }
+        }
         appendTaskRun(entry.taskName, entry.agentName, 'lost')
         if (scheduleLastRun.get(entry.taskName) === entry.injectedAt) {
           scheduleLastRun.delete(entry.taskName)


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [ ] Bug fix (hibajavítás / bug fix)
- [x] Új funkció (feature / new feature)
- [ ] Dokumentáció (docs)
- [ ] Egyéb / Other:

## Rövid leírás / Summary

HU: A `task_runs` tábla eddig csak azt rögzítette, hogyan indult el egy futás. Ezen a telepítésen ez
3267 `fired`, 137 `skipped` és NULLA befejezés -- vagyis egy húsz perce lefutott feladat és egy éppen
futó ugyanaz a sor. Minden fogyasztónak találgatnia kell: a dashboard nem tudja megmondani, fut-e még,
valós futásidőkből nem származtatható timeout, és egy tényleg beragadt feladat pontosan úgy néz ki,
mint egy egészséges, ami már régen végzett.

**A befejezés-jelzés soha nem hiányzott.** A `decideTaskTimeout` tizenöt másodpercenként eldönti, hogy
a célsession üresjáratba ment-e azután, hogy egy fordulót láttunk -- ez pontosan azt jelenti, hogy a
futás véget ért. A sweep ezt az eredményt eddig eldobta egy `Map.delete`-tel. Ez a PR leírja.

**Amire NINCS szükség hozzá: új ágens-oldali szerződés.** Semmi nem változik abban, hogyan írjuk vagy
kézbesítjük a feladatokat.

Az egyetlen valódi veszély az volt, hogy a `'clear'` két ellentétes dolgot jelentett: "üresjárat, tehát
befejeződött" ÉS "letelt a hat óra, tehát abbahagyjuk a figyelést". Ha mindkettőt befejezésként
naplóznánk, minden hosszan futó feladatra sikert bélyegeznénk, ami rosszabb, mint semmit nem naplózni,
mert bizonyítéknak látszik. Ezért a döntés előbb `'done'`-ra és `'abandoned'`-re válik szét, és csak
utána kerül lemezre.

Konkrétan:

- `task_runs` kap `completed_at` + `outcome` oszlopot, **additívan**. A `status` megtartja a jelentését,
  tehát minden korábbi sor és minden meglévő lekérdezés érvényes marad; a `NULL completed_at` azt
  jelenti, hogy "nincs lezárva", ami minden migráció előtti sorra őszinte olvasat.
- `appendTaskRun` visszaadja a sor id-jét; az in-flight bejegyzés hordozza, így a sweep UGYANAZT a sort
  zárja le, amit megnyitott.
- `markTaskRunCompleted` first-writer-wins (`WHERE completed_at IS NULL`), tehát egy reconcile, ami egy
  élő sweeppel versenyez, nem tudja átírni a valódi befejezést.
- A `'lost'` ág az eredeti sort is lezárja, ahelyett hogy nyitva hagyná a saját `'lost'` testvére mellett.
- A command-taskok szinkronok és sosem érik el a pane-watchdogot, ezért ott zárulnak, ahol visszatérnek.
- Egy újraindítás elveszti a memóriában élő térképet, ezért a követési ablaknál régebbi nyitott sorok
  induláskor `'interrupted'`-ként zárulnak -- NEM `'done'`-ként: nem tudjuk.
- A beragadás-riasztás mostantól idézi a feladat SAJÁT befejezett futásainak mediánját ("5 perce fut,
  általában 40 másodperc alatt lefut"). Ez az első dolog, amire az üzemeltetőnek szüksége van, és eddig
  kiszámíthatatlan volt.

**Ismert korlát, hogy ne érje meglepetés a review-t:** az üresjárat-jel session-szintű, a nyilvántartás
viszont `task@agent` kulcsú. Ha két feladat injektálódik ugyanabba a sessionbe és MINDKETTŐ `busy`-nak
látja azt (mert az egyik fut), akkor az üresjáratnál mindkettő `'done'`-ként zárul, holott csak az egyik
futott. A `sawTurn` a gyakori esetet lefedi (aminek a promptját fel sem vették, az `'lost'` lesz), és a
busy-skip miatt a párhuzamos injektálás ritka -- de nem lehetetlen. Egy per-futás korrelációs azonosító
lenne rá a teljes megoldás; azt szándékosan nem építettem bele, mert az már ágens-oldali szerződést
igényel, és ez a PR pont attól akar mentes maradni.

EN: `task_runs` only ever recorded how a run was DISPATCHED -- 3267 'fired', 137 'skipped', zero
completions on a live install -- so "finished twenty minutes ago" and "still running" were the same row.
The completion signal already existed: `decideTaskTimeout` decides every 15 s whether the target session
went idle after a turn was seen, which is exactly "this run finished"; the sweep then discarded it.
This change splits the overloaded `'clear'` decision into `'done'` and `'abandoned'` (recording an
aged-out run as success would be worse than recording nothing), then persists the outcome additively via
`completed_at` + `outcome`, closes the run from every path that can open one (including the synchronous
command tasks and a boot-time reconcile for restart-orphaned rows), and uses the resulting durations to
make the stuck-task alert say what normal looks like. No agent-side contract is introduced.

## Kapcsolódó issue / Related issue

Refs #1077

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [ ] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).

## Titok-kapu / Secret gate

- [x] Nincs a valtoztatasban bizonyitek-/artefaktum-mappa, titok-alaku string vagy idezett csatorna-uzenet.
      / No evidence or artifact directory, secret-shaped string, or quoted channel message in this change.