### PR TITLE
feat(schedules): /api/schedules/summary -- the digest copies a count, never computes one (HBSCHEDSZAM903)

### DIFF
--- a/src/__tests__/schedules-summary.test.ts
+++ b/src/__tests__/schedules-summary.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { summarizeScheduledTasks } from '../web/routes/schedules.js'
+
+// HBSCHEDSZAM903: the heartbeat digest's "enabled schedules" figure was the
+// one number the agent computed itself, and it drifted to a 13x error (376
+// reported vs 29 real). The counts now come pre-computed from
+// GET /api/schedules/summary; these tests pin the counting rule and the
+// route's existence.
+
+describe('summarizeScheduledTasks: the counting rule', () => {
+  it('an absent enabled field counts as enabled (same rule as the toggle route)', () => {
+    expect(summarizeScheduledTasks([{}, { enabled: true }, { enabled: false }])).toEqual({
+      total: 3, enabled: 2, disabled: 1,
+    })
+  })
+
+  it('empty task list yields all zeros, not NaN or negatives', () => {
+    expect(summarizeScheduledTasks([])).toEqual({ total: 0, enabled: 0, disabled: 0 })
+  })
+
+  it('all-disabled counts to zero enabled', () => {
+    expect(summarizeScheduledTasks([{ enabled: false }, { enabled: false }])).toEqual({
+      total: 2, enabled: 0, disabled: 2,
+    })
+  })
+})
+
+describe('the summary is served, not recomputed by consumers', () => {
+  const ROUTE = readFileSync(join(__dirname, '../web/routes/schedules.ts'), 'utf-8')
+
+  it('GET /api/schedules/summary exists and serves summarizeScheduledTasks(listScheduledTasks())', () => {
+    expect(ROUTE).toMatch(/\/api\/schedules\/summary'\s*&&\s*method === 'GET'/)
+    expect(ROUTE).toMatch(/summarizeScheduledTasks\(listScheduledTasks\(\)\)/)
+  })
+})

--- a/src/web/routes/schedules.ts
+++ b/src/web/routes/schedules.ts
@@ -35,6 +35,18 @@ function resolveScheduleDir(rawName: string): { name: string; dir: string } | nu
   } catch { return null }
 }
 
+// HBSCHEDSZAM903: the hourly heartbeat digest's "enabled schedules" figure was
+// the ONE number the agent computed itself (counting enabled:true in the raw
+// /api/schedules array), and it drifted to a 13x error (376 reported vs 29
+// real). Serve the counts pre-computed so the digest copies a number instead
+// of deriving one. Pure and exported so the counting rule is unit-testable.
+export function summarizeScheduledTasks(tasks: Array<{ enabled?: boolean }>): { total: number; enabled: number; disabled: number } {
+  // The same rule the toggle route uses: a task is enabled unless enabled is
+  // explicitly false (absent field = enabled).
+  const enabled = tasks.filter(t => t.enabled !== false).length
+  return { total: tasks.length, enabled, disabled: tasks.length - enabled }
+}
+
 export async function tryHandleSchedules(ctx: RouteContext): Promise<boolean> {
   const { req, res, path, method } = ctx
 
@@ -111,6 +123,11 @@ Az eredmeny CSAK a kibovitett prompt szovege legyen, semmi mas. Ne hasznalj code
 
   if (path === '/api/schedules' && method === 'GET') {
     json(res, listScheduledTasks())
+    return true
+  }
+
+  if (path === '/api/schedules/summary' && method === 'GET') {
+    json(res, summarizeScheduledTasks(listScheduledTasks()))
     return true
   }
 


### PR DESCRIPTION
Card HBSCHEDSZAM903: the heartbeat digest's "enabled schedules" was the ONE figure the agent computed itself, and it drifted to a 13x error (376 reported vs 29 real). This adds `GET /api/schedules/summary` returning `{total, enabled, disabled}`, computed server-side with the same absent-means-enabled rule the toggle route uses (`enabled !== false`).

Tests: `schedules-summary.test.ts` pins the counting rule functionally (absent field, empty list, all-disabled) plus the route's existence. Full suite in the worktree: 377 files / 4870 passed, tsc clean.

The hourly-heartbeat skill on this host is already updated to read the summary endpoint verbatim, with a documented 404 fallback until the host deploys this.

Author is samu, so independent verify before merge please.

🤖 Generated with [Claude Code](https://claude.com/claude-code)