### PR TITLE
fix(migrate): do the systemd side on Linux instead of claiming Done (RENAMELINUX905)

### DIFF
--- a/scripts/__tests__/migrate-agent-id-linux.test.sh
+++ b/scripts/__tests__/migrate-agent-id-linux.test.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+# Contract tests for the Linux (systemd) branch of scripts/migrate-main-agent-id.sh.
+# Run: bash scripts/__tests__/migrate-agent-id-linux.test.sh
+#
+# Regression guard (RENAMELINUX905): on Linux the script rewrote the DB and
+# .env, then printed "Done." while the service stop, the unit rename and the
+# restart were all behind Darwin guards -- a half-renamed install that claimed
+# success. The script must now do the systemd side, and must NOT claim success
+# when a service fails to start.
+#
+# The script branches on `uname -s`, so a PATH shim fakes uname=Linux (plus
+# systemctl/tmux recorders); the test therefore runs on any host, macOS
+# included. sqlite3 and python3 are the real binaries.
+
+set -u
+
+PASS=0; FAIL=0
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
+
+REPO="$(cd "$(dirname "$0")/../.." && pwd)"
+
+# --- throwaway install tree ---------------------------------------------------
+INSTALL="$TMP/install"
+mkdir -p "$INSTALL/scripts" "$INSTALL/store"
+cp "$REPO/scripts/migrate-main-agent-id.sh" "$INSTALL/scripts/"
+echo 'BOT_NAME="Test Bot"' > "$INSTALL/.env"
+
+sqlite3 "$INSTALL/store/claudeclaw.db" <<'SQL'
+CREATE TABLE memories (agent_id TEXT);
+CREATE TABLE daily_logs (agent_id TEXT);
+CREATE TABLE agent_messages (from_agent TEXT, to_agent TEXT);
+CREATE TABLE kanban_cards (assignee TEXT);
+INSERT INTO memories VALUES ('marveen');
+INSERT INTO agent_messages VALUES ('marveen', 'samu');
+INSERT INTO kanban_cards VALUES ('marveen');
+SQL
+
+# --- fake HOME with the installer's unit set ----------------------------------
+FAKE_HOME="$TMP/home"
+UNITS="$FAKE_HOME/.config/systemd/user"
+mkdir -p "$UNITS/marveen-dashboard.service.d" "$UNITS/marveen-channels.service.d"
+for unit in dashboard.service channels.service morning.service morning.timer host-watchdog.service 'notify@.service'; do
+  printf '[Unit]\nDescription=Marveen %s\n' "$unit" > "$UNITS/marveen-${unit}"
+done
+printf '[Unit]\nOnFailure=marveen-notify@%%n.service\n' > "$UNITS/marveen-dashboard.service.d/onfailure.conf"
+printf '[Unit]\nOnFailure=marveen-notify@%%n.service\n' > "$UNITS/marveen-channels.service.d/onfailure.conf"
+
+# --- PATH shim ----------------------------------------------------------------
+BIN="$TMP/bin"
+mkdir -p "$BIN"
+LOG="$TMP/systemctl.log"
+: > "$LOG"
+
+cat > "$BIN/uname" <<'EOF'
+#!/bin/bash
+if [ "${1:-}" = "-s" ]; then echo Linux; else echo Linux; fi
+EOF
+cat > "$BIN/systemctl" <<EOF
+#!/bin/bash
+echo "\$@" >> "$LOG"
+if [ -n "\${SYSTEMCTL_FAIL_ON:-}" ]; then
+  case "\$*" in *"\$SYSTEMCTL_FAIL_ON"*) exit 1;; esac
+fi
+exit 0
+EOF
+cat > "$BIN/tmux" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+chmod +x "$BIN/uname" "$BIN/systemctl" "$BIN/tmux"
+
+run_migrate() {
+  HOME="$FAKE_HOME" PATH="$BIN:$PATH" SYSTEMCTL_FAIL_ON="${1:-}" \
+    bash "$INSTALL/scripts/migrate-main-agent-id.sh" <<< "y" > "$TMP/out.log" 2> "$TMP/err.log"
+}
+
+# ==============================================================================
+echo "migrate-main-agent-id.sh -- Linux systemd branch"
+
+run_migrate ""
+RC=$?
+
+[ "$RC" -eq 0 ] && pass "exit 0 on the happy path" || fail "exit 0 on the happy path (got $RC; err: $(cat "$TMP/err.log"))"
+
+grep -q '^MAIN_AGENT_ID=test-bot$' "$INSTALL/.env" \
+  && pass ".env got MAIN_AGENT_ID=test-bot" || fail ".env got MAIN_AGENT_ID=test-bot"
+
+DB_SLUG=$(sqlite3 "$INSTALL/store/claudeclaw.db" "SELECT assignee FROM kanban_cards")
+[ "$DB_SLUG" = "test-bot" ] && pass "DB rows rewritten to the new slug" || fail "DB rows rewritten (got '$DB_SLUG')"
+
+OLD_LEFT=$(find "$UNITS" -maxdepth 1 -name 'marveen-*' | wc -l | tr -d ' ')
+[ "$OLD_LEFT" = "0" ] && pass "no marveen-* unit files left behind" || fail "no marveen-* left behind ($OLD_LEFT remain)"
+
+ALL_NEW=1
+for unit in dashboard.service channels.service morning.service morning.timer host-watchdog.service 'notify@.service'; do
+  [ -f "$UNITS/test-bot-${unit}" ] || { ALL_NEW=0; fail "renamed unit exists: test-bot-${unit}"; }
+done
+[ "$ALL_NEW" = "1" ] && pass "all six units renamed to test-bot-*"
+
+grep -q 'test-bot-notify@%n.service' "$UNITS/test-bot-dashboard.service.d/onfailure.conf" 2>/dev/null \
+  && pass "OnFailure drop-in renamed AND patched to the new notifier" \
+  || fail "OnFailure drop-in renamed AND patched (dashboard)"
+
+grep -q 'stop marveen-channels.service' "$LOG" \
+  && pass "old units were stopped before the rename" || fail "old units were stopped"
+
+grep -q 'daemon-reload' "$LOG" \
+  && pass "daemon-reload ran after the rename" || fail "daemon-reload ran"
+
+grep -q 'enable --now test-bot-dashboard.service' "$LOG" \
+  && pass "new dashboard unit enabled and started" || fail "new dashboard unit enabled --now"
+
+grep -q 'enable --now test-bot-channels.service' "$LOG" \
+  && pass "new channels unit enabled and started" || fail "new channels unit enabled --now"
+
+grep -q 'enable --now test-bot-morning.timer' "$LOG" \
+  && pass "morning timer enabled and started" || fail "morning timer enabled --now"
+
+if grep -q 'enable test-bot-host-watchdog.service' "$LOG" \
+   && ! grep -q 'enable --now test-bot-host-watchdog.service' "$LOG"; then
+  pass "host-watchdog enabled WITHOUT --now (oneshot, must not run mid-migration)"
+else
+  fail "host-watchdog enabled WITHOUT --now"
+fi
+
+# --- failure honesty: a failed start must not end in Done. --------------------
+# Rebuild the pre-migration state and make enabling the channels unit fail.
+rm -rf "$UNITS"
+mkdir -p "$UNITS/marveen-dashboard.service.d" "$UNITS/marveen-channels.service.d"
+for unit in dashboard.service channels.service morning.service morning.timer host-watchdog.service 'notify@.service'; do
+  printf '[Unit]\nDescription=Marveen %s\n' "$unit" > "$UNITS/marveen-${unit}"
+done
+printf '[Unit]\nOnFailure=marveen-notify@%%n.service\n' > "$UNITS/marveen-dashboard.service.d/onfailure.conf"
+printf '[Unit]\nOnFailure=marveen-notify@%%n.service\n' > "$UNITS/marveen-channels.service.d/onfailure.conf"
+sqlite3 "$INSTALL/store/claudeclaw.db" "UPDATE kanban_cards SET assignee='marveen'"
+sed -i.bak '/^MAIN_AGENT_ID=/d' "$INSTALL/.env"
+: > "$LOG"
+
+run_migrate "enable --now test-bot-channels.service"
+RC=$?
+
+[ "$RC" -ne 0 ] && pass "failed service start exits non-zero" || fail "failed service start exits non-zero"
+
+grep -q '^Done\.' "$TMP/out.log" \
+  && fail "no 'Done.' claim when a service failed to start" \
+  || pass "no 'Done.' claim when a service failed to start"
+
+grep -q 'FAILED to start' "$TMP/err.log" \
+  && pass "the failure is named on stderr" || fail "the failure is named on stderr"
+
+# ==============================================================================
+echo ""
+echo "migrate-agent-id-linux: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/scripts/migrate-main-agent-id.sh
+++ b/scripts/migrate-main-agent-id.sh
@@ -7,8 +7,9 @@
 #   * Reads BOT_NAME from .env, computes the slug.
 #   * If the slug is "marveen" (default install), prints a note and exits --
 #     nothing to migrate, the defaults already match.
-#   * Otherwise: stops the launchd services, rewrites the DB rows from
-#     "marveen" to the new slug, renames the plist files + Label keys,
+#   * Otherwise: stops the services (launchd on macOS, systemd user units on
+#     Linux), rewrites the DB rows from "marveen" to the new slug, renames the
+#     unit files (plist Label keys / systemd unit names + OnFailure drop-ins),
 #     writes MAIN_AGENT_ID into .env, and restarts.
 
 # Dashboard port: env WEB_PORT, else the install .env, else the 3420 default.
@@ -59,11 +60,18 @@ case "$ans" in
 esac
 
 PLIST_DIR="$HOME/Library/LaunchAgents"
+SYSTEMD_DIR="$HOME/.config/systemd/user"
 OS="$(uname -s)"
 
 if [ "$OS" = "Darwin" ]; then
   launchctl unload "$PLIST_DIR/com.marveen.channels.plist" 2>/dev/null || true
   launchctl unload "$PLIST_DIR/com.marveen.dashboard.plist" 2>/dev/null || true
+elif [ "$OS" = "Linux" ]; then
+  # Stop and disable the old-named units before the rename. Missing units are
+  # fine (partial installs); a failure to stop a RUNNING unit is not, but stop
+  # returns 0 for not-loaded units, so the || true only covers no-systemd hosts.
+  systemctl --user stop marveen-channels.service marveen-dashboard.service marveen-morning.timer 2>/dev/null || true
+  systemctl --user disable marveen-channels.service marveen-dashboard.service marveen-morning.timer marveen-host-watchdog.service 2>/dev/null || true
 fi
 tmux kill-session -t marveen-channels 2>/dev/null || true
 
@@ -94,6 +102,37 @@ p = pathlib.Path(sys.argv[1]); slug = sys.argv[2]; kind = sys.argv[3]
 p.write_text(p.read_text().replace(f"com.marveen.{kind}", f"com.{slug}.{kind}"))
 PYEOF
       echo "✓ Renamed $OLD → $NEW"
+    fi
+  done
+elif [ "$OS" = "Linux" ]; then
+  # Rename the systemd user units the installer created (install-linux.sh
+  # [7/7]): dashboard/channels/morning(.timer)/host-watchdog/notify@. The
+  # morning timer binds to its service by name stem, so renaming both files
+  # keeps the binding.
+  for unit in dashboard.service channels.service morning.service morning.timer host-watchdog.service 'notify@.service'; do
+    OLD="$SYSTEMD_DIR/marveen-${unit}"
+    NEW="$SYSTEMD_DIR/${NEW_SLUG}-${unit}"
+    if [ -f "$OLD" ]; then
+      mv "$OLD" "$NEW"
+      echo "✓ Renamed $OLD → $NEW"
+    fi
+  done
+  # OnFailure drop-in dirs: rename the dir AND patch the notifier reference
+  # inside, or every crash of the renamed units would fire a non-existent
+  # marveen-notify@ unit (silently -- OnFailure on a missing unit just logs).
+  for kind in dashboard channels; do
+    OLDD="$SYSTEMD_DIR/marveen-${kind}.service.d"
+    NEWD="$SYSTEMD_DIR/${NEW_SLUG}-${kind}.service.d"
+    if [ -d "$OLDD" ]; then
+      mv "$OLDD" "$NEWD"
+      if [ -f "$NEWD/onfailure.conf" ]; then
+        python3 - "$NEWD/onfailure.conf" "$NEW_SLUG" <<'PYEOF'
+import sys, pathlib
+p = pathlib.Path(sys.argv[1]); slug = sys.argv[2]
+p.write_text(p.read_text().replace('marveen-notify@', f'{slug}-notify@'))
+PYEOF
+      fi
+      echo "✓ Renamed $OLDD → $NEWD"
     fi
   done
 fi
@@ -153,6 +192,34 @@ if [ "$OS" = "Darwin" ]; then
   launchctl load "$PLIST_DIR/com.${NEW_SLUG}.dashboard.plist" 2>/dev/null || true
   launchctl load "$PLIST_DIR/com.${NEW_SLUG}.channels.plist" 2>/dev/null || true
   echo "✓ Services restarted as com.${NEW_SLUG}.*"
+elif [ "$OS" = "Linux" ]; then
+  # Restart under the new names. A failed start here must NOT end in "Done.":
+  # the whole point of the migration is that the services come back.
+  if ! systemctl --user daemon-reload 2>/dev/null; then
+    echo "WARNING: systemctl --user daemon-reload failed (no user systemd?)" >&2
+  fi
+  START_FAILED=0
+  for u in "${NEW_SLUG}-dashboard.service" "${NEW_SLUG}-channels.service" "${NEW_SLUG}-morning.timer"; do
+    if [ -f "$SYSTEMD_DIR/$u" ]; then
+      if ! systemctl --user enable --now "$u"; then
+        echo "ERROR: failed to enable/start $u" >&2
+        START_FAILED=1
+      fi
+    fi
+  done
+  # host-watchdog is a oneshot fired at login; enable it for the next boot but
+  # do not run it now (a mid-migration run would race its btime state file).
+  if [ -f "$SYSTEMD_DIR/${NEW_SLUG}-host-watchdog.service" ]; then
+    if ! systemctl --user enable "${NEW_SLUG}-host-watchdog.service"; then
+      echo "ERROR: failed to enable ${NEW_SLUG}-host-watchdog.service" >&2
+      START_FAILED=1
+    fi
+  fi
+  if [ "$START_FAILED" -ne 0 ]; then
+    echo "Migration applied, but at least one service FAILED to start -- fix and start it manually (systemctl --user status ${NEW_SLUG}-*)." >&2
+    exit 1
+  fi
+  echo "✓ Services restarted as ${NEW_SLUG}-*"
 fi
 
 echo ""


### PR DESCRIPTION
Card RENAMELINUX905: on Linux `migrate-main-agent-id.sh` half-renamed the install -- DB and .env were rewritten, but service stop, unit rename and restart sat behind Darwin guards, and the script still printed `Done.`.

The Linux branch now:
- stops + disables the old `marveen-*` user units before the rename
- renames all six installer units (dashboard, channels, morning.service/.timer, host-watchdog, notify@) and the OnFailure drop-in dirs, patching the `marveen-notify@` reference inside so crash notification keeps firing
- daemon-reloads and re-enables under the new slug; host-watchdog is enabled WITHOUT `--now` (oneshot, must not run mid-migration)
- exits non-zero and names the failure instead of printing `Done.` when a service fails to start

Test: `scripts/__tests__/migrate-agent-id-linux.test.sh` runs the script through a PATH shim (uname=Linux, recording systemctl), so it runs on macOS hosts too. 15/15 green with the fix; mutation control on the unfixed script: 17 assertions red. `ops-scripts-portable` 7/7, `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)