### PR TITLE
feat(gmail): vendor the ArtyMcLabin fork from source + v2_ parallel-run entry

### DIFF
--- a/mcp-catalog.json
+++ b/mcp-catalog.json
@@ -7,7 +7,10 @@
     "category": "productivity",
     "icon": "📁",
     "command": "npx",
-    "args": ["-y", "@piotr-agier/google-drive-mcp"],
+    "args": [
+      "-y",
+      "@piotr-agier/google-drive-mcp"
+    ],
     "env": {},
     "authType": "oauth",
     "authNote": "Első használatkor a böngészőben kell bejelentkezni a Google fiókba",
@@ -21,13 +24,34 @@
     "category": "productivity",
     "icon": "📧",
     "command": "npx",
-    "args": ["-y", "gmail-mcp-server"],
+    "args": [
+      "-y",
+      "gmail-mcp-server"
+    ],
     "env": {},
     "authType": "oauth",
     "authNote": "Google Cloud OAuth kliens kell hozzá (client ID + secret). UGYANAZ az OAuth-app használható a Naptár összekötőhöz is.",
     "infoUrl": "https://github.com/ArtyMcLabin/Gmail-MCP-Server",
     "verifiedAt": "2026-08-27",
     "verifiedNote": "npm-csomag ellenőrizve: gmail-mcp-server v1.0.30 létezik."
+  },
+  {
+    "id": "gmail-v2",
+    "name": "Gmail v2 (fork, parhuzamos proba)",
+    "type": "local",
+    "icon": "📧",
+    "command": "bash",
+    "args": [
+      "vendor/gmail-mcp-fork/run.sh"
+    ],
+    "env": {
+      "GMAIL_MCP_TOOL_PREFIX": "v2_"
+    },
+    "authType": "oauth",
+    "authNote": "ArtyMcLabin/Gmail-MCP-Server fork FORRASBOL vendorolva, pinelt commit 83e8dafebc87dd3e6a26c04acb5ec6e199c1636e (2026-08-12) -- verzio-emeles SOHA nem csendes bump: uj commit + diff + build + parhuzamos igazolasi kor kell (VENDOR.md). Sajat config-konyvtar: ~/.gmail-mcp-v2/ (a regi ~/.gmail-mcp-hez NEM nyul). A v2_ tool-prefix az atmeneti parhuzamos futashoz; a regi gmail-MCP kivetele elott Marveen GO kell.",
+    "infoUrl": "https://github.com/ArtyMcLabin/Gmail-MCP-Server",
+    "verifiedAt": "2026-09-07",
+    "verifiedNote": "Forras-audit: process-en beluli tobb-fiok NINCS (singleton kliens, 28x userId:'me'), tobb fiok = instance-per-account TOOL_PREFIX-szel; kimeno host csak googleapis; build nalunk a pinelt forrasbol, dist/ a repoban a mi buildunk."
   },
   {
     "id": "google-calendar",
@@ -37,7 +61,10 @@
     "category": "productivity",
     "icon": "📅",
     "command": "npx",
-    "args": ["-y", "@cocal/google-calendar-mcp"],
+    "args": [
+      "-y",
+      "@cocal/google-calendar-mcp"
+    ],
     "env": {},
     "authType": "oauth",
     "authNote": "Google Cloud OAuth kliens kell hozzá (client ID + secret). UGYANAZ az OAuth-app használható a Gmail összekötőhöz is, tehát elég egyszer regisztrálni.",
@@ -79,8 +106,13 @@
     "category": "search",
     "icon": "🔍",
     "command": "npx",
-    "args": ["-y", "@modelcontextprotocol/server-brave-search"],
-    "env": {"BRAVE_API_KEY": ""},
+    "args": [
+      "-y",
+      "@modelcontextprotocol/server-brave-search"
+    ],
+    "env": {
+      "BRAVE_API_KEY": ""
+    },
     "authType": "apikey",
     "authNote": "API kulcs: https://brave.com/search/api/",
     "infoUrl": "https://github.com/modelcontextprotocol/servers/tree/main/src/brave-search"
@@ -93,7 +125,11 @@
     "category": "system",
     "icon": "💾",
     "command": "npx",
-    "args": ["-y", "@modelcontextprotocol/server-filesystem", "/"],
+    "args": [
+      "-y",
+      "@modelcontextprotocol/server-filesystem",
+      "/"
+    ],
     "env": {},
     "authType": "none",
     "infoUrl": "https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem"
@@ -106,8 +142,13 @@
     "category": "development",
     "icon": "🐙",
     "command": "npx",
-    "args": ["-y", "@modelcontextprotocol/server-github"],
-    "env": {"GITHUB_TOKEN": ""},
+    "args": [
+      "-y",
+      "@modelcontextprotocol/server-github"
+    ],
+    "env": {
+      "GITHUB_TOKEN": ""
+    },
     "authType": "apikey",
     "authNote": "Personal Access Token: GitHub Settings -> Developer Settings -> Personal Access Tokens",
     "infoUrl": "https://github.com/modelcontextprotocol/servers/tree/main/src/github"
@@ -159,8 +200,13 @@
     "category": "ai",
     "icon": "🔊",
     "command": "npx",
-    "args": ["-y", "elevenlabs-mcp"],
-    "env": {"ELEVENLABS_API_KEY": ""},
+    "args": [
+      "-y",
+      "elevenlabs-mcp"
+    ],
+    "env": {
+      "ELEVENLABS_API_KEY": ""
+    },
     "authType": "apikey",
     "authNote": "API kulcs: https://elevenlabs.io - Settings -> API Keys",
     "infoUrl": "https://github.com/elevenlabs/elevenlabs-mcp"
@@ -173,7 +219,11 @@
     "category": "productivity",
     "icon": "🎙️",
     "command": "npx",
-    "args": ["-y", "mcp-remote", "https://api.fireflies.ai/mcp"],
+    "args": [
+      "-y",
+      "mcp-remote",
+      "https://api.fireflies.ai/mcp"
+    ],
     "env": {},
     "authType": "oauth",
     "authNote": "Első használatkor OAuth bejelentkezés (Google/Microsoft fiók) a böngészőben",
@@ -187,7 +237,10 @@
     "category": "automation",
     "icon": "🌐",
     "command": "npx",
-    "args": ["-y", "@playwright/mcp@latest"],
+    "args": [
+      "-y",
+      "@playwright/mcp@latest"
+    ],
     "env": {},
     "authType": "none",
     "authNote": "Nincs auth. Headed mode-hoz adjuk hozzá az --headed flag-et az args-hoz.",

--- a/vendor/gmail-mcp-fork/.gitignore
+++ b/vendor/gmail-mcp-fork/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+!dist/

--- a/vendor/gmail-mcp-fork/LICENSE
+++ b/vendor/gmail-mcp-fork/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 GongRzhe
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/gmail-mcp-fork/README.md
+++ b/vendor/gmail-mcp-fork/README.md
@@ -1,0 +1,1094 @@
+![Gmail MCP Server](assets/banner.jpg)
+
+# Gmail MCP Server (Actively Maintained Fork)
+
+**Installation:** `npx @artymclabin/gmail-mcp auth` - or just tell your Claude to install the MCP from this repo (`https://github.com/ArtyMcLabin/Gmail-MCP-Server`) and let it set up. Prefer manual steps? See [Installation & Authentication](#installation--authentication).
+
+[![CI](https://github.com/ArtyMcLabin/Gmail-MCP-Server/actions/workflows/ci.yml/badge.svg)](https://github.com/ArtyMcLabin/Gmail-MCP-Server/actions/workflows/ci.yml) [![npm](https://img.shields.io/npm/v/@artymclabin/gmail-mcp)](https://www.npmjs.com/package/@artymclabin/gmail-mcp)
+
+Also on the [official MCP Registry](https://registry.modelcontextprotocol.io) (`io.github.ArtyMcLabin/Gmail-MCP-Server`) and [Smithery](https://smithery.ai/servers/rawceo/gmail-mcp).
+
+> **This is an actively maintained fork of [GongRzhe/Gmail-MCP-Server](https://github.com/GongRzhe/Gmail-MCP-Server).**
+>
+> The original repository has been unmaintained since August 2025 - 7+ months with zero maintainer activity and 72+ unmerged pull requests. I use this MCP server daily as part of my Claude Code workflow and depend on it working correctly, so I picked it up.
+>
+> **Pull requests are welcome.** If you've been sitting on fixes or features with nowhere to submit them, this is the place.
+
+## Philosophy
+
+This fork is **lean and pragmatic**. It's a local stdio MCP server - you run it on your own machine, and your LLM client already has shell + filesystem access. So the threat model is "don't leak credentials to third parties, don't break the Gmail surface" - not "defend a hosted multi-tenant service". I keep dependencies minimal. I use this daily in my own Claude Code workflow - if I wouldn't run it or maintain it myself, it doesn't go in.
+
+There's a downstream fork that took this in the **maximalist** direction. I'm not affiliated with its maintainer and I don't track its security or features - use it at your own risk: **[klodr/gmail-mcp](https://github.com/klodr/gmail-mcp)**. If that's the philosophy you want, go check it out. PRs welcome here as always.
+
+### What this fork adds
+
+- **Fixed reply threading** - auto-resolves `In-Reply-To` and `References` headers so email replies land in the correct thread instead of creating orphaned messages ([upstream PR #91](https://github.com/GongRzhe/Gmail-MCP-Server/pull/91), still pending)
+- **Send-as alias support** - optional `from` parameter for multi-identity email management (send from any configured Gmail alias)
+- **Reply-all tool** - `reply_all` automatically fetches the original email, builds To/CC recipient lists (excluding yourself), and sets proper threading headers ([PR #3](https://github.com/ArtyMcLabin/Gmail-MCP-Server/pull/3) by [@MaxGhenis](https://github.com/MaxGhenis))
+- **Fixed `list_filters`** - was returning empty array due to wrong response property name ([PR #4](https://github.com/ArtyMcLabin/Gmail-MCP-Server/pull/4) by [@nicholas-anthony-ai](https://github.com/nicholas-anthony-ai))
+- **Custom OAuth2 scoping** - `--scopes` flag to request only the permissions you need, with automatic tool filtering ([PR #6](https://github.com/ArtyMcLabin/Gmail-MCP-Server/pull/6) by [@tansanDOTeth](https://github.com/tansanDOTeth))
+- **CI/CD hardening** - fixed shell injection vector in GitHub Actions workflow, added least-privilege permissions scope ([PR #9](https://github.com/ArtyMcLabin/Gmail-MCP-Server/pull/9) by [@JF10R](https://github.com/JF10R))
+- **Security hardening** - fixed path traversal in attachment download, restricted OAuth credential file permissions ([PR #10](https://github.com/ArtyMcLabin/Gmail-MCP-Server/pull/10) by [@JF10R](https://github.com/JF10R))
+- **Dependency security** - upgraded MCP SDK to v1.27.1 (3 CVE fixes), upgraded nodemailer (DoS + routing fix), moved dev-only packages out of production deps ([PR #11](https://github.com/ArtyMcLabin/Gmail-MCP-Server/pull/11) by [@JF10R](https://github.com/JF10R))
+- **Thread-level tools** - `get_thread`, `list_inbox_threads`, `get_inbox_with_threads`, `modify_thread` for efficient thread-based email operations in a single call
+- **CC/BCC visibility** - `read_email` now shows CC and BCC headers when present ([PR #21](https://github.com/ArtyMcLabin/Gmail-MCP-Server/pull/21) by [@panghy](https://github.com/panghy))
+- **Phishing report tools** - `report_phishing` and `batch_report_phishing` for marking messages as spam via the Gmail API ([PR #24](https://github.com/ArtyMcLabin/Gmail-MCP-Server/pull/24) by [@ShivamB25](https://github.com/ShivamB25))
+- **Draft lifecycle tools** - `send_draft`, `delete_draft`, `update_draft` close the orphan-draft gap: `send_draft` atomically sends an existing draft and removes it from Drafts (no ghost copy); `update_draft` mutates a draft in place preserving its ID (no draft pile-up across iteration loops); `delete_draft` discards an abandoned draft ([PR #30](https://github.com/ArtyMcLabin/Gmail-MCP-Server/pull/30) by [@thisisambros](https://github.com/thisisambros))
+- **Tool annotations** - MCP spec annotations (`readOnlyHint`, `destructiveHint`, `idempotentHint`) on all tools for safer LLM tool execution ([PR #14](https://github.com/ArtyMcLabin/Gmail-MCP-Server/pull/14) by [@bryankthompson](https://github.com/bryankthompson))
+- **Download email tool** - `download_email` saves emails to disk in json/eml/txt/html formats without consuming LLM context ([PR #13](https://github.com/ArtyMcLabin/Gmail-MCP-Server/pull/13) by [@icanhasjonas](https://github.com/icanhasjonas))
+- **Durable OAuth sessions** - `refresh_token` is persisted across restarts, ending the hourly re-auth loop ([PR #35](https://github.com/ArtyMcLabin/Gmail-MCP-Server/pull/35) by [@BrentBaccala](https://github.com/BrentBaccala))
+- **Custom OAuth callback port** - the auth listener derives port and path from your callback URL instead of hardcoding 3000 ([PR #41](https://github.com/ArtyMcLabin/Gmail-MCP-Server/pull/41) by [@soapergem](https://github.com/soapergem))
+- **Safe permanent-delete gating** - `delete_email`/`batch_delete_emails` require the opt-in `gmail.full` scope (which also satisfies all other mail scopes), so default auth stays least-privilege ([PR #39](https://github.com/ArtyMcLabin/Gmail-MCP-Server/pull/39) by [@caioribeiroclw-pixel](https://github.com/caioribeiroclw-pixel))
+
+All features are production-tested in daily use.
+
+[![Star History Chart](https://api.star-history.com/svg?repos=ArtyMcLabin/Gmail-MCP-Server&type=Date)](https://star-history.com/#ArtyMcLabin/Gmail-MCP-Server&Date)
+
+---
+
+A Model Context Protocol (MCP) server for Gmail integration in Claude Desktop with auto authentication support. This server enables AI assistants to manage Gmail through natural language interactions.
+
+![](https://badge.mcpx.dev?type=server 'MCP Server')
+
+
+## Features
+
+- Send emails with subject, content, **attachments**, and recipients
+- **Full attachment support** - send and receive file attachments
+- **Download email attachments** to local filesystem
+- **Download full emails** to files in json/eml/txt/html formats
+- **Thread-level operations** - get full threads, list inbox threads, batch-expand threads
+- Support for HTML emails and multipart messages with both HTML and plain text versions
+- Full support for international characters in subject lines and email content
+- Read email messages by ID with advanced MIME structure handling
+- **Enhanced attachment display** showing filenames, types, sizes, and download IDs
+- Search emails with various criteria (subject, sender, date range)
+- **Comprehensive label management with ability to create, update, delete and list labels**
+- List all available Gmail labels (system and user-defined)
+- List emails in inbox, sent, or custom labels
+- Mark emails as read/unread
+- Move emails to different labels/folders
+- Delete emails
+- **Batch operations for efficiently processing multiple emails at once**
+- Full integration with Gmail API
+- Simple OAuth2 authentication flow with auto browser launch
+- Support for both Desktop and Web application credentials
+- Global credential storage for convenience
+
+## Installation & Authentication
+
+### Installing from npm (recommended)
+
+```bash
+npx @artymclabin/gmail-mcp auth
+```
+
+### Installing from source
+
+```bash
+git clone https://github.com/ArtyMcLabin/Gmail-MCP-Server.git
+cd Gmail-MCP-Server
+npm install
+npm run build
+```
+
+> **Note**: The `npx @gongrzhe/server-gmail-autoauth-mcp` commands found in older docs reference the [unmaintained upstream fork](https://github.com/GongRzhe/Gmail-MCP-Server). This fork is published as [`@artymclabin/gmail-mcp`](https://www.npmjs.com/package/@artymclabin/gmail-mcp).
+
+### Setting up Google Cloud credentials
+
+1. Create a Google Cloud Project and obtain credentials:
+
+   a. Create a Google Cloud Project:
+      - Go to [Google Cloud Console](https://console.cloud.google.com/)
+      - Create a new project or select an existing one
+      - Enable the Gmail API for your project
+
+   b. Create OAuth 2.0 Credentials:
+      - Go to "APIs & Services" > "Credentials"
+      - Click "Create Credentials" > "OAuth client ID"
+      - Choose either "Desktop app" or "Web application" as application type
+      - Give it a name and click "Create"
+      - For Web application, add `http://localhost:3000/oauth2callback` to the authorized redirect URIs
+      - Download the JSON file of your client's OAuth keys
+      - Rename the key file to `gcp-oauth.keys.json`
+
+2. Run Authentication:
+
+   You can authenticate in two ways:
+
+   a. Global Authentication (Recommended):
+   ```bash
+   # First time: Place gcp-oauth.keys.json in your home directory's .gmail-mcp folder
+   mkdir -p ~/.gmail-mcp
+   mv gcp-oauth.keys.json ~/.gmail-mcp/
+
+   # Run authentication from anywhere
+   node dist/index.js auth
+   ```
+
+   b. Local Authentication:
+   ```bash
+   # Place gcp-oauth.keys.json in your current directory
+   # The file will be automatically copied to global config
+   node dist/index.js auth
+   ```
+
+   The authentication process will:
+   - Look for `gcp-oauth.keys.json` in the current directory or `~/.gmail-mcp/`
+   - If found in current directory, copy it to `~/.gmail-mcp/`
+   - Open your default browser for Google authentication
+   - Save credentials as `~/.gmail-mcp/credentials.json`
+
+   > **Note**: 
+   > - After successful authentication, credentials are stored globally in `~/.gmail-mcp/` and can be used from any directory
+   > - Both Desktop app and Web application credentials are supported
+   > - For Web application credentials, make sure to add `http://localhost:3000/oauth2callback` to your authorized redirect URIs
+
+   **Custom callback URL / port:** By default the local OAuth server listens on port `3000` at `/oauth2callback`. If port 3000 is unavailable, or you need a different redirect URI, pass a full callback URL as an argument. The listener automatically binds to the port and path from that URL:
+
+   ```bash
+   node dist/index.js auth http://localhost:8080/oauth2callback
+   ```
+
+   The URL you pass must exactly match one of the authorized redirect URIs registered in the Google Cloud Console.
+
+3. Configure in Claude Desktop:
+
+```json
+{
+  "mcpServers": {
+    "gmail": {
+      "command": "node",
+      "args": [
+        "/absolute/path/to/Gmail-MCP-Server/dist/index.js"
+      ]
+    }
+  }
+}
+```
+
+### Docker Support
+
+If you prefer using Docker:
+
+1. Authentication:
+```bash
+docker run -i --rm \
+  --mount type=bind,source=/path/to/gcp-oauth.keys.json,target=/gcp-oauth.keys.json \
+  -v mcp-gmail:/gmail-server \
+  -e GMAIL_OAUTH_PATH=/gcp-oauth.keys.json \
+  -e "GMAIL_CREDENTIALS_PATH=/gmail-server/credentials.json" \
+  -p 3000:3000 \
+  mcp/gmail auth
+```
+
+2. Usage:
+```json
+{
+  "mcpServers": {
+    "gmail": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-v",
+        "mcp-gmail:/gmail-server",
+        "-e",
+        "GMAIL_CREDENTIALS_PATH=/gmail-server/credentials.json",
+        "mcp/gmail"
+      ]
+    }
+  }
+}
+```
+
+### Cloud Server Authentication
+
+For cloud server environments (like n8n), you can specify a custom callback URL during authentication:
+
+```bash
+node dist/index.js auth https://gmail.gongrzhe.com/oauth2callback
+```
+
+#### Setup Instructions for Cloud Environment
+
+1. **Configure Reverse Proxy:**
+   - Set up your n8n container to expose a port for authentication
+   - Configure a reverse proxy to forward traffic from your domain (e.g., `gmail.gongrzhe.com`) to this port
+
+2. **DNS Configuration:**
+   - Add an A record in your DNS settings to resolve your domain to your cloud server's IP address
+
+3. **Google Cloud Platform Setup:**
+   - In your Google Cloud Console, add your custom domain callback URL (e.g., `https://gmail.gongrzhe.com/oauth2callback`) to the authorized redirect URIs list
+
+4. **Run Authentication:**
+   ```bash
+   node dist/index.js auth https://gmail.gongrzhe.com/oauth2callback
+   ```
+
+5. **Configure in your application:**
+   ```json
+   {
+     "mcpServers": {
+       "gmail": {
+         "command": "node",
+         "args": [
+           "/absolute/path/to/Gmail-MCP-Server/dist/index.js"
+         ]
+       }
+     }
+   }
+   ```
+
+This approach allows authentication flows to work properly in environments where localhost isn't accessible, such as containerized applications or cloud servers.
+
+## OAuth Scopes
+
+You can limit the server's Gmail access by specifying OAuth scopes during authentication. This controls which tools are available to the LLM, reducing the attack surface for sensitive operations.
+
+### Available Scopes
+
+| Scope | Description |
+|-------|-------------|
+| `gmail.readonly` | Read-only access to emails (search, read, download attachments) |
+| `gmail.modify` | Full read/write access to emails (superset of `readonly` - includes sending, modifying, deleting) |
+| `gmail.compose` | Create drafts and send emails only |
+| `gmail.send` | Send emails only |
+| `gmail.labels` | Manage labels only |
+| `gmail.settings.basic` | Manage filters and settings |
+
+> **Note**: `gmail.modify` is a superset that includes all read capabilities. You don't need `gmail.readonly` if you have `gmail.modify`.
+
+### Authenticating with Specific Scopes
+
+Use the `--scopes` flag to request only the permissions you need:
+
+```bash
+# Read-only access (recommended for safe browsing)
+node dist/index.js auth --scopes=gmail.readonly
+
+# Read-only with filter management
+node dist/index.js auth --scopes=gmail.readonly,gmail.settings.basic
+
+# Full access (default behavior)
+node dist/index.js auth --scopes=gmail.modify,gmail.settings.basic
+```
+
+If no `--scopes` flag is provided, the server defaults to `gmail.modify,gmail.settings.basic` for full functionality.
+
+### Scope-to-Tool Mapping
+
+The server automatically filters available tools based on your authorized scopes:
+
+| Tools | Required Scope (any) |
+|-------|---------------------|
+| `read_email`, `search_emails`, `download_attachment` | `gmail.readonly` or `gmail.modify` |
+| `list_email_labels` | `gmail.readonly`, `gmail.modify`, or `gmail.labels` |
+| `send_email`, `draft_email`, `reply_all`, `send_draft` | `gmail.modify`, `gmail.compose`, or `gmail.send` |
+| `delete_draft`, `update_draft` | `gmail.modify` or `gmail.compose` |
+| `modify_email`, `batch_modify_emails`, `modify_thread`, `report_phishing`, `batch_report_phishing` | `gmail.modify` |
+| `delete_email`, `batch_delete_emails` | `gmail.full` (`https://mail.google.com/`) |
+| `create_label`, `update_label`, `delete_label`, `get_or_create_label` | `gmail.modify` or `gmail.labels` |
+| `list_filters`, `get_filter`, `create_filter`, `delete_filter`, `create_filter_from_template` | `gmail.settings.basic` |
+
+`gmail.full` is intentionally separate from the default scopes because it grants permanent-delete capability. Prefer `modify_email` / `batch_modify_emails` for archive, mark-read, label, or inbox cleanup flows; re-authenticate with `--scopes=gmail.full,gmail.settings.basic` only when the assistant should be able to permanently delete mail. `gmail.full` is a superset of the other mail scopes, so that combination keeps every read/send/modify/label tool available (settings scopes remain separate - Gmail's filter endpoints only accept `gmail.settings.*`).
+
+### Re-authenticating
+
+To change your scopes, simply run the auth command again with different scopes. This will replace your existing credentials.
+
+## Claude Code CLI Configuration
+
+To use this MCP server with [Claude Code](https://docs.anthropic.com/en/docs/claude-code), add it to your MCP settings.
+
+### Read-Only Configuration (Recommended for Safe Browsing)
+
+First, authenticate with read-only scope:
+
+```bash
+node dist/index.js auth --scopes=gmail.readonly
+```
+
+Then add to your Claude Code MCP settings (`~/.claude/mcp_settings.json` or project-level `.mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "gmail": {
+      "command": "npx",
+      "args": ["/absolute/path/to/Gmail-MCP-Server/dist/index.js"]
+    }
+  }
+}
+```
+
+With read-only scopes, only these 4 tools will be available to Claude:
+- `read_email` - Read email content
+- `search_emails` - Search your inbox
+- `list_email_labels` - List available labels
+- `download_attachment` - Download attachments
+
+### Full Access Configuration
+
+For full Gmail management capabilities:
+
+```bash
+node dist/index.js auth --scopes=gmail.modify,gmail.settings.basic
+```
+
+```json
+{
+  "mcpServers": {
+    "gmail": {
+      "command": "npx",
+      "args": ["/absolute/path/to/Gmail-MCP-Server/dist/index.js"]
+    }
+  }
+}
+```
+
+This enables all 23 tools including sending emails, managing labels, creating filters, reply-all, thread operations, phishing reports, and batch operations.
+
+### Running multiple instances (tool-name prefix)
+
+Some MCP clients dedupe tool entries by their base name across servers, which makes it impossible to run two instances of this server side-by-side (e.g. one for a personal account and one for a shared inbox) - only one instance's tools surface, even though both servers report as connected.
+
+The server accepts an optional `--tool-prefix=<value>` CLI flag (or `GMAIL_MCP_TOOL_PREFIX` env var) that is prepended to every tool name at registration. Default is empty (fully backward-compatible).
+
+Example: register two instances with distinct prefixes in Claude Code:
+
+```bash
+# Personal account
+claude mcp add gmail-personal -s user \
+  -e GMAIL_CREDENTIALS_PATH=$HOME/.gmail-mcp/credentials-personal.json \
+  -- node /absolute/path/to/Gmail-MCP-Server/dist/index.js --tool-prefix=personal_
+
+# Shared inbox
+claude mcp add gmail-info -s user \
+  -- node /absolute/path/to/Gmail-MCP-Server/dist/index.js --tool-prefix=info_
+```
+
+Tools then surface as `mcp__gmail-personal__personal_search_emails`, `mcp__gmail-info__info_search_emails`, etc. - distinct at every layer. The dispatch handler strips the prefix and looks up the resolved name via `getToolByName`; only strips when the result is a known tool (so a prefix value that overlaps a real tool name cannot cause silent mis-dispatch).
+
+The `auth` subcommand runs before the server starts and is unaffected - invoke it without `--tool-prefix`.
+
+## Available Tools
+
+The server provides the following tools that can be used through Claude Desktop:
+
+### 1. Send Email (`send_email`)
+
+Sends a new email immediately. Supports plain text, HTML, or multipart emails **with optional file attachments and inline images**.
+
+Basic Email:
+```json
+{
+  "to": ["recipient@example.com"],
+  "subject": "Meeting Tomorrow",
+  "body": "Hi,\n\nJust a reminder about our meeting tomorrow at 10 AM.\n\nBest regards",
+  "cc": ["cc@example.com"],
+  "bcc": ["bcc@example.com"],
+  "mimeType": "text/plain"
+}
+```
+
+**Email with Attachments:**
+```json
+{
+  "to": ["recipient@example.com"],
+  "subject": "Project Files",
+  "body": "Hi,\n\nPlease find the project files attached.\n\nBest regards",
+  "attachments": [
+    "/path/to/document.pdf",
+    "/path/to/spreadsheet.xlsx",
+    "/path/to/presentation.pptx"
+  ]
+}
+```
+
+HTML Email Example:
+```json
+{
+  "to": ["recipient@example.com"],
+  "subject": "Meeting Tomorrow",
+  "mimeType": "text/html",
+  "body": "<html><body><h1>Meeting Reminder</h1><p>Just a reminder about our <b>meeting tomorrow</b> at 10 AM.</p><p>Best regards</p></body></html>"
+}
+```
+
+Multipart Email Example (HTML + Plain Text):
+```json
+{
+  "to": ["recipient@example.com"],
+  "subject": "Meeting Tomorrow",
+  "mimeType": "multipart/alternative",
+  "body": "Hi,\n\nJust a reminder about our meeting tomorrow at 10 AM.\n\nBest regards",
+  "htmlBody": "<html><body><h1>Meeting Reminder</h1><p>Just a reminder about our <b>meeting tomorrow</b> at 10 AM.</p><p>Best regards</p></body></html>"
+}
+```
+
+**Inline Images (embedded in HTML):**
+
+Embed images inside the HTML body so they render in place, instead of arriving as separate attachments. Reference each image from `htmlBody` by its `cid`, and supply it as a file `path` or base64 `content`. Works the same way on `draft_email`, `update_draft`, and `reply_all`.
+
+```json
+{
+  "to": ["recipient@example.com"],
+  "subject": "Quarterly Report",
+  "body": "Revenue is up. See the chart below.",
+  "htmlBody": "<p>Revenue is up:</p><img src=\"cid:chart1\">",
+  "inlineImages": [
+    { "cid": "chart1", "path": "/path/to/chart.png" }
+  ]
+}
+```
+
+### 2. Draft Email (`draft_email`)
+Creates a draft email without sending it. **Also supports attachments**.
+
+```json
+{
+  "to": ["recipient@example.com"],
+  "subject": "Draft Report",
+  "body": "Here's the draft report for your review.",
+  "cc": ["manager@example.com"],
+  "attachments": ["/path/to/draft_report.docx"]
+}
+```
+
+### 3. Read Email (`read_email`)
+Retrieves the content of a specific email by its ID. **Now shows enhanced attachment information**.
+
+```json
+{
+  "messageId": "182ab45cd67ef"
+}
+```
+
+**Enhanced Response includes CC/BCC headers (when present) and attachment details:**
+```
+Subject: Project Files
+From: sender@example.com
+To: recipient@example.com
+CC: colleague@example.com
+Date: Thu, 19 Jun 2025 10:30:00 -0400
+
+Email body content here...
+
+Attachments (2):
+- document.pdf (application/pdf, 245 KB, ID: ANGjdJ9fkTs-i3GCQo5o97f_itG...)
+- spreadsheet.xlsx (application/vnd.openxmlformats-officedocument.spreadsheetml.sheet, 89 KB, ID: BWHkeL8gkUt-j4HDRp6o98g_juI...)
+```
+
+### 4. **Download Attachment (`download_attachment`)**
+**NEW**: Downloads email attachments to your local filesystem.
+
+```json
+{
+  "messageId": "182ab45cd67ef",
+  "attachmentId": "ANGjdJ9fkTs-i3GCQo5o97f_itG...",
+  "savePath": "/path/to/downloads",
+  "filename": "downloaded_document.pdf"
+}
+```
+
+Parameters:
+- `messageId`: The ID of the email containing the attachment
+- `attachmentId`: The attachment ID (shown in enhanced email display)
+- `savePath`: Directory to save the file (optional, defaults to current directory)
+- `filename`: Custom filename (optional, uses original filename if not provided)
+
+### 5. Search Emails (`search_emails`)
+Searches for emails using Gmail search syntax.
+
+```json
+{
+  "query": "from:sender@example.com after:2024/01/01 has:attachment",
+  "maxResults": 10
+}
+```
+
+### 6. Modify Email (`modify_email`)
+Adds or removes labels from emails (move to different folders, archive, etc.).
+
+```json
+{
+  "messageId": "182ab45cd67ef",
+  "addLabelIds": ["IMPORTANT"],
+  "removeLabelIds": ["INBOX"]
+}
+```
+
+### 7. Delete Email (`delete_email`)
+Permanently deletes an email. This tool requires `gmail.full` (`https://mail.google.com/`); the default `gmail.modify` scope is not enough for Gmail's permanent-delete endpoint.
+
+```json
+{
+  "messageId": "182ab45cd67ef"
+}
+```
+
+### 8. List Email Labels (`list_email_labels`)
+Retrieves all available Gmail labels.
+
+```json
+{}
+```
+
+### 9. Create Label (`create_label`)
+Creates a new Gmail label.
+
+```json
+{
+  "name": "Important Projects",
+  "messageListVisibility": "show",
+  "labelListVisibility": "labelShow"
+}
+```
+
+### 10. Update Label (`update_label`)
+Updates an existing Gmail label.
+
+```json
+{
+  "id": "Label_1234567890",
+  "name": "Urgent Projects",
+  "messageListVisibility": "show",
+  "labelListVisibility": "labelShow"
+}
+```
+
+### 11. Delete Label (`delete_label`)
+Deletes a Gmail label.
+
+```json
+{
+  "id": "Label_1234567890"
+}
+```
+
+### 12. Get or Create Label (`get_or_create_label`)
+Gets an existing label by name or creates it if it doesn't exist.
+
+```json
+{
+  "name": "Project XYZ",
+  "messageListVisibility": "show",
+  "labelListVisibility": "labelShow"
+}
+```
+
+### 13. Batch Modify Emails (`batch_modify_emails`)
+Modifies labels for multiple emails in efficient batches.
+
+```json
+{
+  "messageIds": ["182ab45cd67ef", "182ab45cd67eg", "182ab45cd67eh"],
+  "addLabelIds": ["IMPORTANT"],
+  "removeLabelIds": ["INBOX"],
+  "batchSize": 50
+}
+```
+
+### 14. Batch Delete Emails (`batch_delete_emails`)
+Permanently deletes multiple emails in efficient batches. This tool requires `gmail.full` (`https://mail.google.com/`); the default `gmail.modify` scope is not enough for Gmail's permanent-delete endpoint.
+
+```json
+{
+  "messageIds": ["182ab45cd67ef", "182ab45cd67eg", "182ab45cd67eh"],
+  "batchSize": 50
+}
+```
+
+### 15. Create Filter (`create_filter`)
+Creates a new Gmail filter with custom criteria and actions.
+
+```json
+{
+  "criteria": {
+    "from": "newsletter@company.com",
+    "hasAttachment": false
+  },
+  "action": {
+    "addLabelIds": ["Label_Newsletter"],
+    "removeLabelIds": ["INBOX"]
+  }
+}
+```
+
+### 16. List Filters (`list_filters`)
+Retrieves all Gmail filters.
+
+```json
+{}
+```
+
+### 17. Get Filter (`get_filter`)
+Gets details of a specific Gmail filter.
+
+```json
+{
+  "filterId": "ANe1Bmj1234567890"
+}
+```
+
+### 18. Delete Filter (`delete_filter`)
+Deletes a Gmail filter.
+
+```json
+{
+  "filterId": "ANe1Bmj1234567890"
+}
+```
+
+### 19. Create Filter from Template (`create_filter_from_template`)
+Creates a filter using pre-defined templates for common scenarios.
+
+```json
+{
+  "template": "fromSender",
+  "parameters": {
+    "senderEmail": "notifications@github.com",
+    "labelIds": ["Label_GitHub"],
+    "archive": true
+  }
+}
+```
+
+### 20. Reply All (`reply_all`)
+Replies to all recipients of an email. Automatically fetches the original email to build the recipient list and sets proper threading headers (`In-Reply-To`, `References`, `threadId`).
+
+**How it works:**
+1. Fetches the original email by `messageId`
+2. Builds **To** from the original sender (From header)
+3. Builds **CC** from original To + CC, excluding your own email
+4. Sets threading headers so the reply lands in the correct thread
+5. Sends via the existing `send_email` pipeline (supports attachments, HTML, multipart)
+
+```json
+{
+  "messageId": "182ab45cd67ef",
+  "body": "Thanks for the update, everyone. I'll review and get back to you.",
+  "mimeType": "text/plain"
+}
+```
+
+**With HTML and attachments:**
+```json
+{
+  "messageId": "182ab45cd67ef",
+  "body": "Plain text fallback",
+  "htmlBody": "<p>Thanks for the update. See attached notes.</p>",
+  "mimeType": "multipart/alternative",
+  "attachments": ["/path/to/notes.pdf"]
+}
+```
+
+Parameters:
+- `messageId` (required): ID of the email to reply to
+- `body` (required): Reply body (plain text, or fallback when using multipart)
+- `htmlBody` (optional): HTML version of the reply body
+- `mimeType` (optional): `text/plain` (default), `text/html`, or `multipart/alternative`
+- `attachments` (optional): Array of file paths to attach
+
+### 21. Modify Thread (`modify_thread`)
+Atomically modifies labels on an entire thread (all messages at once). Solves the problem where archiving only the latest message leaves older messages in the inbox.
+
+```json
+{
+  "threadId": "182ab45cd67ef",
+  "addLabelIds": ["IMPORTANT"],
+  "removeLabelIds": ["INBOX"]
+}
+```
+
+### 22. Report Phishing (`report_phishing`)
+Reports a message as phishing using the closest public Gmail API behavior by applying the SPAM label.
+
+```json
+{
+  "messageId": "182ab45cd67ef"
+}
+```
+
+> **Note**: The Gmail API does not expose the full native "Report phishing" workflow. This tool applies the SPAM label as the closest available approximation.
+
+### 23. Batch Report Phishing (`batch_report_phishing`)
+Reports multiple messages as phishing in efficient batches.
+
+```json
+{
+  "messageIds": ["182ab45cd67ef", "182ab45cd67eg", "182ab45cd67eh"],
+  "batchSize": 50
+}
+```
+
+### 24. Send Draft (`send_draft`)
+Atomically sends an existing draft via `users.drafts.send` and removes it from the Drafts folder in the same operation - no orphan/ghost draft left behind. Use after a `draft_email` (or `update_draft`) once the content is confirmed.
+
+```json
+{
+  "draftId": "r-1234567890123456789"
+}
+```
+
+### 25. Update Draft (`update_draft`)
+Replaces a draft's content in place via `users.drafts.update`, **preserving the draft ID**. Critical for iteration loops (draft → user requests changes → re-draft) so Drafts doesn't accumulate N copies. Reuses the same MIME builder as `draft_email`, so attachment and threading semantics match.
+
+```json
+{
+  "draftId": "r-1234567890123456789",
+  "to": ["recipient@example.com"],
+  "subject": "Revised Report",
+  "body": "Updated draft content.",
+  "cc": ["manager@example.com"],
+  "attachments": ["/path/to/report.docx"]
+}
+```
+
+### 26. Delete Draft (`delete_draft`)
+Discards an abandoned draft via `users.drafts.delete`.
+
+```json
+{
+  "draftId": "r-1234567890123456789"
+}
+```
+
+#### Canonical draft lifecycle
+
+```
+draft_email(...) → draftId
+  ↓ (user wants changes)
+update_draft(draftId, ...)   // mutate in place, same ID
+  ↓ (user confirms)
+send_draft(draftId)          // atomic send + draft removal
+```
+
+Or abort: `delete_draft(draftId)`.
+
+## Filter Management Features
+
+### Filter Criteria
+
+You can create filters based on various criteria:
+
+| Criteria | Example | Description |
+|----------|---------|-------------|
+| `from` | `"sender@example.com"` | Emails from a specific sender |
+| `to` | `"recipient@example.com"` | Emails sent to a specific recipient |
+| `subject` | `"Meeting"` | Emails with specific text in subject |
+| `query` | `"has:attachment"` | Gmail search query syntax |
+| `negatedQuery` | `"spam"` | Text that must NOT be present |
+| `hasAttachment` | `true` | Emails with attachments |
+| `size` | `10485760` | Email size in bytes |
+| `sizeComparison` | `"larger"` | Size comparison (`larger`, `smaller`) |
+
+### Filter Actions
+
+Filters can perform the following actions:
+
+| Action | Example | Description |
+|--------|---------|-------------|
+| `addLabelIds` | `["IMPORTANT", "Label_Work"]` | Add labels to matching emails |
+| `removeLabelIds` | `["INBOX", "UNREAD"]` | Remove labels from matching emails |
+| `forward` | `"backup@example.com"` | Forward emails to another address |
+
+### Filter Templates
+
+The server includes pre-built templates for common filtering scenarios:
+
+#### 1. From Sender Template (`fromSender`)
+Filters emails from a specific sender and optionally archives them.
+
+```json
+{
+  "template": "fromSender",
+  "parameters": {
+    "senderEmail": "newsletter@company.com",
+    "labelIds": ["Label_Newsletter"],
+    "archive": true
+  }
+}
+```
+
+#### 2. Subject Filter Template (`withSubject`)
+Filters emails with specific subject text and optionally marks as read.
+
+```json
+{
+  "template": "withSubject",
+  "parameters": {
+    "subjectText": "[URGENT]",
+    "labelIds": ["Label_Urgent"],
+    "markAsRead": false
+  }
+}
+```
+
+#### 3. Attachment Filter Template (`withAttachments`)
+Filters all emails with attachments.
+
+```json
+{
+  "template": "withAttachments",
+  "parameters": {
+    "labelIds": ["Label_Attachments"]
+  }
+}
+```
+
+#### 4. Large Email Template (`largeEmails`)
+Filters emails larger than a specified size.
+
+```json
+{
+  "template": "largeEmails",
+  "parameters": {
+    "sizeInBytes": 10485760,
+    "labelIds": ["Label_Large"]
+  }
+}
+```
+
+#### 5. Content Filter Template (`containingText`)
+Filters emails containing specific text and optionally marks as important.
+
+```json
+{
+  "template": "containingText",
+  "parameters": {
+    "searchText": "invoice",
+    "labelIds": ["Label_Finance"],
+    "markImportant": true
+  }
+}
+```
+
+#### 6. Mailing List Template (`mailingList`)
+Filters mailing list emails and optionally archives them.
+
+```json
+{
+  "template": "mailingList",
+  "parameters": {
+    "listIdentifier": "dev-team",
+    "labelIds": ["Label_DevTeam"],
+    "archive": true
+  }
+}
+```
+
+### Common Filter Examples
+
+Here are some practical filter examples:
+
+**Auto-organize newsletters:**
+```json
+{
+  "criteria": {
+    "from": "newsletter@company.com"
+  },
+  "action": {
+    "addLabelIds": ["Label_Newsletter"],
+    "removeLabelIds": ["INBOX"]
+  }
+}
+```
+
+**Handle promotional emails:**
+```json
+{
+  "criteria": {
+    "query": "unsubscribe OR promotional"
+  },
+  "action": {
+    "addLabelIds": ["Label_Promotions"],
+    "removeLabelIds": ["INBOX", "UNREAD"]
+  }
+}
+```
+
+**Priority emails from boss:**
+```json
+{
+  "criteria": {
+    "from": "boss@company.com"
+  },
+  "action": {
+    "addLabelIds": ["IMPORTANT", "Label_Boss"]
+  }
+}
+```
+
+**Large attachments:**
+```json
+{
+  "criteria": {
+    "size": 10485760,
+    "sizeComparison": "larger",
+    "hasAttachment": true
+  },
+  "action": {
+    "addLabelIds": ["Label_LargeFiles"]
+  }
+}
+```
+
+## Advanced Search Syntax
+
+The `search_emails` tool supports Gmail's powerful search operators:
+
+| Operator | Example | Description |
+|----------|---------|-------------|
+| `from:` | `from:john@example.com` | Emails from a specific sender |
+| `to:` | `to:mary@example.com` | Emails sent to a specific recipient |
+| `subject:` | `subject:"meeting notes"` | Emails with specific text in the subject |
+| `has:attachment` | `has:attachment` | Emails with attachments |
+| `after:` | `after:2024/01/01` | Emails received after a date |
+| `before:` | `before:2024/02/01` | Emails received before a date |
+| `is:` | `is:unread` | Emails with a specific state |
+| `label:` | `label:work` | Emails with a specific label |
+
+You can combine multiple operators: `from:john@example.com after:2024/01/01 has:attachment`
+
+## Advanced Features
+
+### **Email Attachment Support**
+
+The server provides comprehensive attachment functionality:
+
+- **Sending Attachments**: Include file paths in the `attachments` array when sending or drafting emails
+- **Attachment Detection**: Automatically detects MIME types and file sizes
+- **Download Capability**: Download any email attachment to your local filesystem
+- **Enhanced Display**: View detailed attachment information including filenames, types, sizes, and download IDs
+- **Multiple Formats**: Support for all common file types (documents, images, archives, etc.)
+- **RFC822 Compliance**: Uses Nodemailer for proper MIME message formatting
+
+**Supported File Types**: All standard file types including PDF, DOCX, XLSX, PPTX, images (PNG, JPG, GIF), archives (ZIP, RAR), and more.
+
+### Email Content Extraction
+
+The server intelligently extracts email content from complex MIME structures:
+
+- Prioritizes plain text content when available
+- Falls back to HTML content if plain text is not available
+- Handles multi-part MIME messages with nested parts
+- **Processes attachments information (filename, type, size, download ID)**
+- Preserves original email headers (From, To, Subject, Date)
+
+### International Character Support
+
+The server fully supports non-ASCII characters in email subjects and content, including:
+- Turkish, Chinese, Japanese, Korean, and other non-Latin alphabets
+- Special characters and symbols
+- Proper encoding ensures correct display in email clients
+
+### Comprehensive Label Management
+
+The server provides a complete set of tools for managing Gmail labels:
+
+- **Create Labels**: Create new labels with customizable visibility settings
+- **Update Labels**: Rename labels or change their visibility settings
+- **Delete Labels**: Remove user-created labels (system labels are protected)
+- **Find or Create**: Get a label by name or automatically create it if not found
+- **List All Labels**: View all system and user labels with detailed information
+- **Label Visibility Options**: Control how labels appear in message and label lists
+
+Label visibility settings include:
+- `messageListVisibility`: Controls whether the label appears in the message list (`show` or `hide`)
+- `labelListVisibility`: Controls how the label appears in the label list (`labelShow`, `labelShowIfUnread`, or `labelHide`)
+
+These label management features enable sophisticated organization of emails directly through Claude, without needing to switch to the Gmail interface.
+
+### Batch Operations
+
+The server includes efficient batch processing capabilities:
+
+- Process up to 50 emails at once (configurable batch size)
+- Automatic chunking of large email sets to avoid API limits
+- Detailed success/failure reporting for each operation
+- Graceful error handling with individual retries
+- Perfect for bulk inbox management and organization tasks
+
+## Security Notes
+
+- OAuth credentials are stored securely in your local environment (`~/.gmail-mcp/`)
+- The server uses offline access to maintain persistent authentication
+- Never share or commit your credentials to version control
+- Regularly review and revoke unused access in your Google Account settings
+- Credentials are stored globally but are only accessible by the current user
+- **Attachment files are processed locally and never stored permanently by the server**
+
+## Troubleshooting
+
+1. **OAuth Keys Not Found**
+   - Make sure `gcp-oauth.keys.json` is in either your current directory or `~/.gmail-mcp/`
+   - Check file permissions
+
+2. **Invalid Credentials Format**
+   - Ensure your OAuth keys file contains either `web` or `installed` credentials
+   - For web applications, verify the redirect URI is correctly configured
+
+3. **Port Already in Use**
+   - By default authentication uses port 3000; either free it up before running authentication, or run on a different port by passing a custom callback URL (e.g. `node dist/index.js auth http://localhost:8080/oauth2callback`)
+   - If freeing port 3000, you can find and stop the process using that port
+   - A custom callback URL must match one of the authorized redirect URIs registered in the Google Cloud Console
+
+4. **Batch Operation Failures**
+   - If batch operations fail, they automatically retry individual items
+   - Check the detailed error messages for specific failures
+   - Consider reducing the batch size if you encounter rate limiting
+
+5. **Attachment Issues**
+   - **File Not Found**: Ensure attachment file paths are correct and accessible
+   - **Permission Errors**: Check that the server has read access to attachment files
+   - **Size Limits**: Gmail has a 25MB attachment size limit per email
+   - **Download Failures**: Verify you have write permissions to the download directory
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request.
+
+### Branch workflow
+
+This repo uses a **two-branch model**:
+
+- **`main`** - stable. Only receives changes promoted from `experimental` after they're confirmed working. PRs are **never** merged directly into `main`.
+- **`experimental`** - staging / active development. All PRs are retargeted here and merged into `experimental` first.
+
+Lifecycle of a contribution:
+
+```
+PR opened (any base)
+  → retargeted to `experimental`
+  → security audit + review + CI
+  → merged into `experimental`
+  → soak / verify on experimental
+  → `experimental` promoted to `main` (maintainer confirms)
+```
+
+Open your PR against `experimental` when possible. If you target `main`, a maintainer will retarget it to `experimental` before merge.
+
+**CI requires README updates** - every push to `main` and every PR must include a README.md change (even a version bump or changelog entry). This ensures documentation stays current as the codebase evolves.
+
+To bypass for commits that genuinely don't need a docs update (dependency bumps, CI config changes), include `[skip-readme]` or `[no-readme]` in your commit message or PR title.
+
+
+## Running evals
+
+The evals package loads an mcp client that then runs the index.ts file, so there is no need to rebuild between tests. You can load environment variables by prefixing the npx command. Full documentation can be found [here](https://www.mcpevals.io/docs).
+
+```bash
+OPENAI_API_KEY=your-key  npx mcp-eval src/evals/evals.ts src/index.ts
+```
+
+## License
+
+MIT
+
+## Support
+
+If you encounter any issues or have questions, please [file an issue](https://github.com/ArtyMcLabin/Gmail-MCP-Server/issues).

--- a/vendor/gmail-mcp-fork/VENDOR.md
+++ b/vendor/gmail-mcp-fork/VENDOR.md
@@ -1,0 +1,22 @@
+# Vendored: ArtyMcLabin/Gmail-MCP-Server (source tree)
+
+- **Upstream**: https://github.com/ArtyMcLabin/Gmail-MCP-Server (MIT)
+- **Pinned commit**: `83e8dafebc87dd3e6a26c04acb5ec6e199c1636e` (2026-08-12)
+- **Why source, not a bundle**: owner decision 2026-09-07 -- a source tree is
+  auditable, a prebuilt dist is not. The dist/ here is built BY US from this
+  exact source (`npm ci && npm run build`); anyone can rebuild and diff.
+- **Why this fork**: fork of GongRzhe/Gmail-MCP-Server (the package we run
+  today), 98 commits ahead, actively maintained. Multi-account model:
+  INSTANCE-PER-ACCOUNT via `GMAIL_MCP_TOOL_PREFIX` + per-instance
+  `GMAIL_OAUTH_PATH`/`GMAIL_CREDENTIALS_PATH` -- the account lives in the
+  tool NAME, so there is no silent default-account fallback to mis-route a
+  send (the risk the owner flagged on #1162).
+- **Version bumps are never silent**: to lift the pin, repeat the whole path
+  -- fetch the new commit, diff the source, rebuild, run the parallel
+  verification round (old tools AND new tools working side by side), then
+  swap. Same as the original migration (card PR1162VENDOR907 thread).
+- **src/evals removed**: upstream's eval harness, not needed at runtime and
+  it drags extra dev-deps into audit scope.
+
+Rebuild: `cd vendor/gmail-mcp-fork && npm ci && npm run build`
+Run: `run.sh` (installs prod deps on first run, then execs `dist/index.js`).

--- a/vendor/gmail-mcp-fork/dist/email-export.js
+++ b/vendor/gmail-mcp-fork/dist/email-export.js
@@ -1,0 +1,121 @@
+/**
+ * Email export utilities for converting Gmail messages to various formats
+ */
+import emailAddresses from "email-addresses";
+/**
+ * Parse email address string into name and email components
+ * Uses RFC 5322 compliant parser (email-addresses package)
+ */
+export function parseEmailAddress(address) {
+    if (!address)
+        return { name: "", email: "" };
+    const parsed = emailAddresses.parseOneAddress(address);
+    if (parsed && parsed.type === "mailbox") {
+        return {
+            name: parsed.name || "",
+            email: parsed.address || "",
+        };
+    }
+    return { name: "", email: address.trim() };
+}
+/**
+ * Parse comma-separated list of email addresses
+ * Uses RFC 5322 compliant parser (email-addresses package)
+ */
+export function parseEmailAddresses(addresses) {
+    if (!addresses)
+        return [];
+    const parsed = emailAddresses.parseAddressList(addresses);
+    if (!parsed)
+        return [];
+    return parsed
+        .filter((entry) => entry.type === "mailbox")
+        .map((entry) => ({
+        name: entry.name || "",
+        email: entry.address || "",
+    }));
+}
+/**
+ * Convert Gmail API message to structured JSON
+ */
+export function gmailMessageToJson(message, emailContent, attachments) {
+    const headers = message.payload?.headers || [];
+    const getHeader = (name) => headers.find((h) => h.name?.toLowerCase() === name.toLowerCase())?.value || "";
+    const dateStr = getHeader("date");
+    let isoDate = "";
+    try {
+        isoDate = new Date(dateStr).toISOString();
+    }
+    catch {
+        isoDate = dateStr; // Keep original if parsing fails
+    }
+    return {
+        messageId: message.id,
+        threadId: message.threadId,
+        subject: getHeader("subject"),
+        from: parseEmailAddress(getHeader("from")),
+        to: parseEmailAddresses(getHeader("to")),
+        cc: parseEmailAddresses(getHeader("cc")),
+        bcc: parseEmailAddresses(getHeader("bcc")),
+        date: isoDate,
+        labels: message.labelIds || [],
+        snippet: message.snippet || "",
+        body: {
+            plain: emailContent.text,
+            html: emailContent.html,
+        },
+        attachments,
+        headers: {
+            "Message-ID": getHeader("message-id"),
+            "In-Reply-To": getHeader("in-reply-to"),
+            References: getHeader("references"),
+        },
+    };
+}
+/**
+ * Format address for display
+ */
+function formatAddress(a) {
+    return a.name ? `${a.name} <${a.email}>` : a.email;
+}
+/**
+ * Format list of addresses for display
+ */
+function formatAddresses(addrs) {
+    return addrs.map(formatAddress).join(", ");
+}
+/**
+ * Convert email to plain text format
+ */
+export function emailToTxt(message, emailContent, attachments) {
+    const headers = message.payload?.headers || [];
+    const getHeader = (name) => headers.find((h) => h.name?.toLowerCase() === name.toLowerCase())?.value || "";
+    const from = getHeader("from");
+    const to = getHeader("to");
+    const cc = getHeader("cc");
+    const subject = getHeader("subject");
+    const date = getHeader("date");
+    const lines = [`From: ${from}`, `To: ${to}`];
+    if (cc) {
+        lines.push(`CC: ${cc}`);
+    }
+    lines.push(`Subject: ${subject}`);
+    lines.push(`Date: ${date}`);
+    lines.push("");
+    lines.push(emailContent.text || "[No plain text content]");
+    if (attachments.length > 0) {
+        lines.push("");
+        lines.push("---");
+        lines.push(`Attachments: ${attachments.map((a) => a.filename).join(", ")}`);
+    }
+    return lines.join("\n");
+}
+/**
+ * Extract HTML content from email, or throw if none exists
+ */
+export function emailToHtml(emailContent) {
+    if (!emailContent.html) {
+        throw new Error("This email has no HTML content");
+    }
+    return emailContent.html;
+}

--- a/vendor/gmail-mcp-fork/dist/filter-manager.js
+++ b/vendor/gmail-mcp-fork/dist/filter-manager.js
@@ -1,0 +1,150 @@
+/**
+ * Filter Manager for Gmail MCP Server
+ * Provides comprehensive filter management functionality
+ */
+/**
+ * Creates a new Gmail filter
+ * @param gmail - Gmail API instance
+ * @param criteria - Filter criteria to match messages
+ * @param action - Actions to perform on matching messages
+ * @returns The newly created filter
+ */
+export async function createFilter(gmail, criteria, action) {
+    try {
+        const filterBody = {
+            criteria,
+            action
+        };
+        const response = await gmail.users.settings.filters.create({
+            userId: 'me',
+            requestBody: filterBody,
+        });
+        return response.data;
+    }
+    catch (error) {
+        if (error.code === 400) {
+            throw new Error(`Invalid filter criteria or action: ${error.message}`);
+        }
+        throw new Error(`Failed to create filter: ${error.message}`);
+    }
+}
+/**
+ * Lists all Gmail filters
+ * @param gmail - Gmail API instance
+ * @returns Array of all filters
+ */
+export async function listFilters(gmail) {
+    try {
+        const response = await gmail.users.settings.filters.list({
+            userId: 'me',
+        });
+        const filters = response.data.filter || [];
+        return {
+            filters,
+            count: filters.length
+        };
+    }
+    catch (error) {
+        throw new Error(`Failed to list filters: ${error.message}`);
+    }
+}
+/**
+ * Gets a specific Gmail filter by ID
+ * @param gmail - Gmail API instance
+ * @param filterId - ID of the filter to retrieve
+ * @returns The filter details
+ */
+export async function getFilter(gmail, filterId) {
+    try {
+        const response = await gmail.users.settings.filters.get({
+            userId: 'me',
+            id: filterId,
+        });
+        return response.data;
+    }
+    catch (error) {
+        if (error.code === 404) {
+            throw new Error(`Filter with ID "${filterId}" not found.`);
+        }
+        throw new Error(`Failed to get filter: ${error.message}`);
+    }
+}
+/**
+ * Deletes a Gmail filter
+ * @param gmail - Gmail API instance
+ * @param filterId - ID of the filter to delete
+ * @returns Success message
+ */
+export async function deleteFilter(gmail, filterId) {
+    try {
+        await gmail.users.settings.filters.delete({
+            userId: 'me',
+            id: filterId,
+        });
+        return { success: true, message: `Filter "${filterId}" deleted successfully.` };
+    }
+    catch (error) {
+        if (error.code === 404) {
+            throw new Error(`Filter with ID "${filterId}" not found.`);
+        }
+        throw new Error(`Failed to delete filter: ${error.message}`);
+    }
+}
+/**
+ * Helper function to create common filter patterns
+ */
+export const filterTemplates = {
+    /**
+     * Filter emails from a specific sender
+     */
+    fromSender: (senderEmail, labelIds = [], archive = false) => ({
+        criteria: { from: senderEmail },
+        action: {
+            addLabelIds: labelIds,
+            removeLabelIds: archive ? ['INBOX'] : undefined
+        }
+    }),
+    /**
+     * Filter emails with specific subject
+     */
+    withSubject: (subjectText, labelIds = [], markAsRead = false) => ({
+        criteria: { subject: subjectText },
+        action: {
+            addLabelIds: labelIds,
+            removeLabelIds: markAsRead ? ['UNREAD'] : undefined
+        }
+    }),
+    /**
+     * Filter emails with attachments
+     */
+    withAttachments: (labelIds = []) => ({
+        criteria: { hasAttachment: true },
+        action: { addLabelIds: labelIds }
+    }),
+    /**
+     * Filter large emails
+     */
+    largeEmails: (sizeInBytes, labelIds = []) => ({
+        criteria: { size: sizeInBytes, sizeComparison: 'larger' },
+        action: { addLabelIds: labelIds }
+    }),
+    /**
+     * Filter emails containing specific text
+     */
+    containingText: (searchText, labelIds = [], markImportant = false) => ({
+        criteria: { query: `"${searchText}"` },
+        action: {
+            addLabelIds: markImportant ? [...labelIds, 'IMPORTANT'] : labelIds
+        }
+    }),
+    /**
+     * Filter mailing list emails (common patterns)
+     */
+    mailingList: (listIdentifier, labelIds = [], archive = true) => ({
+        criteria: { query: `list:${listIdentifier} OR subject:[${listIdentifier}]` },
+        action: {
+            addLabelIds: labelIds,
+            removeLabelIds: archive ? ['INBOX'] : undefined
+        }
+    })
+};

--- a/vendor/gmail-mcp-fork/dist/index.js
+++ b/vendor/gmail-mcp-fork/dist/index.js
@@ -1,0 +1,1482 @@
+#!/usr/bin/env node
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { CallToolRequestSchema, ListToolsRequestSchema, } from "@modelcontextprotocol/sdk/types.js";
+import { google } from 'googleapis';
+import { OAuth2Client } from 'google-auth-library';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import http from 'http';
+import open from 'open';
+import os from 'os';
+import { createEmailMessage, createEmailWithNodemailer, needsRawBuilder } from "./utl.js";
+import { createLabel, updateLabel, deleteLabel, listLabels, getOrCreateLabel } from "./label-manager.js";
+import { createFilter, listFilters, getFilter, deleteFilter, filterTemplates } from "./filter-manager.js";
+import { addRePrefix, buildReferencesHeader, buildReplyAllRecipients } from "./reply-all-helpers.js";
+import { DEFAULT_SCOPES, scopeNamesToUrls, parseScopes, validateScopes, hasScope, getAvailableScopeNames } from "./scopes.js";
+import { toolDefinitions, toMcpTools, getToolByName, SendEmailSchema, ReadEmailSchema, SearchEmailsSchema, ModifyEmailSchema, DeleteEmailSchema, BatchModifyEmailsSchema, ReportPhishingSchema, BatchReportPhishingSchema, BatchDeleteEmailsSchema, CreateLabelSchema, UpdateLabelSchema, DeleteLabelSchema, GetOrCreateLabelSchema, CreateFilterSchema, GetFilterSchema, DeleteFilterSchema, CreateFilterFromTemplateSchema, DownloadAttachmentSchema, ReplyAllSchema, GetThreadSchema, ListInboxThreadsSchema, GetInboxWithThreadsSchema, DownloadEmailSchema, ModifyThreadSchema, SendDraftSchema, DeleteDraftSchema, UpdateDraftSchema } from "./tools.js";
+import { gmailMessageToJson, emailToTxt, emailToHtml } from "./email-export.js";
+import { resolveToolPrefix } from "./tool-prefix.js";
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+// Configuration paths
+const CONFIG_DIR = path.join(os.homedir(), '.gmail-mcp');
+const OAUTH_PATH = process.env.GMAIL_OAUTH_PATH || path.join(CONFIG_DIR, 'gcp-oauth.keys.json');
+const CREDENTIALS_PATH = process.env.GMAIL_CREDENTIALS_PATH || path.join(CONFIG_DIR, 'credentials.json');
+// Optional tool-name prefix — lets multiple instances of this server run side-by-side
+// without their tool names colliding in clients that disambiguate by base name.
+// Precedence: --tool-prefix=<value> / --tool-prefix <value> CLI flag, then
+// GMAIL_MCP_TOOL_PREFIX env var, then empty (no prefix → backward compatible).
+// Does not affect the `auth` subcommand, which is detected via process.argv[2] === 'auth'
+// and exits before the server starts — run `auth` without --tool-prefix.
+const TOOL_PREFIX = resolveToolPrefix(process.argv.slice(2), process.env);
+// OAuth2 configuration
+let oauth2Client;
+let authorizedScopes = DEFAULT_SCOPES;
+let callbackUrl;
+/**
+ * Recursively extract email body content from MIME message parts
+ * Handles complex email structures with nested parts
+ */
+function extractEmailContent(messagePart) {
+    // Initialize containers for different content types
+    let textContent = '';
+    let htmlContent = '';
+    // If the part has a body with data, process it based on MIME type
+    if (messagePart.body && messagePart.body.data) {
+        const content = Buffer.from(messagePart.body.data, 'base64').toString('utf8');
+        // Store content based on its MIME type
+        if (messagePart.mimeType === 'text/plain') {
+            textContent = content;
+        }
+        else if (messagePart.mimeType === 'text/html') {
+            htmlContent = content;
+        }
+    }
+    // If the part has nested parts, recursively process them
+    if (messagePart.parts && messagePart.parts.length > 0) {
+        for (const part of messagePart.parts) {
+            const { text, html } = extractEmailContent(part);
+            if (text)
+                textContent += text;
+            if (html)
+                htmlContent += html;
+        }
+    }
+    // Return both plain text and HTML content
+    return { text: textContent, html: htmlContent };
+}
+/**
+ * Extract common headers from Gmail message payload
+ */
+function extractHeaders(payload) {
+    const headers = payload?.headers || [];
+    const getHeader = (name) => headers.find((h) => h.name?.toLowerCase() === name.toLowerCase())?.value || "";
+    return {
+        subject: getHeader("subject"),
+        from: getHeader("from"),
+        to: getHeader("to"),
+        cc: getHeader("cc"),
+        bcc: getHeader("bcc"),
+        date: getHeader("date"),
+        rfcMessageId: getHeader("message-id"),
+    };
+}
+/**
+ * Extract attachments from Gmail message payload
+ */
+function extractAttachments(payload) {
+    const attachments = [];
+    function processAttachmentParts(part) {
+        if (part.body && part.body.attachmentId) {
+            attachments.push({
+                id: part.body.attachmentId,
+                filename: part.filename || `attachment-${part.body.attachmentId}`,
+                mimeType: part.mimeType || "application/octet-stream",
+                size: part.body.size || 0,
+            });
+        }
+        if (part.parts) {
+            part.parts.forEach((subpart) => processAttachmentParts(subpart));
+        }
+    }
+    processAttachmentParts(payload);
+    return attachments;
+}
+async function loadCredentials() {
+    try {
+        // Create config directory if it doesn't exist
+        if (!process.env.GMAIL_OAUTH_PATH && !process.env.GMAIL_CREDENTIALS_PATH && !fs.existsSync(CONFIG_DIR)) {
+            fs.mkdirSync(CONFIG_DIR, { recursive: true, mode: 0o700 });
+        }
+        // Check for OAuth keys in current directory first, then in config directory
+        const localOAuthPath = path.join(process.cwd(), 'gcp-oauth.keys.json');
+        let oauthPath = OAUTH_PATH;
+        if (fs.existsSync(localOAuthPath)) {
+            // If found in current directory, copy to config directory
+            fs.copyFileSync(localOAuthPath, OAUTH_PATH);
+            console.log('OAuth keys found in current directory, copied to global config.');
+        }
+        if (!fs.existsSync(OAUTH_PATH)) {
+            console.error('Error: OAuth keys file not found. Please place gcp-oauth.keys.json in current directory or', CONFIG_DIR);
+            process.exit(1);
+        }
+        const keysContent = JSON.parse(fs.readFileSync(OAUTH_PATH, 'utf8'));
+        const keys = keysContent.installed || keysContent.web;
+        if (!keys) {
+            console.error('Error: Invalid OAuth keys file format. File should contain either "installed" or "web" credentials.');
+            process.exit(1);
+        }
+        // Parse callback URL from args (must be a URL, not a flag)
+        // Supports: node index.js auth https://example.com/callback
+        // Or: node index.js auth --scopes=gmail.readonly (uses default callback)
+        const callbackArg = process.argv.find(arg => arg.startsWith('http://') || arg.startsWith('https://'));
+        const callback = callbackArg || "http://localhost:3000/oauth2callback";
+        callbackUrl = new URL(callback);
+        // The built-in listener is plain HTTP. An https:// callback is only valid
+        // in the documented reverse-proxy setup (README "Cloud Server Authentication"),
+        // where TLS terminates at the proxy and traffic is forwarded to the local
+        // listener on port 3000. Direct browser->listener https would hang.
+        if (callbackUrl.protocol === 'https:') {
+            console.log('https callback URL detected: assuming a reverse proxy terminates TLS and forwards to the local listener on port 3000 (see README "Cloud Server Authentication").');
+        }
+        oauth2Client = new OAuth2Client(keys.client_id, keys.client_secret, callback);
+        if (fs.existsSync(CREDENTIALS_PATH)) {
+            const credentials = JSON.parse(fs.readFileSync(CREDENTIALS_PATH, 'utf8'));
+            // Credentials file structure (v1.2.0+):
+            //   { "tokens": { access_token, refresh_token, ... }, "scopes": ["gmail.readonly", ...] }
+            //
+            // Legacy structure (pre-v1.2.0):
+            //   { access_token, refresh_token, ... }
+            //
+            // We support both formats for backwards compatibility. Users with legacy
+            // credentials will get DEFAULT_SCOPES (full access) until they re-authenticate.
+            const tokens = credentials.tokens || credentials;
+            oauth2Client.setCredentials(tokens);
+            if (credentials.scopes) {
+                authorizedScopes = credentials.scopes;
+            }
+            // Persist refreshed tokens so refresh_token survives access_token rotation.
+            // Without this, google-auth-library's silent refresh updates only the
+            // in-memory client; on next process start we'd re-read a stale token.
+            oauth2Client.on('tokens', (newTokens) => {
+                try {
+                    const onDisk = JSON.parse(fs.readFileSync(CREDENTIALS_PATH, 'utf8'));
+                    const currentTokens = onDisk.tokens || onDisk;
+                    const mergedTokens = newTokens.refresh_token
+                        ? { ...currentTokens, ...newTokens }
+                        : { ...currentTokens, access_token: newTokens.access_token, expiry_date: newTokens.expiry_date };
+                    const updated = onDisk.tokens
+                        ? { ...onDisk, tokens: mergedTokens }
+                        : mergedTokens;
+                    fs.writeFileSync(CREDENTIALS_PATH, JSON.stringify(updated, null, 2), { mode: 0o600 });
+                }
+                catch (err) {
+                    console.error('Failed to persist refreshed tokens:', err);
+                }
+            });
+        }
+    }
+    catch (error) {
+        console.error('Error loading credentials:', error);
+        process.exit(1);
+    }
+}
+async function authenticate(scopes) {
+    const server = http.createServer();
+    // Port derivation:
+    // - explicit port in the callback URL -> use it
+    // - portless http -> protocol default 80 (NOT 3000 — that fallback caused
+    //   the silent-hang bug this derivation exists to fix)
+    // - https -> reverse-proxy setup; the proxy forwards to the local listener
+    //   on 3000 (documented default in README "Cloud Server Authentication")
+    const port = callbackUrl.port
+        ? Number(callbackUrl.port)
+        : (callbackUrl.protocol === 'https:' ? 3000 : 80);
+    server.listen(port, '127.0.0.1');
+    // Convert shorthand scope names (e.g., "gmail.readonly") to full Google API URLs
+    const scopeUrls = scopeNamesToUrls(scopes);
+    return new Promise((resolve, reject) => {
+        const authUrl = oauth2Client.generateAuthUrl({
+            access_type: 'offline',
+            prompt: 'consent',
+            scope: scopeUrls,
+        });
+        console.log('Requesting scopes:', scopes.join(', '));
+        console.log('Please visit this URL to authenticate:', authUrl);
+        open(authUrl);
+        server.on('request', async (req, res) => {
+            if (!req.url?.startsWith(callbackUrl.pathname))
+                return;
+            const url = new URL(req.url, callbackUrl.origin);
+            const code = url.searchParams.get('code');
+            if (!code) {
+                res.writeHead(400);
+                res.end('No code provided');
+                reject(new Error('No code provided'));
+                return;
+            }
+            try {
+                const { tokens } = await oauth2Client.getToken(code);
+                oauth2Client.setCredentials(tokens);
+                // Store both tokens and authorized scopes for runtime filtering
+                const credentials = { tokens, scopes };
+                fs.writeFileSync(CREDENTIALS_PATH, JSON.stringify(credentials, null, 2), { mode: 0o600 });
+                res.writeHead(200);
+                res.end('Authentication successful! You can close this window.');
+                console.log('Credentials saved with scopes:', scopes.join(', '));
+                server.close();
+                resolve();
+            }
+            catch (error) {
+                res.writeHead(500);
+                res.end('Authentication failed');
+                reject(error);
+            }
+        });
+    });
+}
+// Main function
+async function main() {
+    await loadCredentials();
+    if (process.argv[2] === 'auth') {
+        // Parse --scopes flag from CLI arguments
+        // Usage: node dist/index.js auth --scopes=<scope1,scope2,...>
+        // Example: node dist/index.js auth --scopes=gmail.readonly
+        // Example: node dist/index.js auth --scopes=gmail.readonly,gmail.settings.basic
+        const scopesArg = process.argv.find(arg => arg.startsWith('--scopes='));
+        let scopes = DEFAULT_SCOPES;
+        if (scopesArg) {
+            const scopesValue = scopesArg.slice('--scopes='.length);
+            scopes = parseScopes(scopesValue);
+            const validation = validateScopes(scopes);
+            if (!validation.valid) {
+                console.error('Error: Invalid scope(s):', validation.invalid.join(', '));
+                console.error('Available scopes:', getAvailableScopeNames().join(', '));
+                process.exit(1);
+            }
+        }
+        else {
+            console.log('No --scopes flag specified, using defaults:', DEFAULT_SCOPES.join(', '));
+            console.log('Tip: Use --scopes=gmail.readonly for read-only access');
+            console.log('Available scopes:', getAvailableScopeNames().join(', '));
+        }
+        await authenticate(scopes);
+        console.log('Authentication completed successfully');
+        process.exit(0);
+    }
+    // Initialize Gmail API
+    const gmail = google.gmail({ version: 'v1', auth: oauth2Client });
+    // Server implementation
+    const server = new Server({
+        name: "gmail",
+        version: "1.0.0",
+    }, {
+        capabilities: {
+            tools: {},
+        },
+    });
+    // Tool handlers
+    // Filter available tools based on authorized scopes
+    server.setRequestHandler(ListToolsRequestSchema, async () => {
+        const availableTools = toolDefinitions.filter(tool => hasScope(authorizedScopes, tool.scopes));
+        const mcpTools = toMcpTools(availableTools);
+        // Apply optional TOOL_PREFIX so multiple server instances can coexist
+        // in clients that dedupe tool entries by base name.
+        return { tools: mcpTools.map(t => ({ ...t, name: TOOL_PREFIX + t.name })) };
+    });
+    server.setRequestHandler(CallToolRequestSchema, async (request) => {
+        const { name: rawName, arguments: args } = request.params;
+        // Strip TOOL_PREFIX only if the result is a known base tool name.
+        // Guards against accidental over-stripping when the prefix overlaps a tool name's start
+        // (e.g. prefix="send_" + rawName="send_email" → "email", which is not a tool).
+        const stripped = TOOL_PREFIX && rawName.startsWith(TOOL_PREFIX)
+            ? rawName.slice(TOOL_PREFIX.length)
+            : rawName;
+        const name = getToolByName(stripped) ? stripped : rawName;
+        // Verify the tool is authorized for the current scopes
+        // This guards against direct tool calls that bypass ListTools
+        const toolDef = getToolByName(name);
+        if (!toolDef || !hasScope(authorizedScopes, toolDef.scopes)) {
+            return {
+                content: [{
+                        type: "text",
+                        text: `Error: Tool "${name}" is not available. You may need to re-authenticate with additional scopes.`,
+                    }],
+            };
+        }
+        async function handleEmailAction(action, validatedArgs) {
+            let message;
+            try {
+                // Auto-resolve threading headers when threadId is provided but inReplyTo is missing
+                if (validatedArgs.threadId && !validatedArgs.inReplyTo) {
+                    try {
+                        const threadResponse = await gmail.users.threads.get({
+                            userId: 'me',
+                            id: validatedArgs.threadId,
+                            format: 'metadata',
+                            metadataHeaders: ['Message-ID'],
+                        });
+                        const threadMessages = threadResponse.data.messages || [];
+                        if (threadMessages.length > 0) {
+                            // Collect all Message-ID values for the References chain
+                            const allMessageIds = [];
+                            for (const msg of threadMessages) {
+                                const msgHeaders = msg.payload?.headers || [];
+                                const messageIdHeader = msgHeaders.find((h) => h.name?.toLowerCase() === 'message-id');
+                                if (messageIdHeader?.value) {
+                                    allMessageIds.push(messageIdHeader.value);
+                                }
+                            }
+                            // Last message's Message-ID becomes In-Reply-To
+                            const lastMessage = threadMessages[threadMessages.length - 1];
+                            const lastHeaders = lastMessage.payload?.headers || [];
+                            const lastMessageId = lastHeaders.find((h) => h.name?.toLowerCase() === 'message-id')?.value;
+                            if (lastMessageId) {
+                                validatedArgs.inReplyTo = lastMessageId;
+                            }
+                            if (allMessageIds.length > 0) {
+                                validatedArgs.references = allMessageIds.join(' ');
+                            }
+                        }
+                    }
+                    catch (threadError) {
+                        console.warn(`Warning: Could not fetch thread ${validatedArgs.threadId} for header resolution: ${threadError.message}`);
+                        // Continue without threading headers - degraded but not broken
+                    }
+                }
+                // Route attachment- or inline-image-bearing mail through the raw MIME builder
+                if (needsRawBuilder(validatedArgs)) {
+                    // Use Nodemailer to create properly formatted RFC822 message
+                    message = await createEmailWithNodemailer(validatedArgs);
+                    if (action === "send") {
+                        const encodedMessage = Buffer.from(message).toString('base64')
+                            .replace(/\+/g, '-')
+                            .replace(/\//g, '_')
+                            .replace(/=+$/, '');
+                        const result = await gmail.users.messages.send({
+                            userId: 'me',
+                            requestBody: {
+                                raw: encodedMessage,
+                                ...(validatedArgs.threadId && { threadId: validatedArgs.threadId })
+                            }
+                        });
+                        return {
+                            content: [
+                                {
+                                    type: "text",
+                                    text: `Email sent successfully with ID: ${result.data.id}`,
+                                },
+                            ],
+                        };
+                    }
+                    else {
+                        // For drafts with attachments, use the raw message
+                        const encodedMessage = Buffer.from(message).toString('base64')
+                            .replace(/\+/g, '-')
+                            .replace(/\//g, '_')
+                            .replace(/=+$/, '');
+                        const messageRequest = {
+                            raw: encodedMessage,
+                            ...(validatedArgs.threadId && { threadId: validatedArgs.threadId })
+                        };
+                        const response = await gmail.users.drafts.create({
+                            userId: 'me',
+                            requestBody: {
+                                message: messageRequest,
+                            },
+                        });
+                        return {
+                            content: [
+                                {
+                                    type: "text",
+                                    text: `Email draft created successfully with ID: ${response.data.id}`,
+                                },
+                            ],
+                        };
+                    }
+                }
+                else {
+                    // For plain / simple-HTML mail with no attachments or inline images
+                    message = createEmailMessage(validatedArgs);
+                    const encodedMessage = Buffer.from(message).toString('base64')
+                        .replace(/\+/g, '-')
+                        .replace(/\//g, '_')
+                        .replace(/=+$/, '');
+                    const messageRequest = {
+                        raw: encodedMessage,
+                    };
+                    // Add threadId if specified
+                    if (validatedArgs.threadId) {
+                        messageRequest.threadId = validatedArgs.threadId;
+                    }
+                    if (action === "send") {
+                        const response = await gmail.users.messages.send({
+                            userId: 'me',
+                            requestBody: messageRequest,
+                        });
+                        return {
+                            content: [
+                                {
+                                    type: "text",
+                                    text: `Email sent successfully with ID: ${response.data.id}`,
+                                },
+                            ],
+                        };
+                    }
+                    else {
+                        const response = await gmail.users.drafts.create({
+                            userId: 'me',
+                            requestBody: {
+                                message: messageRequest,
+                            },
+                        });
+                        return {
+                            content: [
+                                {
+                                    type: "text",
+                                    text: `Email draft created successfully with ID: ${response.data.id}`,
+                                },
+                            ],
+                        };
+                    }
+                }
+            }
+            catch (error) {
+                // Log attachment / inline-image errors for debugging
+                if (needsRawBuilder(validatedArgs)) {
+                    const nAtt = validatedArgs.attachments?.length || 0;
+                    const nImg = validatedArgs.inlineImages?.length || 0;
+                    console.error(`Failed to send email with ${nAtt} attachment(s) and ${nImg} inline image(s):`, error.message);
+                }
+                throw error;
+            }
+        }
+        // Helper function to process operations in batches
+        async function processBatches(items, batchSize, processFn) {
+            const successes = [];
+            const failures = [];
+            // Process in batches
+            for (let i = 0; i < items.length; i += batchSize) {
+                const batch = items.slice(i, i + batchSize);
+                try {
+                    const results = await processFn(batch);
+                    successes.push(...results);
+                }
+                catch (error) {
+                    // If batch fails, try individual items
+                    for (const item of batch) {
+                        try {
+                            const result = await processFn([item]);
+                            successes.push(...result);
+                        }
+                        catch (itemError) {
+                            failures.push({ item, error: itemError });
+                        }
+                    }
+                }
+            }
+            return { successes, failures };
+        }
+        try {
+            switch (name) {
+                case "send_email":
+                case "draft_email": {
+                    const validatedArgs = SendEmailSchema.parse(args);
+                    const action = name === "send_email" ? "send" : "draft";
+                    return await handleEmailAction(action, validatedArgs);
+                }
+                case "read_email": {
+                    const validatedArgs = ReadEmailSchema.parse(args);
+                    const response = await gmail.users.messages.get({
+                        userId: 'me',
+                        id: validatedArgs.messageId,
+                        format: 'full',
+                    });
+                    const { subject, from, to, cc, bcc, date, rfcMessageId } = extractHeaders(response.data.payload);
+                    const threadId = response.data.threadId || '';
+                    const { text, html } = extractEmailContent(response.data.payload || {});
+                    const attachments = extractAttachments(response.data.payload);
+                    // Use plain text content if available, otherwise use HTML content
+                    const body = text || html || '';
+                    const contentTypeNote = !text && html ?
+                        '[Note: This email is HTML-formatted. Plain text version not available.]\n\n' : '';
+                    // Add attachment info to output if any are present
+                    const attachmentInfo = attachments.length > 0 ?
+                        `\n\nAttachments (${attachments.length}):\n` +
+                            attachments.map(a => `- ${a.filename} (${a.mimeType}, ${Math.round(a.size / 1024)} KB, ID: ${a.id})`).join('\n') : '';
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: `Thread ID: ${threadId}\nMessage-ID: ${rfcMessageId}\nSubject: ${subject}\nFrom: ${from}\nTo: ${to}${cc ? `\nCC: ${cc}` : ''}${bcc ? `\nBCC: ${bcc}` : ''}\nDate: ${date}\n\n${contentTypeNote}${body}${attachmentInfo}`,
+                            },
+                        ],
+                    };
+                }
+                case "search_emails": {
+                    const validatedArgs = SearchEmailsSchema.parse(args);
+                    const response = await gmail.users.messages.list({
+                        userId: 'me',
+                        q: validatedArgs.query,
+                        maxResults: validatedArgs.maxResults || 10,
+                    });
+                    const messages = response.data.messages || [];
+                    const results = await Promise.all(messages.map(async (msg) => {
+                        const detail = await gmail.users.messages.get({
+                            userId: 'me',
+                            id: msg.id,
+                            format: 'metadata',
+                            metadataHeaders: ['Subject', 'From', 'Date'],
+                        });
+                        const headers = detail.data.payload?.headers || [];
+                        return {
+                            id: msg.id,
+                            subject: headers.find(h => h.name === 'Subject')?.value || '',
+                            from: headers.find(h => h.name === 'From')?.value || '',
+                            date: headers.find(h => h.name === 'Date')?.value || '',
+                        };
+                    }));
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: results.map(r => `ID: ${r.id}\nSubject: ${r.subject}\nFrom: ${r.from}\nDate: ${r.date}\n`).join('\n'),
+                            },
+                        ],
+                    };
+                }
+                case "download_email": {
+                    const validatedArgs = DownloadEmailSchema.parse(args);
+                    const { messageId, savePath, format } = validatedArgs;
+                    try {
+                        // Ensure save directory exists
+                        if (!fs.existsSync(savePath)) {
+                            fs.mkdirSync(savePath, { recursive: true });
+                        }
+                        // Always fetch full message for metadata (needed for attachments list)
+                        const fullResponse = await gmail.users.messages.get({
+                            userId: "me",
+                            id: messageId,
+                            format: "full",
+                        });
+                        const { subject, from, date } = extractHeaders(fullResponse.data.payload);
+                        const attachments = extractAttachments(fullResponse.data.payload);
+                        let content;
+                        if (format === "eml") {
+                            // For EML format, fetch raw RFC822 message
+                            const rawResponse = await gmail.users.messages.get({
+                                userId: "me",
+                                id: messageId,
+                                format: "raw",
+                            });
+                            content = Buffer.from(rawResponse.data.raw || "", "base64url").toString("utf-8");
+                        }
+                        else {
+                            // Extract email content for json/txt/html
+                            const emailContent = extractEmailContent(fullResponse.data.payload || {});
+                            if (format === "json") {
+                                const jsonData = gmailMessageToJson(fullResponse.data, emailContent, attachments);
+                                content = JSON.stringify(jsonData, null, 2);
+                            }
+                            else if (format === "txt") {
+                                content = emailToTxt(fullResponse.data, emailContent, attachments);
+                            }
+                            else {
+                                // html - just return the raw HTML content
+                                content = emailToHtml(emailContent);
+                            }
+                        }
+                        // Write file
+                        const filename = `${messageId}.${format}`;
+                        const fullPath = path.join(savePath, filename);
+                        fs.writeFileSync(fullPath, content, "utf-8");
+                        const stats = fs.statSync(fullPath);
+                        // Return metadata with attachments
+                        const result = {
+                            status: "saved",
+                            path: fullPath,
+                            size: stats.size,
+                            messageId,
+                            subject,
+                            from,
+                            date,
+                            attachments,
+                        };
+                        return {
+                            content: [
+                                {
+                                    type: "text",
+                                    text: JSON.stringify(result, null, 2),
+                                },
+                            ],
+                        };
+                    }
+                    catch (error) {
+                        return {
+                            content: [
+                                {
+                                    type: "text",
+                                    text: `Failed to download email: ${error.message}`,
+                                },
+                            ],
+                        };
+                    }
+                }
+                // Updated implementation for the modify_email handler
+                case "modify_email": {
+                    const validatedArgs = ModifyEmailSchema.parse(args);
+                    // Prepare request body
+                    const requestBody = {};
+                    if (validatedArgs.labelIds) {
+                        requestBody.addLabelIds = validatedArgs.labelIds;
+                    }
+                    if (validatedArgs.addLabelIds) {
+                        requestBody.addLabelIds = validatedArgs.addLabelIds;
+                    }
+                    if (validatedArgs.removeLabelIds) {
+                        requestBody.removeLabelIds = validatedArgs.removeLabelIds;
+                    }
+                    await gmail.users.messages.modify({
+                        userId: 'me',
+                        id: validatedArgs.messageId,
+                        requestBody: requestBody,
+                    });
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: `Email ${validatedArgs.messageId} labels updated successfully`,
+                            },
+                        ],
+                    };
+                }
+                case "delete_email": {
+                    const validatedArgs = DeleteEmailSchema.parse(args);
+                    await gmail.users.messages.delete({
+                        userId: 'me',
+                        id: validatedArgs.messageId,
+                    });
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: `Email ${validatedArgs.messageId} deleted successfully`,
+                            },
+                        ],
+                    };
+                }
+                case "send_draft": {
+                    const validatedArgs = SendDraftSchema.parse(args);
+                    const response = await gmail.users.drafts.send({
+                        userId: 'me',
+                        requestBody: { id: validatedArgs.draftId },
+                    });
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: `Draft ${validatedArgs.draftId} sent successfully as message ID: ${response.data.id}. The draft has been removed from Drafts.`,
+                            },
+                        ],
+                    };
+                }
+                case "delete_draft": {
+                    const validatedArgs = DeleteDraftSchema.parse(args);
+                    await gmail.users.drafts.delete({
+                        userId: 'me',
+                        id: validatedArgs.draftId,
+                    });
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: `Draft ${validatedArgs.draftId} deleted successfully.`,
+                            },
+                        ],
+                    };
+                }
+                case "update_draft": {
+                    const validatedArgs = UpdateDraftSchema.parse(args);
+                    const { draftId, ...messageArgs } = validatedArgs;
+                    // Build the new MIME message using the same helpers as draft_email/send_email
+                    let message;
+                    if (needsRawBuilder(messageArgs)) {
+                        message = await createEmailWithNodemailer(messageArgs);
+                    }
+                    else {
+                        message = createEmailMessage(messageArgs);
+                    }
+                    const encodedMessage = Buffer.from(message).toString('base64')
+                        .replace(/\+/g, '-')
+                        .replace(/\//g, '_')
+                        .replace(/=+$/, '');
+                    const messageRequest = { raw: encodedMessage };
+                    if (messageArgs.threadId)
+                        messageRequest.threadId = messageArgs.threadId;
+                    const response = await gmail.users.drafts.update({
+                        userId: 'me',
+                        id: draftId,
+                        requestBody: { message: messageRequest },
+                    });
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: `Draft ${draftId} updated successfully (draft ID unchanged, content replaced).`,
+                            },
+                        ],
+                    };
+                }
+                case "list_email_labels": {
+                    const labelResults = await listLabels(gmail);
+                    const systemLabels = labelResults.system;
+                    const userLabels = labelResults.user;
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: `Found ${labelResults.count.total} labels (${labelResults.count.system} system, ${labelResults.count.user} user):\n\n` +
+                                    "System Labels:\n" +
+                                    systemLabels.map((l) => `ID: ${l.id}\nName: ${l.name}\n`).join('\n') +
+                                    "\nUser Labels:\n" +
+                                    userLabels.map((l) => `ID: ${l.id}\nName: ${l.name}\n`).join('\n')
+                            },
+                        ],
+                    };
+                }
+                case "batch_modify_emails": {
+                    const validatedArgs = BatchModifyEmailsSchema.parse(args);
+                    const messageIds = validatedArgs.messageIds;
+                    const batchSize = validatedArgs.batchSize || 50;
+                    // Prepare request body
+                    const requestBody = {};
+                    if (validatedArgs.addLabelIds) {
+                        requestBody.addLabelIds = validatedArgs.addLabelIds;
+                    }
+                    if (validatedArgs.removeLabelIds) {
+                        requestBody.removeLabelIds = validatedArgs.removeLabelIds;
+                    }
+                    // Process messages in batches
+                    const { successes, failures } = await processBatches(messageIds, batchSize, async (batch) => {
+                        const results = await Promise.all(batch.map(async (messageId) => {
+                            const result = await gmail.users.messages.modify({
+                                userId: 'me',
+                                id: messageId,
+                                requestBody: requestBody,
+                            });
+                            return { messageId, success: true };
+                        }));
+                        return results;
+                    });
+                    // Generate summary of the operation
+                    const successCount = successes.length;
+                    const failureCount = failures.length;
+                    let resultText = `Batch label modification complete.\n`;
+                    resultText += `Successfully processed: ${successCount} messages\n`;
+                    if (failureCount > 0) {
+                        resultText += `Failed to process: ${failureCount} messages\n\n`;
+                        resultText += `Failed message IDs:\n`;
+                        resultText += failures.map(f => `- ${f.item.substring(0, 16)}... (${f.error.message})`).join('\n');
+                    }
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: resultText,
+                            },
+                        ],
+                    };
+                }
+                case "report_phishing": {
+                    const validatedArgs = ReportPhishingSchema.parse(args);
+                    await gmail.users.messages.modify({
+                        userId: 'me',
+                        id: validatedArgs.messageId,
+                        requestBody: {
+                            addLabelIds: ['SPAM'],
+                        },
+                    });
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: `Email ${validatedArgs.messageId} was updated with the SPAM label as the closest public Gmail API approximation of reporting phishing. Note: the Gmail API does not expose the full native Report phishing workflow.`,
+                            },
+                        ],
+                    };
+                }
+                case "batch_report_phishing": {
+                    const validatedArgs = BatchReportPhishingSchema.parse(args);
+                    const messageIds = validatedArgs.messageIds;
+                    const batchSize = validatedArgs.batchSize || 50;
+                    const { successes, failures } = await processBatches(messageIds, batchSize, async (batch) => {
+                        await gmail.users.messages.batchModify({
+                            userId: 'me',
+                            requestBody: {
+                                ids: batch,
+                                addLabelIds: ['SPAM'],
+                            },
+                        });
+                        return batch.map((messageId) => ({ messageId, success: true }));
+                    });
+                    const successCount = successes.length;
+                    const failureCount = failures.length;
+                    let resultText = `Batch phishing report complete.\n`;
+                    resultText += `Successfully processed: ${successCount} messages\n`;
+                    resultText += `Behavior: each message was updated with the SPAM label as the closest public Gmail API approximation of reporting phishing.\n`;
+                    resultText += `Limitation: the Gmail API does not expose the full native Report phishing workflow.\n`;
+                    if (failureCount > 0) {
+                        resultText += `Failed to process: ${failureCount} messages\n\n`;
+                        resultText += `Failed message IDs:\n`;
+                        resultText += failures.map(f => `- ${f.item.substring(0, 16)}... (${f.error.message})`).join('\n');
+                    }
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: resultText,
+                            },
+                        ],
+                    };
+                }
+                case "batch_delete_emails": {
+                    const validatedArgs = BatchDeleteEmailsSchema.parse(args);
+                    const messageIds = validatedArgs.messageIds;
+                    const batchSize = validatedArgs.batchSize || 50;
+                    // Process messages in batches
+                    const { successes, failures } = await processBatches(messageIds, batchSize, async (batch) => {
+                        const results = await Promise.all(batch.map(async (messageId) => {
+                            await gmail.users.messages.delete({
+                                userId: 'me',
+                                id: messageId,
+                            });
+                            return { messageId, success: true };
+                        }));
+                        return results;
+                    });
+                    // Generate summary of the operation
+                    const successCount = successes.length;
+                    const failureCount = failures.length;
+                    let resultText = `Batch delete operation complete.\n`;
+                    resultText += `Successfully deleted: ${successCount} messages\n`;
+                    if (failureCount > 0) {
+                        resultText += `Failed to delete: ${failureCount} messages\n\n`;
+                        resultText += `Failed message IDs:\n`;
+                        resultText += failures.map(f => `- ${f.item.substring(0, 16)}... (${f.error.message})`).join('\n');
+                    }
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: resultText,
+                            },
+                        ],
+                    };
+                }
+                // New label management handlers
+                case "create_label": {
+                    const validatedArgs = CreateLabelSchema.parse(args);
+                    const result = await createLabel(gmail, validatedArgs.name, {
+                        messageListVisibility: validatedArgs.messageListVisibility,
+                        labelListVisibility: validatedArgs.labelListVisibility,
+                    });
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: `Label created successfully:\nID: ${result.id}\nName: ${result.name}\nType: ${result.type}`,
+                            },
+                        ],
+                    };
+                }
+                case "update_label": {
+                    const validatedArgs = UpdateLabelSchema.parse(args);
+                    // Prepare request body with only the fields that were provided
+                    const updates = {};
+                    if (validatedArgs.name)
+                        updates.name = validatedArgs.name;
+                    if (validatedArgs.messageListVisibility)
+                        updates.messageListVisibility = validatedArgs.messageListVisibility;
+                    if (validatedArgs.labelListVisibility)
+                        updates.labelListVisibility = validatedArgs.labelListVisibility;
+                    const result = await updateLabel(gmail, validatedArgs.id, updates);
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: `Label updated successfully:\nID: ${result.id}\nName: ${result.name}\nType: ${result.type}`,
+                            },
+                        ],
+                    };
+                }
+                case "delete_label": {
+                    const validatedArgs = DeleteLabelSchema.parse(args);
+                    const result = await deleteLabel(gmail, validatedArgs.id);
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: result.message,
+                            },
+                        ],
+                    };
+                }
+                case "get_or_create_label": {
+                    const validatedArgs = GetOrCreateLabelSchema.parse(args);
+                    const result = await getOrCreateLabel(gmail, validatedArgs.name, {
+                        messageListVisibility: validatedArgs.messageListVisibility,
+                        labelListVisibility: validatedArgs.labelListVisibility,
+                    });
+                    const action = result.type === 'user' && result.name === validatedArgs.name ? 'found existing' : 'created new';
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: `Successfully ${action} label:\nID: ${result.id}\nName: ${result.name}\nType: ${result.type}`,
+                            },
+                        ],
+                    };
+                }
+                // Filter management handlers
+                case "create_filter": {
+                    const validatedArgs = CreateFilterSchema.parse(args);
+                    const result = await createFilter(gmail, validatedArgs.criteria, validatedArgs.action);
+                    // Format criteria for display
+                    const criteriaText = Object.entries(validatedArgs.criteria)
+                        .filter(([_, value]) => value !== undefined)
+                        .map(([key, value]) => `${key}: ${value}`)
+                        .join(', ');
+                    // Format actions for display
+                    const actionText = Object.entries(validatedArgs.action)
+                        .filter(([_, value]) => value !== undefined && (Array.isArray(value) ? value.length > 0 : true))
+                        .map(([key, value]) => `${key}: ${Array.isArray(value) ? value.join(', ') : value}`)
+                        .join(', ');
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: `Filter created successfully:\nID: ${result.id}\nCriteria: ${criteriaText}\nActions: ${actionText}`,
+                            },
+                        ],
+                    };
+                }
+                case "list_filters": {
+                    const result = await listFilters(gmail);
+                    const filters = result.filters;
+                    if (filters.length === 0) {
+                        return {
+                            content: [
+                                {
+                                    type: "text",
+                                    text: "No filters found.",
+                                },
+                            ],
+                        };
+                    }
+                    const filtersText = filters.map((filter) => {
+                        const criteriaEntries = Object.entries(filter.criteria || {})
+                            .filter(([_, value]) => value !== undefined)
+                            .map(([key, value]) => `${key}: ${value}`)
+                            .join(', ');
+                        const actionEntries = Object.entries(filter.action || {})
+                            .filter(([_, value]) => value !== undefined && (Array.isArray(value) ? value.length > 0 : true))
+                            .map(([key, value]) => `${key}: ${Array.isArray(value) ? value.join(', ') : value}`)
+                            .join(', ');
+                        return `ID: ${filter.id}\nCriteria: ${criteriaEntries}\nActions: ${actionEntries}\n`;
+                    }).join('\n');
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: `Found ${result.count} filters:\n\n${filtersText}`,
+                            },
+                        ],
+                    };
+                }
+                case "get_filter": {
+                    const validatedArgs = GetFilterSchema.parse(args);
+                    const result = await getFilter(gmail, validatedArgs.filterId);
+                    const criteriaText = Object.entries(result.criteria || {})
+                        .filter(([_, value]) => value !== undefined)
+                        .map(([key, value]) => `${key}: ${value}`)
+                        .join(', ');
+                    const actionText = Object.entries(result.action || {})
+                        .filter(([_, value]) => value !== undefined && (Array.isArray(value) ? value.length > 0 : true))
+                        .map(([key, value]) => `${key}: ${Array.isArray(value) ? value.join(', ') : value}`)
+                        .join(', ');
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: `Filter details:\nID: ${result.id}\nCriteria: ${criteriaText}\nActions: ${actionText}`,
+                            },
+                        ],
+                    };
+                }
+                case "delete_filter": {
+                    const validatedArgs = DeleteFilterSchema.parse(args);
+                    const result = await deleteFilter(gmail, validatedArgs.filterId);
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: result.message,
+                            },
+                        ],
+                    };
+                }
+                case "create_filter_from_template": {
+                    const validatedArgs = CreateFilterFromTemplateSchema.parse(args);
+                    const template = validatedArgs.template;
+                    const params = validatedArgs.parameters;
+                    let filterConfig;
+                    switch (template) {
+                        case 'fromSender':
+                            if (!params.senderEmail)
+                                throw new Error("senderEmail is required for fromSender template");
+                            filterConfig = filterTemplates.fromSender(params.senderEmail, params.labelIds, params.archive);
+                            break;
+                        case 'withSubject':
+                            if (!params.subjectText)
+                                throw new Error("subjectText is required for withSubject template");
+                            filterConfig = filterTemplates.withSubject(params.subjectText, params.labelIds, params.markAsRead);
+                            break;
+                        case 'withAttachments':
+                            filterConfig = filterTemplates.withAttachments(params.labelIds);
+                            break;
+                        case 'largeEmails':
+                            if (!params.sizeInBytes)
+                                throw new Error("sizeInBytes is required for largeEmails template");
+                            filterConfig = filterTemplates.largeEmails(params.sizeInBytes, params.labelIds);
+                            break;
+                        case 'containingText':
+                            if (!params.searchText)
+                                throw new Error("searchText is required for containingText template");
+                            filterConfig = filterTemplates.containingText(params.searchText, params.labelIds, params.markImportant);
+                            break;
+                        case 'mailingList':
+                            if (!params.listIdentifier)
+                                throw new Error("listIdentifier is required for mailingList template");
+                            filterConfig = filterTemplates.mailingList(params.listIdentifier, params.labelIds, params.archive);
+                            break;
+                        default:
+                            throw new Error(`Unknown template: ${template}`);
+                    }
+                    const result = await createFilter(gmail, filterConfig.criteria, filterConfig.action);
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: `Filter created from template '${template}':\nID: ${result.id}\nTemplate used: ${template}`,
+                            },
+                        ],
+                    };
+                }
+                case "download_attachment": {
+                    const validatedArgs = DownloadAttachmentSchema.parse(args);
+                    try {
+                        // Get the attachment data from Gmail API
+                        const attachmentResponse = await gmail.users.messages.attachments.get({
+                            userId: 'me',
+                            messageId: validatedArgs.messageId,
+                            id: validatedArgs.attachmentId,
+                        });
+                        if (!attachmentResponse.data.data) {
+                            throw new Error('No attachment data received');
+                        }
+                        // Decode the base64 data
+                        const data = attachmentResponse.data.data;
+                        const buffer = Buffer.from(data, 'base64url');
+                        // Determine save path and filename
+                        const savePath = validatedArgs.savePath || process.cwd();
+                        let filename = validatedArgs.filename;
+                        if (!filename) {
+                            // Get original filename from message if not provided
+                            const messageResponse = await gmail.users.messages.get({
+                                userId: 'me',
+                                id: validatedArgs.messageId,
+                                format: 'full',
+                            });
+                            // Find the attachment part to get original filename
+                            const findAttachment = (part) => {
+                                if (part.body && part.body.attachmentId === validatedArgs.attachmentId) {
+                                    return part.filename || `attachment-${validatedArgs.attachmentId}`;
+                                }
+                                if (part.parts) {
+                                    for (const subpart of part.parts) {
+                                        const found = findAttachment(subpart);
+                                        if (found)
+                                            return found;
+                                    }
+                                }
+                                return null;
+                            };
+                            filename = findAttachment(messageResponse.data.payload) || `attachment-${validatedArgs.attachmentId}`;
+                        }
+                        // Sanitize filename to prevent path traversal
+                        filename = path.basename(filename);
+                        // Ensure save directory exists
+                        if (!fs.existsSync(savePath)) {
+                            fs.mkdirSync(savePath, { recursive: true });
+                        }
+                        // Resolve and validate final path stays within savePath
+                        const resolvedSavePath = path.resolve(savePath);
+                        const fullPath = path.resolve(resolvedSavePath, filename);
+                        if (!fullPath.startsWith(resolvedSavePath + path.sep) && fullPath !== resolvedSavePath) {
+                            throw new Error('Invalid filename: path traversal detected');
+                        }
+                        fs.writeFileSync(fullPath, buffer);
+                        return {
+                            content: [
+                                {
+                                    type: "text",
+                                    text: `Attachment downloaded successfully:\nFile: ${filename}\nSize: ${buffer.length} bytes\nSaved to: ${fullPath}`,
+                                },
+                            ],
+                        };
+                    }
+                    catch (error) {
+                        return {
+                            content: [
+                                {
+                                    type: "text",
+                                    text: `Failed to download attachment: ${error.message}`,
+                                },
+                            ],
+                        };
+                    }
+                }
+                case "get_thread": {
+                    const validatedArgs = GetThreadSchema.parse(args);
+                    const threadResponse = await gmail.users.threads.get({
+                        userId: 'me',
+                        id: validatedArgs.threadId,
+                        format: validatedArgs.format || 'full',
+                    });
+                    const threadMessages = threadResponse.data.messages || [];
+                    // Process each message in the thread (already chronological from API)
+                    const messagesOutput = threadMessages.map((msg) => {
+                        const headers = msg.payload?.headers || [];
+                        const subject = headers.find(h => h.name?.toLowerCase() === 'subject')?.value || '';
+                        const from = headers.find(h => h.name?.toLowerCase() === 'from')?.value || '';
+                        const to = headers.find(h => h.name?.toLowerCase() === 'to')?.value || '';
+                        const cc = headers.find(h => h.name?.toLowerCase() === 'cc')?.value || '';
+                        const bcc = headers.find(h => h.name?.toLowerCase() === 'bcc')?.value || '';
+                        const date = headers.find(h => h.name?.toLowerCase() === 'date')?.value || '';
+                        // Extract body content
+                        let body = '';
+                        if (validatedArgs.format !== 'minimal') {
+                            const { text, html } = extractEmailContent(msg.payload || {});
+                            body = text || html || '';
+                        }
+                        // Extract attachment metadata
+                        const attachments = [];
+                        const processAttachmentParts = (part) => {
+                            if (part.body && part.body.attachmentId) {
+                                const filename = part.filename || `attachment-${part.body.attachmentId}`;
+                                attachments.push({
+                                    id: part.body.attachmentId,
+                                    filename: filename,
+                                    mimeType: part.mimeType || 'application/octet-stream',
+                                    size: part.body.size || 0,
+                                });
+                            }
+                            if (part.parts) {
+                                part.parts.forEach((subpart) => processAttachmentParts(subpart));
+                            }
+                        };
+                        if (msg.payload) {
+                            processAttachmentParts(msg.payload);
+                        }
+                        return {
+                            messageId: msg.id || '',
+                            threadId: msg.threadId || '',
+                            from,
+                            to,
+                            cc,
+                            bcc,
+                            subject,
+                            date,
+                            body,
+                            labelIds: msg.labelIds || [],
+                            attachments: attachments.map(a => ({
+                                filename: a.filename,
+                                mimeType: a.mimeType,
+                                size: a.size,
+                            })),
+                        };
+                    });
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: JSON.stringify({
+                                    threadId: validatedArgs.threadId,
+                                    messageCount: messagesOutput.length,
+                                    messages: messagesOutput,
+                                }, null, 2),
+                            },
+                        ],
+                    };
+                }
+                case "list_inbox_threads": {
+                    const validatedArgs = ListInboxThreadsSchema.parse(args);
+                    const threadsResponse = await gmail.users.threads.list({
+                        userId: 'me',
+                        q: validatedArgs.query || 'in:inbox',
+                        maxResults: validatedArgs.maxResults || 50,
+                    });
+                    const threads = threadsResponse.data.threads || [];
+                    // Fetch metadata for each thread to get message count and latest message info
+                    const threadDetails = await Promise.all(threads.map(async (thread) => {
+                        const detail = await gmail.users.threads.get({
+                            userId: 'me',
+                            id: thread.id,
+                            format: 'metadata',
+                            metadataHeaders: ['Subject', 'From', 'Date'],
+                        });
+                        const messages = detail.data.messages || [];
+                        const latestMessage = messages[messages.length - 1];
+                        const latestHeaders = latestMessage?.payload?.headers || [];
+                        return {
+                            threadId: thread.id || '',
+                            snippet: thread.snippet || '',
+                            historyId: thread.historyId || '',
+                            messageCount: messages.length,
+                            latestMessage: {
+                                from: latestHeaders.find(h => h.name === 'From')?.value || '',
+                                subject: latestHeaders.find(h => h.name === 'Subject')?.value || '',
+                                date: latestHeaders.find(h => h.name === 'Date')?.value || '',
+                            },
+                        };
+                    }));
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: JSON.stringify({
+                                    resultCount: threadDetails.length,
+                                    threads: threadDetails,
+                                }, null, 2),
+                            },
+                        ],
+                    };
+                }
+                case "get_inbox_with_threads": {
+                    const validatedArgs = GetInboxWithThreadsSchema.parse(args);
+                    const threadsResponse = await gmail.users.threads.list({
+                        userId: 'me',
+                        q: validatedArgs.query || 'in:inbox',
+                        maxResults: validatedArgs.maxResults || 50,
+                    });
+                    const threads = threadsResponse.data.threads || [];
+                    if (!validatedArgs.expandThreads) {
+                        // Return basic thread list without expansion (same as list_inbox_threads)
+                        const threadSummaries = await Promise.all(threads.map(async (thread) => {
+                            const detail = await gmail.users.threads.get({
+                                userId: 'me',
+                                id: thread.id,
+                                format: 'metadata',
+                                metadataHeaders: ['Subject', 'From', 'Date'],
+                            });
+                            const messages = detail.data.messages || [];
+                            const latestMessage = messages[messages.length - 1];
+                            const latestHeaders = latestMessage?.payload?.headers || [];
+                            return {
+                                threadId: thread.id || '',
+                                snippet: thread.snippet || '',
+                                historyId: thread.historyId || '',
+                                messageCount: messages.length,
+                                latestMessage: {
+                                    from: latestHeaders.find(h => h.name === 'From')?.value || '',
+                                    subject: latestHeaders.find(h => h.name === 'Subject')?.value || '',
+                                    date: latestHeaders.find(h => h.name === 'Date')?.value || '',
+                                },
+                            };
+                        }));
+                        return {
+                            content: [
+                                {
+                                    type: "text",
+                                    text: JSON.stringify({
+                                        resultCount: threadSummaries.length,
+                                        threads: threadSummaries,
+                                    }, null, 2),
+                                },
+                            ],
+                        };
+                    }
+                    // Expand each thread with full message content (parallel fetch)
+                    const expandedThreads = await Promise.all(threads.map(async (thread) => {
+                        const threadDetail = await gmail.users.threads.get({
+                            userId: 'me',
+                            id: thread.id,
+                            format: 'full',
+                        });
+                        const threadMessages = threadDetail.data.messages || [];
+                        const messages = threadMessages.map((msg) => {
+                            const headers = msg.payload?.headers || [];
+                            const subject = headers.find(h => h.name?.toLowerCase() === 'subject')?.value || '';
+                            const from = headers.find(h => h.name?.toLowerCase() === 'from')?.value || '';
+                            const to = headers.find(h => h.name?.toLowerCase() === 'to')?.value || '';
+                            const cc = headers.find(h => h.name?.toLowerCase() === 'cc')?.value || '';
+                            const bcc = headers.find(h => h.name?.toLowerCase() === 'bcc')?.value || '';
+                            const date = headers.find(h => h.name?.toLowerCase() === 'date')?.value || '';
+                            const { text, html } = extractEmailContent(msg.payload || {});
+                            const body = text || html || '';
+                            // Extract attachment metadata
+                            const attachments = [];
+                            const processAttachmentParts = (part) => {
+                                if (part.body && part.body.attachmentId) {
+                                    const filename = part.filename || `attachment-${part.body.attachmentId}`;
+                                    attachments.push({
+                                        id: part.body.attachmentId,
+                                        filename: filename,
+                                        mimeType: part.mimeType || 'application/octet-stream',
+                                        size: part.body.size || 0,
+                                    });
+                                }
+                                if (part.parts) {
+                                    part.parts.forEach((subpart) => processAttachmentParts(subpart));
+                                }
+                            };
+                            if (msg.payload) {
+                                processAttachmentParts(msg.payload);
+                            }
+                            return {
+                                messageId: msg.id || '',
+                                threadId: msg.threadId || '',
+                                from,
+                                to,
+                                cc,
+                                bcc,
+                                subject,
+                                date,
+                                body,
+                                labelIds: msg.labelIds || [],
+                                attachments: attachments.map(a => ({
+                                    filename: a.filename,
+                                    mimeType: a.mimeType,
+                                    size: a.size,
+                                })),
+                            };
+                        });
+                        return {
+                            threadId: thread.id || '',
+                            messageCount: messages.length,
+                            messages,
+                        };
+                    }));
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: JSON.stringify({
+                                    resultCount: expandedThreads.length,
+                                    threads: expandedThreads,
+                                }, null, 2),
+                            },
+                        ],
+                    };
+                }
+                case "reply_all": {
+                    const validatedArgs = ReplyAllSchema.parse(args);
+                    // Fetch the original email to get headers
+                    const originalEmail = await gmail.users.messages.get({
+                        userId: 'me',
+                        id: validatedArgs.messageId,
+                        format: 'full',
+                    });
+                    const headers = originalEmail.data.payload?.headers || [];
+                    const threadId = originalEmail.data.threadId || '';
+                    // Extract relevant headers
+                    const originalFrom = headers.find(h => h.name?.toLowerCase() === 'from')?.value || '';
+                    const originalTo = headers.find(h => h.name?.toLowerCase() === 'to')?.value || '';
+                    const originalCc = headers.find(h => h.name?.toLowerCase() === 'cc')?.value || '';
+                    const originalSubject = headers.find(h => h.name?.toLowerCase() === 'subject')?.value || '';
+                    const originalMessageId = headers.find(h => h.name?.toLowerCase() === 'message-id')?.value || '';
+                    const originalReferences = headers.find(h => h.name?.toLowerCase() === 'references')?.value || '';
+                    // Get authenticated user's email to exclude from recipients
+                    const profile = await gmail.users.getProfile({ userId: 'me' });
+                    const myEmail = profile.data.emailAddress?.toLowerCase() || '';
+                    // Build recipient list using helper functions
+                    const { to: replyTo, cc: replyCc } = buildReplyAllRecipients(originalFrom, originalTo, originalCc, myEmail);
+                    if (replyTo.length === 0) {
+                        throw new Error('Could not determine recipient for reply');
+                    }
+                    // Build subject with "Re:" prefix if not already present
+                    const replySubject = addRePrefix(originalSubject);
+                    // Build References header (original References + original Message-ID)
+                    const references = buildReferencesHeader(originalReferences, originalMessageId);
+                    // Prepare the email arguments for handleEmailAction
+                    const emailArgs = {
+                        to: replyTo,
+                        cc: replyCc.length > 0 ? replyCc : undefined,
+                        subject: replySubject,
+                        body: validatedArgs.body,
+                        htmlBody: validatedArgs.htmlBody,
+                        mimeType: validatedArgs.mimeType,
+                        threadId: threadId,
+                        inReplyTo: originalMessageId,
+                        attachments: validatedArgs.attachments,
+                        inlineImages: validatedArgs.inlineImages,
+                    };
+                    // Use the existing handleEmailAction to send the reply
+                    const result = await handleEmailAction("send", emailArgs);
+                    // Enhance the response with reply-all specific info
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: `Reply-all sent successfully!\nTo: ${replyTo.join(', ')}${replyCc.length > 0 ? `\nCC: ${replyCc.join(', ')}` : ''}\nSubject: ${replySubject}\nThread ID: ${threadId}`,
+                            },
+                        ],
+                    };
+                }
+                case "modify_thread": {
+                    const validatedArgs = ModifyThreadSchema.parse(args);
+                    // Prepare request body for threads.modify
+                    const modifyRequestBody = {};
+                    if (validatedArgs.addLabelIds) {
+                        modifyRequestBody.addLabelIds = validatedArgs.addLabelIds;
+                    }
+                    if (validatedArgs.removeLabelIds) {
+                        modifyRequestBody.removeLabelIds = validatedArgs.removeLabelIds;
+                    }
+                    await gmail.users.threads.modify({
+                        userId: 'me',
+                        id: validatedArgs.threadId,
+                        requestBody: modifyRequestBody,
+                    });
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: `Thread ${validatedArgs.threadId} labels updated successfully (all messages in thread modified)`,
+                            },
+                        ],
+                    };
+                }
+                default:
+                    throw new Error(`Unknown tool: ${name}`);
+            }
+        }
+        catch (error) {
+            return {
+                content: [
+                    {
+                        type: "text",
+                        text: `Error: ${error.message}`,
+                    },
+                ],
+            };
+        }
+    });
+    const transport = new StdioServerTransport();
+    server.connect(transport);
+}
+main().catch((error) => {
+    console.error('Server error:', error);
+    process.exit(1);
+});

--- a/vendor/gmail-mcp-fork/dist/label-manager.js
+++ b/vendor/gmail-mcp-fork/dist/label-manager.js
@@ -1,0 +1,159 @@
+/**
+ * Label Manager for Gmail MCP Server
+ * Provides comprehensive label management functionality
+ */
+/**
+ * Creates a new Gmail label
+ * @param gmail - Gmail API instance
+ * @param labelName - Name of the label to create
+ * @param options - Optional settings for the label
+ * @returns The newly created label
+ */
+export async function createLabel(gmail, labelName, options = {}) {
+    try {
+        // Default visibility settings if not provided
+        const messageListVisibility = options.messageListVisibility || 'show';
+        const labelListVisibility = options.labelListVisibility || 'labelShow';
+        const response = await gmail.users.labels.create({
+            userId: 'me',
+            requestBody: {
+                name: labelName,
+                messageListVisibility,
+                labelListVisibility,
+            },
+        });
+        return response.data;
+    }
+    catch (error) {
+        // Handle duplicate labels more gracefully
+        if (error.message && error.message.includes('already exists')) {
+            throw new Error(`Label "${labelName}" already exists. Please use a different name.`);
+        }
+        throw new Error(`Failed to create label: ${error.message}`);
+    }
+}
+/**
+ * Updates an existing Gmail label
+ * @param gmail - Gmail API instance
+ * @param labelId - ID of the label to update
+ * @param updates - Properties to update
+ * @returns The updated label
+ */
+export async function updateLabel(gmail, labelId, updates) {
+    try {
+        // Verify the label exists before updating
+        await gmail.users.labels.get({
+            userId: 'me',
+            id: labelId,
+        });
+        const response = await gmail.users.labels.update({
+            userId: 'me',
+            id: labelId,
+            requestBody: updates,
+        });
+        return response.data;
+    }
+    catch (error) {
+        if (error.code === 404) {
+            throw new Error(`Label with ID "${labelId}" not found.`);
+        }
+        throw new Error(`Failed to update label: ${error.message}`);
+    }
+}
+/**
+ * Deletes a Gmail label
+ * @param gmail - Gmail API instance
+ * @param labelId - ID of the label to delete
+ * @returns Success message
+ */
+export async function deleteLabel(gmail, labelId) {
+    try {
+        // Ensure we're not trying to delete system labels
+        const label = await gmail.users.labels.get({
+            userId: 'me',
+            id: labelId,
+        });
+        if (label.data.type === 'system') {
+            throw new Error(`Cannot delete system label with ID "${labelId}".`);
+        }
+        await gmail.users.labels.delete({
+            userId: 'me',
+            id: labelId,
+        });
+        return { success: true, message: `Label "${label.data.name}" deleted successfully.` };
+    }
+    catch (error) {
+        if (error.code === 404) {
+            throw new Error(`Label with ID "${labelId}" not found.`);
+        }
+        throw new Error(`Failed to delete label: ${error.message}`);
+    }
+}
+/**
+ * Gets a detailed list of all Gmail labels
+ * @param gmail - Gmail API instance
+ * @returns Object containing system and user labels
+ */
+export async function listLabels(gmail) {
+    try {
+        const response = await gmail.users.labels.list({
+            userId: 'me',
+        });
+        const labels = response.data.labels || [];
+        // Group labels by type for better organization
+        const systemLabels = labels.filter((label) => label.type === 'system');
+        const userLabels = labels.filter((label) => label.type === 'user');
+        return {
+            all: labels,
+            system: systemLabels,
+            user: userLabels,
+            count: {
+                total: labels.length,
+                system: systemLabels.length,
+                user: userLabels.length
+            }
+        };
+    }
+    catch (error) {
+        throw new Error(`Failed to list labels: ${error.message}`);
+    }
+}
+/**
+ * Finds a label by name
+ * @param gmail - Gmail API instance
+ * @param labelName - Name of the label to find
+ * @returns The found label or null if not found
+ */
+export async function findLabelByName(gmail, labelName) {
+    try {
+        const labelsResponse = await listLabels(gmail);
+        const allLabels = labelsResponse.all;
+        // Case-insensitive match
+        const foundLabel = allLabels.find((label) => label.name.toLowerCase() === labelName.toLowerCase());
+        return foundLabel || null;
+    }
+    catch (error) {
+        throw new Error(`Failed to find label: ${error.message}`);
+    }
+}
+/**
+ * Creates label if it doesn't exist or returns existing label
+ * @param gmail - Gmail API instance
+ * @param labelName - Name of the label to create
+ * @param options - Optional settings for the label
+ * @returns The new or existing label
+ */
+export async function getOrCreateLabel(gmail, labelName, options = {}) {
+    try {
+        // First try to find an existing label
+        const existingLabel = await findLabelByName(gmail, labelName);
+        if (existingLabel) {
+            return existingLabel;
+        }
+        // If not found, create a new one
+        return await createLabel(gmail, labelName, options);
+    }
+    catch (error) {
+        throw new Error(`Failed to get or create label: ${error.message}`);
+    }
+}

--- a/vendor/gmail-mcp-fork/dist/reply-all-helpers.js
+++ b/vendor/gmail-mcp-fork/dist/reply-all-helpers.js
@@ -1,0 +1,97 @@
+/**
+ * Helper functions for reply_all email functionality.
+ * Extracted for testability.
+ */
+/**
+ * Parses email addresses from a header value.
+ * Handles formats like:
+ * - "email@example.com"
+ * - "Name <email@example.com>"
+ * - Multiple addresses separated by commas
+ *
+ * @param headerValue - The raw header value (e.g., From, To, CC)
+ * @returns Array of extracted email addresses
+ */
+export function parseEmailAddresses(headerValue) {
+    if (!headerValue)
+        return [];
+    const emails = [];
+    const parts = headerValue.split(',');
+    for (const part of parts) {
+        const trimmed = part.trim();
+        // Extract email from "Name <email>" format
+        const match = trimmed.match(/<([^>]+)>/);
+        if (match) {
+            emails.push(match[1].trim());
+        }
+        else if (trimmed.includes('@')) {
+            emails.push(trimmed);
+        }
+    }
+    return emails;
+}
+/**
+ * Filters out the authenticated user's email from a list of emails.
+ * Case-insensitive comparison.
+ *
+ * @param emails - Array of email addresses to filter
+ * @param myEmail - The authenticated user's email address
+ * @returns Filtered array excluding the user's email
+ */
+export function filterOutEmail(emails, myEmail) {
+    const myEmailLower = myEmail.toLowerCase();
+    return emails.filter(email => email.toLowerCase() !== myEmailLower);
+}
+/**
+ * Adds "Re: " prefix to a subject if not already present.
+ * Case-insensitive check for existing prefix.
+ *
+ * @param subject - The original email subject
+ * @returns Subject with "Re: " prefix
+ */
+export function addRePrefix(subject) {
+    if (subject.toLowerCase().startsWith('re:')) {
+        return subject;
+    }
+    return `Re: ${subject}`;
+}
+/**
+ * Builds the References header for a reply email.
+ * Combines original References with original Message-ID.
+ *
+ * @param originalReferences - The References header from the original email
+ * @param originalMessageId - The Message-ID of the original email
+ * @returns Combined References header value
+ */
+export function buildReferencesHeader(originalReferences, originalMessageId) {
+    if (!originalMessageId) {
+        return originalReferences;
+    }
+    return originalReferences ? `${originalReferences} ${originalMessageId}` : originalMessageId;
+}
+/**
+ * Builds recipient lists for a reply-all email.
+ *
+ * Rules:
+ * - TO: original From (sender of the email)
+ * - CC: original To + original CC (excluding the authenticated user)
+ *
+ * @param originalFrom - From header value
+ * @param originalTo - To header value
+ * @param originalCc - CC header value
+ * @param myEmail - The authenticated user's email address
+ * @returns Object with 'to' and 'cc' arrays
+ */
+export function buildReplyAllRecipients(originalFrom, originalTo, originalCc, myEmail) {
+    const fromEmails = parseEmailAddresses(originalFrom);
+    const toEmails = parseEmailAddresses(originalTo);
+    const ccEmails = parseEmailAddresses(originalCc);
+    // TO recipients: original From (the person who sent the email), excluding myself
+    const replyTo = filterOutEmail(fromEmails, myEmail);
+    // CC recipients: everyone else who was on To and CC, excluding myself
+    const replyCc = filterOutEmail([...toEmails, ...ccEmails], myEmail);
+    return {
+        to: replyTo,
+        cc: replyCc
+    };
+}

--- a/vendor/gmail-mcp-fork/dist/scopes.js
+++ b/vendor/gmail-mcp-fork/dist/scopes.js
@@ -1,0 +1,77 @@
+// Gmail API OAuth2 scope definitions and helpers
+//
+// Scope hierarchy (for reference):
+//   - gmail.readonly: Read-only access to emails
+//   - gmail.modify: Read AND write access (superset of readonly)
+//   - gmail.compose: Create drafts and send emails
+//   - gmail.send: Send emails only
+//   - gmail.labels: Manage labels only
+//   - gmail.settings.basic: Manage filters and settings
+//   - gmail.full: Full mailbox access, including permanent deletion
+//
+// Note: gmail.modify includes all capabilities of gmail.readonly,
+// so you don't need both scopes together.
+// Map shorthand scope names to full Google API URLs
+export const SCOPE_MAP = {
+    "gmail.readonly": "https://www.googleapis.com/auth/gmail.readonly",
+    "gmail.modify": "https://www.googleapis.com/auth/gmail.modify",
+    "gmail.compose": "https://www.googleapis.com/auth/gmail.compose",
+    "gmail.send": "https://www.googleapis.com/auth/gmail.send",
+    "gmail.labels": "https://www.googleapis.com/auth/gmail.labels",
+    "gmail.full": "https://mail.google.com/",
+    "gmail.settings.basic": "https://www.googleapis.com/auth/gmail.settings.basic",
+    "gmail.settings.sharing": "https://www.googleapis.com/auth/gmail.settings.sharing",
+};
+// Reverse map for converting full URLs back to shorthand
+export const SCOPE_REVERSE_MAP = Object.fromEntries(Object.entries(SCOPE_MAP).map(([short, full]) => [full, short]));
+// Default scopes (original behavior)
+export const DEFAULT_SCOPES = ["gmail.modify", "gmail.settings.basic"];
+// Convert shorthand scope name to full Google API URL
+// e.g., "gmail.readonly" -> "https://www.googleapis.com/auth/gmail.readonly"
+export function scopeNameToUrl(scope) {
+    return SCOPE_MAP[scope] || scope;
+}
+// Convert full Google API URL to shorthand name
+// e.g., "https://www.googleapis.com/auth/gmail.readonly" -> "gmail.readonly"
+export function scopeUrlToName(scope) {
+    return SCOPE_REVERSE_MAP[scope] || scope;
+}
+// Convert array of shorthand scope names to full Google API URLs
+export function scopeNamesToUrls(scopes) {
+    return scopes.map(scopeNameToUrl);
+}
+// Scopes satisfied by gmail.full (https://mail.google.com/), which Google
+// treats as a superset of the mail scopes. It does NOT cover the settings
+// scopes — Gmail's settings endpoints only accept gmail.settings.* .
+const GMAIL_FULL_COVERS = new Set([
+    "gmail.readonly",
+    "gmail.modify",
+    "gmail.compose",
+    "gmail.send",
+    "gmail.labels",
+    "gmail.full",
+]);
+// Check if the authorized scopes grant access to a tool
+// Returns true if ANY of the tool's required scopes are present in authorizedScopes
+export function hasScope(authorizedScopes, requiredScopes) {
+    // Normalize to shorthand names for comparison (handles both URL and shorthand input)
+    const normalizedAuth = authorizedScopes.map(scopeUrlToName);
+    const hasFull = normalizedAuth.includes("gmail.full");
+    return requiredScopes.some(scope => normalizedAuth.includes(scope) || (hasFull && GMAIL_FULL_COVERS.has(scope)));
+}
+// Parse scope input from CLI (comma-separated or space-separated)
+export function parseScopes(input) {
+    return input
+        .split(/[,\s]+/)
+        .map(s => s.trim())
+        .filter(s => s.length > 0);
+}
+// Validate that all scopes are recognized
+export function validateScopes(scopes) {
+    const invalid = scopes.filter(s => !SCOPE_MAP[s]);
+    return { valid: invalid.length === 0, invalid };
+}
+// Get available scope names for help text
+export function getAvailableScopeNames() {
+    return Object.keys(SCOPE_MAP);
+}

--- a/vendor/gmail-mcp-fork/dist/tool-prefix.js
+++ b/vendor/gmail-mcp-fork/dist/tool-prefix.js
@@ -1,0 +1,29 @@
+/**
+ * Resolves the optional tool-name prefix that lets multiple instances of this
+ * server run side-by-side without their tool names colliding in MCP clients
+ * that disambiguate tools by base name.
+ *
+ * Precedence: `--tool-prefix=<value>` / `--tool-prefix <value>` CLI flag, then
+ * the `GMAIL_MCP_TOOL_PREFIX` env var, then empty string (no prefix — the
+ * backward-compatible default).
+ *
+ * Pure function: argv (already sliced past the node binary and script) and the
+ * env map are passed in explicitly, so it is unit-testable without spawning the
+ * process.
+ *
+ * @param args - `process.argv.slice(2)`: CLI args past the node binary and script
+ * @param env  - environment map (`process.env`)
+ * @returns the resolved prefix, or `''` when none is configured
+ */
+export function resolveToolPrefix(args, env) {
+    for (let i = 0; i < args.length; i++) {
+        const arg = args[i] ?? '';
+        if (arg.startsWith('--tool-prefix=')) {
+            return arg.slice('--tool-prefix='.length);
+        }
+        if (arg === '--tool-prefix' && i + 1 < args.length) {
+            return args[i + 1] ?? '';
+        }
+    }
+    return env.GMAIL_MCP_TOOL_PREFIX || '';
+}

--- a/vendor/gmail-mcp-fork/dist/tools.js
+++ b/vendor/gmail-mcp-fork/dist/tools.js
@@ -1,0 +1,420 @@
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
+// Schema definitions
+// Inline image embedded in an HTML body and referenced via a cid: URL.
+// Exactly one of `path` / `content` must be set; `contentType` is required with `content`.
+export const InlineImageSchema = z.object({
+    cid: z.string().min(1).regex(/^[^\s<>]+$/, "cid must not contain whitespace or angle brackets")
+        .describe("Content-ID for the image, referenced from htmlBody as <img src=\"cid:CID\">"),
+    path: z.string().optional().describe("Absolute file path to the image (use this OR content)"),
+    content: z.string().optional().describe("Base64-encoded image data (use this OR path)"),
+    contentType: z.enum(['image/png', 'image/jpeg', 'image/gif', 'image/webp', 'image/bmp', 'image/x-icon']).optional()
+        .describe("Image MIME type — required when using `content`. SVG is intentionally unsupported."),
+    filename: z.string().optional().describe("Display filename for the image part (defaults derived from path or cid)"),
+})
+    .refine(d => (d.path ? 1 : 0) + (d.content ? 1 : 0) === 1, {
+    message: "Each inline image must set exactly one of `path` or `content`",
+})
+    .refine(d => !d.content || !!d.contentType, {
+    message: "`contentType` is required when an inline image uses `content`",
+});
+export const SendEmailSchema = z.object({
+    to: z.array(z.string()).describe("List of recipient email addresses"),
+    subject: z.string().describe("Email subject"),
+    body: z.string().describe("Email body content (used for text/plain or when htmlBody not provided)"),
+    from: z.string().optional().describe("Sender email address (must be a configured send-as alias in Gmail settings). Defaults to account's default send-as address if not specified."),
+    htmlBody: z.string().optional().describe("HTML version of the email body"),
+    mimeType: z.enum(['text/plain', 'text/html', 'multipart/alternative']).optional().default('text/plain').describe("Email content type"),
+    cc: z.array(z.string()).optional().describe("List of CC recipients"),
+    bcc: z.array(z.string()).optional().describe("List of BCC recipients"),
+    threadId: z.string().optional().describe("Thread ID to reply to"),
+    inReplyTo: z.string().optional().describe("Message ID being replied to"),
+    attachments: z.array(z.string()).optional().describe("List of file paths to attach to the email"),
+    inlineImages: z.array(InlineImageSchema).optional().describe("Images embedded inline in the HTML body, each referenced from htmlBody as <img src=\"cid:CID\">. Requires htmlBody to be set."),
+});
+export const ReadEmailSchema = z.object({
+    messageId: z.string().describe("ID of the email message to retrieve"),
+});
+export const SearchEmailsSchema = z.object({
+    query: z.string().describe("Gmail search query (e.g., 'from:example@gmail.com')"),
+    maxResults: z.number().optional().describe("Maximum number of results to return"),
+});
+export const ModifyEmailSchema = z.object({
+    messageId: z.string().describe("ID of the email message to modify"),
+    labelIds: z.array(z.string()).optional().describe("List of label IDs to apply"),
+    addLabelIds: z.array(z.string()).optional().describe("List of label IDs to add to the message"),
+    removeLabelIds: z.array(z.string()).optional().describe("List of label IDs to remove from the message"),
+});
+export const DeleteEmailSchema = z.object({
+    messageId: z.string().describe("ID of the email message to delete"),
+});
+// Draft lifecycle schemas
+export const SendDraftSchema = z.object({
+    draftId: z.string().describe("ID of the draft to send (returned by draft_email)"),
+});
+export const DeleteDraftSchema = z.object({
+    draftId: z.string().describe("ID of the draft to delete"),
+});
+export const UpdateDraftSchema = z.object({
+    draftId: z.string().describe("ID of the draft to update"),
+    to: z.array(z.string()).describe("List of recipient email addresses"),
+    subject: z.string().describe("Email subject"),
+    body: z.string().describe("Email body content (used for text/plain or when htmlBody not provided)"),
+    from: z.string().optional().describe("Sender email address (must be a configured send-as alias in Gmail settings). Defaults to account's default send-as address if not specified."),
+    htmlBody: z.string().optional().describe("HTML version of the email body"),
+    mimeType: z.enum(['text/plain', 'text/html', 'multipart/alternative']).optional().default('text/plain').describe("Email content type"),
+    cc: z.array(z.string()).optional().describe("List of CC recipients"),
+    bcc: z.array(z.string()).optional().describe("List of BCC recipients"),
+    threadId: z.string().optional().describe("Thread ID to reply to"),
+    inReplyTo: z.string().optional().describe("Message ID being replied to"),
+    attachments: z.array(z.string()).optional().describe("List of file paths to attach to the email"),
+    inlineImages: z.array(InlineImageSchema).optional().describe("Images embedded inline in the HTML body, each referenced from htmlBody as <img src=\"cid:CID\">. Requires htmlBody to be set."),
+});
+export const ListEmailLabelsSchema = z.object({}).describe("Retrieves all available Gmail labels");
+export const CreateLabelSchema = z.object({
+    name: z.string().describe("Name for the new label"),
+    messageListVisibility: z.enum(['show', 'hide']).optional().describe("Whether to show or hide the label in the message list"),
+    labelListVisibility: z.enum(['labelShow', 'labelShowIfUnread', 'labelHide']).optional().describe("Visibility of the label in the label list"),
+}).describe("Creates a new Gmail label");
+export const UpdateLabelSchema = z.object({
+    id: z.string().describe("ID of the label to update"),
+    name: z.string().optional().describe("New name for the label"),
+    messageListVisibility: z.enum(['show', 'hide']).optional().describe("Whether to show or hide the label in the message list"),
+    labelListVisibility: z.enum(['labelShow', 'labelShowIfUnread', 'labelHide']).optional().describe("Visibility of the label in the label list"),
+}).describe("Updates an existing Gmail label");
+export const DeleteLabelSchema = z.object({
+    id: z.string().describe("ID of the label to delete"),
+}).describe("Deletes a Gmail label");
+export const GetOrCreateLabelSchema = z.object({
+    name: z.string().describe("Name of the label to get or create"),
+    messageListVisibility: z.enum(['show', 'hide']).optional().describe("Whether to show or hide the label in the message list"),
+    labelListVisibility: z.enum(['labelShow', 'labelShowIfUnread', 'labelHide']).optional().describe("Visibility of the label in the label list"),
+}).describe("Gets an existing label by name or creates it if it doesn't exist");
+export const BatchModifyEmailsSchema = z.object({
+    messageIds: z.array(z.string()).describe("List of message IDs to modify"),
+    addLabelIds: z.array(z.string()).optional().describe("List of label IDs to add to all messages"),
+    removeLabelIds: z.array(z.string()).optional().describe("List of label IDs to remove from all messages"),
+    batchSize: z.number().optional().default(50).describe("Number of messages to process in each batch (default: 50)"),
+});
+export const ReportPhishingSchema = z.object({
+    messageId: z.string().describe("ID of the email message to report as phishing"),
+}).describe("Reports a message as phishing using the closest public Gmail API behavior by applying the SPAM label");
+export const BatchReportPhishingSchema = z.object({
+    messageIds: z.array(z.string()).describe("List of message IDs to report as phishing"),
+    batchSize: z.number().optional().default(50).describe("Number of messages to process in each batch (default: 50)"),
+}).describe("Reports multiple messages as phishing using the closest public Gmail API behavior by applying the SPAM label");
+export const BatchDeleteEmailsSchema = z.object({
+    messageIds: z.array(z.string()).describe("List of message IDs to delete"),
+    batchSize: z.number().optional().default(50).describe("Number of messages to process in each batch (default: 50)"),
+});
+export const CreateFilterSchema = z.object({
+    criteria: z.object({
+        from: z.string().optional().describe("Sender email address to match"),
+        to: z.string().optional().describe("Recipient email address to match"),
+        subject: z.string().optional().describe("Subject text to match"),
+        query: z.string().optional().describe("Gmail search query (e.g., 'has:attachment')"),
+        negatedQuery: z.string().optional().describe("Text that must NOT be present"),
+        hasAttachment: z.boolean().optional().describe("Whether to match emails with attachments"),
+        excludeChats: z.boolean().optional().describe("Whether to exclude chat messages"),
+        size: z.number().optional().describe("Email size in bytes"),
+        sizeComparison: z.enum(['unspecified', 'smaller', 'larger']).optional().describe("Size comparison operator")
+    }).describe("Criteria for matching emails"),
+    action: z.object({
+        addLabelIds: z.array(z.string()).optional().describe("Label IDs to add to matching emails"),
+        removeLabelIds: z.array(z.string()).optional().describe("Label IDs to remove from matching emails"),
+        forward: z.string().optional().describe("Email address to forward matching emails to")
+    }).describe("Actions to perform on matching emails")
+}).describe("Creates a new Gmail filter");
+export const ListFiltersSchema = z.object({}).describe("Retrieves all Gmail filters");
+export const GetFilterSchema = z.object({
+    filterId: z.string().describe("ID of the filter to retrieve")
+}).describe("Gets details of a specific Gmail filter");
+export const DeleteFilterSchema = z.object({
+    filterId: z.string().describe("ID of the filter to delete")
+}).describe("Deletes a Gmail filter");
+export const CreateFilterFromTemplateSchema = z.object({
+    template: z.enum(['fromSender', 'withSubject', 'withAttachments', 'largeEmails', 'containingText', 'mailingList']).describe("Pre-defined filter template to use"),
+    parameters: z.object({
+        senderEmail: z.string().optional().describe("Sender email (for fromSender template)"),
+        subjectText: z.string().optional().describe("Subject text (for withSubject template)"),
+        searchText: z.string().optional().describe("Text to search for (for containingText template)"),
+        listIdentifier: z.string().optional().describe("Mailing list identifier (for mailingList template)"),
+        sizeInBytes: z.number().optional().describe("Size threshold in bytes (for largeEmails template)"),
+        labelIds: z.array(z.string()).optional().describe("Label IDs to apply"),
+        archive: z.boolean().optional().describe("Whether to archive (skip inbox)"),
+        markAsRead: z.boolean().optional().describe("Whether to mark as read"),
+        markImportant: z.boolean().optional().describe("Whether to mark as important")
+    }).describe("Template-specific parameters")
+}).describe("Creates a filter using a pre-defined template");
+export const DownloadAttachmentSchema = z.object({
+    messageId: z.string().describe("ID of the email message containing the attachment"),
+    attachmentId: z.string().describe("ID of the attachment to download"),
+    filename: z.string().optional().describe("Filename to save the attachment as (if not provided, uses original filename)"),
+    savePath: z.string().optional().describe("Directory path to save the attachment (defaults to current directory)"),
+});
+export const DownloadEmailSchema = z.object({
+    messageId: z.string().describe("ID of the email message to download"),
+    savePath: z.string().describe("Directory path to save the email file"),
+    format: z.enum(['json', 'eml', 'txt', 'html']).optional().default('json')
+        .describe("Output format: json (structured data), eml (raw RFC822), txt (plain text), html (formatted HTML)"),
+});
+export const ModifyThreadSchema = z.object({
+    threadId: z.string().describe("ID of the Gmail thread to modify"),
+    addLabelIds: z.array(z.string()).optional().describe("List of label IDs to add to all messages in the thread"),
+    removeLabelIds: z.array(z.string()).optional().describe("List of label IDs to remove from all messages in the thread"),
+});
+// Thread-level schemas
+export const GetThreadSchema = z.object({
+    threadId: z.string().describe("ID of the email thread to retrieve"),
+    format: z.enum(['full', 'metadata', 'minimal']).optional().default('full').describe("Format of the email messages returned (default: full)"),
+});
+export const ListInboxThreadsSchema = z.object({
+    query: z.string().optional().default('in:inbox').describe("Gmail search query (default: 'in:inbox')"),
+    maxResults: z.number().optional().default(50).describe("Maximum number of threads to return (default: 50)"),
+});
+export const GetInboxWithThreadsSchema = z.object({
+    query: z.string().optional().default('in:inbox').describe("Gmail search query (default: 'in:inbox')"),
+    maxResults: z.number().optional().default(50).describe("Maximum number of threads to return (default: 50)"),
+    expandThreads: z.boolean().optional().default(true).describe("Whether to fetch full thread content for each thread (default: true)"),
+});
+// Reply All schema - fetches original email and builds recipient list automatically
+export const ReplyAllSchema = z.object({
+    messageId: z.string().describe("ID of the email message to reply to"),
+    body: z.string().describe("Reply body content (used for text/plain or when htmlBody not provided)"),
+    htmlBody: z.string().optional().describe("HTML version of the reply body"),
+    mimeType: z.enum(['text/plain', 'text/html', 'multipart/alternative']).optional().default('text/plain').describe("Email content type"),
+    attachments: z.array(z.string()).optional().describe("List of file paths to attach to the reply"),
+    inlineImages: z.array(InlineImageSchema).optional().describe("Images embedded inline in the HTML body, each referenced from htmlBody as <img src=\"cid:CID\">. Requires htmlBody to be set."),
+});
+// Tool registry with scope requirements
+export const toolDefinitions = [
+    // Read-only email operations
+    {
+        name: "read_email",
+        description: "Retrieves the content of a specific email",
+        schema: ReadEmailSchema,
+        scopes: ["gmail.readonly", "gmail.modify"],
+        annotations: { title: "Read Email", readOnlyHint: true },
+    },
+    {
+        name: "search_emails",
+        description: "Searches for emails using Gmail search syntax",
+        schema: SearchEmailsSchema,
+        scopes: ["gmail.readonly", "gmail.modify"],
+        annotations: { title: "Search Emails", readOnlyHint: true },
+    },
+    {
+        name: "download_attachment",
+        description: "Downloads an email attachment to a specified location",
+        schema: DownloadAttachmentSchema,
+        scopes: ["gmail.readonly", "gmail.modify"],
+        annotations: { title: "Download Attachment", readOnlyHint: true },
+    },
+    // Thread-level operations
+    {
+        name: "get_thread",
+        description: "Retrieves all messages in an email thread in one call. Returns messages ordered chronologically (oldest first) with full content, headers, labels, and attachment metadata.",
+        schema: GetThreadSchema,
+        scopes: ["gmail.readonly", "gmail.modify"],
+        annotations: { title: "Get Thread", readOnlyHint: true },
+    },
+    {
+        name: "list_inbox_threads",
+        description: "Lists email threads matching a query (default: inbox). Returns thread-level view with snippet, message count, and latest message metadata.",
+        schema: ListInboxThreadsSchema,
+        scopes: ["gmail.readonly", "gmail.modify"],
+        annotations: { title: "List Inbox Threads", readOnlyHint: true },
+    },
+    {
+        name: "get_inbox_with_threads",
+        description: "Convenience tool that lists threads and optionally expands each with full message content. One call returns the full inbox with complete thread bodies.",
+        schema: GetInboxWithThreadsSchema,
+        scopes: ["gmail.readonly", "gmail.modify"],
+        annotations: { title: "Get Inbox with Threads", readOnlyHint: true },
+    },
+    {
+        name: "modify_thread",
+        description: "Modifies labels on ALL messages in a thread atomically using the Gmail threads.modify endpoint. Use this instead of modify_email when you want to apply label changes (e.g., archive, mark as read) to an entire thread at once.",
+        schema: ModifyThreadSchema,
+        scopes: ["gmail.modify"],
+        annotations: { title: "Modify Thread", destructiveHint: true, idempotentHint: true },
+    },
+    {
+        name: "download_email",
+        description: "Downloads an email to a file in various formats (json, eml, txt, html). Returns metadata only - useful for saving emails without consuming context.",
+        schema: DownloadEmailSchema,
+        scopes: ["gmail.readonly", "gmail.modify"],
+        annotations: { title: "Download Email", readOnlyHint: true },
+    },
+    // Email write operations
+    {
+        name: "send_email",
+        description: "Sends a new email. Supports plain text, HTML, file attachments, and images embedded inline in the HTML body via inlineImages.",
+        schema: SendEmailSchema,
+        scopes: ["gmail.modify", "gmail.compose", "gmail.send"],
+        annotations: { title: "Send Email", destructiveHint: false },
+    },
+    {
+        name: "draft_email",
+        description: "Draft a new email. Supports plain text, HTML, file attachments, and images embedded inline in the HTML body via inlineImages.",
+        schema: SendEmailSchema,
+        scopes: ["gmail.modify", "gmail.compose"],
+        annotations: { title: "Draft Email", destructiveHint: false },
+    },
+    {
+        name: "send_draft",
+        description: "Sends an existing draft (created via draft_email) and atomically removes it from Drafts. Prefer this over send_email when you've previously created a draft for review — avoids leaving an orphan draft in the user's Drafts folder.",
+        schema: SendDraftSchema,
+        scopes: ["gmail.modify", "gmail.compose", "gmail.send"],
+        annotations: { title: "Send Draft", destructiveHint: false },
+    },
+    {
+        name: "delete_draft",
+        description: "Deletes a draft. Use to discard an abandoned or superseded draft.",
+        schema: DeleteDraftSchema,
+        scopes: ["gmail.modify", "gmail.compose"],
+        annotations: { title: "Delete Draft", destructiveHint: true },
+    },
+    {
+        name: "update_draft",
+        description: "Replaces the content of an existing draft. Use during iteration (\"change this and that\") instead of creating a new draft each time — avoids accumulating draft copies in the user's Drafts folder.",
+        schema: UpdateDraftSchema,
+        scopes: ["gmail.modify", "gmail.compose"],
+        annotations: { title: "Update Draft", destructiveHint: false },
+    },
+    {
+        name: "modify_email",
+        description: "Modifies email labels (move to different folders)",
+        schema: ModifyEmailSchema,
+        scopes: ["gmail.modify"],
+        annotations: { title: "Modify Email", destructiveHint: true, idempotentHint: true },
+    },
+    {
+        name: "delete_email",
+        description: "Permanently deletes an email. Requires gmail.full because Gmail's delete endpoint is not covered by gmail.modify.",
+        schema: DeleteEmailSchema,
+        scopes: ["gmail.full"],
+        annotations: { title: "Delete Email", destructiveHint: true },
+    },
+    {
+        name: "batch_modify_emails",
+        description: "Modifies labels for multiple emails in batches",
+        schema: BatchModifyEmailsSchema,
+        scopes: ["gmail.modify"],
+        annotations: { title: "Batch Modify Emails", destructiveHint: true, idempotentHint: true },
+    },
+    {
+        name: "report_phishing",
+        description: "Reports a message as phishing using the closest public Gmail API behavior by applying the SPAM label",
+        schema: ReportPhishingSchema,
+        scopes: ["gmail.modify"],
+        annotations: { title: "Report Phishing", destructiveHint: true, idempotentHint: true },
+    },
+    {
+        name: "batch_report_phishing",
+        description: "Reports multiple messages as phishing using the closest public Gmail API behavior by applying the SPAM label",
+        schema: BatchReportPhishingSchema,
+        scopes: ["gmail.modify"],
+        annotations: { title: "Batch Report Phishing", destructiveHint: true, idempotentHint: true },
+    },
+    {
+        name: "batch_delete_emails",
+        description: "Permanently deletes multiple emails in batches. Requires gmail.full because Gmail's batchDelete endpoint is not covered by gmail.modify.",
+        schema: BatchDeleteEmailsSchema,
+        scopes: ["gmail.full"],
+        annotations: { title: "Batch Delete Emails", destructiveHint: true },
+    },
+    // Label operations
+    {
+        name: "list_email_labels",
+        description: "Retrieves all available Gmail labels",
+        schema: ListEmailLabelsSchema,
+        scopes: ["gmail.readonly", "gmail.modify", "gmail.labels"],
+        annotations: { title: "List Email Labels", readOnlyHint: true },
+    },
+    {
+        name: "create_label",
+        description: "Creates a new Gmail label",
+        schema: CreateLabelSchema,
+        scopes: ["gmail.modify", "gmail.labels"],
+        annotations: { title: "Create Label", destructiveHint: false },
+    },
+    {
+        name: "update_label",
+        description: "Updates an existing Gmail label",
+        schema: UpdateLabelSchema,
+        scopes: ["gmail.modify", "gmail.labels"],
+        annotations: { title: "Update Label", destructiveHint: true, idempotentHint: true },
+    },
+    {
+        name: "delete_label",
+        description: "Deletes a Gmail label",
+        schema: DeleteLabelSchema,
+        scopes: ["gmail.modify", "gmail.labels"],
+        annotations: { title: "Delete Label", destructiveHint: true },
+    },
+    {
+        name: "get_or_create_label",
+        description: "Gets an existing label by name or creates it if it doesn't exist",
+        schema: GetOrCreateLabelSchema,
+        scopes: ["gmail.modify", "gmail.labels"],
+        annotations: { title: "Get or Create Label", destructiveHint: false, idempotentHint: true },
+    },
+    // Filter operations (require settings scope)
+    {
+        name: "list_filters",
+        description: "Retrieves all Gmail filters",
+        schema: ListFiltersSchema,
+        scopes: ["gmail.settings.basic"],
+        annotations: { title: "List Filters", readOnlyHint: true },
+    },
+    {
+        name: "get_filter",
+        description: "Gets details of a specific Gmail filter",
+        schema: GetFilterSchema,
+        scopes: ["gmail.settings.basic"],
+        annotations: { title: "Get Filter", readOnlyHint: true },
+    },
+    {
+        name: "create_filter",
+        description: "Creates a new Gmail filter with custom criteria and actions",
+        schema: CreateFilterSchema,
+        scopes: ["gmail.settings.basic"],
+        annotations: { title: "Create Filter", destructiveHint: false },
+    },
+    {
+        name: "delete_filter",
+        description: "Deletes a Gmail filter",
+        schema: DeleteFilterSchema,
+        scopes: ["gmail.settings.basic"],
+        annotations: { title: "Delete Filter", destructiveHint: true },
+    },
+    {
+        name: "create_filter_from_template",
+        description: "Creates a filter using a pre-defined template for common scenarios",
+        schema: CreateFilterFromTemplateSchema,
+        scopes: ["gmail.settings.basic"],
+        annotations: { title: "Create Filter from Template", destructiveHint: false },
+    },
+    // Reply-all operation
+    {
+        name: "reply_all",
+        description: "Replies to all recipients of an email. Automatically fetches the original email to build the recipient list (To, CC) and sets proper threading headers.",
+        schema: ReplyAllSchema,
+        scopes: ["gmail.modify", "gmail.compose", "gmail.send"],
+        annotations: { title: "Reply All", destructiveHint: false },
+    },
+];
+// Convert tool definitions to MCP tool format
+export function toMcpTools(tools) {
+    return tools.map(tool => ({
+        name: tool.name,
+        description: tool.description,
+        inputSchema: zodToJsonSchema(tool.schema),
+        annotations: tool.annotations,
+    }));
+}
+// Get a tool definition by name
+export function getToolByName(name) {
+    return toolDefinitions.find(t => t.name === name);
+}

--- a/vendor/gmail-mcp-fork/dist/utl.js
+++ b/vendor/gmail-mcp-fork/dist/utl.js
@@ -1,0 +1,198 @@
+import fs from 'fs';
+import path from 'path';
+import nodemailer from 'nodemailer';
+/**
+ * Upper bound on the decoded size of a base64 `content` inline image. Rejecting
+ * oversized payloads before nodemailer buffers them prevents host-process memory
+ * exhaustion. File-path images stream and are not subject to this check.
+ */
+export const MAX_INLINE_IMAGE_CONTENT_BYTES = 10 * 1024 * 1024;
+/**
+ * Helper function to encode email headers containing non-ASCII characters
+ * according to RFC 2047 MIME specification
+ */
+function encodeEmailHeader(text) {
+    // Only encode if the text contains non-ASCII characters
+    if (/[^\x00-\x7F]/.test(text)) {
+        // Use MIME Words encoding (RFC 2047)
+        return '=?UTF-8?B?' + Buffer.from(text).toString('base64') + '?=';
+    }
+    return text;
+}
+export const validateEmail = (email) => {
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    return emailRegex.test(email);
+};
+/**
+ * Sanitize a value destined for an email header to prevent CRLF injection.
+ * Strips \r, \n, and \0 characters that could inject additional headers.
+ */
+function sanitizeHeaderValue(value) {
+    return value.replace(/[\r\n\0]/g, '');
+}
+export function createEmailMessage(validatedArgs) {
+    const encodedSubject = encodeEmailHeader(sanitizeHeaderValue(validatedArgs.subject));
+    // Determine content type based on available content and explicit mimeType
+    let mimeType = validatedArgs.mimeType || 'text/plain';
+    // If htmlBody is provided and mimeType isn't explicitly set to text/plain,
+    // use multipart/alternative to include both versions
+    if (validatedArgs.htmlBody && mimeType !== 'text/plain') {
+        mimeType = 'multipart/alternative';
+    }
+    // Generate a random boundary string for multipart messages
+    const boundary = `----=_NextPart_${Math.random().toString(36).substring(2)}`;
+    // Validate email addresses
+    validatedArgs.to.forEach(email => {
+        if (!validateEmail(email)) {
+            throw new Error(`Recipient email address is invalid: ${email}`);
+        }
+    });
+    // Sanitize all user-supplied header values to prevent CRLF injection
+    const from = sanitizeHeaderValue(validatedArgs.from || 'me');
+    const to = validatedArgs.to.map(sanitizeHeaderValue).join(', ');
+    const cc = validatedArgs.cc ? validatedArgs.cc.map(sanitizeHeaderValue).join(', ') : '';
+    const bcc = validatedArgs.bcc ? validatedArgs.bcc.map(sanitizeHeaderValue).join(', ') : '';
+    const inReplyTo = validatedArgs.inReplyTo ? sanitizeHeaderValue(validatedArgs.inReplyTo) : '';
+    const references = validatedArgs.references
+        ? sanitizeHeaderValue(validatedArgs.references)
+        : validatedArgs.inReplyTo ? sanitizeHeaderValue(validatedArgs.inReplyTo) : '';
+    // Common email headers
+    const emailParts = [
+        `From: ${from}`,
+        `To: ${to}`,
+        cc ? `Cc: ${cc}` : '',
+        bcc ? `Bcc: ${bcc}` : '',
+        `Subject: ${encodedSubject}`,
+        inReplyTo ? `In-Reply-To: ${inReplyTo}` : '',
+        references ? `References: ${references}` : '',
+        'MIME-Version: 1.0',
+    ].filter(Boolean);
+    // Construct the email based on the content type
+    if (mimeType === 'multipart/alternative') {
+        // Multipart email with both plain text and HTML
+        emailParts.push(`Content-Type: multipart/alternative; boundary="${boundary}"`);
+        emailParts.push('');
+        // Plain text part
+        emailParts.push(`--${boundary}`);
+        emailParts.push('Content-Type: text/plain; charset=UTF-8');
+        emailParts.push('Content-Transfer-Encoding: 7bit');
+        emailParts.push('');
+        emailParts.push(validatedArgs.body);
+        emailParts.push('');
+        // HTML part
+        emailParts.push(`--${boundary}`);
+        emailParts.push('Content-Type: text/html; charset=UTF-8');
+        emailParts.push('Content-Transfer-Encoding: 7bit');
+        emailParts.push('');
+        emailParts.push(validatedArgs.htmlBody || validatedArgs.body); // Use body as fallback
+        emailParts.push('');
+        // Close the boundary
+        emailParts.push(`--${boundary}--`);
+    }
+    else if (mimeType === 'text/html') {
+        // HTML-only email
+        emailParts.push('Content-Type: text/html; charset=UTF-8');
+        emailParts.push('Content-Transfer-Encoding: 7bit');
+        emailParts.push('');
+        emailParts.push(validatedArgs.htmlBody || validatedArgs.body);
+    }
+    else {
+        // Plain text email (default)
+        emailParts.push('Content-Type: text/plain; charset=UTF-8');
+        emailParts.push('Content-Transfer-Encoding: 7bit');
+        emailParts.push('');
+        emailParts.push(validatedArgs.body);
+    }
+    return emailParts.join('\r\n');
+}
+export async function createEmailWithNodemailer(validatedArgs) {
+    // Validate email addresses
+    validatedArgs.to.forEach(email => {
+        if (!validateEmail(email)) {
+            throw new Error(`Recipient email address is invalid: ${email}`);
+        }
+    });
+    // Create a nodemailer transporter (we won't actually send, just generate the message)
+    const transporter = nodemailer.createTransport({
+        streamTransport: true,
+        newline: 'unix',
+        buffer: true
+    });
+    // Inline images can only be referenced from an HTML body via cid: URLs.
+    const inlineImages = validatedArgs.inlineImages || [];
+    if (inlineImages.length > 0 && !validatedArgs.htmlBody) {
+        throw new Error('inlineImages require htmlBody — a cid: reference only resolves from HTML content');
+    }
+    // Prepare attachments for nodemailer
+    const attachments = [];
+    for (const filePath of (validatedArgs.attachments || [])) {
+        if (!fs.existsSync(filePath)) {
+            throw new Error(`File does not exist: ${filePath}`);
+        }
+        const fileName = path.basename(filePath);
+        attachments.push({
+            filename: fileName,
+            path: filePath
+        });
+    }
+    // Inline images: nodemailer emits a multipart/related container and sets
+    // Content-ID + Content-Disposition: inline for any attachment carrying a `cid`.
+    for (const img of inlineImages) {
+        // `cid` lands in a Content-ID header — strip CR/LF/NUL as defense in depth
+        // on top of the schema-level character restriction.
+        const cid = sanitizeHeaderValue(String(img.cid || ''));
+        if (!cid) {
+            throw new Error('Inline image cid must be a non-empty string');
+        }
+        const part = { cid };
+        if (img.path) {
+            if (!fs.existsSync(img.path)) {
+                throw new Error(`Inline image file does not exist: ${img.path}`);
+            }
+            part.path = img.path;
+            part.filename = img.filename || path.basename(img.path);
+        }
+        else {
+            // Reject oversized base64 payloads before nodemailer buffers them in
+            // memory. Estimate decoded size from the base64 length (~3/4 ratio).
+            const estimatedBytes = Math.floor((String(img.content || '').length * 3) / 4);
+            if (estimatedBytes > MAX_INLINE_IMAGE_CONTENT_BYTES) {
+                throw new Error(`Inline image '${cid}' exceeds the ${MAX_INLINE_IMAGE_CONTENT_BYTES / (1024 * 1024)} MB size limit`);
+            }
+            part.content = img.content;
+            part.encoding = 'base64';
+            part.filename = img.filename || cid;
+        }
+        if (img.contentType) {
+            part.contentType = img.contentType;
+        }
+        attachments.push(part);
+    }
+    const mailOptions = {
+        from: validatedArgs.from || 'me', // Gmail API uses default send-as if 'me', or specified alias
+        to: validatedArgs.to.join(', '),
+        cc: validatedArgs.cc?.join(', '),
+        bcc: validatedArgs.bcc?.join(', '),
+        subject: validatedArgs.subject,
+        text: validatedArgs.body,
+        html: validatedArgs.htmlBody,
+        attachments: attachments,
+        inReplyTo: validatedArgs.inReplyTo,
+        references: validatedArgs.references || validatedArgs.inReplyTo
+    };
+    // Generate the raw message
+    const info = await transporter.sendMail(mailOptions);
+    const rawMessage = info.message.toString();
+    return rawMessage;
+}
+/**
+ * Decide which email builder to use. Messages carrying file attachments or
+ * inline images need the nodemailer-based raw builder (multipart/mixed and
+ * multipart/related); plain or simple HTML mail uses the lightweight
+ * createEmailMessage() builder.
+ */
+export function needsRawBuilder(args) {
+    const hasAttachments = Array.isArray(args?.attachments) && args.attachments.length > 0;
+    const hasInlineImages = Array.isArray(args?.inlineImages) && args.inlineImages.length > 0;
+    return hasAttachments || hasInlineImages;
+}

--- a/vendor/gmail-mcp-fork/package-lock.json
+++ b/vendor/gmail-mcp-fork/package-lock.json
@@ -1,0 +1,5416 @@
+{
+  "name": "@artymclabin/gmail-mcp",
+  "version": "1.2.3",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@artymclabin/gmail-mcp",
+      "version": "1.2.3",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.27.1",
+        "email-addresses": "^5.0.0",
+        "google-auth-library": "^9.4.1",
+        "googleapis": "^129.0.0",
+        "mime-types": "^3.0.1",
+        "nodemailer": "^7.0.11",
+        "open": "^10.0.0",
+        "zod": "^3.22.4",
+        "zod-to-json-schema": "^3.22.1"
+      },
+      "bin": {
+        "gmail-mcp": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/mime-types": "^2.1.4",
+        "@types/node": "^20.10.5",
+        "@types/nodemailer": "^6.4.17",
+        "lockfile-lint": "^5.0.0",
+        "mcp-evals": "^1.0.18",
+        "typescript": "^5.3.3",
+        "vitest": "^4.0.18"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@actions/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@actions/exec": "^1.1.1",
+        "@actions/http-client": "^2.0.1"
+      }
+    },
+    "node_modules/@actions/exec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.1.tgz",
+      "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@actions/io": "^1.0.1"
+      }
+    },
+    "node_modules/@actions/http-client": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.3.tgz",
+      "integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tunnel": "^0.0.6",
+        "undici": "^5.25.4"
+      }
+    },
+    "node_modules/@actions/io": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
+      "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@ai-sdk/openai": {
+      "version": "1.3.24",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-1.3.24.tgz",
+      "integrity": "sha512-GYXnGJTHRTZc4gJMSmFRgEQudjqd4PUN0ZjQhPwOAYH1yOAvQoG/Ikqs+HyISRbLPCrhbZnPKCNHuRU4OfpW0Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "@ai-sdk/provider-utils": "2.2.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.0.0"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.1.3.tgz",
+      "integrity": "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-2.2.8.tgz",
+      "integrity": "sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "nanoid": "^3.3.8",
+        "secure-json-parse": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@ai-sdk/react": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-1.2.12.tgz",
+      "integrity": "sha512-jK1IZZ22evPZoQW3vlkZ7wvjYGYF+tRBKXtrcolduIkQ/m/sOAVcVeVDUDvh1T91xCnWCdUGCPZg2avZ90mv3g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider-utils": "2.2.8",
+        "@ai-sdk/ui-utils": "1.2.11",
+        "swr": "^2.2.5",
+        "throttleit": "2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ai-sdk/ui-utils": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/ui-utils/-/ui-utils-1.2.11.tgz",
+      "integrity": "sha512-3zcwCc8ezzFlwp3ZD15wAPjf2Au4s3vAbKsXQVyhxODHcmu0iyPO2Eua6D/vicq/AUm/BAo60r97O6HU+EI0+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "@ai-sdk/provider-utils": "2.2.8",
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.8.1.tgz",
+      "integrity": "sha512-59etePenCizVx1O8Qhi1T1ruE04ISfNzCnyhZNcsss1QljsLmYS83jttarMNEvGYcsUF7rwxw2lzcC3Zbxao7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "digest-fetch": "^1.3.0",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7",
+        "web-streams-polyfill": "^3.2.1"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk/node_modules/@types/node": {
+      "version": "18.19.87",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.87.tgz",
+      "integrity": "sha512-OIAAu6ypnVZHmsHCeJ+7CCSub38QNBS9uceMQeg7K5Ur0Jr+wG9wEOEvvMbhp09pxD5czIUy/jND7s7Tb6Nw7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.3.tgz",
+      "integrity": "sha512-W8bFfPA8DowP8l//sxjJLSLkD8iEjMc7cBVyP+u4cEv9sM7mdUCkgsj+t0n/BWPFtv7WWCN5Yzj0N6FJNUUqBQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.3.tgz",
+      "integrity": "sha512-PuwVXbnP87Tcff5I9ngV0lmiSu40xw1At6i3GsU77U7cjDDB4s0X2cyFuBiDa1SBk9DnvWwnGvVaGBqoFWPb7A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.3.tgz",
+      "integrity": "sha512-XelR6MzjlZuBM4f5z2IQHK6LkK34Cvv6Rj2EntER3lwCBFdg6h2lKbtRjpTTsdEjD/WSe1q8UyPBXP1x3i/wYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.3.tgz",
+      "integrity": "sha512-ogtTpYHT/g1GWS/zKM0cc/tIebFjm1F9Aw1boQ2Y0eUQ+J89d0jFY//s9ei9jVIlkYi8AfOjiixcLJSGNSOAdQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.3.tgz",
+      "integrity": "sha512-eESK5yfPNTqpAmDfFWNsOhmIOaQA59tAcF/EfYvo5/QWQCzXn5iUSOnqt3ra3UdzBv073ykTtmeLJZGt3HhA+w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.3.tgz",
+      "integrity": "sha512-Kd8glo7sIZtwOLcPbW0yLpKmBNWMANZhrC1r6K++uDR2zyzb6AeOYtI6udbtabmQpFaxJ8uduXMAo1gs5ozz8A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.3.tgz",
+      "integrity": "sha512-EJiyS70BYybOBpJth3M0KLOus0n+RRMKTYzhYhFeMwp7e/RaajXvP+BWlmEXNk6uk+KAu46j/kaQzr6au+JcIw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.3.tgz",
+      "integrity": "sha512-Q+wSjaLpGxYf7zC0kL0nDlhsfuFkoN+EXrx2KSB33RhinWzejOd6AvgmP5JbkgXKmjhmpfgKZq24pneodYqE8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.3.tgz",
+      "integrity": "sha512-dUOVmAUzuHy2ZOKIHIKHCm58HKzFqd+puLaS424h6I85GlSDRZIA5ycBixb3mFgM0Jdh+ZOSB6KptX30DD8YOQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.3.tgz",
+      "integrity": "sha512-xCUgnNYhRD5bb1C1nqrDV1PfkwgbswTTBRbAd8aH5PhYzikdf/ddtsYyMXFfGSsb/6t6QaPSzxtbfAZr9uox4A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.3.tgz",
+      "integrity": "sha512-yplPOpczHOO4jTYKmuYuANI3WhvIPSVANGcNUeMlxH4twz/TeXuzEP41tGKNGWJjuMhotpGabeFYGAOU2ummBw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.3.tgz",
+      "integrity": "sha512-P4BLP5/fjyihmXCELRGrLd793q/lBtKMQl8ARGpDxgzgIKJDRJ/u4r1A/HgpBpKpKZelGct2PGI4T+axcedf6g==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.3.tgz",
+      "integrity": "sha512-eRAOV2ODpu6P5divMEMa26RRqb2yUoYsuQQOuFUexUoQndm4MdpXXDBbUoKIc0iPa4aCO7gIhtnYomkn2x+bag==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.3.tgz",
+      "integrity": "sha512-ZC4jV2p7VbzTlnl8nZKLcBkfzIf4Yad1SJM4ZMKYnJqZFD4rTI+pBG65u8ev4jk3/MPwY9DvGn50wi3uhdaghg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.3.tgz",
+      "integrity": "sha512-LDDODcFzNtECTrUUbVCs6j9/bDVqy7DDRsuIXJg6so+mFksgwG7ZVnTruYi5V+z3eE5y+BJZw7VvUadkbfg7QA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.3.tgz",
+      "integrity": "sha512-s+w/NOY2k0yC2p9SLen+ymflgcpRkvwwa02fqmAwhBRI3SC12uiS10edHHXlVWwfAagYSY5UpmT/zISXPMW3tQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.3.tgz",
+      "integrity": "sha512-nQHDz4pXjSDC6UfOE1Fw9Q8d6GCAd9KdvMZpfVGWSJztYCarRgSDfOVBY5xwhQXseiyxapkiSJi/5/ja8mRFFA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.3.tgz",
+      "integrity": "sha512-1QaLtOWq0mzK6tzzp0jRN3eccmN3hezey7mhLnzC6oNlJoUJz4nym5ZD7mDnS/LZQgkrhEbEiTn515lPeLpgWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.3.tgz",
+      "integrity": "sha512-i5Hm68HXHdgv8wkrt+10Bc50zM0/eonPb/a/OFVfB6Qvpiirco5gBA5bz7S2SHuU+Y4LWn/zehzNX14Sp4r27g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.3.tgz",
+      "integrity": "sha512-zGAVApJEYTbOC6H/3QBr2mq3upG/LBEXr85/pTtKiv2IXcgKV0RT0QA/hSXZqSvLEpXeIxah7LczB4lkiYhTAQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.3.tgz",
+      "integrity": "sha512-fpqctI45NnCIDKBH5AXQBsD0NDPbEFczK98hk/aa6HJxbl+UtLkJV2+Bvy5hLSLk3LHmqt0NTkKNso1A9y1a4w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.3.tgz",
+      "integrity": "sha512-ROJhm7d8bk9dMCUZjkS8fgzsPAZEjtRJqCAmVgB0gMrvG7hfmPmz9k1rwO4jSiblFjYmNvbECL9uhaPzONMfgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.3.tgz",
+      "integrity": "sha512-YWcow8peiHpNBiIXHwaswPnAXLsLVygFwCB3A7Bh5jRkIBFWHGmNQ48AlX4xDvQNoMZlPYzjVOQDYEzWCqufMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.3.tgz",
+      "integrity": "sha512-qspTZOIGoXVS4DpNqUYUs9UxVb04khS1Degaw/MnfMe7goQ3lTfQ13Vw4qY/Nj0979BGvMRpAYbs/BAxEvU8ew==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.3.tgz",
+      "integrity": "sha512-ICgUR+kPimx0vvRzf+N/7L7tVSQeE3BYY+NhHRHXS1kBuPO7z2+7ea2HbhDyZdTephgvNvKrlDDKUexuCVBVvg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
+      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/diff-match-patch": {
+      "version": "1.0.36",
+      "resolved": "https://registry.npmjs.org/@types/diff-match-patch/-/diff-match-patch-1.0.36.tgz",
+      "integrity": "sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mime-types": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.4.tgz",
+      "integrity": "sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.17.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.10.tgz",
+      "integrity": "sha512-/jrvh5h6NXhEauFFexRin69nA0uHJ5gwk4iDivp/DeoEua3uwCUto6PC86IpRITBOs4+6i2I56K5x5b6WYGXHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.12.tgz",
+      "integrity": "sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "6.4.17",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.17.tgz",
+      "integrity": "sha512-I9CCaIp6DTldEg7vyUTZi8+9Vo0hi1/T8gv3C89yk1rSAAzoKQ8H8ki/jBYJSFoH/BisgLP8tkZMlQ91CIquww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@yarnpkg/parsers": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/parsers/-/parsers-3.0.3.tgz",
+      "integrity": "sha512-mQZgUSgFurUtA07ceMjxrWkYz8QtDuYkvPlu0ZqncgjopQ0t6CNEo/OSealkmnagSUx8ZD5ewvezUwUuMqutQg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "js-yaml": "^3.10.0",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
+    "node_modules/@yarnpkg/parsers/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/@yarnpkg/parsers/node_modules/js-yaml": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/ai": {
+      "version": "4.3.19",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-4.3.19.tgz",
+      "integrity": "sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "@ai-sdk/provider-utils": "2.2.8",
+        "@ai-sdk/react": "1.2.12",
+        "@ai-sdk/ui-utils": "1.2.11",
+        "@opentelemetry/api": "1.9.0",
+        "jsondiffpatch": "0.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/base-64": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
+      "integrity": "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA==",
+      "dev": true
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
+      "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/cosmiconfig": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
+      "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/default-browser": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
+      "integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
+      "integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/diff-match-patch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/digest-fetch": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/digest-fetch/-/digest-fetch-1.3.0.tgz",
+      "integrity": "sha512-CGJuv6iKNM7QyZlM2T3sPAdZWd/p9zQiRNS9G+9COUCwzWFTs0Xp8NF5iePx7wtvhDykReiRRrSeNb4oMmB8lA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "base-64": "^0.1.0",
+        "md5": "^2.3.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/email-addresses": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-5.0.0.tgz",
+      "integrity": "sha512-4OIPYlA6JXqtVn8zpHpGiI7vE6EQOAg16aGnDMIAlZVinnoZ8208tW1hAbjWydgN/4PLTT9q+O1K6AH/vALJGw==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.3.tgz",
+      "integrity": "sha512-qKA6Pvai73+M2FtftpNKRxJ78GIjmFXFxd/1DVBqGo/qNhLSfv+G12n9pNoWdytJC8U00TrViOwpjT0zgqQS8Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.3",
+        "@esbuild/android-arm": "0.25.3",
+        "@esbuild/android-arm64": "0.25.3",
+        "@esbuild/android-x64": "0.25.3",
+        "@esbuild/darwin-arm64": "0.25.3",
+        "@esbuild/darwin-x64": "0.25.3",
+        "@esbuild/freebsd-arm64": "0.25.3",
+        "@esbuild/freebsd-x64": "0.25.3",
+        "@esbuild/linux-arm": "0.25.3",
+        "@esbuild/linux-arm64": "0.25.3",
+        "@esbuild/linux-ia32": "0.25.3",
+        "@esbuild/linux-loong64": "0.25.3",
+        "@esbuild/linux-mips64el": "0.25.3",
+        "@esbuild/linux-ppc64": "0.25.3",
+        "@esbuild/linux-riscv64": "0.25.3",
+        "@esbuild/linux-s390x": "0.25.3",
+        "@esbuild/linux-x64": "0.25.3",
+        "@esbuild/netbsd-arm64": "0.25.3",
+        "@esbuild/netbsd-x64": "0.25.3",
+        "@esbuild/openbsd-arm64": "0.25.3",
+        "@esbuild/openbsd-x64": "0.25.3",
+        "@esbuild/sunos-x64": "0.25.3",
+        "@esbuild/win32-arm64": "0.25.3",
+        "@esbuild/win32-ia32": "0.25.3",
+        "@esbuild/win32-x64": "0.25.3"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.6.tgz",
+      "integrity": "sha512-l19WpE2m9hSuyP06+FbuUUf1G+R0SFLrtQfbRb9PRr+oimOfxQhgGCbVaXg5IvZyyTThJsxh6L/srkMiCeBPDA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.1.tgz",
+      "integrity": "sha512-VARTJ9CYeuQYb0pZEPbzi740OWFgpHe7AYJ2WFZVnUDUQp5Dk2yJUgF36YsZ81cOyxT0QxmXD2EQpapAouzWVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
+      }
+    },
+    "node_modules/formdata-node/node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.0.tgz",
+      "integrity": "sha512-Jh/AIwwgaxan+7ZUUmRLCjtchyDiqh4KjBJ5tW3plBZb5iL/BPcso8A5DlzeD9qlw0duCamnNdpFjxwaT0KyKg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.0.tgz",
+      "integrity": "sha512-kGzZ3LWWQcGIAmg6iWvXn0ei6WDtV26wzHRMwDSzmAbcXrTEXxHy6IehI6/4eT6VRKyMP1eF1VqwrVUmE/LR7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.0.tgz",
+      "integrity": "sha512-7ccSEJFDFO7exFbO6NRyC+xH8/mZ1GZGG2xxx9iHxZWcjUjJpjWxIMw3cofAKcueZ6DATiukmmprD7yavQHOyQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/googleapis": {
+      "version": "129.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-129.0.0.tgz",
+      "integrity": "sha512-gFatrzby+oh/GxEeMhJOKzgs9eG7yksRcTon9b+kPie4ZnDSgGQ85JgtUaBtLSBkcKpUKukdSP6Km1aCjs4y4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^9.0.0",
+        "googleapis-common": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/googleapis-common": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-7.2.0.tgz",
+      "integrity": "sha512-/fhDZEJZvOV3X5jmD+fKxMqma5q2Q9nZNSF3kn1F18tpxmA86BcTxAGBQdM0N89Z3bEaIs+HVznSmFJEAmMTjA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "gaxios": "^6.0.3",
+        "google-auth-library": "^9.7.0",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.29",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.29.tgz",
+      "integrity": "sha512-1hNiRjawYrLq/4m3DQQjPGFg0VZkk4RjQJDff/excI6Dm9BiL75qxGrd7/c6YOxPdq6AscP3LiXhQ6fKFC1Waw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
+      "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.0.tgz",
+      "integrity": "sha512-xsfE1TcSCbUdo6U07tR0mvhg0flGxU8tPLbF03mirl2ukGQENhUg4ubGYQnhVH0b5stLlPM+WOqDkEl1R1y5sQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "dev": true,
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/jsondiffpatch": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/jsondiffpatch/-/jsondiffpatch-0.6.0.tgz",
+      "integrity": "sha512-3QItJOXp2AP1uv7waBkao5nCvhEv+QmJAd38Ybq7wNI74Q+BBmnLn4EDKz6yI9xGAIQoUF87qHt+kc1IVxB4zQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/diff-match-patch": "^1.0.36",
+        "chalk": "^5.3.0",
+        "diff-match-patch": "^1.0.5"
+      },
+      "bin": {
+        "jsondiffpatch": "bin/jsondiffpatch.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/jsondiffpatch/node_modules/chalk": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lockfile-lint": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/lockfile-lint/-/lockfile-lint-5.0.0.tgz",
+      "integrity": "sha512-QcVIVITLZAhWYHU2wbNSOMgwc6EN4Y2sy6mjgS5aikYyRzgDIfotXUsCrm38En+3fZpc58Yu7DF9dNeT/goi1A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cosmiconfig": "^9.0.0",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.2",
+        "lockfile-lint-api": "^5.9.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "lockfile-lint": "bin/lockfile-lint.js"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/lockfile-lint-api": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/lockfile-lint-api/-/lockfile-lint-api-5.9.2.tgz",
+      "integrity": "sha512-3QhxWxl3jT9GcMxuCnTsU8Tz5U6U1lKBlKBu2zOYOz/x3ONUoojEtky3uzoaaDgExcLqIX0Aqv2I7TZXE383CQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@yarnpkg/parsers": "^3.0.0-rc.48.1",
+        "debug": "^4.3.4",
+        "object-hash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mcp-evals": {
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/mcp-evals/-/mcp-evals-1.0.18.tgz",
+      "integrity": "sha512-khDcEG0XWshdCRirqLXogNoDLmzFA86QyuKoi5ioXsbeRZ3XQra8Zsg7vD+C0K5vwkFIoB1vTuPjHEHMhdLFtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@actions/core": "^1.10.0",
+        "@ai-sdk/openai": "^1.3.17",
+        "@anthropic-ai/sdk": "^0.8.0",
+        "@modelcontextprotocol/sdk": "^1.10.2",
+        "ai": "^4.3.9",
+        "chalk": "^4.1.2",
+        "dotenv": "^16.3.1",
+        "openai": "^4.24.1",
+        "tsx": "^4.19.3"
+      },
+      "bin": {
+        "mcp-eval": "dist/cli.js"
+      },
+      "peerDependencies": {
+        "react": "^19.1.0"
+      }
+    },
+    "node_modules/md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "7.0.13",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.13.tgz",
+      "integrity": "sha512-PNDFSJdP+KFgdsG3ZzMXCgquO7I6McjY2vlqILjtJd0hy8wEvtugS9xKRF2NWlPNGxvLCXlTNIae4serI7dinw==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/open": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.1.0.tgz",
+      "integrity": "sha512-mnkeQ1qP5Ue2wd+aivTD3NHd/lZ96Lu0jgf0pwktLPtx6cTZiH7tyeGRRHs0zX0rbrahXPnXlUnbeXyaBBuIaw==",
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openai": {
+      "version": "4.96.2",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.96.2.tgz",
+      "integrity": "sha512-R2XnxvMsizkROr7BV3uNp1q/3skwPZ7fmPjO1bXLnfB4Tu5xKxrT1EVwzjhxn0MZKBKAvOaGWS63jTMN6KrIXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      },
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/openai/node_modules/@types/node": {
+      "version": "18.19.87",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.87.tgz",
+      "integrity": "sha512-OIAAu6ypnVZHmsHCeJ+7CCSub38QNBS9uceMQeg7K5Ur0Jr+wG9wEOEvvMbhp09pxD5czIUy/jND7s7Tb6Nw7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/openai/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz",
+      "integrity": "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
+      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
+      "integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/secure-json-parse": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
+      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/swr": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.1.tgz",
+      "integrity": "sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.19.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.4.tgz",
+      "integrity": "sha512-gK5GVzDkJK1SI1zwHf32Mqxf2tSJkNx+eYcNly5+nHvWqXUJYUkWBQtKauoESz3ymezAI++ZwT855x5p5eop+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+      "license": "BSD"
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "8.1.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
+      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.4",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.1.tgz",
+      "integrity": "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.1.tgz",
+      "integrity": "sha512-3h08nf3Vw3Wl3PK+q3ow/lIil81IT2Oa7YpQyUUDsEWbXveMesdfK1xBd2RhCkynwZndAxixji/7SYJJowr62w==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.24.1"
+      }
+    }
+  }
+}

--- a/vendor/gmail-mcp-fork/package.json
+++ b/vendor/gmail-mcp-fork/package.json
@@ -1,0 +1,76 @@
+{
+  "name": "@artymclabin/gmail-mcp",
+  "version": "1.2.3",
+  "mcpName": "io.github.ArtyMcLabin/Gmail-MCP-Server",
+  "description": "Lean Gmail MCP server with auto authentication support (maintained fork of GongRzhe/Gmail-MCP-Server)",
+  "type": "module",
+  "main": "dist/index.js",
+  "bin": {
+    "gmail-mcp": "./dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "start": "node dist/index.js",
+    "auth": "node dist/index.js auth",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lockfile:lint": "lockfile-lint --path package-lock.json --type npm --validate-https --allowed-hosts npm",
+    "prepare": "npm run build",
+    "prepublishOnly": "npm run build"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "keywords": [
+    "gmail",
+    "mcp",
+    "cursor",
+    "ai",
+    "oauth",
+    "model-context-protocol",
+    "google-gmail",
+    "claude",
+    "auto-auth"
+  ],
+  "author": "Arty McLabin",
+  "contributors": [
+    "gongrzhe (original upstream author)"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ArtyMcLabin/Gmail-MCP-Server.git"
+  },
+  "bugs": {
+    "url": "https://github.com/ArtyMcLabin/Gmail-MCP-Server/issues"
+  },
+  "homepage": "https://github.com/ArtyMcLabin/Gmail-MCP-Server#readme",
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "node": ">=14.0.0"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.27.1",
+    "email-addresses": "^5.0.0",
+    "google-auth-library": "^9.4.1",
+    "googleapis": "^129.0.0",
+    "mime-types": "^3.0.1",
+    "nodemailer": "^7.0.11",
+    "open": "^10.0.0",
+    "zod": "^3.22.4",
+    "zod-to-json-schema": "^3.22.1"
+  },
+  "devDependencies": {
+    "@types/mime-types": "^2.1.4",
+    "@types/node": "^20.10.5",
+    "@types/nodemailer": "^6.4.17",
+    "lockfile-lint": "^5.0.0",
+    "mcp-evals": "^1.0.18",
+    "typescript": "^5.3.3",
+    "vitest": "^4.0.18"
+  }
+}

--- a/vendor/gmail-mcp-fork/run.sh
+++ b/vendor/gmail-mcp-fork/run.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Launcher for the vendored Gmail MCP fork (see VENDOR.md).
+# Self-healing: prod deps installed on first run; config dir defaults to the
+# v2 path so the parallel-run phase NEVER touches the live ~/.gmail-mcp of
+# the current MCP (Marveen's condition, 2026-09-07: separate dir even for
+# the same account, so rollback stays one step and token files cannot
+# cross-write).
+set -e
+DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$DIR"
+if [ ! -d node_modules ]; then
+  npm ci --omit=dev --silent
+fi
+export GMAIL_OAUTH_PATH="${GMAIL_OAUTH_PATH:-$HOME/.gmail-mcp-v2/gcp-oauth.keys.json}"
+export GMAIL_CREDENTIALS_PATH="${GMAIL_CREDENTIALS_PATH:-$HOME/.gmail-mcp-v2/credentials.json}"
+exec node dist/index.js "$@"

--- a/vendor/gmail-mcp-fork/run.sh
+++ b/vendor/gmail-mcp-fork/run.sh
@@ -9,7 +9,7 @@ set -e
 DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$DIR"
 if [ ! -d node_modules ]; then
-  npm ci --omit=dev --silent
+  npm ci --omit=dev --ignore-scripts --silent
 fi
 export GMAIL_OAUTH_PATH="${GMAIL_OAUTH_PATH:-$HOME/.gmail-mcp-v2/gcp-oauth.keys.json}"
 export GMAIL_CREDENTIALS_PATH="${GMAIL_CREDENTIALS_PATH:-$HOME/.gmail-mcp-v2/credentials.json}"

--- a/vendor/gmail-mcp-fork/src/delete-scopes.test.ts
+++ b/vendor/gmail-mcp-fork/src/delete-scopes.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { getAvailableScopeNames, hasScope, scopeNameToUrl } from './scopes.js';
+import { getToolByName } from './tools.js';
+
+describe('permanent delete scope requirements', () => {
+  it('recognizes gmail.full as the permanent-delete Gmail scope', () => {
+    expect(getAvailableScopeNames()).toContain('gmail.full');
+    expect(scopeNameToUrl('gmail.full')).toBe('https://mail.google.com/');
+  });
+
+  it('does not expose permanent delete tools with only gmail.modify', () => {
+    const deleteEmail = getToolByName('delete_email')!;
+    const batchDeleteEmails = getToolByName('batch_delete_emails')!;
+
+    expect(deleteEmail.scopes).toEqual(['gmail.full']);
+    expect(batchDeleteEmails.scopes).toEqual(['gmail.full']);
+    expect(hasScope(['gmail.modify'], deleteEmail.scopes)).toBe(false);
+    expect(hasScope(['gmail.modify'], batchDeleteEmails.scopes)).toBe(false);
+  });
+
+  it('exposes permanent delete tools with gmail.full shorthand or URL scope', () => {
+    const deleteEmail = getToolByName('delete_email')!;
+    const batchDeleteEmails = getToolByName('batch_delete_emails')!;
+
+    expect(hasScope(['gmail.full'], deleteEmail.scopes)).toBe(true);
+    expect(hasScope(['https://mail.google.com/'], batchDeleteEmails.scopes)).toBe(true);
+  });
+
+  it('gmail.full satisfies all mail scopes (superset), so read/send/modify tools stay visible', () => {
+    // The README recommends re-authing with --scopes=gmail.full,gmail.settings.basic;
+    // without superset handling that combination would hide every non-delete mail tool.
+    for (const tool of ['read_email', 'search_emails', 'send_email', 'modify_email', 'create_label']) {
+      const t = getToolByName(tool)!;
+      expect(hasScope(['gmail.full'], t.scopes), `${tool} should be visible under gmail.full`).toBe(true);
+    }
+  });
+
+  it('gmail.full does NOT satisfy settings scopes (filters still need gmail.settings.basic)', () => {
+    const listFilters = getToolByName('list_filters')!;
+    expect(hasScope(['gmail.full'], listFilters.scopes)).toBe(false);
+    expect(hasScope(['gmail.full', 'gmail.settings.basic'], listFilters.scopes)).toBe(true);
+  });
+});

--- a/vendor/gmail-mcp-fork/src/download-email.test.ts
+++ b/vendor/gmail-mcp-fork/src/download-email.test.ts
@@ -1,0 +1,347 @@
+/**
+ * Test plan for download_email tool (PR #13)
+ *
+ * 1. Verify download_email with each format (json, eml, txt, html)
+ * 2. Verify scope filtering works (tool visible with gmail.readonly)
+ * 3. Verify directory creation when savePath doesn't exist
+ * 4. Verify existing tools still work after extractHeaders refactor
+ */
+
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  gmailMessageToJson,
+  emailToTxt,
+  emailToHtml,
+  parseEmailAddress,
+  parseEmailAddresses,
+} from "./email-export.js";
+import { toolDefinitions, getToolByName, DownloadEmailSchema } from "./tools.js";
+import { hasScope } from "./scopes.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Shared mock data
+const mockHeaders = [
+  { name: "From", value: "Alice <alice@example.com>" },
+  { name: "To", value: "Bob <bob@example.com>, Carol <carol@example.com>" },
+  { name: "Cc", value: "dave@example.com" },
+  { name: "Bcc", value: "eve@example.com" },
+  { name: "Subject", value: "Test Email Subject" },
+  { name: "Date", value: "Fri, 13 Mar 2026 10:00:00 +0000" },
+  { name: "Message-ID", value: "<msg123@example.com>" },
+  { name: "In-Reply-To", value: "<prev@example.com>" },
+  { name: "References", value: "<orig@example.com> <prev@example.com>" },
+];
+
+const mockMessage = {
+  id: "msg_abc123",
+  threadId: "thread_xyz",
+  labelIds: ["INBOX", "UNREAD"],
+  snippet: "This is a test email...",
+  payload: { headers: mockHeaders },
+};
+
+const mockContent = {
+  text: "Hello, this is the plain text body.",
+  html: "<html><body><p>Hello, this is the <b>HTML</b> body.</p></body></html>",
+};
+
+const mockAttachments = [
+  { id: "att1", filename: "report.pdf", mimeType: "application/pdf", size: 102400 },
+  { id: "att2", filename: "photo.jpg", mimeType: "image/jpeg", size: 204800 },
+];
+
+// ─────────────────────────────────────────────
+// 1. Format tests (json, txt, html)
+// ─────────────────────────────────────────────
+describe("download_email formats", () => {
+  describe("JSON format", () => {
+    it("produces valid structured JSON with all fields", () => {
+      const json = gmailMessageToJson(mockMessage, mockContent, mockAttachments);
+
+      expect(json.messageId).toBe("msg_abc123");
+      expect(json.threadId).toBe("thread_xyz");
+      expect(json.subject).toBe("Test Email Subject");
+      expect(json.from.email).toBe("alice@example.com");
+      expect(json.from.name).toBe("Alice");
+      expect(json.to).toHaveLength(2);
+      expect(json.to[0].email).toBe("bob@example.com");
+      expect(json.cc).toHaveLength(1);
+      expect(json.cc[0].email).toBe("dave@example.com");
+      expect(json.labels).toEqual(["INBOX", "UNREAD"]);
+      expect(json.snippet).toBe("This is a test email...");
+      expect(json.body.plain).toBe(mockContent.text);
+      expect(json.body.html).toBe(mockContent.html);
+      expect(json.attachments).toHaveLength(2);
+      expect(json.attachments[0].filename).toBe("report.pdf");
+      expect(json.headers["Message-ID"]).toBe("<msg123@example.com>");
+      expect(json.headers["In-Reply-To"]).toBe("<prev@example.com>");
+      expect(json.headers["References"]).toBe("<orig@example.com> <prev@example.com>");
+    });
+
+    it("converts date to ISO format", () => {
+      const json = gmailMessageToJson(mockMessage, mockContent, []);
+      expect(json.date).toBe("2026-03-13T10:00:00.000Z");
+    });
+
+    it("handles missing headers gracefully", () => {
+      const emptyMessage = { id: "x", threadId: "t", payload: { headers: [] } };
+      const json = gmailMessageToJson(emptyMessage, { text: "", html: "" }, []);
+      expect(json.subject).toBe("");
+      expect(json.from.email).toBe("");
+      expect(json.to).toEqual([]);
+    });
+
+    it("serializes to valid JSON string", () => {
+      const json = gmailMessageToJson(mockMessage, mockContent, mockAttachments);
+      const str = JSON.stringify(json, null, 2);
+      expect(() => JSON.parse(str)).not.toThrow();
+    });
+  });
+
+  describe("TXT format", () => {
+    it("produces headers and body in plain text", () => {
+      const txt = emailToTxt(mockMessage, mockContent, mockAttachments);
+
+      expect(txt).toContain("From: Alice <alice@example.com>");
+      expect(txt).toContain("To: Bob <bob@example.com>, Carol <carol@example.com>");
+      expect(txt).toContain("CC: dave@example.com");
+      expect(txt).toContain("Subject: Test Email Subject");
+      expect(txt).toContain("Date: Fri, 13 Mar 2026 10:00:00 +0000");
+      expect(txt).toContain("Hello, this is the plain text body.");
+      expect(txt).toContain("Attachments: report.pdf, photo.jpg");
+    });
+
+    it("omits CC line when empty", () => {
+      const noCcHeaders = mockHeaders.filter((h) => h.name !== "Cc");
+      const msg = { ...mockMessage, payload: { headers: noCcHeaders } };
+      const txt = emailToTxt(msg, mockContent, []);
+      expect(txt).not.toContain("CC:");
+    });
+
+    it("shows placeholder when no text content", () => {
+      const txt = emailToTxt(mockMessage, { text: "", html: "<p>HTML only</p>" }, []);
+      expect(txt).toContain("[No plain text content]");
+    });
+
+    it("omits attachment section when no attachments", () => {
+      const txt = emailToTxt(mockMessage, mockContent, []);
+      expect(txt).not.toContain("Attachments:");
+    });
+  });
+
+  describe("HTML format", () => {
+    it("returns raw HTML content", () => {
+      const html = emailToHtml(mockContent);
+      expect(html).toBe(mockContent.html);
+      expect(html).toContain("<b>HTML</b>");
+    });
+
+    it("throws when no HTML content available", () => {
+      expect(() => emailToHtml({ text: "plain only", html: "" })).toThrow(
+        "This email has no HTML content"
+      );
+    });
+  });
+});
+
+// ─────────────────────────────────────────────
+// 2. Scope filtering
+// ─────────────────────────────────────────────
+describe("download_email scope filtering", () => {
+  it("is registered in toolDefinitions", () => {
+    const tool = getToolByName("download_email");
+    expect(tool).toBeDefined();
+    expect(tool!.name).toBe("download_email");
+  });
+
+  it("is visible with gmail.readonly scope", () => {
+    const tool = getToolByName("download_email")!;
+    expect(hasScope(["gmail.readonly"], tool.scopes)).toBe(true);
+  });
+
+  it("is visible with gmail.modify scope", () => {
+    const tool = getToolByName("download_email")!;
+    expect(hasScope(["gmail.modify"], tool.scopes)).toBe(true);
+  });
+
+  it("is NOT visible with only gmail.send scope", () => {
+    const tool = getToolByName("download_email")!;
+    expect(hasScope(["gmail.send"], tool.scopes)).toBe(false);
+  });
+
+  it("is NOT visible with only gmail.compose scope", () => {
+    const tool = getToolByName("download_email")!;
+    expect(hasScope(["gmail.compose"], tool.scopes)).toBe(false);
+  });
+
+  it("works with full URL scope format", () => {
+    const tool = getToolByName("download_email")!;
+    expect(
+      hasScope(["https://www.googleapis.com/auth/gmail.readonly"], tool.scopes)
+    ).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────
+// 3. Schema validation
+// ─────────────────────────────────────────────
+describe("DownloadEmailSchema", () => {
+  it("accepts valid input with all fields", () => {
+    const result = DownloadEmailSchema.parse({
+      messageId: "msg123",
+      savePath: "/tmp/emails",
+      format: "json",
+    });
+    expect(result.messageId).toBe("msg123");
+    expect(result.savePath).toBe("/tmp/emails");
+    expect(result.format).toBe("json");
+  });
+
+  it("defaults format to json", () => {
+    const result = DownloadEmailSchema.parse({
+      messageId: "msg123",
+      savePath: "/tmp/emails",
+    });
+    expect(result.format).toBe("json");
+  });
+
+  it("accepts all valid formats", () => {
+    for (const fmt of ["json", "eml", "txt", "html"]) {
+      const result = DownloadEmailSchema.parse({
+        messageId: "msg123",
+        savePath: "/tmp",
+        format: fmt,
+      });
+      expect(result.format).toBe(fmt);
+    }
+  });
+
+  it("rejects invalid format", () => {
+    expect(() =>
+      DownloadEmailSchema.parse({
+        messageId: "msg123",
+        savePath: "/tmp",
+        format: "xml",
+      })
+    ).toThrow();
+  });
+
+  it("requires messageId", () => {
+    expect(() =>
+      DownloadEmailSchema.parse({ savePath: "/tmp" })
+    ).toThrow();
+  });
+
+  it("requires savePath", () => {
+    expect(() =>
+      DownloadEmailSchema.parse({ messageId: "msg123" })
+    ).toThrow();
+  });
+});
+
+// ─────────────────────────────────────────────
+// 4. extractHeaders refactor verification
+// ─────────────────────────────────────────────
+describe("extractHeaders refactor - source verification", () => {
+  const indexSource = fs.readFileSync(path.join(__dirname, "index.ts"), "utf-8");
+
+  it("extractHeaders function exists and returns rfcMessageId", () => {
+    expect(indexSource).toContain("function extractHeaders");
+    expect(indexSource).toContain("rfcMessageId");
+    expect(indexSource).toContain('getHeader("message-id")');
+  });
+
+  it("read_email uses extractHeaders (not inline header extraction)", () => {
+    // The read_email case should use destructured extractHeaders call
+    expect(indexSource).toContain("const { subject, from, to, cc, bcc, date, rfcMessageId } = extractHeaders(");
+  });
+
+  it("download_email uses extractHeaders", () => {
+    // download_email should also use extractHeaders
+    expect(indexSource).toContain('const { subject, from, date } = extractHeaders(');
+  });
+
+  it("read_email still outputs Message-ID in response", () => {
+    expect(indexSource).toContain("Message-ID: ${rfcMessageId}");
+  });
+});
+
+// ─────────────────────────────────────────────
+// Email address parsing (email-export.ts)
+// ─────────────────────────────────────────────
+describe("email-export parseEmailAddress", () => {
+  it('parses "Name" <email> format', () => {
+    const result = parseEmailAddress('"John Doe" <john@example.com>');
+    expect(result.name).toBe("John Doe");
+    expect(result.email).toBe("john@example.com");
+  });
+
+  it("parses Name <email> without quotes", () => {
+    const result = parseEmailAddress("Alice <alice@example.com>");
+    expect(result.name).toBe("Alice");
+    expect(result.email).toBe("alice@example.com");
+  });
+
+  it("parses bare email", () => {
+    const result = parseEmailAddress("user@example.com");
+    expect(result.name).toBe("");
+    expect(result.email).toBe("user@example.com");
+  });
+
+  it("handles empty string", () => {
+    const result = parseEmailAddress("");
+    expect(result.email).toBe("");
+  });
+});
+
+describe("email-export parseEmailAddresses", () => {
+  it("splits comma-separated addresses", () => {
+    const results = parseEmailAddresses("a@test.com, b@test.com");
+    expect(results).toHaveLength(2);
+    expect(results[0].email).toBe("a@test.com");
+    expect(results[1].email).toBe("b@test.com");
+  });
+
+  it("handles undefined", () => {
+    expect(parseEmailAddresses(undefined)).toEqual([]);
+  });
+});
+
+
+// ─────────────────────────────────────────────
+// extractHeaders CC/BCC support
+// ─────────────────────────────────────────────
+describe("extractHeaders CC/BCC", () => {
+  // extractHeaders is not exported, so we verify via source inspection
+  const indexSource = fs.readFileSync(path.join(__dirname, "index.ts"), "utf-8");
+
+  it("extractHeaders returns cc and bcc fields in its return type", () => {
+    expect(indexSource).toContain("cc: getHeader(\"cc\")");
+    expect(indexSource).toContain("bcc: getHeader(\"bcc\")");
+  });
+
+  it("extractHeaders return type includes cc and bcc", () => {
+    // Verify the type annotation includes cc and bcc
+    expect(indexSource).toMatch(/function extractHeaders.*cc: string.*bcc: string/);
+  });
+
+  it("read_email output includes CC conditionally", () => {
+    // The template should conditionally include CC
+    expect(indexSource).toContain("CC: ${cc}");
+  });
+
+  it("read_email output includes BCC conditionally", () => {
+    // The template should conditionally include BCC
+    expect(indexSource).toContain("BCC: ${bcc}");
+  });
+
+  it("CC and BCC lines are conditional (not always shown)", () => {
+    // Verify the conditional pattern - only show when value exists
+    expect(indexSource).toContain("${cc ? `\\nCC: ${cc}` : ''}");
+    expect(indexSource).toContain("${bcc ? `\\nBCC: ${bcc}` : ''}");
+  });
+});

--- a/vendor/gmail-mcp-fork/src/email-export.ts
+++ b/vendor/gmail-mcp-fork/src/email-export.ts
@@ -1,0 +1,178 @@
+/**
+ * Email export utilities for converting Gmail messages to various formats
+ */
+
+import emailAddresses from "email-addresses";
+
+// Types
+export interface ParsedAddress {
+    name: string;
+    email: string;
+}
+
+export interface EmailAttachment {
+    id: string;
+    filename: string;
+    mimeType: string;
+    size: number;
+}
+
+export interface EmailJson {
+    messageId: string;
+    threadId: string;
+    subject: string;
+    from: ParsedAddress;
+    to: ParsedAddress[];
+    cc: ParsedAddress[];
+    bcc: ParsedAddress[];
+    date: string;
+    labels: string[];
+    snippet: string;
+    body: {
+        plain: string;
+        html: string;
+    };
+    attachments: EmailAttachment[];
+    headers: Record<string, string>;
+}
+
+/**
+ * Parse email address string into name and email components
+ * Uses RFC 5322 compliant parser (email-addresses package)
+ */
+export function parseEmailAddress(address: string): ParsedAddress {
+    if (!address) return { name: "", email: "" };
+
+    const parsed = emailAddresses.parseOneAddress(address);
+    if (parsed && parsed.type === "mailbox") {
+        return {
+            name: parsed.name || "",
+            email: parsed.address || "",
+        };
+    }
+    return { name: "", email: address.trim() };
+}
+
+/**
+ * Parse comma-separated list of email addresses
+ * Uses RFC 5322 compliant parser (email-addresses package)
+ */
+export function parseEmailAddresses(addresses: string | undefined): ParsedAddress[] {
+    if (!addresses) return [];
+
+    const parsed = emailAddresses.parseAddressList(addresses);
+    if (!parsed) return [];
+
+    return parsed
+        .filter((entry): entry is emailAddresses.ParsedMailbox => entry.type === "mailbox")
+        .map((entry) => ({
+            name: entry.name || "",
+            email: entry.address || "",
+        }));
+}
+
+/**
+ * Convert Gmail API message to structured JSON
+ */
+export function gmailMessageToJson(
+    message: any,
+    emailContent: { text: string; html: string },
+    attachments: EmailAttachment[]
+): EmailJson {
+    const headers = message.payload?.headers || [];
+    const getHeader = (name: string) =>
+        headers.find((h: any) => h.name?.toLowerCase() === name.toLowerCase())?.value || "";
+
+    const dateStr = getHeader("date");
+    let isoDate = "";
+    try {
+        isoDate = new Date(dateStr).toISOString();
+    } catch {
+        isoDate = dateStr; // Keep original if parsing fails
+    }
+
+    return {
+        messageId: message.id,
+        threadId: message.threadId,
+        subject: getHeader("subject"),
+        from: parseEmailAddress(getHeader("from")),
+        to: parseEmailAddresses(getHeader("to")),
+        cc: parseEmailAddresses(getHeader("cc")),
+        bcc: parseEmailAddresses(getHeader("bcc")),
+        date: isoDate,
+        labels: message.labelIds || [],
+        snippet: message.snippet || "",
+        body: {
+            plain: emailContent.text,
+            html: emailContent.html,
+        },
+        attachments,
+        headers: {
+            "Message-ID": getHeader("message-id"),
+            "In-Reply-To": getHeader("in-reply-to"),
+            References: getHeader("references"),
+        },
+    };
+}
+
+/**
+ * Format address for display
+ */
+function formatAddress(a: ParsedAddress): string {
+    return a.name ? `${a.name} <${a.email}>` : a.email;
+}
+
+/**
+ * Format list of addresses for display
+ */
+function formatAddresses(addrs: ParsedAddress[]): string {
+    return addrs.map(formatAddress).join(", ");
+}
+
+/**
+ * Convert email to plain text format
+ */
+export function emailToTxt(
+    message: any,
+    emailContent: { text: string; html: string },
+    attachments: EmailAttachment[]
+): string {
+    const headers = message.payload?.headers || [];
+    const getHeader = (name: string) =>
+        headers.find((h: any) => h.name?.toLowerCase() === name.toLowerCase())?.value || "";
+
+    const from = getHeader("from");
+    const to = getHeader("to");
+    const cc = getHeader("cc");
+    const subject = getHeader("subject");
+    const date = getHeader("date");
+
+    const lines = [`From: ${from}`, `To: ${to}`];
+
+    if (cc) {
+        lines.push(`CC: ${cc}`);
+    }
+
+    lines.push(`Subject: ${subject}`);
+    lines.push(`Date: ${date}`);
+    lines.push("");
+    lines.push(emailContent.text || "[No plain text content]");
+
+    if (attachments.length > 0) {
+        lines.push("");
+        lines.push("---");
+        lines.push(`Attachments: ${attachments.map((a) => a.filename).join(", ")}`);
+    }
+
+    return lines.join("\n");
+}
+
+/**
+ * Extract HTML content from email, or throw if none exists
+ */
+export function emailToHtml(emailContent: { text: string; html: string }): string {
+    if (!emailContent.html) {
+        throw new Error("This email has no HTML content");
+    }
+    return emailContent.html;
+}

--- a/vendor/gmail-mcp-fork/src/filter-manager.ts
+++ b/vendor/gmail-mcp-fork/src/filter-manager.ts
@@ -1,0 +1,187 @@
+/**
+ * Filter Manager for Gmail MCP Server
+ * Provides comprehensive filter management functionality
+ */
+
+// Type definitions for Gmail API filters
+export interface GmailFilterCriteria {
+    from?: string;
+    to?: string;
+    subject?: string;
+    query?: string;
+    negatedQuery?: string;
+    hasAttachment?: boolean;
+    excludeChats?: boolean;
+    size?: number;
+    sizeComparison?: 'unspecified' | 'smaller' | 'larger';
+}
+
+export interface GmailFilterAction {
+    addLabelIds?: string[];
+    removeLabelIds?: string[];
+    forward?: string;
+}
+
+export interface GmailFilter {
+    id?: string;
+    criteria: GmailFilterCriteria;
+    action: GmailFilterAction;
+}
+
+/**
+ * Creates a new Gmail filter
+ * @param gmail - Gmail API instance
+ * @param criteria - Filter criteria to match messages
+ * @param action - Actions to perform on matching messages
+ * @returns The newly created filter
+ */
+export async function createFilter(gmail: any, criteria: GmailFilterCriteria, action: GmailFilterAction) {
+    try {
+        const filterBody: GmailFilter = {
+            criteria,
+            action
+        };
+
+        const response = await gmail.users.settings.filters.create({
+            userId: 'me',
+            requestBody: filterBody,
+        });
+
+        return response.data;
+    } catch (error: any) {
+        if (error.code === 400) {
+            throw new Error(`Invalid filter criteria or action: ${error.message}`);
+        }
+        throw new Error(`Failed to create filter: ${error.message}`);
+    }
+}
+
+/**
+ * Lists all Gmail filters
+ * @param gmail - Gmail API instance
+ * @returns Array of all filters
+ */
+export async function listFilters(gmail: any) {
+    try {
+        const response = await gmail.users.settings.filters.list({
+            userId: 'me',
+        });
+
+        const filters = response.data.filter || [];
+        
+        return {
+            filters,
+            count: filters.length
+        };
+    } catch (error: any) {
+        throw new Error(`Failed to list filters: ${error.message}`);
+    }
+}
+
+/**
+ * Gets a specific Gmail filter by ID
+ * @param gmail - Gmail API instance
+ * @param filterId - ID of the filter to retrieve
+ * @returns The filter details
+ */
+export async function getFilter(gmail: any, filterId: string) {
+    try {
+        const response = await gmail.users.settings.filters.get({
+            userId: 'me',
+            id: filterId,
+        });
+
+        return response.data;
+    } catch (error: any) {
+        if (error.code === 404) {
+            throw new Error(`Filter with ID "${filterId}" not found.`);
+        }
+        throw new Error(`Failed to get filter: ${error.message}`);
+    }
+}
+
+/**
+ * Deletes a Gmail filter
+ * @param gmail - Gmail API instance
+ * @param filterId - ID of the filter to delete
+ * @returns Success message
+ */
+export async function deleteFilter(gmail: any, filterId: string) {
+    try {
+        await gmail.users.settings.filters.delete({
+            userId: 'me',
+            id: filterId,
+        });
+
+        return { success: true, message: `Filter "${filterId}" deleted successfully.` };
+    } catch (error: any) {
+        if (error.code === 404) {
+            throw new Error(`Filter with ID "${filterId}" not found.`);
+        }
+        throw new Error(`Failed to delete filter: ${error.message}`);
+    }
+}
+
+/**
+ * Helper function to create common filter patterns
+ */
+export const filterTemplates = {
+    /**
+     * Filter emails from a specific sender
+     */
+    fromSender: (senderEmail: string, labelIds: string[] = [], archive: boolean = false): { criteria: GmailFilterCriteria, action: GmailFilterAction } => ({
+        criteria: { from: senderEmail },
+        action: {
+            addLabelIds: labelIds,
+            removeLabelIds: archive ? ['INBOX'] : undefined
+        }
+    }),
+
+    /**
+     * Filter emails with specific subject
+     */
+    withSubject: (subjectText: string, labelIds: string[] = [], markAsRead: boolean = false): { criteria: GmailFilterCriteria, action: GmailFilterAction } => ({
+        criteria: { subject: subjectText },
+        action: {
+            addLabelIds: labelIds,
+            removeLabelIds: markAsRead ? ['UNREAD'] : undefined
+        }
+    }),
+
+    /**
+     * Filter emails with attachments
+     */
+    withAttachments: (labelIds: string[] = []): { criteria: GmailFilterCriteria, action: GmailFilterAction } => ({
+        criteria: { hasAttachment: true },
+        action: { addLabelIds: labelIds }
+    }),
+
+    /**
+     * Filter large emails
+     */
+    largeEmails: (sizeInBytes: number, labelIds: string[] = []): { criteria: GmailFilterCriteria, action: GmailFilterAction } => ({
+        criteria: { size: sizeInBytes, sizeComparison: 'larger' },
+        action: { addLabelIds: labelIds }
+    }),
+
+    /**
+     * Filter emails containing specific text
+     */
+    containingText: (searchText: string, labelIds: string[] = [], markImportant: boolean = false): { criteria: GmailFilterCriteria, action: GmailFilterAction } => ({
+        criteria: { query: `"${searchText}"` },
+        action: {
+            addLabelIds: markImportant ? [...labelIds, 'IMPORTANT'] : labelIds
+        }
+    }),
+
+    /**
+     * Filter mailing list emails (common patterns)
+     */
+    mailingList: (listIdentifier: string, labelIds: string[] = [], archive: boolean = true): { criteria: GmailFilterCriteria, action: GmailFilterAction } => ({
+        criteria: { query: `list:${listIdentifier} OR subject:[${listIdentifier}]` },
+        action: {
+            addLabelIds: labelIds,
+            removeLabelIds: archive ? ['INBOX'] : undefined
+        }
+    })
+}; 

--- a/vendor/gmail-mcp-fork/src/index.ts
+++ b/vendor/gmail-mcp-fork/src/index.ts
@@ -1,0 +1,1753 @@
+#!/usr/bin/env node
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+    CallToolRequestSchema,
+    ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import { google } from 'googleapis';
+import { OAuth2Client } from 'google-auth-library';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import http from 'http';
+import open from 'open';
+import os from 'os';
+import {createEmailMessage, createEmailWithNodemailer, needsRawBuilder} from "./utl.js";
+import { createLabel, updateLabel, deleteLabel, listLabels, findLabelByName, getOrCreateLabel, GmailLabel } from "./label-manager.js";
+import { createFilter, listFilters, getFilter, deleteFilter, filterTemplates, GmailFilterCriteria, GmailFilterAction } from "./filter-manager.js";
+import { parseEmailAddresses, filterOutEmail, addRePrefix, buildReferencesHeader, buildReplyAllRecipients } from "./reply-all-helpers.js";
+import { DEFAULT_SCOPES, scopeNamesToUrls, parseScopes, validateScopes, hasScope, getAvailableScopeNames } from "./scopes.js";
+import { toolDefinitions, toMcpTools, getToolByName, SendEmailSchema, ReadEmailSchema, SearchEmailsSchema, ModifyEmailSchema, DeleteEmailSchema, BatchModifyEmailsSchema, ReportPhishingSchema, BatchReportPhishingSchema, BatchDeleteEmailsSchema, CreateLabelSchema, UpdateLabelSchema, DeleteLabelSchema, GetOrCreateLabelSchema, CreateFilterSchema, GetFilterSchema, DeleteFilterSchema, CreateFilterFromTemplateSchema, DownloadAttachmentSchema, ReplyAllSchema, GetThreadSchema, ListInboxThreadsSchema, GetInboxWithThreadsSchema, DownloadEmailSchema, ModifyThreadSchema, SendDraftSchema, DeleteDraftSchema, UpdateDraftSchema } from "./tools.js";
+import { gmailMessageToJson, emailToTxt, emailToHtml, EmailAttachment } from "./email-export.js";
+import { resolveToolPrefix } from "./tool-prefix.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Configuration paths
+const CONFIG_DIR = path.join(os.homedir(), '.gmail-mcp');
+const OAUTH_PATH = process.env.GMAIL_OAUTH_PATH || path.join(CONFIG_DIR, 'gcp-oauth.keys.json');
+const CREDENTIALS_PATH = process.env.GMAIL_CREDENTIALS_PATH || path.join(CONFIG_DIR, 'credentials.json');
+
+// Optional tool-name prefix — lets multiple instances of this server run side-by-side
+// without their tool names colliding in clients that disambiguate by base name.
+// Precedence: --tool-prefix=<value> / --tool-prefix <value> CLI flag, then
+// GMAIL_MCP_TOOL_PREFIX env var, then empty (no prefix → backward compatible).
+// Does not affect the `auth` subcommand, which is detected via process.argv[2] === 'auth'
+// and exits before the server starts — run `auth` without --tool-prefix.
+const TOOL_PREFIX = resolveToolPrefix(process.argv.slice(2), process.env);
+
+// Type definitions for Gmail API responses
+interface GmailMessagePart {
+    partId?: string;
+    mimeType?: string;
+    filename?: string;
+    headers?: Array<{
+        name: string;
+        value: string;
+    }>;
+    body?: {
+        attachmentId?: string;
+        size?: number;
+        data?: string;
+    };
+    parts?: GmailMessagePart[];
+}
+
+interface EmailContent {
+    text: string;
+    html: string;
+}
+
+// OAuth2 configuration
+let oauth2Client: OAuth2Client;
+let authorizedScopes: string[] = DEFAULT_SCOPES;
+let callbackUrl: URL;
+
+/**
+ * Recursively extract email body content from MIME message parts
+ * Handles complex email structures with nested parts
+ */
+function extractEmailContent(messagePart: GmailMessagePart): EmailContent {
+    // Initialize containers for different content types
+    let textContent = '';
+    let htmlContent = '';
+
+    // If the part has a body with data, process it based on MIME type
+    if (messagePart.body && messagePart.body.data) {
+        const content = Buffer.from(messagePart.body.data, 'base64').toString('utf8');
+
+        // Store content based on its MIME type
+        if (messagePart.mimeType === 'text/plain') {
+            textContent = content;
+        } else if (messagePart.mimeType === 'text/html') {
+            htmlContent = content;
+        }
+    }
+
+    // If the part has nested parts, recursively process them
+    if (messagePart.parts && messagePart.parts.length > 0) {
+        for (const part of messagePart.parts) {
+            const { text, html } = extractEmailContent(part);
+            if (text) textContent += text;
+            if (html) htmlContent += html;
+        }
+    }
+
+    // Return both plain text and HTML content
+    return { text: textContent, html: htmlContent };
+}
+
+/**
+ * Extract common headers from Gmail message payload
+ */
+function extractHeaders(payload: any): { subject: string; from: string; to: string; cc: string; bcc: string; date: string; rfcMessageId: string } {
+    const headers = payload?.headers || [];
+    const getHeader = (name: string) =>
+        headers.find((h: any) => h.name?.toLowerCase() === name.toLowerCase())?.value || "";
+    return {
+        subject: getHeader("subject"),
+        from: getHeader("from"),
+        to: getHeader("to"),
+        cc: getHeader("cc"),
+        bcc: getHeader("bcc"),
+        date: getHeader("date"),
+        rfcMessageId: getHeader("message-id"),
+    };
+}
+
+/**
+ * Extract attachments from Gmail message payload
+ */
+function extractAttachments(payload: GmailMessagePart): EmailAttachment[] {
+    const attachments: EmailAttachment[] = [];
+
+    function processAttachmentParts(part: GmailMessagePart) {
+        if (part.body && part.body.attachmentId) {
+            attachments.push({
+                id: part.body.attachmentId,
+                filename: part.filename || `attachment-${part.body.attachmentId}`,
+                mimeType: part.mimeType || "application/octet-stream",
+                size: part.body.size || 0,
+            });
+        }
+        if (part.parts) {
+            part.parts.forEach((subpart: GmailMessagePart) => processAttachmentParts(subpart));
+        }
+    }
+
+    processAttachmentParts(payload);
+    return attachments;
+}
+
+async function loadCredentials() {
+    try {
+        // Create config directory if it doesn't exist
+        if (!process.env.GMAIL_OAUTH_PATH && !process.env.GMAIL_CREDENTIALS_PATH && !fs.existsSync(CONFIG_DIR)) {
+            fs.mkdirSync(CONFIG_DIR, { recursive: true, mode: 0o700 });
+        }
+
+        // Check for OAuth keys in current directory first, then in config directory
+        const localOAuthPath = path.join(process.cwd(), 'gcp-oauth.keys.json');
+        let oauthPath = OAUTH_PATH;
+
+        if (fs.existsSync(localOAuthPath)) {
+            // If found in current directory, copy to config directory
+            fs.copyFileSync(localOAuthPath, OAUTH_PATH);
+            console.log('OAuth keys found in current directory, copied to global config.');
+        }
+
+        if (!fs.existsSync(OAUTH_PATH)) {
+            console.error('Error: OAuth keys file not found. Please place gcp-oauth.keys.json in current directory or', CONFIG_DIR);
+            process.exit(1);
+        }
+
+        const keysContent = JSON.parse(fs.readFileSync(OAUTH_PATH, 'utf8'));
+        const keys = keysContent.installed || keysContent.web;
+
+        if (!keys) {
+            console.error('Error: Invalid OAuth keys file format. File should contain either "installed" or "web" credentials.');
+            process.exit(1);
+        }
+
+        // Parse callback URL from args (must be a URL, not a flag)
+        // Supports: node index.js auth https://example.com/callback
+        // Or: node index.js auth --scopes=gmail.readonly (uses default callback)
+        const callbackArg = process.argv.find(arg =>
+            arg.startsWith('http://') || arg.startsWith('https://')
+        );
+        const callback = callbackArg || "http://localhost:3000/oauth2callback";
+        callbackUrl = new URL(callback);
+
+        // The built-in listener is plain HTTP. An https:// callback is only valid
+        // in the documented reverse-proxy setup (README "Cloud Server Authentication"),
+        // where TLS terminates at the proxy and traffic is forwarded to the local
+        // listener on port 3000. Direct browser->listener https would hang.
+        if (callbackUrl.protocol === 'https:') {
+            console.log('https callback URL detected: assuming a reverse proxy terminates TLS and forwards to the local listener on port 3000 (see README "Cloud Server Authentication").');
+        }
+
+        oauth2Client = new OAuth2Client(
+            keys.client_id,
+            keys.client_secret,
+            callback
+        );
+
+        if (fs.existsSync(CREDENTIALS_PATH)) {
+            const credentials = JSON.parse(fs.readFileSync(CREDENTIALS_PATH, 'utf8'));
+
+            // Credentials file structure (v1.2.0+):
+            //   { "tokens": { access_token, refresh_token, ... }, "scopes": ["gmail.readonly", ...] }
+            //
+            // Legacy structure (pre-v1.2.0):
+            //   { access_token, refresh_token, ... }
+            //
+            // We support both formats for backwards compatibility. Users with legacy
+            // credentials will get DEFAULT_SCOPES (full access) until they re-authenticate.
+            const tokens = credentials.tokens || credentials;
+            oauth2Client.setCredentials(tokens);
+
+            if (credentials.scopes) {
+                authorizedScopes = credentials.scopes;
+            }
+
+            // Persist refreshed tokens so refresh_token survives access_token rotation.
+            // Without this, google-auth-library's silent refresh updates only the
+            // in-memory client; on next process start we'd re-read a stale token.
+            oauth2Client.on('tokens', (newTokens) => {
+                try {
+                    const onDisk = JSON.parse(fs.readFileSync(CREDENTIALS_PATH, 'utf8'));
+                    const currentTokens = onDisk.tokens || onDisk;
+                    const mergedTokens = newTokens.refresh_token
+                        ? { ...currentTokens, ...newTokens }
+                        : { ...currentTokens, access_token: newTokens.access_token, expiry_date: newTokens.expiry_date };
+                    const updated = onDisk.tokens
+                        ? { ...onDisk, tokens: mergedTokens }
+                        : mergedTokens;
+                    fs.writeFileSync(CREDENTIALS_PATH, JSON.stringify(updated, null, 2), { mode: 0o600 });
+                } catch (err) {
+                    console.error('Failed to persist refreshed tokens:', err);
+                }
+            });
+        }
+    } catch (error) {
+        console.error('Error loading credentials:', error);
+        process.exit(1);
+    }
+}
+
+async function authenticate(scopes: string[]) {
+    const server = http.createServer();
+    // Port derivation:
+    // - explicit port in the callback URL -> use it
+    // - portless http -> protocol default 80 (NOT 3000 — that fallback caused
+    //   the silent-hang bug this derivation exists to fix)
+    // - https -> reverse-proxy setup; the proxy forwards to the local listener
+    //   on 3000 (documented default in README "Cloud Server Authentication")
+    const port = callbackUrl.port
+        ? Number(callbackUrl.port)
+        : (callbackUrl.protocol === 'https:' ? 3000 : 80);
+    server.listen(port, '127.0.0.1');
+
+    // Convert shorthand scope names (e.g., "gmail.readonly") to full Google API URLs
+    const scopeUrls = scopeNamesToUrls(scopes);
+
+    return new Promise<void>((resolve, reject) => {
+        const authUrl = oauth2Client.generateAuthUrl({
+            access_type: 'offline',
+            prompt: 'consent',
+            scope: scopeUrls,
+        });
+
+        console.log('Requesting scopes:', scopes.join(', '));
+        console.log('Please visit this URL to authenticate:', authUrl);
+        open(authUrl);
+
+        server.on('request', async (req, res) => {
+            if (!req.url?.startsWith(callbackUrl.pathname)) return;
+
+            const url = new URL(req.url, callbackUrl.origin);
+            const code = url.searchParams.get('code');
+
+            if (!code) {
+                res.writeHead(400);
+                res.end('No code provided');
+                reject(new Error('No code provided'));
+                return;
+            }
+
+            try {
+                const { tokens } = await oauth2Client.getToken(code);
+                oauth2Client.setCredentials(tokens);
+
+                // Store both tokens and authorized scopes for runtime filtering
+                const credentials = { tokens, scopes };
+                fs.writeFileSync(CREDENTIALS_PATH, JSON.stringify(credentials, null, 2), { mode: 0o600 });
+
+                res.writeHead(200);
+                res.end('Authentication successful! You can close this window.');
+                console.log('Credentials saved with scopes:', scopes.join(', '));
+                server.close();
+                resolve();
+            } catch (error) {
+                res.writeHead(500);
+                res.end('Authentication failed');
+                reject(error);
+            }
+        });
+    });
+}
+
+// Main function
+async function main() {
+    await loadCredentials();
+
+    if (process.argv[2] === 'auth') {
+        // Parse --scopes flag from CLI arguments
+        // Usage: node dist/index.js auth --scopes=<scope1,scope2,...>
+        // Example: node dist/index.js auth --scopes=gmail.readonly
+        // Example: node dist/index.js auth --scopes=gmail.readonly,gmail.settings.basic
+        const scopesArg = process.argv.find(arg => arg.startsWith('--scopes='));
+        let scopes = DEFAULT_SCOPES;
+
+        if (scopesArg) {
+            const scopesValue = scopesArg.slice('--scopes='.length);
+            scopes = parseScopes(scopesValue);
+            const validation = validateScopes(scopes);
+
+            if (!validation.valid) {
+                console.error('Error: Invalid scope(s):', validation.invalid.join(', '));
+                console.error('Available scopes:', getAvailableScopeNames().join(', '));
+                process.exit(1);
+            }
+        } else {
+            console.log('No --scopes flag specified, using defaults:', DEFAULT_SCOPES.join(', '));
+            console.log('Tip: Use --scopes=gmail.readonly for read-only access');
+            console.log('Available scopes:', getAvailableScopeNames().join(', '));
+        }
+
+        await authenticate(scopes);
+        console.log('Authentication completed successfully');
+        process.exit(0);
+    }
+
+    // Initialize Gmail API
+    const gmail = google.gmail({ version: 'v1', auth: oauth2Client });
+
+    // Server implementation
+    const server = new Server(
+        {
+            name: "gmail",
+            version: "1.0.0",
+        },
+        {
+            capabilities: {
+                tools: {},
+            },
+        },
+    );
+
+    // Tool handlers
+    // Filter available tools based on authorized scopes
+    server.setRequestHandler(ListToolsRequestSchema, async () => {
+        const availableTools = toolDefinitions.filter(tool =>
+            hasScope(authorizedScopes, tool.scopes)
+        );
+        const mcpTools = toMcpTools(availableTools);
+        // Apply optional TOOL_PREFIX so multiple server instances can coexist
+        // in clients that dedupe tool entries by base name.
+        return { tools: mcpTools.map(t => ({ ...t, name: TOOL_PREFIX + t.name })) };
+    });
+
+    server.setRequestHandler(CallToolRequestSchema, async (request) => {
+        const { name: rawName, arguments: args } = request.params;
+
+        // Strip TOOL_PREFIX only if the result is a known base tool name.
+        // Guards against accidental over-stripping when the prefix overlaps a tool name's start
+        // (e.g. prefix="send_" + rawName="send_email" → "email", which is not a tool).
+        const stripped = TOOL_PREFIX && rawName.startsWith(TOOL_PREFIX)
+            ? rawName.slice(TOOL_PREFIX.length)
+            : rawName;
+        const name = getToolByName(stripped) ? stripped : rawName;
+
+        // Verify the tool is authorized for the current scopes
+        // This guards against direct tool calls that bypass ListTools
+        const toolDef = getToolByName(name);
+        if (!toolDef || !hasScope(authorizedScopes, toolDef.scopes)) {
+            return {
+                content: [{
+                    type: "text",
+                    text: `Error: Tool "${name}" is not available. You may need to re-authenticate with additional scopes.`,
+                }],
+            };
+        }
+
+        async function handleEmailAction(action: "send" | "draft", validatedArgs: any) {
+            let message: string;
+
+            try {
+                // Auto-resolve threading headers when threadId is provided but inReplyTo is missing
+                if (validatedArgs.threadId && !validatedArgs.inReplyTo) {
+                    try {
+                        const threadResponse = await gmail.users.threads.get({
+                            userId: 'me',
+                            id: validatedArgs.threadId,
+                            format: 'metadata',
+                            metadataHeaders: ['Message-ID'],
+                        });
+
+                        const threadMessages = threadResponse.data.messages || [];
+                        if (threadMessages.length > 0) {
+                            // Collect all Message-ID values for the References chain
+                            const allMessageIds: string[] = [];
+                            for (const msg of threadMessages) {
+                                const msgHeaders = msg.payload?.headers || [];
+                                const messageIdHeader = msgHeaders.find(
+                                    (h) => h.name?.toLowerCase() === 'message-id'
+                                );
+                                if (messageIdHeader?.value) {
+                                    allMessageIds.push(messageIdHeader.value);
+                                }
+                            }
+
+                            // Last message's Message-ID becomes In-Reply-To
+                            const lastMessage = threadMessages[threadMessages.length - 1];
+                            const lastHeaders = lastMessage.payload?.headers || [];
+                            const lastMessageId = lastHeaders.find(
+                                (h) => h.name?.toLowerCase() === 'message-id'
+                            )?.value;
+
+                            if (lastMessageId) {
+                                validatedArgs.inReplyTo = lastMessageId;
+                            }
+                            if (allMessageIds.length > 0) {
+                                validatedArgs.references = allMessageIds.join(' ');
+                            }
+                        }
+                    } catch (threadError: any) {
+                        console.warn(`Warning: Could not fetch thread ${validatedArgs.threadId} for header resolution: ${threadError.message}`);
+                        // Continue without threading headers - degraded but not broken
+                    }
+                }
+
+                // Route attachment- or inline-image-bearing mail through the raw MIME builder
+                if (needsRawBuilder(validatedArgs)) {
+                    // Use Nodemailer to create properly formatted RFC822 message
+                    message = await createEmailWithNodemailer(validatedArgs);
+                    
+                    if (action === "send") {
+                        const encodedMessage = Buffer.from(message).toString('base64')
+                            .replace(/\+/g, '-')
+                            .replace(/\//g, '_')
+                            .replace(/=+$/, '');
+
+                        const result = await gmail.users.messages.send({
+                            userId: 'me',
+                            requestBody: {
+                                raw: encodedMessage,
+                                ...(validatedArgs.threadId && { threadId: validatedArgs.threadId })
+                            }
+                        });
+                        
+                        return {
+                            content: [
+                                {
+                                    type: "text",
+                                    text: `Email sent successfully with ID: ${result.data.id}`,
+                                },
+                            ],
+                        };
+                    } else {
+                        // For drafts with attachments, use the raw message
+                        const encodedMessage = Buffer.from(message).toString('base64')
+                            .replace(/\+/g, '-')
+                            .replace(/\//g, '_')
+                            .replace(/=+$/, '');
+                        
+                        const messageRequest = {
+                            raw: encodedMessage,
+                            ...(validatedArgs.threadId && { threadId: validatedArgs.threadId })
+                        };
+                        
+                        const response = await gmail.users.drafts.create({
+                            userId: 'me',
+                            requestBody: {
+                                message: messageRequest,
+                            },
+                        });
+                        return {
+                            content: [
+                                {
+                                    type: "text",
+                                    text: `Email draft created successfully with ID: ${response.data.id}`,
+                                },
+                            ],
+                        };
+                    }
+                } else {
+                    // For plain / simple-HTML mail with no attachments or inline images
+                    message = createEmailMessage(validatedArgs);
+                    
+                    const encodedMessage = Buffer.from(message).toString('base64')
+                        .replace(/\+/g, '-')
+                        .replace(/\//g, '_')
+                        .replace(/=+$/, '');
+
+                    // Define the type for messageRequest
+                    interface GmailMessageRequest {
+                        raw: string;
+                        threadId?: string;
+                    }
+
+                    const messageRequest: GmailMessageRequest = {
+                        raw: encodedMessage,
+                    };
+
+                    // Add threadId if specified
+                    if (validatedArgs.threadId) {
+                        messageRequest.threadId = validatedArgs.threadId;
+                    }
+
+                    if (action === "send") {
+                        const response = await gmail.users.messages.send({
+                            userId: 'me',
+                            requestBody: messageRequest,
+                        });
+                        return {
+                            content: [
+                                {
+                                    type: "text",
+                                    text: `Email sent successfully with ID: ${response.data.id}`,
+                                },
+                            ],
+                        };
+                    } else {
+                        const response = await gmail.users.drafts.create({
+                            userId: 'me',
+                            requestBody: {
+                                message: messageRequest,
+                        },
+                        });
+                        return {
+                            content: [
+                                {
+                                    type: "text",
+                                    text: `Email draft created successfully with ID: ${response.data.id}`,
+                                },
+                            ],
+                        };
+                    }
+                }
+            } catch (error: any) {
+                // Log attachment / inline-image errors for debugging
+                if (needsRawBuilder(validatedArgs)) {
+                    const nAtt = validatedArgs.attachments?.length || 0;
+                    const nImg = validatedArgs.inlineImages?.length || 0;
+                    console.error(`Failed to send email with ${nAtt} attachment(s) and ${nImg} inline image(s):`, error.message);
+                }
+                throw error;
+            }
+        }
+
+        // Helper function to process operations in batches
+        async function processBatches<T, U>(
+            items: T[],
+            batchSize: number,
+            processFn: (batch: T[]) => Promise<U[]>
+        ): Promise<{ successes: U[], failures: { item: T, error: Error }[] }> {
+            const successes: U[] = [];
+            const failures: { item: T, error: Error }[] = [];
+            
+            // Process in batches
+            for (let i = 0; i < items.length; i += batchSize) {
+                const batch = items.slice(i, i + batchSize);
+                try {
+                    const results = await processFn(batch);
+                    successes.push(...results);
+                } catch (error) {
+                    // If batch fails, try individual items
+                    for (const item of batch) {
+                        try {
+                            const result = await processFn([item]);
+                            successes.push(...result);
+                        } catch (itemError) {
+                            failures.push({ item, error: itemError as Error });
+                        }
+                    }
+                }
+            }
+            
+            return { successes, failures };
+        }
+
+        try {
+            switch (name) {
+                case "send_email":
+                case "draft_email": {
+                    const validatedArgs = SendEmailSchema.parse(args);
+                    const action = name === "send_email" ? "send" : "draft";
+                    return await handleEmailAction(action, validatedArgs);
+                }
+
+                case "read_email": {
+                    const validatedArgs = ReadEmailSchema.parse(args);
+                    const response = await gmail.users.messages.get({
+                        userId: 'me',
+                        id: validatedArgs.messageId,
+                        format: 'full',
+                    });
+
+                    const { subject, from, to, cc, bcc, date, rfcMessageId } = extractHeaders(response.data.payload);
+                    const threadId = response.data.threadId || '';
+                    const { text, html } = extractEmailContent(response.data.payload as GmailMessagePart || {});
+                    const attachments = extractAttachments(response.data.payload as GmailMessagePart);
+
+                    // Use plain text content if available, otherwise use HTML content
+                    const body = text || html || '';
+                    const contentTypeNote = !text && html ?
+                        '[Note: This email is HTML-formatted. Plain text version not available.]\n\n' : '';
+
+                    // Add attachment info to output if any are present
+                    const attachmentInfo = attachments.length > 0 ?
+                        `\n\nAttachments (${attachments.length}):\n` +
+                        attachments.map(a => `- ${a.filename} (${a.mimeType}, ${Math.round(a.size/1024)} KB, ID: ${a.id})`).join('\n') : '';
+
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: `Thread ID: ${threadId}\nMessage-ID: ${rfcMessageId}\nSubject: ${subject}\nFrom: ${from}\nTo: ${to}${cc ? `\nCC: ${cc}` : ''}${bcc ? `\nBCC: ${bcc}` : ''}\nDate: ${date}\n\n${contentTypeNote}${body}${attachmentInfo}`,
+                            },
+                        ],
+                    };
+                }
+
+                case "search_emails": {
+                    const validatedArgs = SearchEmailsSchema.parse(args);
+                    const response = await gmail.users.messages.list({
+                        userId: 'me',
+                        q: validatedArgs.query,
+                        maxResults: validatedArgs.maxResults || 10,
+                    });
+
+                    const messages = response.data.messages || [];
+                    const results = await Promise.all(
+                        messages.map(async (msg) => {
+                            const detail = await gmail.users.messages.get({
+                                userId: 'me',
+                                id: msg.id!,
+                                format: 'metadata',
+                                metadataHeaders: ['Subject', 'From', 'Date'],
+                            });
+                            const headers = detail.data.payload?.headers || [];
+                            return {
+                                id: msg.id,
+                                subject: headers.find(h => h.name === 'Subject')?.value || '',
+                                from: headers.find(h => h.name === 'From')?.value || '',
+                                date: headers.find(h => h.name === 'Date')?.value || '',
+                            };
+                        })
+                    );
+
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: results.map(r =>
+                                    `ID: ${r.id}\nSubject: ${r.subject}\nFrom: ${r.from}\nDate: ${r.date}\n`
+                                ).join('\n'),
+                            },
+                        ],
+                    };
+                }
+
+                case "download_email": {
+                    const validatedArgs = DownloadEmailSchema.parse(args);
+                    const { messageId, savePath, format } = validatedArgs;
+
+                    try {
+                        // Ensure save directory exists
+                        if (!fs.existsSync(savePath)) {
+                            fs.mkdirSync(savePath, { recursive: true });
+                        }
+
+                        // Always fetch full message for metadata (needed for attachments list)
+                        const fullResponse = await gmail.users.messages.get({
+                            userId: "me",
+                            id: messageId,
+                            format: "full",
+                        });
+
+                        const { subject, from, date } = extractHeaders(fullResponse.data.payload);
+                        const attachments = extractAttachments(fullResponse.data.payload as GmailMessagePart);
+
+                        let content: string;
+
+                        if (format === "eml") {
+                            // For EML format, fetch raw RFC822 message
+                            const rawResponse = await gmail.users.messages.get({
+                                userId: "me",
+                                id: messageId,
+                                format: "raw",
+                            });
+                            content = Buffer.from(rawResponse.data.raw || "", "base64url").toString("utf-8");
+                        } else {
+                            // Extract email content for json/txt/html
+                            const emailContent = extractEmailContent(fullResponse.data.payload as GmailMessagePart || {});
+
+                            if (format === "json") {
+                                const jsonData = gmailMessageToJson(fullResponse.data, emailContent, attachments);
+                                content = JSON.stringify(jsonData, null, 2);
+                            } else if (format === "txt") {
+                                content = emailToTxt(fullResponse.data, emailContent, attachments);
+                            } else {
+                                // html - just return the raw HTML content
+                                content = emailToHtml(emailContent);
+                            }
+                        }
+
+                        // Write file
+                        const filename = `${messageId}.${format}`;
+                        const fullPath = path.join(savePath, filename);
+                        fs.writeFileSync(fullPath, content, "utf-8");
+                        const stats = fs.statSync(fullPath);
+
+                        // Return metadata with attachments
+                        const result = {
+                            status: "saved",
+                            path: fullPath,
+                            size: stats.size,
+                            messageId,
+                            subject,
+                            from,
+                            date,
+                            attachments,
+                        };
+
+                        return {
+                            content: [
+                                {
+                                    type: "text",
+                                    text: JSON.stringify(result, null, 2),
+                                },
+                            ],
+                        };
+                    } catch (error: any) {
+                        return {
+                            content: [
+                                {
+                                    type: "text",
+                                    text: `Failed to download email: ${error.message}`,
+                                },
+                            ],
+                        };
+                    }
+                }
+
+                // Updated implementation for the modify_email handler
+                case "modify_email": {
+                    const validatedArgs = ModifyEmailSchema.parse(args);
+                    
+                    // Prepare request body
+                    const requestBody: any = {};
+                    
+                    if (validatedArgs.labelIds) {
+                        requestBody.addLabelIds = validatedArgs.labelIds;
+                    }
+                    
+                    if (validatedArgs.addLabelIds) {
+                        requestBody.addLabelIds = validatedArgs.addLabelIds;
+                    }
+                    
+                    if (validatedArgs.removeLabelIds) {
+                        requestBody.removeLabelIds = validatedArgs.removeLabelIds;
+                    }
+                    
+                    await gmail.users.messages.modify({
+                        userId: 'me',
+                        id: validatedArgs.messageId,
+                        requestBody: requestBody,
+                    });
+
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: `Email ${validatedArgs.messageId} labels updated successfully`,
+                            },
+                        ],
+                    };
+                }
+
+                case "delete_email": {
+                    const validatedArgs = DeleteEmailSchema.parse(args);
+                    await gmail.users.messages.delete({
+                        userId: 'me',
+                        id: validatedArgs.messageId,
+                    });
+
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: `Email ${validatedArgs.messageId} deleted successfully`,
+                            },
+                        ],
+                    };
+                }
+
+                case "send_draft": {
+                    const validatedArgs = SendDraftSchema.parse(args);
+                    const response = await gmail.users.drafts.send({
+                        userId: 'me',
+                        requestBody: { id: validatedArgs.draftId },
+                    });
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: `Draft ${validatedArgs.draftId} sent successfully as message ID: ${response.data.id}. The draft has been removed from Drafts.`,
+                            },
+                        ],
+                    };
+                }
+
+                case "delete_draft": {
+                    const validatedArgs = DeleteDraftSchema.parse(args);
+                    await gmail.users.drafts.delete({
+                        userId: 'me',
+                        id: validatedArgs.draftId,
+                    });
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: `Draft ${validatedArgs.draftId} deleted successfully.`,
+                            },
+                        ],
+                    };
+                }
+
+                case "update_draft": {
+                    const validatedArgs = UpdateDraftSchema.parse(args);
+                    const { draftId, ...messageArgs } = validatedArgs;
+
+                    // Build the new MIME message using the same helpers as draft_email/send_email
+                    let message: string;
+                    if (needsRawBuilder(messageArgs)) {
+                        message = await createEmailWithNodemailer(messageArgs);
+                    } else {
+                        message = createEmailMessage(messageArgs);
+                    }
+
+                    const encodedMessage = Buffer.from(message).toString('base64')
+                        .replace(/\+/g, '-')
+                        .replace(/\//g, '_')
+                        .replace(/=+$/, '');
+
+                    const messageRequest: any = { raw: encodedMessage };
+                    if (messageArgs.threadId) messageRequest.threadId = messageArgs.threadId;
+
+                    const response = await gmail.users.drafts.update({
+                        userId: 'me',
+                        id: draftId,
+                        requestBody: { message: messageRequest },
+                    });
+
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: `Draft ${draftId} updated successfully (draft ID unchanged, content replaced).`,
+                            },
+                        ],
+                    };
+                }
+
+                case "list_email_labels": {
+                    const labelResults = await listLabels(gmail);
+                    const systemLabels = labelResults.system;
+                    const userLabels = labelResults.user;
+
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: `Found ${labelResults.count.total} labels (${labelResults.count.system} system, ${labelResults.count.user} user):\n\n` +
+                                    "System Labels:\n" +
+                                    systemLabels.map((l: GmailLabel) => `ID: ${l.id}\nName: ${l.name}\n`).join('\n') +
+                                    "\nUser Labels:\n" +
+                                    userLabels.map((l: GmailLabel) => `ID: ${l.id}\nName: ${l.name}\n`).join('\n')
+                            },
+                        ],
+                    };
+                }
+
+                case "batch_modify_emails": {
+                    const validatedArgs = BatchModifyEmailsSchema.parse(args);
+                    const messageIds = validatedArgs.messageIds;
+                    const batchSize = validatedArgs.batchSize || 50;
+                    
+                    // Prepare request body
+                    const requestBody: any = {};
+                    
+                    if (validatedArgs.addLabelIds) {
+                        requestBody.addLabelIds = validatedArgs.addLabelIds;
+                    }
+                    
+                    if (validatedArgs.removeLabelIds) {
+                        requestBody.removeLabelIds = validatedArgs.removeLabelIds;
+                    }
+
+                    // Process messages in batches
+                    const { successes, failures } = await processBatches(
+                        messageIds,
+                        batchSize,
+                        async (batch) => {
+                            const results = await Promise.all(
+                                batch.map(async (messageId) => {
+                                    const result = await gmail.users.messages.modify({
+                                        userId: 'me',
+                                        id: messageId,
+                                        requestBody: requestBody,
+                                    });
+                                    return { messageId, success: true };
+                                })
+                            );
+                            return results;
+                        }
+                    );
+
+                    // Generate summary of the operation
+                    const successCount = successes.length;
+                    const failureCount = failures.length;
+                    
+                    let resultText = `Batch label modification complete.\n`;
+                    resultText += `Successfully processed: ${successCount} messages\n`;
+                    
+                    if (failureCount > 0) {
+                        resultText += `Failed to process: ${failureCount} messages\n\n`;
+                        resultText += `Failed message IDs:\n`;
+                        resultText += failures.map(f => `- ${(f.item as string).substring(0, 16)}... (${f.error.message})`).join('\n');
+                    }
+
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: resultText,
+                            },
+                        ],
+                    };
+                }
+
+                case "report_phishing": {
+                    const validatedArgs = ReportPhishingSchema.parse(args);
+
+                    await gmail.users.messages.modify({
+                        userId: 'me',
+                        id: validatedArgs.messageId,
+                        requestBody: {
+                            addLabelIds: ['SPAM'],
+                        },
+                    });
+
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: `Email ${validatedArgs.messageId} was updated with the SPAM label as the closest public Gmail API approximation of reporting phishing. Note: the Gmail API does not expose the full native Report phishing workflow.`,
+                            },
+                        ],
+                    };
+                }
+
+                case "batch_report_phishing": {
+                    const validatedArgs = BatchReportPhishingSchema.parse(args);
+                    const messageIds = validatedArgs.messageIds;
+                    const batchSize = validatedArgs.batchSize || 50;
+
+                    const { successes, failures } = await processBatches(
+                        messageIds,
+                        batchSize,
+                        async (batch) => {
+                            await gmail.users.messages.batchModify({
+                                userId: 'me',
+                                requestBody: {
+                                    ids: batch,
+                                    addLabelIds: ['SPAM'],
+                                },
+                            });
+
+                            return batch.map((messageId) => ({ messageId, success: true }));
+                        }
+                    );
+
+                    const successCount = successes.length;
+                    const failureCount = failures.length;
+
+                    let resultText = `Batch phishing report complete.\n`;
+                    resultText += `Successfully processed: ${successCount} messages\n`;
+                    resultText += `Behavior: each message was updated with the SPAM label as the closest public Gmail API approximation of reporting phishing.\n`;
+                    resultText += `Limitation: the Gmail API does not expose the full native Report phishing workflow.\n`;
+
+                    if (failureCount > 0) {
+                        resultText += `Failed to process: ${failureCount} messages\n\n`;
+                        resultText += `Failed message IDs:\n`;
+                        resultText += failures.map(f => `- ${(f.item as string).substring(0, 16)}... (${f.error.message})`).join('\n');
+                    }
+
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: resultText,
+                            },
+                        ],
+                    };
+                }
+
+                case "batch_delete_emails": {
+                    const validatedArgs = BatchDeleteEmailsSchema.parse(args);
+                    const messageIds = validatedArgs.messageIds;
+                    const batchSize = validatedArgs.batchSize || 50;
+
+                    // Process messages in batches
+                    const { successes, failures } = await processBatches(
+                        messageIds,
+                        batchSize,
+                        async (batch) => {
+                            const results = await Promise.all(
+                                batch.map(async (messageId) => {
+                                    await gmail.users.messages.delete({
+                                        userId: 'me',
+                                        id: messageId,
+                                    });
+                                    return { messageId, success: true };
+                                })
+                            );
+                            return results;
+                        }
+                    );
+
+                    // Generate summary of the operation
+                    const successCount = successes.length;
+                    const failureCount = failures.length;
+                    
+                    let resultText = `Batch delete operation complete.\n`;
+                    resultText += `Successfully deleted: ${successCount} messages\n`;
+                    
+                    if (failureCount > 0) {
+                        resultText += `Failed to delete: ${failureCount} messages\n\n`;
+                        resultText += `Failed message IDs:\n`;
+                        resultText += failures.map(f => `- ${(f.item as string).substring(0, 16)}... (${f.error.message})`).join('\n');
+                    }
+
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: resultText,
+                            },
+                        ],
+                    };
+                }
+
+                // New label management handlers
+                case "create_label": {
+                    const validatedArgs = CreateLabelSchema.parse(args);
+                    const result = await createLabel(gmail, validatedArgs.name, {
+                        messageListVisibility: validatedArgs.messageListVisibility,
+                        labelListVisibility: validatedArgs.labelListVisibility,
+                    });
+
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: `Label created successfully:\nID: ${result.id}\nName: ${result.name}\nType: ${result.type}`,
+                            },
+                        ],
+                    };
+                }
+
+                case "update_label": {
+                    const validatedArgs = UpdateLabelSchema.parse(args);
+                    
+                    // Prepare request body with only the fields that were provided
+                    const updates: any = {};
+                    if (validatedArgs.name) updates.name = validatedArgs.name;
+                    if (validatedArgs.messageListVisibility) updates.messageListVisibility = validatedArgs.messageListVisibility;
+                    if (validatedArgs.labelListVisibility) updates.labelListVisibility = validatedArgs.labelListVisibility;
+                    
+                    const result = await updateLabel(gmail, validatedArgs.id, updates);
+
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: `Label updated successfully:\nID: ${result.id}\nName: ${result.name}\nType: ${result.type}`,
+                            },
+                        ],
+                    };
+                }
+
+                case "delete_label": {
+                    const validatedArgs = DeleteLabelSchema.parse(args);
+                    const result = await deleteLabel(gmail, validatedArgs.id);
+
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: result.message,
+                            },
+                        ],
+                    };
+                }
+
+                case "get_or_create_label": {
+                    const validatedArgs = GetOrCreateLabelSchema.parse(args);
+                    const result = await getOrCreateLabel(gmail, validatedArgs.name, {
+                        messageListVisibility: validatedArgs.messageListVisibility,
+                        labelListVisibility: validatedArgs.labelListVisibility,
+                    });
+
+                    const action = result.type === 'user' && result.name === validatedArgs.name ? 'found existing' : 'created new';
+                    
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: `Successfully ${action} label:\nID: ${result.id}\nName: ${result.name}\nType: ${result.type}`,
+                            },
+                        ],
+                    };
+                }
+
+
+                // Filter management handlers
+                case "create_filter": {
+                    const validatedArgs = CreateFilterSchema.parse(args);
+                    const result = await createFilter(gmail, validatedArgs.criteria, validatedArgs.action);
+
+                    // Format criteria for display
+                    const criteriaText = Object.entries(validatedArgs.criteria)
+                        .filter(([_, value]) => value !== undefined)
+                        .map(([key, value]) => `${key}: ${value}`)
+                        .join(', ');
+
+                    // Format actions for display
+                    const actionText = Object.entries(validatedArgs.action)
+                        .filter(([_, value]) => value !== undefined && (Array.isArray(value) ? value.length > 0 : true))
+                        .map(([key, value]) => `${key}: ${Array.isArray(value) ? value.join(', ') : value}`)
+                        .join(', ');
+
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: `Filter created successfully:\nID: ${result.id}\nCriteria: ${criteriaText}\nActions: ${actionText}`,
+                            },
+                        ],
+                    };
+                }
+
+                case "list_filters": {
+                    const result = await listFilters(gmail);
+                    const filters = result.filters;
+
+                    if (filters.length === 0) {
+                        return {
+                            content: [
+                                {
+                                    type: "text",
+                                    text: "No filters found.",
+                                },
+                            ],
+                        };
+                    }
+
+                    const filtersText = filters.map((filter: any) => {
+                        const criteriaEntries = Object.entries(filter.criteria || {})
+                            .filter(([_, value]) => value !== undefined)
+                            .map(([key, value]) => `${key}: ${value}`)
+                            .join(', ');
+                        
+                        const actionEntries = Object.entries(filter.action || {})
+                            .filter(([_, value]) => value !== undefined && (Array.isArray(value) ? value.length > 0 : true))
+                            .map(([key, value]) => `${key}: ${Array.isArray(value) ? value.join(', ') : value}`)
+                            .join(', ');
+
+                        return `ID: ${filter.id}\nCriteria: ${criteriaEntries}\nActions: ${actionEntries}\n`;
+                    }).join('\n');
+
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: `Found ${result.count} filters:\n\n${filtersText}`,
+                            },
+                        ],
+                    };
+                }
+
+                case "get_filter": {
+                    const validatedArgs = GetFilterSchema.parse(args);
+                    const result = await getFilter(gmail, validatedArgs.filterId);
+
+                    const criteriaText = Object.entries(result.criteria || {})
+                        .filter(([_, value]) => value !== undefined)
+                        .map(([key, value]) => `${key}: ${value}`)
+                        .join(', ');
+                    
+                    const actionText = Object.entries(result.action || {})
+                        .filter(([_, value]) => value !== undefined && (Array.isArray(value) ? value.length > 0 : true))
+                        .map(([key, value]) => `${key}: ${Array.isArray(value) ? value.join(', ') : value}`)
+                        .join(', ');
+
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: `Filter details:\nID: ${result.id}\nCriteria: ${criteriaText}\nActions: ${actionText}`,
+                            },
+                        ],
+                    };
+                }
+
+                case "delete_filter": {
+                    const validatedArgs = DeleteFilterSchema.parse(args);
+                    const result = await deleteFilter(gmail, validatedArgs.filterId);
+
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: result.message,
+                            },
+                        ],
+                    };
+                }
+
+                case "create_filter_from_template": {
+                    const validatedArgs = CreateFilterFromTemplateSchema.parse(args);
+                    const template = validatedArgs.template;
+                    const params = validatedArgs.parameters;
+
+                    let filterConfig;
+                    
+                    switch (template) {
+                        case 'fromSender':
+                            if (!params.senderEmail) throw new Error("senderEmail is required for fromSender template");
+                            filterConfig = filterTemplates.fromSender(params.senderEmail, params.labelIds, params.archive);
+                            break;
+                        case 'withSubject':
+                            if (!params.subjectText) throw new Error("subjectText is required for withSubject template");
+                            filterConfig = filterTemplates.withSubject(params.subjectText, params.labelIds, params.markAsRead);
+                            break;
+                        case 'withAttachments':
+                            filterConfig = filterTemplates.withAttachments(params.labelIds);
+                            break;
+                        case 'largeEmails':
+                            if (!params.sizeInBytes) throw new Error("sizeInBytes is required for largeEmails template");
+                            filterConfig = filterTemplates.largeEmails(params.sizeInBytes, params.labelIds);
+                            break;
+                        case 'containingText':
+                            if (!params.searchText) throw new Error("searchText is required for containingText template");
+                            filterConfig = filterTemplates.containingText(params.searchText, params.labelIds, params.markImportant);
+                            break;
+                        case 'mailingList':
+                            if (!params.listIdentifier) throw new Error("listIdentifier is required for mailingList template");
+                            filterConfig = filterTemplates.mailingList(params.listIdentifier, params.labelIds, params.archive);
+                            break;
+                        default:
+                            throw new Error(`Unknown template: ${template}`);
+                    }
+
+                    const result = await createFilter(gmail, filterConfig.criteria, filterConfig.action);
+
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: `Filter created from template '${template}':\nID: ${result.id}\nTemplate used: ${template}`,
+                            },
+                        ],
+                    };
+                }
+                case "download_attachment": {
+                    const validatedArgs = DownloadAttachmentSchema.parse(args);
+
+                    try {
+                        // Get the attachment data from Gmail API
+                        const attachmentResponse = await gmail.users.messages.attachments.get({
+                            userId: 'me',
+                            messageId: validatedArgs.messageId,
+                            id: validatedArgs.attachmentId,
+                        });
+
+                        if (!attachmentResponse.data.data) {
+                            throw new Error('No attachment data received');
+                        }
+
+                        // Decode the base64 data
+                        const data = attachmentResponse.data.data;
+                        const buffer = Buffer.from(data, 'base64url');
+
+                        // Determine save path and filename
+                        const savePath = validatedArgs.savePath || process.cwd();
+                        let filename = validatedArgs.filename;
+
+                        if (!filename) {
+                            // Get original filename from message if not provided
+                            const messageResponse = await gmail.users.messages.get({
+                                userId: 'me',
+                                id: validatedArgs.messageId,
+                                format: 'full',
+                            });
+
+                            // Find the attachment part to get original filename
+                            const findAttachment = (part: any): string | null => {
+                                if (part.body && part.body.attachmentId === validatedArgs.attachmentId) {
+                                    return part.filename || `attachment-${validatedArgs.attachmentId}`;
+                                }
+                                if (part.parts) {
+                                    for (const subpart of part.parts) {
+                                        const found = findAttachment(subpart);
+                                        if (found) return found;
+                                    }
+                                }
+                                return null;
+                            };
+
+                            filename = findAttachment(messageResponse.data.payload) || `attachment-${validatedArgs.attachmentId}`;
+                        }
+
+                        // Sanitize filename to prevent path traversal
+                        filename = path.basename(filename);
+
+                        // Ensure save directory exists
+                        if (!fs.existsSync(savePath)) {
+                            fs.mkdirSync(savePath, { recursive: true });
+                        }
+
+                        // Resolve and validate final path stays within savePath
+                        const resolvedSavePath = path.resolve(savePath);
+                        const fullPath = path.resolve(resolvedSavePath, filename);
+                        if (!fullPath.startsWith(resolvedSavePath + path.sep) && fullPath !== resolvedSavePath) {
+                            throw new Error('Invalid filename: path traversal detected');
+                        }
+                        fs.writeFileSync(fullPath, buffer);
+
+                        return {
+                            content: [
+                                {
+                                    type: "text",
+                                    text: `Attachment downloaded successfully:\nFile: ${filename}\nSize: ${buffer.length} bytes\nSaved to: ${fullPath}`,
+                                },
+                            ],
+                        };
+                    } catch (error: any) {
+                        return {
+                            content: [
+                                {
+                                    type: "text",
+                                    text: `Failed to download attachment: ${error.message}`,
+                                },
+                            ],
+                        };
+                    }
+                }
+
+                case "get_thread": {
+                    const validatedArgs = GetThreadSchema.parse(args);
+                    const threadResponse = await gmail.users.threads.get({
+                        userId: 'me',
+                        id: validatedArgs.threadId,
+                        format: validatedArgs.format || 'full',
+                    });
+
+                    const threadMessages = threadResponse.data.messages || [];
+
+                    // Process each message in the thread (already chronological from API)
+                    const messagesOutput = threadMessages.map((msg) => {
+                        const headers = msg.payload?.headers || [];
+                        const subject = headers.find(h => h.name?.toLowerCase() === 'subject')?.value || '';
+                        const from = headers.find(h => h.name?.toLowerCase() === 'from')?.value || '';
+                        const to = headers.find(h => h.name?.toLowerCase() === 'to')?.value || '';
+                        const cc = headers.find(h => h.name?.toLowerCase() === 'cc')?.value || '';
+                        const bcc = headers.find(h => h.name?.toLowerCase() === 'bcc')?.value || '';
+                        const date = headers.find(h => h.name?.toLowerCase() === 'date')?.value || '';
+
+                        // Extract body content
+                        let body = '';
+                        if (validatedArgs.format !== 'minimal') {
+                            const { text, html } = extractEmailContent(msg.payload as GmailMessagePart || {});
+                            body = text || html || '';
+                        }
+
+                        // Extract attachment metadata
+                        const attachments: EmailAttachment[] = [];
+                        const processAttachmentParts = (part: GmailMessagePart) => {
+                            if (part.body && part.body.attachmentId) {
+                                const filename = part.filename || `attachment-${part.body.attachmentId}`;
+                                attachments.push({
+                                    id: part.body.attachmentId,
+                                    filename: filename,
+                                    mimeType: part.mimeType || 'application/octet-stream',
+                                    size: part.body.size || 0,
+                                });
+                            }
+                            if (part.parts) {
+                                part.parts.forEach((subpart: GmailMessagePart) => processAttachmentParts(subpart));
+                            }
+                        };
+                        if (msg.payload) {
+                            processAttachmentParts(msg.payload as GmailMessagePart);
+                        }
+
+                        return {
+                            messageId: msg.id || '',
+                            threadId: msg.threadId || '',
+                            from,
+                            to,
+                            cc,
+                            bcc,
+                            subject,
+                            date,
+                            body,
+                            labelIds: msg.labelIds || [],
+                            attachments: attachments.map(a => ({
+                                filename: a.filename,
+                                mimeType: a.mimeType,
+                                size: a.size,
+                            })),
+                        };
+                    });
+
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: JSON.stringify({
+                                    threadId: validatedArgs.threadId,
+                                    messageCount: messagesOutput.length,
+                                    messages: messagesOutput,
+                                }, null, 2),
+                            },
+                        ],
+                    };
+                }
+
+                case "list_inbox_threads": {
+                    const validatedArgs = ListInboxThreadsSchema.parse(args);
+                    const threadsResponse = await gmail.users.threads.list({
+                        userId: 'me',
+                        q: validatedArgs.query || 'in:inbox',
+                        maxResults: validatedArgs.maxResults || 50,
+                    });
+
+                    const threads = threadsResponse.data.threads || [];
+
+                    // Fetch metadata for each thread to get message count and latest message info
+                    const threadDetails = await Promise.all(
+                        threads.map(async (thread) => {
+                            const detail = await gmail.users.threads.get({
+                                userId: 'me',
+                                id: thread.id!,
+                                format: 'metadata',
+                                metadataHeaders: ['Subject', 'From', 'Date'],
+                            });
+
+                            const messages = detail.data.messages || [];
+                            const latestMessage = messages[messages.length - 1];
+                            const latestHeaders = latestMessage?.payload?.headers || [];
+
+                            return {
+                                threadId: thread.id || '',
+                                snippet: thread.snippet || '',
+                                historyId: thread.historyId || '',
+                                messageCount: messages.length,
+                                latestMessage: {
+                                    from: latestHeaders.find(h => h.name === 'From')?.value || '',
+                                    subject: latestHeaders.find(h => h.name === 'Subject')?.value || '',
+                                    date: latestHeaders.find(h => h.name === 'Date')?.value || '',
+                                },
+                            };
+                        })
+                    );
+
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: JSON.stringify({
+                                    resultCount: threadDetails.length,
+                                    threads: threadDetails,
+                                }, null, 2),
+                            },
+                        ],
+                    };
+                }
+
+                case "get_inbox_with_threads": {
+                    const validatedArgs = GetInboxWithThreadsSchema.parse(args);
+                    const threadsResponse = await gmail.users.threads.list({
+                        userId: 'me',
+                        q: validatedArgs.query || 'in:inbox',
+                        maxResults: validatedArgs.maxResults || 50,
+                    });
+
+                    const threads = threadsResponse.data.threads || [];
+
+                    if (!validatedArgs.expandThreads) {
+                        // Return basic thread list without expansion (same as list_inbox_threads)
+                        const threadSummaries = await Promise.all(
+                            threads.map(async (thread) => {
+                                const detail = await gmail.users.threads.get({
+                                    userId: 'me',
+                                    id: thread.id!,
+                                    format: 'metadata',
+                                    metadataHeaders: ['Subject', 'From', 'Date'],
+                                });
+
+                                const messages = detail.data.messages || [];
+                                const latestMessage = messages[messages.length - 1];
+                                const latestHeaders = latestMessage?.payload?.headers || [];
+
+                                return {
+                                    threadId: thread.id || '',
+                                    snippet: thread.snippet || '',
+                                    historyId: thread.historyId || '',
+                                    messageCount: messages.length,
+                                    latestMessage: {
+                                        from: latestHeaders.find(h => h.name === 'From')?.value || '',
+                                        subject: latestHeaders.find(h => h.name === 'Subject')?.value || '',
+                                        date: latestHeaders.find(h => h.name === 'Date')?.value || '',
+                                    },
+                                };
+                            })
+                        );
+
+                        return {
+                            content: [
+                                {
+                                    type: "text",
+                                    text: JSON.stringify({
+                                        resultCount: threadSummaries.length,
+                                        threads: threadSummaries,
+                                    }, null, 2),
+                                },
+                            ],
+                        };
+                    }
+
+                    // Expand each thread with full message content (parallel fetch)
+                    const expandedThreads = await Promise.all(
+                        threads.map(async (thread) => {
+                            const threadDetail = await gmail.users.threads.get({
+                                userId: 'me',
+                                id: thread.id!,
+                                format: 'full',
+                            });
+
+                            const threadMessages = threadDetail.data.messages || [];
+
+                            const messages = threadMessages.map((msg) => {
+                                const headers = msg.payload?.headers || [];
+                                const subject = headers.find(h => h.name?.toLowerCase() === 'subject')?.value || '';
+                                const from = headers.find(h => h.name?.toLowerCase() === 'from')?.value || '';
+                                const to = headers.find(h => h.name?.toLowerCase() === 'to')?.value || '';
+                                const cc = headers.find(h => h.name?.toLowerCase() === 'cc')?.value || '';
+                                const bcc = headers.find(h => h.name?.toLowerCase() === 'bcc')?.value || '';
+                                const date = headers.find(h => h.name?.toLowerCase() === 'date')?.value || '';
+
+                                const { text, html } = extractEmailContent(msg.payload as GmailMessagePart || {});
+                                const body = text || html || '';
+
+                                // Extract attachment metadata
+                                const attachments: EmailAttachment[] = [];
+                                const processAttachmentParts = (part: GmailMessagePart) => {
+                                    if (part.body && part.body.attachmentId) {
+                                        const filename = part.filename || `attachment-${part.body.attachmentId}`;
+                                        attachments.push({
+                                            id: part.body.attachmentId,
+                                            filename: filename,
+                                            mimeType: part.mimeType || 'application/octet-stream',
+                                            size: part.body.size || 0,
+                                        });
+                                    }
+                                    if (part.parts) {
+                                        part.parts.forEach((subpart: GmailMessagePart) => processAttachmentParts(subpart));
+                                    }
+                                };
+                                if (msg.payload) {
+                                    processAttachmentParts(msg.payload as GmailMessagePart);
+                                }
+
+                                return {
+                                    messageId: msg.id || '',
+                                    threadId: msg.threadId || '',
+                                    from,
+                                    to,
+                                    cc,
+                                    bcc,
+                                    subject,
+                                    date,
+                                    body,
+                                    labelIds: msg.labelIds || [],
+                                    attachments: attachments.map(a => ({
+                                        filename: a.filename,
+                                        mimeType: a.mimeType,
+                                        size: a.size,
+                                    })),
+                                };
+                            });
+
+                            return {
+                                threadId: thread.id || '',
+                                messageCount: messages.length,
+                                messages,
+                            };
+                        })
+                    );
+
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: JSON.stringify({
+                                    resultCount: expandedThreads.length,
+                                    threads: expandedThreads,
+                                }, null, 2),
+                            },
+                        ],
+                    };
+                }
+
+                case "reply_all": {
+                    const validatedArgs = ReplyAllSchema.parse(args);
+
+                    // Fetch the original email to get headers
+                    const originalEmail = await gmail.users.messages.get({
+                        userId: 'me',
+                        id: validatedArgs.messageId,
+                        format: 'full',
+                    });
+
+                    const headers = originalEmail.data.payload?.headers || [];
+                    const threadId = originalEmail.data.threadId || '';
+
+                    // Extract relevant headers
+                    const originalFrom = headers.find(h => h.name?.toLowerCase() === 'from')?.value || '';
+                    const originalTo = headers.find(h => h.name?.toLowerCase() === 'to')?.value || '';
+                    const originalCc = headers.find(h => h.name?.toLowerCase() === 'cc')?.value || '';
+                    const originalSubject = headers.find(h => h.name?.toLowerCase() === 'subject')?.value || '';
+                    const originalMessageId = headers.find(h => h.name?.toLowerCase() === 'message-id')?.value || '';
+                    const originalReferences = headers.find(h => h.name?.toLowerCase() === 'references')?.value || '';
+
+                    // Get authenticated user's email to exclude from recipients
+                    const profile = await gmail.users.getProfile({ userId: 'me' });
+                    const myEmail = profile.data.emailAddress?.toLowerCase() || '';
+
+                    // Build recipient list using helper functions
+                    const { to: replyTo, cc: replyCc } = buildReplyAllRecipients(
+                        originalFrom,
+                        originalTo,
+                        originalCc,
+                        myEmail
+                    );
+
+                    if (replyTo.length === 0) {
+                        throw new Error('Could not determine recipient for reply');
+                    }
+
+                    // Build subject with "Re:" prefix if not already present
+                    const replySubject = addRePrefix(originalSubject);
+
+                    // Build References header (original References + original Message-ID)
+                    const references = buildReferencesHeader(originalReferences, originalMessageId);
+
+                    // Prepare the email arguments for handleEmailAction
+                    const emailArgs = {
+                        to: replyTo,
+                        cc: replyCc.length > 0 ? replyCc : undefined,
+                        subject: replySubject,
+                        body: validatedArgs.body,
+                        htmlBody: validatedArgs.htmlBody,
+                        mimeType: validatedArgs.mimeType,
+                        threadId: threadId,
+                        inReplyTo: originalMessageId,
+                        attachments: validatedArgs.attachments,
+                        inlineImages: validatedArgs.inlineImages,
+                    };
+
+                    // Use the existing handleEmailAction to send the reply
+                    const result = await handleEmailAction("send", emailArgs);
+
+                    // Enhance the response with reply-all specific info
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: `Reply-all sent successfully!\nTo: ${replyTo.join(', ')}${replyCc.length > 0 ? `\nCC: ${replyCc.join(', ')}` : ''}\nSubject: ${replySubject}\nThread ID: ${threadId}`,
+                            },
+                        ],
+                    };
+                }
+
+                case "modify_thread": {
+                    const validatedArgs = ModifyThreadSchema.parse(args);
+
+                    // Prepare request body for threads.modify
+                    const modifyRequestBody: any = {};
+
+                    if (validatedArgs.addLabelIds) {
+                        modifyRequestBody.addLabelIds = validatedArgs.addLabelIds;
+                    }
+
+                    if (validatedArgs.removeLabelIds) {
+                        modifyRequestBody.removeLabelIds = validatedArgs.removeLabelIds;
+                    }
+
+                    await gmail.users.threads.modify({
+                        userId: 'me',
+                        id: validatedArgs.threadId,
+                        requestBody: modifyRequestBody,
+                    });
+
+                    return {
+                        content: [
+                            {
+                                type: "text",
+                                text: `Thread ${validatedArgs.threadId} labels updated successfully (all messages in thread modified)`,
+                            },
+                        ],
+                    };
+                }
+
+                default:
+                    throw new Error(`Unknown tool: ${name}`);
+            }
+        } catch (error: any) {
+            return {
+                content: [
+                    {
+                        type: "text",
+                        text: `Error: ${error.message}`,
+                    },
+                ],
+            };
+        }
+    });
+
+    const transport = new StdioServerTransport();
+    server.connect(transport);
+}
+
+main().catch((error) => {
+    console.error('Server error:', error);
+    process.exit(1);
+});

--- a/vendor/gmail-mcp-fork/src/inline-images.test.ts
+++ b/vendor/gmail-mcp-fork/src/inline-images.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Tests for inline images in HTML emails (multipart/related + Content-ID).
+ *
+ * Verifies:
+ *  - createEmailWithNodemailer emits multipart/related with Content-ID + inline disposition
+ *  - path-based and base64 content-based image sources both work
+ *  - a regular attachment coexists with an inline image (multipart/mixed wrapper)
+ *  - cid values are sanitized against CRLF header injection
+ *  - inlineImages without htmlBody is rejected
+ *  - a missing inline image file is rejected
+ *  - needsRawBuilder routes attachment / inline-image mail to the raw builder
+ *  - InlineImageSchema refinements (exactly-one source, contentType-with-content, cid shape)
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createEmailWithNodemailer, needsRawBuilder, MAX_INLINE_IMAGE_CONTENT_BYTES } from './utl.js';
+import { InlineImageSchema, ReplyAllSchema } from './tools.js';
+
+// Minimal 1x1 transparent PNG used as the test image.
+const PNG_B64 =
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNgAAIAAAUAAen63NgAAAAASUVORK5CYII=';
+let imgPath: string;
+
+beforeAll(() => {
+    imgPath = path.join(os.tmpdir(), `inline-img-test-${Date.now()}.png`);
+    fs.writeFileSync(imgPath, Buffer.from(PNG_B64, 'base64'));
+});
+
+afterAll(() => {
+    if (imgPath && fs.existsSync(imgPath)) fs.unlinkSync(imgPath);
+});
+
+const baseArgs = {
+    to: ['recipient@example.com'],
+    subject: 'Inline image test',
+    body: 'Plain-text fallback',
+    htmlBody: '<p>Look:</p><img src="cid:logo1">',
+};
+
+describe('createEmailWithNodemailer — inline images', () => {
+    it('emits multipart/related with Content-ID and inline disposition (path source)', async () => {
+        const raw = await createEmailWithNodemailer({
+            ...baseArgs,
+            inlineImages: [{ cid: 'logo1', path: imgPath }],
+        });
+        expect(raw).toMatch(/Content-Type: multipart\/related/i);
+        expect(raw).toMatch(/Content-ID: <logo1>/i);
+        expect(raw).toMatch(/Content-Disposition: inline/i);
+    });
+
+    it('supports a base64 content source', async () => {
+        const raw = await createEmailWithNodemailer({
+            ...baseArgs,
+            inlineImages: [{ cid: 'logo1', content: PNG_B64, contentType: 'image/png' }],
+        });
+        expect(raw).toMatch(/multipart\/related/i);
+        expect(raw).toMatch(/Content-ID: <logo1>/i);
+        expect(raw).toMatch(/Content-Disposition: inline/i);
+    });
+
+    it('keeps the plain-text + HTML alternative present', async () => {
+        const raw = await createEmailWithNodemailer({
+            ...baseArgs,
+            inlineImages: [{ cid: 'logo1', path: imgPath }],
+        });
+        expect(raw).toMatch(/multipart\/alternative/i);
+        expect(raw).toMatch(/text\/html/i);
+        expect(raw).toMatch(/text\/plain/i);
+    });
+
+    it('embeds a regular attachment alongside an inline image (multipart/mixed)', async () => {
+        const raw = await createEmailWithNodemailer({
+            ...baseArgs,
+            attachments: [imgPath],
+            inlineImages: [{ cid: 'logo1', path: imgPath }],
+        });
+        expect(raw).toMatch(/multipart\/mixed/i);
+        expect(raw).toMatch(/multipart\/related/i);
+        expect(raw).toMatch(/Content-ID: <logo1>/i);
+    });
+
+    it('handles multiple inline images', async () => {
+        const raw = await createEmailWithNodemailer({
+            ...baseArgs,
+            htmlBody: '<img src="cid:a"><img src="cid:b">',
+            inlineImages: [
+                { cid: 'a', path: imgPath },
+                { cid: 'b', content: PNG_B64, contentType: 'image/png' },
+            ],
+        });
+        expect(raw).toMatch(/Content-ID: <a>/i);
+        expect(raw).toMatch(/Content-ID: <b>/i);
+    });
+
+    it('sanitizes CRLF injection attempts in cid (no injected header line)', async () => {
+        const raw = await createEmailWithNodemailer({
+            ...baseArgs,
+            inlineImages: [{ cid: 'logo1\r\nX-Injected: evil', path: imgPath }],
+        });
+        // The CRLF is stripped, so "X-Injected:" can never begin its own header line.
+        expect(raw).not.toMatch(/\nX-Injected:/i);
+        expect(raw).toMatch(/Content-ID:/i);
+    });
+
+    it('rejects inlineImages without htmlBody', async () => {
+        await expect(
+            createEmailWithNodemailer({
+                to: ['recipient@example.com'],
+                subject: 'No html',
+                body: 'plain only',
+                inlineImages: [{ cid: 'logo1', path: imgPath }],
+            }),
+        ).rejects.toThrow(/htmlBody/);
+    });
+
+    it('rejects a missing inline image file', async () => {
+        await expect(
+            createEmailWithNodemailer({
+                ...baseArgs,
+                inlineImages: [{ cid: 'logo1', path: '/nonexistent/path/nope.png' }],
+            }),
+        ).rejects.toThrow(/does not exist/);
+    });
+
+    it('rejects a base64 content image over the size limit', async () => {
+        const tooBig = 'A'.repeat(Math.ceil((MAX_INLINE_IMAGE_CONTENT_BYTES * 4) / 3) + 1000);
+        await expect(
+            createEmailWithNodemailer({
+                ...baseArgs,
+                inlineImages: [{ cid: 'big', content: tooBig, contentType: 'image/png' }],
+            }),
+        ).rejects.toThrow(/size limit/);
+    });
+
+    it('works with an HTML body and no plain-text body', async () => {
+        const raw = await createEmailWithNodemailer({
+            to: ['recipient@example.com'],
+            subject: 'HTML only',
+            htmlBody: '<p>No plain text here</p><img src="cid:logo1">',
+            inlineImages: [{ cid: 'logo1', path: imgPath }],
+        });
+        expect(raw).toMatch(/multipart\/related/i);
+        expect(raw).toMatch(/Content-ID: <logo1>/i);
+    });
+});
+
+describe('needsRawBuilder', () => {
+    it('is false for plain mail', () => {
+        expect(needsRawBuilder({ to: ['a@b.com'], body: 'x' })).toBe(false);
+    });
+
+    it('is true with attachments', () => {
+        expect(needsRawBuilder({ attachments: ['/a.pdf'] })).toBe(true);
+    });
+
+    it('is true with inline images', () => {
+        expect(needsRawBuilder({ inlineImages: [{ cid: 'x', path: '/a.png' }] })).toBe(true);
+    });
+
+    it('is false for empty arrays', () => {
+        expect(needsRawBuilder({ attachments: [], inlineImages: [] })).toBe(false);
+    });
+
+    it('is false for undefined args', () => {
+        expect(needsRawBuilder(undefined)).toBe(false);
+    });
+});
+
+describe('ReplyAllSchema — inline images', () => {
+    it('accepts an inlineImages array', () => {
+        expect(() =>
+            ReplyAllSchema.parse({
+                messageId: 'abc123',
+                body: 'reply text',
+                htmlBody: '<img src="cid:sig">',
+                inlineImages: [{ cid: 'sig', path: '/abs/sig.png' }],
+            }),
+        ).not.toThrow();
+    });
+});
+
+describe('InlineImageSchema', () => {
+    it('accepts a valid path-based image', () => {
+        expect(() => InlineImageSchema.parse({ cid: 'logo', path: '/abs/logo.png' })).not.toThrow();
+    });
+
+    it('accepts a valid content-based image', () => {
+        expect(() =>
+            InlineImageSchema.parse({ cid: 'logo', content: 'AAAA', contentType: 'image/png' }),
+        ).not.toThrow();
+    });
+
+    it('rejects when both path and content are set', () => {
+        expect(() =>
+            InlineImageSchema.parse({
+                cid: 'logo',
+                path: '/a.png',
+                content: 'AAAA',
+                contentType: 'image/png',
+            }),
+        ).toThrow();
+    });
+
+    it('rejects when neither path nor content is set', () => {
+        expect(() => InlineImageSchema.parse({ cid: 'logo' })).toThrow();
+    });
+
+    it('rejects content without contentType', () => {
+        expect(() => InlineImageSchema.parse({ cid: 'logo', content: 'AAAA' })).toThrow();
+    });
+
+    it('rejects a cid with whitespace or angle brackets', () => {
+        expect(() => InlineImageSchema.parse({ cid: 'bad cid', path: '/a.png' })).toThrow();
+        expect(() => InlineImageSchema.parse({ cid: '<bad>', path: '/a.png' })).toThrow();
+    });
+
+    it('rejects image/svg+xml contentType', () => {
+        expect(() =>
+            InlineImageSchema.parse({ cid: 'logo', content: 'AAAA', contentType: 'image/svg+xml' }),
+        ).toThrow();
+    });
+});

--- a/vendor/gmail-mcp-fork/src/label-manager.ts
+++ b/vendor/gmail-mcp-fork/src/label-manager.ts
@@ -1,0 +1,203 @@
+/**
+ * Label Manager for Gmail MCP Server
+ * Provides comprehensive label management functionality
+ */
+
+// Type definitions for Gmail API labels
+export interface GmailLabel {
+    id: string;
+    name: string;
+    type?: string;
+    messageListVisibility?: string;
+    labelListVisibility?: string;
+    messagesTotal?: number;
+    messagesUnread?: number;
+    color?: {
+        textColor?: string;
+        backgroundColor?: string;
+    };
+}
+
+/**
+ * Creates a new Gmail label
+ * @param gmail - Gmail API instance
+ * @param labelName - Name of the label to create
+ * @param options - Optional settings for the label
+ * @returns The newly created label
+ */
+export async function createLabel(gmail: any, labelName: string, options: {
+    messageListVisibility?: string;
+    labelListVisibility?: string;
+} = {}) {
+    try {
+        // Default visibility settings if not provided
+        const messageListVisibility = options.messageListVisibility || 'show';
+        const labelListVisibility = options.labelListVisibility || 'labelShow';
+
+        const response = await gmail.users.labels.create({
+            userId: 'me',
+            requestBody: {
+                name: labelName,
+                messageListVisibility,
+                labelListVisibility,
+            },
+        });
+
+        return response.data;
+    } catch (error: any) {
+        // Handle duplicate labels more gracefully
+        if (error.message && error.message.includes('already exists')) {
+            throw new Error(`Label "${labelName}" already exists. Please use a different name.`);
+        }
+        
+        throw new Error(`Failed to create label: ${error.message}`);
+    }
+}
+
+/**
+ * Updates an existing Gmail label
+ * @param gmail - Gmail API instance
+ * @param labelId - ID of the label to update
+ * @param updates - Properties to update
+ * @returns The updated label
+ */
+export async function updateLabel(gmail: any, labelId: string, updates: {
+    name?: string;
+    messageListVisibility?: string;
+    labelListVisibility?: string;
+}) {
+    try {
+        // Verify the label exists before updating
+        await gmail.users.labels.get({
+            userId: 'me',
+            id: labelId,
+        });
+
+        const response = await gmail.users.labels.update({
+            userId: 'me',
+            id: labelId,
+            requestBody: updates,
+        });
+
+        return response.data;
+    } catch (error: any) {
+        if (error.code === 404) {
+            throw new Error(`Label with ID "${labelId}" not found.`);
+        }
+        
+        throw new Error(`Failed to update label: ${error.message}`);
+    }
+}
+
+/**
+ * Deletes a Gmail label
+ * @param gmail - Gmail API instance
+ * @param labelId - ID of the label to delete
+ * @returns Success message
+ */
+export async function deleteLabel(gmail: any, labelId: string) {
+    try {
+        // Ensure we're not trying to delete system labels
+        const label = await gmail.users.labels.get({
+            userId: 'me',
+            id: labelId,
+        });
+        
+        if (label.data.type === 'system') {
+            throw new Error(`Cannot delete system label with ID "${labelId}".`);
+        }
+        
+        await gmail.users.labels.delete({
+            userId: 'me',
+            id: labelId,
+        });
+
+        return { success: true, message: `Label "${label.data.name}" deleted successfully.` };
+    } catch (error: any) {
+        if (error.code === 404) {
+            throw new Error(`Label with ID "${labelId}" not found.`);
+        }
+        
+        throw new Error(`Failed to delete label: ${error.message}`);
+    }
+}
+
+/**
+ * Gets a detailed list of all Gmail labels
+ * @param gmail - Gmail API instance
+ * @returns Object containing system and user labels
+ */
+export async function listLabels(gmail: any) {
+    try {
+        const response = await gmail.users.labels.list({
+            userId: 'me',
+        });
+
+        const labels = response.data.labels || [];
+        
+        // Group labels by type for better organization
+        const systemLabels = labels.filter((label:GmailLabel) => label.type === 'system');
+        const userLabels = labels.filter((label:GmailLabel) => label.type === 'user');
+
+        return {
+            all: labels,
+            system: systemLabels,
+            user: userLabels,
+            count: {
+                total: labels.length,
+                system: systemLabels.length,
+                user: userLabels.length
+            }
+        };
+    } catch (error: any) {
+        throw new Error(`Failed to list labels: ${error.message}`);
+    }
+}
+
+/**
+ * Finds a label by name
+ * @param gmail - Gmail API instance
+ * @param labelName - Name of the label to find
+ * @returns The found label or null if not found
+ */
+export async function findLabelByName(gmail: any, labelName: string) {
+    try {
+        const labelsResponse = await listLabels(gmail);
+        const allLabels = labelsResponse.all;
+        
+        // Case-insensitive match
+        const foundLabel = allLabels.find(
+            (label: GmailLabel) => label.name.toLowerCase() === labelName.toLowerCase()
+        );
+        
+        return foundLabel || null;
+    } catch (error: any) {
+        throw new Error(`Failed to find label: ${error.message}`);
+    }
+}
+
+/**
+ * Creates label if it doesn't exist or returns existing label
+ * @param gmail - Gmail API instance
+ * @param labelName - Name of the label to create
+ * @param options - Optional settings for the label
+ * @returns The new or existing label
+ */
+export async function getOrCreateLabel(gmail: any, labelName: string, options: {
+    messageListVisibility?: string;
+    labelListVisibility?: string;
+} = {}) {
+    try {
+        // First try to find an existing label
+        const existingLabel = await findLabelByName(gmail, labelName);
+        
+        if (existingLabel) {
+            return existingLabel;
+        }
+        
+        // If not found, create a new one
+        return await createLabel(gmail, labelName, options);
+    } catch (error: any) {
+        throw new Error(`Failed to get or create label: ${error.message}`);
+    }
+}

--- a/vendor/gmail-mcp-fork/src/phishing-tools.test.ts
+++ b/vendor/gmail-mcp-fork/src/phishing-tools.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+    ReportPhishingSchema,
+    BatchReportPhishingSchema,
+    getToolByName,
+    toolDefinitions,
+} from './tools.js';
+import { hasScope } from './scopes.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const srcDir = __dirname;
+
+describe('ReportPhishingSchema', () => {
+    it('parses valid single-message input', () => {
+        const result = ReportPhishingSchema.parse({ messageId: 'msg123' });
+        expect(result.messageId).toBe('msg123');
+    });
+
+    it('rejects missing messageId', () => {
+        expect(() => ReportPhishingSchema.parse({})).toThrow();
+    });
+});
+
+describe('BatchReportPhishingSchema', () => {
+    it('parses valid batch input', () => {
+        const result = BatchReportPhishingSchema.parse({
+            messageIds: ['a', 'b'],
+            batchSize: 10,
+        });
+        expect(result.messageIds).toEqual(['a', 'b']);
+        expect(result.batchSize).toBe(10);
+    });
+
+    it('defaults batchSize to 50', () => {
+        const result = BatchReportPhishingSchema.parse({
+            messageIds: ['a'],
+        });
+        expect(result.batchSize).toBe(50);
+    });
+});
+
+describe('Phishing tool definitions', () => {
+    it('registers report_phishing in toolDefinitions', () => {
+        const tool = getToolByName('report_phishing');
+        expect(tool).toBeDefined();
+        expect(tool!.name).toBe('report_phishing');
+        expect(tool!.scopes).toContain('gmail.modify');
+    });
+
+    it('registers batch_report_phishing in toolDefinitions', () => {
+        const tool = getToolByName('batch_report_phishing');
+        expect(tool).toBeDefined();
+        expect(tool!.name).toBe('batch_report_phishing');
+        expect(tool!.scopes).toContain('gmail.modify');
+    });
+
+    it('includes both phishing tools in the global tool list', () => {
+        const phishingTools = toolDefinitions.filter(t =>
+            ['report_phishing', 'batch_report_phishing'].includes(t.name)
+        );
+        expect(phishingTools).toHaveLength(2);
+    });
+
+    it('makes phishing tools available with gmail.modify scope', () => {
+        const singleTool = getToolByName('report_phishing')!;
+        const batchTool = getToolByName('batch_report_phishing')!;
+        expect(hasScope(['gmail.modify'], singleTool.scopes)).toBe(true);
+        expect(hasScope(['gmail.modify'], batchTool.scopes)).toBe(true);
+    });
+});
+
+describe('Source verification', () => {
+    it('single phishing report uses SPAM label flow', () => {
+        const source = fs.readFileSync(path.join(srcDir, 'index.ts'), 'utf-8');
+        expect(source).toContain('case "report_phishing"');
+        expect(source).toContain("addLabelIds: ['SPAM']");
+        expect(source).toContain('closest public Gmail API approximation of reporting phishing');
+        expect(source).toContain('does not expose the full native Report phishing workflow');
+    });
+
+    it('batch phishing report uses batchModify with SPAM label flow and documents limitation', () => {
+        const source = fs.readFileSync(path.join(srcDir, 'index.ts'), 'utf-8');
+        expect(source).toContain('case "batch_report_phishing"');
+        expect(source).toContain('gmail.users.messages.batchModify');
+        expect(source).toContain('ids: batch');
+        expect(source).toContain('Batch phishing report complete.');
+        expect(source).toContain('closest public Gmail API approximation of reporting phishing');
+        expect(source).toContain('does not expose the full native Report phishing workflow');
+    });
+});

--- a/vendor/gmail-mcp-fork/src/reply-all-helpers.test.ts
+++ b/vendor/gmail-mcp-fork/src/reply-all-helpers.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect } from 'vitest';
+import {
+    parseEmailAddresses,
+    filterOutEmail,
+    addRePrefix,
+    buildReferencesHeader,
+    buildReplyAllRecipients
+} from './reply-all-helpers.js';
+
+describe('parseEmailAddresses', () => {
+    it('extracts email from simple email address', () => {
+        expect(parseEmailAddresses('user@example.com')).toEqual(['user@example.com']);
+    });
+
+    it('extracts email from "Name <email>" format', () => {
+        expect(parseEmailAddresses('John Doe <john@example.com>')).toEqual(['john@example.com']);
+    });
+
+    it('handles multiple addresses separated by commas', () => {
+        expect(parseEmailAddresses('alice@example.com, bob@example.com'))
+            .toEqual(['alice@example.com', 'bob@example.com']);
+    });
+
+    it('handles mixed formats with multiple addresses', () => {
+        expect(parseEmailAddresses('Alice <alice@example.com>, bob@example.com, Carol Smith <carol@example.com>'))
+            .toEqual(['alice@example.com', 'bob@example.com', 'carol@example.com']);
+    });
+
+    it('handles empty string', () => {
+        expect(parseEmailAddresses('')).toEqual([]);
+    });
+
+    it('handles whitespace around addresses', () => {
+        expect(parseEmailAddresses('  user@example.com  ,  other@example.com  '))
+            .toEqual(['user@example.com', 'other@example.com']);
+    });
+
+    it('handles angle brackets with spaces', () => {
+        expect(parseEmailAddresses('Name < email@example.com >')).toEqual(['email@example.com']);
+    });
+
+    it('ignores entries without @ symbol', () => {
+        expect(parseEmailAddresses('invalid, user@example.com')).toEqual(['user@example.com']);
+    });
+});
+
+describe('filterOutEmail', () => {
+    it('filters out matching email', () => {
+        const emails = ['alice@example.com', 'bob@example.com', 'carol@example.com'];
+        expect(filterOutEmail(emails, 'bob@example.com')).toEqual(['alice@example.com', 'carol@example.com']);
+    });
+
+    it('is case insensitive', () => {
+        const emails = ['Alice@Example.com', 'bob@example.com'];
+        expect(filterOutEmail(emails, 'alice@example.com')).toEqual(['bob@example.com']);
+    });
+
+    it('returns all emails if none match', () => {
+        const emails = ['alice@example.com', 'bob@example.com'];
+        expect(filterOutEmail(emails, 'carol@example.com')).toEqual(['alice@example.com', 'bob@example.com']);
+    });
+
+    it('handles empty array', () => {
+        expect(filterOutEmail([], 'user@example.com')).toEqual([]);
+    });
+
+    it('handles empty filter email', () => {
+        const emails = ['alice@example.com'];
+        expect(filterOutEmail(emails, '')).toEqual(['alice@example.com']);
+    });
+});
+
+describe('addRePrefix', () => {
+    it('adds Re: prefix to subject without it', () => {
+        expect(addRePrefix('Hello')).toBe('Re: Hello');
+    });
+
+    it('does not add Re: prefix if already present (lowercase)', () => {
+        expect(addRePrefix('re: Hello')).toBe('re: Hello');
+    });
+
+    it('does not add Re: prefix if already present (uppercase)', () => {
+        expect(addRePrefix('Re: Hello')).toBe('Re: Hello');
+    });
+
+    it('does not add Re: prefix if already present (mixed case)', () => {
+        expect(addRePrefix('RE: Hello')).toBe('RE: Hello');
+    });
+
+    it('handles empty subject', () => {
+        expect(addRePrefix('')).toBe('Re: ');
+    });
+
+    it('adds prefix when subject starts with similar but not Re:', () => {
+        expect(addRePrefix('Regarding: Hello')).toBe('Re: Regarding: Hello');
+    });
+});
+
+describe('buildReferencesHeader', () => {
+    it('returns message ID when no original references', () => {
+        expect(buildReferencesHeader('', '<msg123@example.com>')).toBe('<msg123@example.com>');
+    });
+
+    it('appends message ID to existing references', () => {
+        expect(buildReferencesHeader('<ref1@example.com>', '<msg123@example.com>'))
+            .toBe('<ref1@example.com> <msg123@example.com>');
+    });
+
+    it('returns empty string when both are empty', () => {
+        expect(buildReferencesHeader('', '')).toBe('');
+    });
+
+    it('returns original references when message ID is empty', () => {
+        expect(buildReferencesHeader('<ref1@example.com>', '')).toBe('<ref1@example.com>');
+    });
+
+    it('handles multiple existing references', () => {
+        expect(buildReferencesHeader('<ref1@example.com> <ref2@example.com>', '<msg123@example.com>'))
+            .toBe('<ref1@example.com> <ref2@example.com> <msg123@example.com>');
+    });
+});
+
+describe('buildReplyAllRecipients', () => {
+    const myEmail = 'me@example.com';
+
+    it('puts original sender in To field', () => {
+        const result = buildReplyAllRecipients(
+            'sender@example.com',
+            'me@example.com',
+            '',
+            myEmail
+        );
+        expect(result.to).toEqual(['sender@example.com']);
+    });
+
+    it('puts original To and CC in CC field', () => {
+        const result = buildReplyAllRecipients(
+            'sender@example.com',
+            'recipient1@example.com, recipient2@example.com',
+            'cc1@example.com',
+            myEmail
+        );
+        expect(result.cc).toEqual(['recipient1@example.com', 'recipient2@example.com', 'cc1@example.com']);
+    });
+
+    it('excludes authenticated user from CC', () => {
+        const result = buildReplyAllRecipients(
+            'sender@example.com',
+            'me@example.com, other@example.com',
+            'me@example.com, another@example.com',
+            myEmail
+        );
+        expect(result.cc).toEqual(['other@example.com', 'another@example.com']);
+        expect(result.cc).not.toContain('me@example.com');
+    });
+
+    it('excludes authenticated user from To when sender is self', () => {
+        const result = buildReplyAllRecipients(
+            'me@example.com',
+            'recipient@example.com',
+            '',
+            myEmail
+        );
+        expect(result.to).toEqual([]);
+    });
+
+    it('handles Name <email> format in From', () => {
+        const result = buildReplyAllRecipients(
+            'John Doe <john@example.com>',
+            'me@example.com',
+            '',
+            myEmail
+        );
+        expect(result.to).toEqual(['john@example.com']);
+    });
+
+    it('handles complex scenario with mixed formats', () => {
+        const result = buildReplyAllRecipients(
+            'Alice <alice@example.com>',
+            'Me <me@example.com>, Bob <bob@example.com>',
+            'Carol <carol@example.com>, me@example.com',
+            myEmail
+        );
+        expect(result.to).toEqual(['alice@example.com']);
+        expect(result.cc).toEqual(['bob@example.com', 'carol@example.com']);
+    });
+
+    it('handles empty CC header', () => {
+        const result = buildReplyAllRecipients(
+            'sender@example.com',
+            'recipient@example.com',
+            '',
+            myEmail
+        );
+        expect(result.cc).toEqual(['recipient@example.com']);
+    });
+
+    it('is case insensitive when excluding authenticated user', () => {
+        const result = buildReplyAllRecipients(
+            'sender@example.com',
+            'ME@EXAMPLE.COM, other@example.com',
+            '',
+            myEmail
+        );
+        expect(result.cc).toEqual(['other@example.com']);
+    });
+});

--- a/vendor/gmail-mcp-fork/src/reply-all-helpers.ts
+++ b/vendor/gmail-mcp-fork/src/reply-all-helpers.ts
@@ -1,0 +1,111 @@
+/**
+ * Helper functions for reply_all email functionality.
+ * Extracted for testability.
+ */
+
+/**
+ * Parses email addresses from a header value.
+ * Handles formats like:
+ * - "email@example.com"
+ * - "Name <email@example.com>"
+ * - Multiple addresses separated by commas
+ *
+ * @param headerValue - The raw header value (e.g., From, To, CC)
+ * @returns Array of extracted email addresses
+ */
+export function parseEmailAddresses(headerValue: string): string[] {
+    if (!headerValue) return [];
+
+    const emails: string[] = [];
+    const parts = headerValue.split(',');
+
+    for (const part of parts) {
+        const trimmed = part.trim();
+        // Extract email from "Name <email>" format
+        const match = trimmed.match(/<([^>]+)>/);
+        if (match) {
+            emails.push(match[1].trim());
+        } else if (trimmed.includes('@')) {
+            emails.push(trimmed);
+        }
+    }
+
+    return emails;
+}
+
+/**
+ * Filters out the authenticated user's email from a list of emails.
+ * Case-insensitive comparison.
+ *
+ * @param emails - Array of email addresses to filter
+ * @param myEmail - The authenticated user's email address
+ * @returns Filtered array excluding the user's email
+ */
+export function filterOutEmail(emails: string[], myEmail: string): string[] {
+    const myEmailLower = myEmail.toLowerCase();
+    return emails.filter(email => email.toLowerCase() !== myEmailLower);
+}
+
+/**
+ * Adds "Re: " prefix to a subject if not already present.
+ * Case-insensitive check for existing prefix.
+ *
+ * @param subject - The original email subject
+ * @returns Subject with "Re: " prefix
+ */
+export function addRePrefix(subject: string): string {
+    if (subject.toLowerCase().startsWith('re:')) {
+        return subject;
+    }
+    return `Re: ${subject}`;
+}
+
+/**
+ * Builds the References header for a reply email.
+ * Combines original References with original Message-ID.
+ *
+ * @param originalReferences - The References header from the original email
+ * @param originalMessageId - The Message-ID of the original email
+ * @returns Combined References header value
+ */
+export function buildReferencesHeader(originalReferences: string, originalMessageId: string): string {
+    if (!originalMessageId) {
+        return originalReferences;
+    }
+    return originalReferences ? `${originalReferences} ${originalMessageId}` : originalMessageId;
+}
+
+/**
+ * Builds recipient lists for a reply-all email.
+ *
+ * Rules:
+ * - TO: original From (sender of the email)
+ * - CC: original To + original CC (excluding the authenticated user)
+ *
+ * @param originalFrom - From header value
+ * @param originalTo - To header value
+ * @param originalCc - CC header value
+ * @param myEmail - The authenticated user's email address
+ * @returns Object with 'to' and 'cc' arrays
+ */
+export function buildReplyAllRecipients(
+    originalFrom: string,
+    originalTo: string,
+    originalCc: string,
+    myEmail: string
+): { to: string[]; cc: string[] } {
+    const fromEmails = parseEmailAddresses(originalFrom);
+    const toEmails = parseEmailAddresses(originalTo);
+    const ccEmails = parseEmailAddresses(originalCc);
+
+    // TO recipients: original From (the person who sent the email), excluding myself
+    const replyTo = filterOutEmail(fromEmails, myEmail);
+
+    // CC recipients: everyone else who was on To and CC, excluding myself
+    const replyCc = filterOutEmail([...toEmails, ...ccEmails], myEmail);
+
+    return {
+        to: replyTo,
+        cc: replyCc
+    };
+}

--- a/vendor/gmail-mcp-fork/src/scopes.ts
+++ b/vendor/gmail-mcp-fork/src/scopes.ts
@@ -1,0 +1,92 @@
+// Gmail API OAuth2 scope definitions and helpers
+//
+// Scope hierarchy (for reference):
+//   - gmail.readonly: Read-only access to emails
+//   - gmail.modify: Read AND write access (superset of readonly)
+//   - gmail.compose: Create drafts and send emails
+//   - gmail.send: Send emails only
+//   - gmail.labels: Manage labels only
+//   - gmail.settings.basic: Manage filters and settings
+//   - gmail.full: Full mailbox access, including permanent deletion
+//
+// Note: gmail.modify includes all capabilities of gmail.readonly,
+// so you don't need both scopes together.
+
+// Map shorthand scope names to full Google API URLs
+export const SCOPE_MAP: Record<string, string> = {
+  "gmail.readonly": "https://www.googleapis.com/auth/gmail.readonly",
+  "gmail.modify": "https://www.googleapis.com/auth/gmail.modify",
+  "gmail.compose": "https://www.googleapis.com/auth/gmail.compose",
+  "gmail.send": "https://www.googleapis.com/auth/gmail.send",
+  "gmail.labels": "https://www.googleapis.com/auth/gmail.labels",
+  "gmail.full": "https://mail.google.com/",
+  "gmail.settings.basic": "https://www.googleapis.com/auth/gmail.settings.basic",
+  "gmail.settings.sharing": "https://www.googleapis.com/auth/gmail.settings.sharing",
+};
+
+// Reverse map for converting full URLs back to shorthand
+export const SCOPE_REVERSE_MAP: Record<string, string> = Object.fromEntries(
+  Object.entries(SCOPE_MAP).map(([short, full]) => [full, short])
+);
+
+// Default scopes (original behavior)
+export const DEFAULT_SCOPES = ["gmail.modify", "gmail.settings.basic"];
+
+// Convert shorthand scope name to full Google API URL
+// e.g., "gmail.readonly" -> "https://www.googleapis.com/auth/gmail.readonly"
+export function scopeNameToUrl(scope: string): string {
+  return SCOPE_MAP[scope] || scope;
+}
+
+// Convert full Google API URL to shorthand name
+// e.g., "https://www.googleapis.com/auth/gmail.readonly" -> "gmail.readonly"
+export function scopeUrlToName(scope: string): string {
+  return SCOPE_REVERSE_MAP[scope] || scope;
+}
+
+// Convert array of shorthand scope names to full Google API URLs
+export function scopeNamesToUrls(scopes: string[]): string[] {
+  return scopes.map(scopeNameToUrl);
+}
+
+// Scopes satisfied by gmail.full (https://mail.google.com/), which Google
+// treats as a superset of the mail scopes. It does NOT cover the settings
+// scopes — Gmail's settings endpoints only accept gmail.settings.* .
+const GMAIL_FULL_COVERS = new Set([
+  "gmail.readonly",
+  "gmail.modify",
+  "gmail.compose",
+  "gmail.send",
+  "gmail.labels",
+  "gmail.full",
+]);
+
+// Check if the authorized scopes grant access to a tool
+// Returns true if ANY of the tool's required scopes are present in authorizedScopes
+export function hasScope(authorizedScopes: string[], requiredScopes: string[]): boolean {
+  // Normalize to shorthand names for comparison (handles both URL and shorthand input)
+  const normalizedAuth = authorizedScopes.map(scopeUrlToName);
+  const hasFull = normalizedAuth.includes("gmail.full");
+  return requiredScopes.some(scope =>
+    normalizedAuth.includes(scope) || (hasFull && GMAIL_FULL_COVERS.has(scope))
+  );
+}
+
+// Parse scope input from CLI (comma-separated or space-separated)
+export function parseScopes(input: string): string[] {
+  return input
+    .split(/[,\s]+/)
+    .map(s => s.trim())
+    .filter(s => s.length > 0);
+}
+
+// Validate that all scopes are recognized
+export function validateScopes(scopes: string[]): { valid: boolean; invalid: string[] } {
+  const invalid = scopes.filter(s => !SCOPE_MAP[s]);
+  return { valid: invalid.length === 0, invalid };
+}
+
+// Get available scope names for help text
+export function getAvailableScopeNames(): string[] {
+  return Object.keys(SCOPE_MAP);
+}

--- a/vendor/gmail-mcp-fork/src/thread-tools.test.ts
+++ b/vendor/gmail-mcp-fork/src/thread-tools.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect } from 'vitest';
+import {
+    GetThreadSchema,
+    ListInboxThreadsSchema,
+    GetInboxWithThreadsSchema,
+    ModifyThreadSchema,
+    toolDefinitions,
+    getToolByName,
+} from './tools.js';
+
+describe('GetThreadSchema', () => {
+    it('parses with required threadId', () => {
+        const result = GetThreadSchema.parse({ threadId: '18abc123' });
+        expect(result.threadId).toBe('18abc123');
+        expect(result.format).toBe('full'); // default
+    });
+
+    it('accepts optional format parameter', () => {
+        const result = GetThreadSchema.parse({ threadId: '18abc123', format: 'metadata' });
+        expect(result.format).toBe('metadata');
+    });
+
+    it('accepts minimal format', () => {
+        const result = GetThreadSchema.parse({ threadId: '18abc123', format: 'minimal' });
+        expect(result.format).toBe('minimal');
+    });
+
+    it('rejects invalid format', () => {
+        expect(() => GetThreadSchema.parse({ threadId: '18abc123', format: 'invalid' })).toThrow();
+    });
+
+    it('rejects missing threadId', () => {
+        expect(() => GetThreadSchema.parse({})).toThrow();
+    });
+});
+
+describe('ListInboxThreadsSchema', () => {
+    it('parses with defaults when no args provided', () => {
+        const result = ListInboxThreadsSchema.parse({});
+        expect(result.query).toBe('in:inbox');
+        expect(result.maxResults).toBe(50);
+    });
+
+    it('accepts custom query', () => {
+        const result = ListInboxThreadsSchema.parse({ query: 'from:user@example.com' });
+        expect(result.query).toBe('from:user@example.com');
+    });
+
+    it('accepts custom maxResults', () => {
+        const result = ListInboxThreadsSchema.parse({ maxResults: 10 });
+        expect(result.maxResults).toBe(10);
+    });
+
+    it('accepts both custom query and maxResults', () => {
+        const result = ListInboxThreadsSchema.parse({ query: 'is:unread', maxResults: 25 });
+        expect(result.query).toBe('is:unread');
+        expect(result.maxResults).toBe(25);
+    });
+});
+
+describe('GetInboxWithThreadsSchema', () => {
+    it('parses with defaults when no args provided', () => {
+        const result = GetInboxWithThreadsSchema.parse({});
+        expect(result.query).toBe('in:inbox');
+        expect(result.maxResults).toBe(50);
+        expect(result.expandThreads).toBe(true);
+    });
+
+    it('accepts expandThreads = false', () => {
+        const result = GetInboxWithThreadsSchema.parse({ expandThreads: false });
+        expect(result.expandThreads).toBe(false);
+    });
+
+    it('accepts all custom parameters', () => {
+        const result = GetInboxWithThreadsSchema.parse({
+            query: 'label:important',
+            maxResults: 5,
+            expandThreads: false,
+        });
+        expect(result.query).toBe('label:important');
+        expect(result.maxResults).toBe(5);
+        expect(result.expandThreads).toBe(false);
+    });
+});
+
+describe('ModifyThreadSchema', () => {
+    it('parses with required threadId only', () => {
+        const result = ModifyThreadSchema.parse({ threadId: '18abc123' });
+        expect(result.threadId).toBe('18abc123');
+        expect(result.addLabelIds).toBeUndefined();
+        expect(result.removeLabelIds).toBeUndefined();
+    });
+
+    it('accepts addLabelIds', () => {
+        const result = ModifyThreadSchema.parse({
+            threadId: '18abc123',
+            addLabelIds: ['Label_1', 'Label_2'],
+        });
+        expect(result.addLabelIds).toEqual(['Label_1', 'Label_2']);
+    });
+
+    it('accepts removeLabelIds', () => {
+        const result = ModifyThreadSchema.parse({
+            threadId: '18abc123',
+            removeLabelIds: ['INBOX', 'UNREAD'],
+        });
+        expect(result.removeLabelIds).toEqual(['INBOX', 'UNREAD']);
+    });
+
+    it('accepts both addLabelIds and removeLabelIds', () => {
+        const result = ModifyThreadSchema.parse({
+            threadId: '18abc123',
+            addLabelIds: ['Label_1'],
+            removeLabelIds: ['INBOX'],
+        });
+        expect(result.addLabelIds).toEqual(['Label_1']);
+        expect(result.removeLabelIds).toEqual(['INBOX']);
+    });
+
+    it('rejects missing threadId', () => {
+        expect(() => ModifyThreadSchema.parse({})).toThrow();
+    });
+
+    it('rejects non-string threadId', () => {
+        expect(() => ModifyThreadSchema.parse({ threadId: 12345 })).toThrow();
+    });
+
+    it('rejects non-array addLabelIds', () => {
+        expect(() => ModifyThreadSchema.parse({ threadId: '18abc123', addLabelIds: 'INBOX' })).toThrow();
+    });
+
+    it('rejects non-array removeLabelIds', () => {
+        expect(() => ModifyThreadSchema.parse({ threadId: '18abc123', removeLabelIds: 'INBOX' })).toThrow();
+    });
+});
+
+describe('Thread tool definitions', () => {
+    it('registers get_thread in toolDefinitions', () => {
+        const tool = getToolByName('get_thread');
+        expect(tool).toBeDefined();
+        expect(tool!.name).toBe('get_thread');
+        expect(tool!.scopes).toContain('gmail.readonly');
+        expect(tool!.scopes).toContain('gmail.modify');
+    });
+
+    it('registers list_inbox_threads in toolDefinitions', () => {
+        const tool = getToolByName('list_inbox_threads');
+        expect(tool).toBeDefined();
+        expect(tool!.name).toBe('list_inbox_threads');
+        expect(tool!.scopes).toContain('gmail.readonly');
+        expect(tool!.scopes).toContain('gmail.modify');
+    });
+
+    it('registers get_inbox_with_threads in toolDefinitions', () => {
+        const tool = getToolByName('get_inbox_with_threads');
+        expect(tool).toBeDefined();
+        expect(tool!.name).toBe('get_inbox_with_threads');
+        expect(tool!.scopes).toContain('gmail.readonly');
+        expect(tool!.scopes).toContain('gmail.modify');
+    });
+
+    it('registers modify_thread in toolDefinitions', () => {
+        const tool = getToolByName('modify_thread');
+        expect(tool).toBeDefined();
+        expect(tool!.name).toBe('modify_thread');
+        expect(tool!.scopes).toContain('gmail.modify');
+        expect(tool!.annotations.destructiveHint).toBe(true);
+        expect(tool!.annotations.idempotentHint).toBe(true);
+    });
+
+    it('modify_thread description mentions atomic thread-level operation', () => {
+        const tool = getToolByName('modify_thread');
+        expect(tool!.description).toContain('ALL messages');
+        expect(tool!.description).toContain('atomically');
+    });
+
+    it('has descriptions for all thread tools', () => {
+        const threadTools = ['get_thread', 'list_inbox_threads', 'get_inbox_with_threads', 'modify_thread'];
+        for (const toolName of threadTools) {
+            const tool = getToolByName(toolName);
+            expect(tool!.description).toBeTruthy();
+            expect(tool!.description.length).toBeGreaterThan(10);
+        }
+    });
+
+    it('total tool count includes the 4 thread tools', () => {
+        const threadToolNames = ['get_thread', 'list_inbox_threads', 'get_inbox_with_threads', 'modify_thread'];
+        const threadTools = toolDefinitions.filter(t => threadToolNames.includes(t.name));
+        expect(threadTools).toHaveLength(4);
+    });
+});

--- a/vendor/gmail-mcp-fork/src/tool-prefix.test.ts
+++ b/vendor/gmail-mcp-fork/src/tool-prefix.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { resolveToolPrefix } from './tool-prefix.js';
+
+const NO_ENV: NodeJS.ProcessEnv = {};
+
+describe('resolveToolPrefix', () => {
+    describe('default (backward compatibility)', () => {
+        it('returns empty string when no args and no env var', () => {
+            expect(resolveToolPrefix([], NO_ENV)).toBe('');
+        });
+
+        it('returns empty string for unrelated args', () => {
+            expect(resolveToolPrefix(['auth', '--scopes=gmail.readonly'], NO_ENV)).toBe('');
+        });
+    });
+
+    describe('--tool-prefix=<value> form', () => {
+        it('parses the value after the equals sign', () => {
+            expect(resolveToolPrefix(['--tool-prefix=personal_'], NO_ENV)).toBe('personal_');
+        });
+
+        it('treats an empty value as no prefix', () => {
+            expect(resolveToolPrefix(['--tool-prefix='], NO_ENV)).toBe('');
+        });
+
+        it('finds the flag among other args', () => {
+            expect(resolveToolPrefix(['--scopes=gmail.modify', '--tool-prefix=info_'], NO_ENV)).toBe('info_');
+        });
+
+        it('preserves a value that itself contains an equals sign', () => {
+            expect(resolveToolPrefix(['--tool-prefix=a=b_'], NO_ENV)).toBe('a=b_');
+        });
+    });
+
+    describe('--tool-prefix <value> (space-separated) form', () => {
+        it('parses the value in the next argv slot', () => {
+            expect(resolveToolPrefix(['--tool-prefix', 'shared_'], NO_ENV)).toBe('shared_');
+        });
+
+        it('falls through when the flag is the final arg with no value', () => {
+            expect(resolveToolPrefix(['--tool-prefix'], NO_ENV)).toBe('');
+        });
+    });
+
+    describe('GMAIL_MCP_TOOL_PREFIX env var fallback', () => {
+        it('uses the env var when no CLI flag is present', () => {
+            expect(resolveToolPrefix([], { GMAIL_MCP_TOOL_PREFIX: 'envprefix_' })).toBe('envprefix_');
+        });
+
+        it('treats an empty env var as no prefix', () => {
+            expect(resolveToolPrefix([], { GMAIL_MCP_TOOL_PREFIX: '' })).toBe('');
+        });
+    });
+
+    describe('precedence', () => {
+        it('CLI flag (=form) overrides the env var', () => {
+            expect(resolveToolPrefix(['--tool-prefix=cli_'], { GMAIL_MCP_TOOL_PREFIX: 'env_' })).toBe('cli_');
+        });
+
+        it('CLI flag (space form) overrides the env var', () => {
+            expect(resolveToolPrefix(['--tool-prefix', 'cli_'], { GMAIL_MCP_TOOL_PREFIX: 'env_' })).toBe('cli_');
+        });
+
+        it('first --tool-prefix occurrence wins when the flag is repeated', () => {
+            expect(resolveToolPrefix(['--tool-prefix=first_', '--tool-prefix=second_'], NO_ENV)).toBe('first_');
+        });
+    });
+});

--- a/vendor/gmail-mcp-fork/src/tool-prefix.ts
+++ b/vendor/gmail-mcp-fork/src/tool-prefix.ts
@@ -1,0 +1,29 @@
+/**
+ * Resolves the optional tool-name prefix that lets multiple instances of this
+ * server run side-by-side without their tool names colliding in MCP clients
+ * that disambiguate tools by base name.
+ *
+ * Precedence: `--tool-prefix=<value>` / `--tool-prefix <value>` CLI flag, then
+ * the `GMAIL_MCP_TOOL_PREFIX` env var, then empty string (no prefix — the
+ * backward-compatible default).
+ *
+ * Pure function: argv (already sliced past the node binary and script) and the
+ * env map are passed in explicitly, so it is unit-testable without spawning the
+ * process.
+ *
+ * @param args - `process.argv.slice(2)`: CLI args past the node binary and script
+ * @param env  - environment map (`process.env`)
+ * @returns the resolved prefix, or `''` when none is configured
+ */
+export function resolveToolPrefix(args: string[], env: NodeJS.ProcessEnv): string {
+    for (let i = 0; i < args.length; i++) {
+        const arg = args[i] ?? '';
+        if (arg.startsWith('--tool-prefix=')) {
+            return arg.slice('--tool-prefix='.length);
+        }
+        if (arg === '--tool-prefix' && i + 1 < args.length) {
+            return args[i + 1] ?? '';
+        }
+    }
+    return env.GMAIL_MCP_TOOL_PREFIX || '';
+}

--- a/vendor/gmail-mcp-fork/src/tools.ts
+++ b/vendor/gmail-mcp-fork/src/tools.ts
@@ -1,0 +1,476 @@
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
+
+// Schema definitions
+
+// Inline image embedded in an HTML body and referenced via a cid: URL.
+// Exactly one of `path` / `content` must be set; `contentType` is required with `content`.
+export const InlineImageSchema = z.object({
+  cid: z.string().min(1).regex(/^[^\s<>]+$/, "cid must not contain whitespace or angle brackets")
+    .describe("Content-ID for the image, referenced from htmlBody as <img src=\"cid:CID\">"),
+  path: z.string().optional().describe("Absolute file path to the image (use this OR content)"),
+  content: z.string().optional().describe("Base64-encoded image data (use this OR path)"),
+  contentType: z.enum(['image/png', 'image/jpeg', 'image/gif', 'image/webp', 'image/bmp', 'image/x-icon']).optional()
+    .describe("Image MIME type — required when using `content`. SVG is intentionally unsupported."),
+  filename: z.string().optional().describe("Display filename for the image part (defaults derived from path or cid)"),
+})
+  .refine(d => (d.path ? 1 : 0) + (d.content ? 1 : 0) === 1, {
+    message: "Each inline image must set exactly one of `path` or `content`",
+  })
+  .refine(d => !d.content || !!d.contentType, {
+    message: "`contentType` is required when an inline image uses `content`",
+  });
+
+export const SendEmailSchema = z.object({
+  to: z.array(z.string()).describe("List of recipient email addresses"),
+  subject: z.string().describe("Email subject"),
+  body: z.string().describe("Email body content (used for text/plain or when htmlBody not provided)"),
+  from: z.string().optional().describe("Sender email address (must be a configured send-as alias in Gmail settings). Defaults to account's default send-as address if not specified."),
+  htmlBody: z.string().optional().describe("HTML version of the email body"),
+  mimeType: z.enum(['text/plain', 'text/html', 'multipart/alternative']).optional().default('text/plain').describe("Email content type"),
+  cc: z.array(z.string()).optional().describe("List of CC recipients"),
+  bcc: z.array(z.string()).optional().describe("List of BCC recipients"),
+  threadId: z.string().optional().describe("Thread ID to reply to"),
+  inReplyTo: z.string().optional().describe("Message ID being replied to"),
+  attachments: z.array(z.string()).optional().describe("List of file paths to attach to the email"),
+  inlineImages: z.array(InlineImageSchema).optional().describe("Images embedded inline in the HTML body, each referenced from htmlBody as <img src=\"cid:CID\">. Requires htmlBody to be set."),
+});
+
+export const ReadEmailSchema = z.object({
+  messageId: z.string().describe("ID of the email message to retrieve"),
+});
+
+export const SearchEmailsSchema = z.object({
+  query: z.string().describe("Gmail search query (e.g., 'from:example@gmail.com')"),
+  maxResults: z.number().optional().describe("Maximum number of results to return"),
+});
+
+export const ModifyEmailSchema = z.object({
+  messageId: z.string().describe("ID of the email message to modify"),
+  labelIds: z.array(z.string()).optional().describe("List of label IDs to apply"),
+  addLabelIds: z.array(z.string()).optional().describe("List of label IDs to add to the message"),
+  removeLabelIds: z.array(z.string()).optional().describe("List of label IDs to remove from the message"),
+});
+
+export const DeleteEmailSchema = z.object({
+  messageId: z.string().describe("ID of the email message to delete"),
+});
+
+// Draft lifecycle schemas
+export const SendDraftSchema = z.object({
+  draftId: z.string().describe("ID of the draft to send (returned by draft_email)"),
+});
+
+export const DeleteDraftSchema = z.object({
+  draftId: z.string().describe("ID of the draft to delete"),
+});
+
+export const UpdateDraftSchema = z.object({
+  draftId: z.string().describe("ID of the draft to update"),
+  to: z.array(z.string()).describe("List of recipient email addresses"),
+  subject: z.string().describe("Email subject"),
+  body: z.string().describe("Email body content (used for text/plain or when htmlBody not provided)"),
+  from: z.string().optional().describe("Sender email address (must be a configured send-as alias in Gmail settings). Defaults to account's default send-as address if not specified."),
+  htmlBody: z.string().optional().describe("HTML version of the email body"),
+  mimeType: z.enum(['text/plain', 'text/html', 'multipart/alternative']).optional().default('text/plain').describe("Email content type"),
+  cc: z.array(z.string()).optional().describe("List of CC recipients"),
+  bcc: z.array(z.string()).optional().describe("List of BCC recipients"),
+  threadId: z.string().optional().describe("Thread ID to reply to"),
+  inReplyTo: z.string().optional().describe("Message ID being replied to"),
+  attachments: z.array(z.string()).optional().describe("List of file paths to attach to the email"),
+  inlineImages: z.array(InlineImageSchema).optional().describe("Images embedded inline in the HTML body, each referenced from htmlBody as <img src=\"cid:CID\">. Requires htmlBody to be set."),
+});
+
+export const ListEmailLabelsSchema = z.object({}).describe("Retrieves all available Gmail labels");
+
+export const CreateLabelSchema = z.object({
+  name: z.string().describe("Name for the new label"),
+  messageListVisibility: z.enum(['show', 'hide']).optional().describe("Whether to show or hide the label in the message list"),
+  labelListVisibility: z.enum(['labelShow', 'labelShowIfUnread', 'labelHide']).optional().describe("Visibility of the label in the label list"),
+}).describe("Creates a new Gmail label");
+
+export const UpdateLabelSchema = z.object({
+  id: z.string().describe("ID of the label to update"),
+  name: z.string().optional().describe("New name for the label"),
+  messageListVisibility: z.enum(['show', 'hide']).optional().describe("Whether to show or hide the label in the message list"),
+  labelListVisibility: z.enum(['labelShow', 'labelShowIfUnread', 'labelHide']).optional().describe("Visibility of the label in the label list"),
+}).describe("Updates an existing Gmail label");
+
+export const DeleteLabelSchema = z.object({
+  id: z.string().describe("ID of the label to delete"),
+}).describe("Deletes a Gmail label");
+
+export const GetOrCreateLabelSchema = z.object({
+  name: z.string().describe("Name of the label to get or create"),
+  messageListVisibility: z.enum(['show', 'hide']).optional().describe("Whether to show or hide the label in the message list"),
+  labelListVisibility: z.enum(['labelShow', 'labelShowIfUnread', 'labelHide']).optional().describe("Visibility of the label in the label list"),
+}).describe("Gets an existing label by name or creates it if it doesn't exist");
+
+export const BatchModifyEmailsSchema = z.object({
+  messageIds: z.array(z.string()).describe("List of message IDs to modify"),
+  addLabelIds: z.array(z.string()).optional().describe("List of label IDs to add to all messages"),
+  removeLabelIds: z.array(z.string()).optional().describe("List of label IDs to remove from all messages"),
+  batchSize: z.number().optional().default(50).describe("Number of messages to process in each batch (default: 50)"),
+});
+
+export const ReportPhishingSchema = z.object({
+  messageId: z.string().describe("ID of the email message to report as phishing"),
+}).describe("Reports a message as phishing using the closest public Gmail API behavior by applying the SPAM label");
+
+export const BatchReportPhishingSchema = z.object({
+  messageIds: z.array(z.string()).describe("List of message IDs to report as phishing"),
+  batchSize: z.number().optional().default(50).describe("Number of messages to process in each batch (default: 50)"),
+}).describe("Reports multiple messages as phishing using the closest public Gmail API behavior by applying the SPAM label");
+
+export const BatchDeleteEmailsSchema = z.object({
+  messageIds: z.array(z.string()).describe("List of message IDs to delete"),
+  batchSize: z.number().optional().default(50).describe("Number of messages to process in each batch (default: 50)"),
+});
+
+export const CreateFilterSchema = z.object({
+  criteria: z.object({
+    from: z.string().optional().describe("Sender email address to match"),
+    to: z.string().optional().describe("Recipient email address to match"),
+    subject: z.string().optional().describe("Subject text to match"),
+    query: z.string().optional().describe("Gmail search query (e.g., 'has:attachment')"),
+    negatedQuery: z.string().optional().describe("Text that must NOT be present"),
+    hasAttachment: z.boolean().optional().describe("Whether to match emails with attachments"),
+    excludeChats: z.boolean().optional().describe("Whether to exclude chat messages"),
+    size: z.number().optional().describe("Email size in bytes"),
+    sizeComparison: z.enum(['unspecified', 'smaller', 'larger']).optional().describe("Size comparison operator")
+  }).describe("Criteria for matching emails"),
+  action: z.object({
+    addLabelIds: z.array(z.string()).optional().describe("Label IDs to add to matching emails"),
+    removeLabelIds: z.array(z.string()).optional().describe("Label IDs to remove from matching emails"),
+    forward: z.string().optional().describe("Email address to forward matching emails to")
+  }).describe("Actions to perform on matching emails")
+}).describe("Creates a new Gmail filter");
+
+export const ListFiltersSchema = z.object({}).describe("Retrieves all Gmail filters");
+
+export const GetFilterSchema = z.object({
+  filterId: z.string().describe("ID of the filter to retrieve")
+}).describe("Gets details of a specific Gmail filter");
+
+export const DeleteFilterSchema = z.object({
+  filterId: z.string().describe("ID of the filter to delete")
+}).describe("Deletes a Gmail filter");
+
+export const CreateFilterFromTemplateSchema = z.object({
+  template: z.enum(['fromSender', 'withSubject', 'withAttachments', 'largeEmails', 'containingText', 'mailingList']).describe("Pre-defined filter template to use"),
+  parameters: z.object({
+    senderEmail: z.string().optional().describe("Sender email (for fromSender template)"),
+    subjectText: z.string().optional().describe("Subject text (for withSubject template)"),
+    searchText: z.string().optional().describe("Text to search for (for containingText template)"),
+    listIdentifier: z.string().optional().describe("Mailing list identifier (for mailingList template)"),
+    sizeInBytes: z.number().optional().describe("Size threshold in bytes (for largeEmails template)"),
+    labelIds: z.array(z.string()).optional().describe("Label IDs to apply"),
+    archive: z.boolean().optional().describe("Whether to archive (skip inbox)"),
+    markAsRead: z.boolean().optional().describe("Whether to mark as read"),
+    markImportant: z.boolean().optional().describe("Whether to mark as important")
+  }).describe("Template-specific parameters")
+}).describe("Creates a filter using a pre-defined template");
+
+export const DownloadAttachmentSchema = z.object({
+  messageId: z.string().describe("ID of the email message containing the attachment"),
+  attachmentId: z.string().describe("ID of the attachment to download"),
+  filename: z.string().optional().describe("Filename to save the attachment as (if not provided, uses original filename)"),
+  savePath: z.string().optional().describe("Directory path to save the attachment (defaults to current directory)"),
+});
+
+export const DownloadEmailSchema = z.object({
+  messageId: z.string().describe("ID of the email message to download"),
+  savePath: z.string().describe("Directory path to save the email file"),
+  format: z.enum(['json', 'eml', 'txt', 'html']).optional().default('json')
+    .describe("Output format: json (structured data), eml (raw RFC822), txt (plain text), html (formatted HTML)"),
+});
+
+export const ModifyThreadSchema = z.object({
+  threadId: z.string().describe("ID of the Gmail thread to modify"),
+  addLabelIds: z.array(z.string()).optional().describe("List of label IDs to add to all messages in the thread"),
+  removeLabelIds: z.array(z.string()).optional().describe("List of label IDs to remove from all messages in the thread"),
+});
+
+// Thread-level schemas
+export const GetThreadSchema = z.object({
+  threadId: z.string().describe("ID of the email thread to retrieve"),
+  format: z.enum(['full', 'metadata', 'minimal']).optional().default('full').describe("Format of the email messages returned (default: full)"),
+});
+
+export const ListInboxThreadsSchema = z.object({
+  query: z.string().optional().default('in:inbox').describe("Gmail search query (default: 'in:inbox')"),
+  maxResults: z.number().optional().default(50).describe("Maximum number of threads to return (default: 50)"),
+});
+
+export const GetInboxWithThreadsSchema = z.object({
+  query: z.string().optional().default('in:inbox').describe("Gmail search query (default: 'in:inbox')"),
+  maxResults: z.number().optional().default(50).describe("Maximum number of threads to return (default: 50)"),
+  expandThreads: z.boolean().optional().default(true).describe("Whether to fetch full thread content for each thread (default: true)"),
+});
+
+// Reply All schema - fetches original email and builds recipient list automatically
+export const ReplyAllSchema = z.object({
+  messageId: z.string().describe("ID of the email message to reply to"),
+  body: z.string().describe("Reply body content (used for text/plain or when htmlBody not provided)"),
+  htmlBody: z.string().optional().describe("HTML version of the reply body"),
+  mimeType: z.enum(['text/plain', 'text/html', 'multipart/alternative']).optional().default('text/plain').describe("Email content type"),
+  attachments: z.array(z.string()).optional().describe("List of file paths to attach to the reply"),
+  inlineImages: z.array(InlineImageSchema).optional().describe("Images embedded inline in the HTML body, each referenced from htmlBody as <img src=\"cid:CID\">. Requires htmlBody to be set."),
+});
+
+// Tool definition type
+export interface ToolAnnotations {
+  title: string;
+  readOnlyHint?: boolean;
+  destructiveHint?: boolean;
+  idempotentHint?: boolean;
+  openWorldHint?: boolean;
+}
+
+export interface ToolDefinition {
+  name: string;
+  description: string;
+  schema: z.ZodType<any>;
+  scopes: string[]; // Any of these scopes grants access
+  annotations: ToolAnnotations;
+}
+
+// Tool registry with scope requirements
+export const toolDefinitions: ToolDefinition[] = [
+  // Read-only email operations
+  {
+    name: "read_email",
+    description: "Retrieves the content of a specific email",
+    schema: ReadEmailSchema,
+    scopes: ["gmail.readonly", "gmail.modify"],
+    annotations: { title: "Read Email", readOnlyHint: true },
+  },
+  {
+    name: "search_emails",
+    description: "Searches for emails using Gmail search syntax",
+    schema: SearchEmailsSchema,
+    scopes: ["gmail.readonly", "gmail.modify"],
+    annotations: { title: "Search Emails", readOnlyHint: true },
+  },
+  {
+    name: "download_attachment",
+    description: "Downloads an email attachment to a specified location",
+    schema: DownloadAttachmentSchema,
+    scopes: ["gmail.readonly", "gmail.modify"],
+    annotations: { title: "Download Attachment", readOnlyHint: true },
+  },
+
+  // Thread-level operations
+  {
+    name: "get_thread",
+    description: "Retrieves all messages in an email thread in one call. Returns messages ordered chronologically (oldest first) with full content, headers, labels, and attachment metadata.",
+    schema: GetThreadSchema,
+    scopes: ["gmail.readonly", "gmail.modify"],
+    annotations: { title: "Get Thread", readOnlyHint: true },
+  },
+  {
+    name: "list_inbox_threads",
+    description: "Lists email threads matching a query (default: inbox). Returns thread-level view with snippet, message count, and latest message metadata.",
+    schema: ListInboxThreadsSchema,
+    scopes: ["gmail.readonly", "gmail.modify"],
+    annotations: { title: "List Inbox Threads", readOnlyHint: true },
+  },
+  {
+    name: "get_inbox_with_threads",
+    description: "Convenience tool that lists threads and optionally expands each with full message content. One call returns the full inbox with complete thread bodies.",
+    schema: GetInboxWithThreadsSchema,
+    scopes: ["gmail.readonly", "gmail.modify"],
+    annotations: { title: "Get Inbox with Threads", readOnlyHint: true },
+  },
+  {
+    name: "modify_thread",
+    description: "Modifies labels on ALL messages in a thread atomically using the Gmail threads.modify endpoint. Use this instead of modify_email when you want to apply label changes (e.g., archive, mark as read) to an entire thread at once.",
+    schema: ModifyThreadSchema,
+    scopes: ["gmail.modify"],
+    annotations: { title: "Modify Thread", destructiveHint: true, idempotentHint: true },
+  },
+  {
+    name: "download_email",
+    description: "Downloads an email to a file in various formats (json, eml, txt, html). Returns metadata only - useful for saving emails without consuming context.",
+    schema: DownloadEmailSchema,
+    scopes: ["gmail.readonly", "gmail.modify"],
+    annotations: { title: "Download Email", readOnlyHint: true },
+  },
+
+  // Email write operations
+  {
+    name: "send_email",
+    description: "Sends a new email. Supports plain text, HTML, file attachments, and images embedded inline in the HTML body via inlineImages.",
+    schema: SendEmailSchema,
+    scopes: ["gmail.modify", "gmail.compose", "gmail.send"],
+    annotations: { title: "Send Email", destructiveHint: false },
+  },
+  {
+    name: "draft_email",
+    description: "Draft a new email. Supports plain text, HTML, file attachments, and images embedded inline in the HTML body via inlineImages.",
+    schema: SendEmailSchema,
+    scopes: ["gmail.modify", "gmail.compose"],
+    annotations: { title: "Draft Email", destructiveHint: false },
+  },
+  {
+    name: "send_draft",
+    description: "Sends an existing draft (created via draft_email) and atomically removes it from Drafts. Prefer this over send_email when you've previously created a draft for review — avoids leaving an orphan draft in the user's Drafts folder.",
+    schema: SendDraftSchema,
+    scopes: ["gmail.modify", "gmail.compose", "gmail.send"],
+    annotations: { title: "Send Draft", destructiveHint: false },
+  },
+  {
+    name: "delete_draft",
+    description: "Deletes a draft. Use to discard an abandoned or superseded draft.",
+    schema: DeleteDraftSchema,
+    scopes: ["gmail.modify", "gmail.compose"],
+    annotations: { title: "Delete Draft", destructiveHint: true },
+  },
+  {
+    name: "update_draft",
+    description: "Replaces the content of an existing draft. Use during iteration (\"change this and that\") instead of creating a new draft each time — avoids accumulating draft copies in the user's Drafts folder.",
+    schema: UpdateDraftSchema,
+    scopes: ["gmail.modify", "gmail.compose"],
+    annotations: { title: "Update Draft", destructiveHint: false },
+  },
+  {
+    name: "modify_email",
+    description: "Modifies email labels (move to different folders)",
+    schema: ModifyEmailSchema,
+    scopes: ["gmail.modify"],
+    annotations: { title: "Modify Email", destructiveHint: true, idempotentHint: true },
+  },
+  {
+    name: "delete_email",
+    description: "Permanently deletes an email. Requires gmail.full because Gmail's delete endpoint is not covered by gmail.modify.",
+    schema: DeleteEmailSchema,
+    scopes: ["gmail.full"],
+    annotations: { title: "Delete Email", destructiveHint: true },
+  },
+  {
+    name: "batch_modify_emails",
+    description: "Modifies labels for multiple emails in batches",
+    schema: BatchModifyEmailsSchema,
+    scopes: ["gmail.modify"],
+    annotations: { title: "Batch Modify Emails", destructiveHint: true, idempotentHint: true },
+  },
+  {
+    name: "report_phishing",
+    description: "Reports a message as phishing using the closest public Gmail API behavior by applying the SPAM label",
+    schema: ReportPhishingSchema,
+    scopes: ["gmail.modify"],
+    annotations: { title: "Report Phishing", destructiveHint: true, idempotentHint: true },
+  },
+  {
+    name: "batch_report_phishing",
+    description: "Reports multiple messages as phishing using the closest public Gmail API behavior by applying the SPAM label",
+    schema: BatchReportPhishingSchema,
+    scopes: ["gmail.modify"],
+    annotations: { title: "Batch Report Phishing", destructiveHint: true, idempotentHint: true },
+  },
+  {
+    name: "batch_delete_emails",
+    description: "Permanently deletes multiple emails in batches. Requires gmail.full because Gmail's batchDelete endpoint is not covered by gmail.modify.",
+    schema: BatchDeleteEmailsSchema,
+    scopes: ["gmail.full"],
+    annotations: { title: "Batch Delete Emails", destructiveHint: true },
+  },
+
+  // Label operations
+  {
+    name: "list_email_labels",
+    description: "Retrieves all available Gmail labels",
+    schema: ListEmailLabelsSchema,
+    scopes: ["gmail.readonly", "gmail.modify", "gmail.labels"],
+    annotations: { title: "List Email Labels", readOnlyHint: true },
+  },
+  {
+    name: "create_label",
+    description: "Creates a new Gmail label",
+    schema: CreateLabelSchema,
+    scopes: ["gmail.modify", "gmail.labels"],
+    annotations: { title: "Create Label", destructiveHint: false },
+  },
+  {
+    name: "update_label",
+    description: "Updates an existing Gmail label",
+    schema: UpdateLabelSchema,
+    scopes: ["gmail.modify", "gmail.labels"],
+    annotations: { title: "Update Label", destructiveHint: true, idempotentHint: true },
+  },
+  {
+    name: "delete_label",
+    description: "Deletes a Gmail label",
+    schema: DeleteLabelSchema,
+    scopes: ["gmail.modify", "gmail.labels"],
+    annotations: { title: "Delete Label", destructiveHint: true },
+  },
+  {
+    name: "get_or_create_label",
+    description: "Gets an existing label by name or creates it if it doesn't exist",
+    schema: GetOrCreateLabelSchema,
+    scopes: ["gmail.modify", "gmail.labels"],
+    annotations: { title: "Get or Create Label", destructiveHint: false, idempotentHint: true },
+  },
+
+  // Filter operations (require settings scope)
+  {
+    name: "list_filters",
+    description: "Retrieves all Gmail filters",
+    schema: ListFiltersSchema,
+    scopes: ["gmail.settings.basic"],
+    annotations: { title: "List Filters", readOnlyHint: true },
+  },
+  {
+    name: "get_filter",
+    description: "Gets details of a specific Gmail filter",
+    schema: GetFilterSchema,
+    scopes: ["gmail.settings.basic"],
+    annotations: { title: "Get Filter", readOnlyHint: true },
+  },
+  {
+    name: "create_filter",
+    description: "Creates a new Gmail filter with custom criteria and actions",
+    schema: CreateFilterSchema,
+    scopes: ["gmail.settings.basic"],
+    annotations: { title: "Create Filter", destructiveHint: false },
+  },
+  {
+    name: "delete_filter",
+    description: "Deletes a Gmail filter",
+    schema: DeleteFilterSchema,
+    scopes: ["gmail.settings.basic"],
+    annotations: { title: "Delete Filter", destructiveHint: true },
+  },
+  {
+    name: "create_filter_from_template",
+    description: "Creates a filter using a pre-defined template for common scenarios",
+    schema: CreateFilterFromTemplateSchema,
+    scopes: ["gmail.settings.basic"],
+    annotations: { title: "Create Filter from Template", destructiveHint: false },
+  },
+
+  // Reply-all operation
+  {
+    name: "reply_all",
+    description: "Replies to all recipients of an email. Automatically fetches the original email to build the recipient list (To, CC) and sets proper threading headers.",
+    schema: ReplyAllSchema,
+    scopes: ["gmail.modify", "gmail.compose", "gmail.send"],
+    annotations: { title: "Reply All", destructiveHint: false },
+  },
+];
+
+// Convert tool definitions to MCP tool format
+export function toMcpTools(tools: ToolDefinition[]) {
+  return tools.map(tool => ({
+    name: tool.name,
+    description: tool.description,
+    inputSchema: zodToJsonSchema(tool.schema),
+    annotations: tool.annotations,
+  }));
+}
+
+// Get a tool definition by name
+export function getToolByName(name: string): ToolDefinition | undefined {
+  return toolDefinitions.find(t => t.name === name);
+}

--- a/vendor/gmail-mcp-fork/src/utl.test.ts
+++ b/vendor/gmail-mcp-fork/src/utl.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Tests for email threading header fixes (issue #66)
+ *
+ * Verifies:
+ * 1. createEmailMessage uses separate `references` field when provided
+ * 2. createEmailMessage falls back to `inReplyTo` for References when no `references` field
+ * 3. No References/In-Reply-To headers on new emails
+ * 4. Source verification: createEmailWithNodemailer uses references field
+ * 5. Source verification: handleEmailAction auto-resolves threading headers
+ * 6. Source verification: read_email returns Message-ID
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createEmailMessage } from './utl.js';
+
+// Resolve src directory
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const srcDir = __dirname;
+
+// Helper: extract a header value from a raw MIME message string
+function getHeader(raw: string, headerName: string): string | null {
+    const regex = new RegExp(`^${headerName}:\\s*(.+)$`, 'mi');
+    const match = raw.match(regex);
+    return match ? match[1].trim() : null;
+}
+
+describe('Email threading headers', () => {
+    it('uses separate references field when provided', () => {
+        const args = {
+            to: ['test@example.com'],
+            subject: 'Re: Thread test',
+            body: 'Reply body',
+            inReplyTo: '<msg3@example.com>',
+            references: '<msg1@example.com> <msg2@example.com> <msg3@example.com>',
+        };
+        const raw = createEmailMessage(args);
+
+        expect(getHeader(raw, 'References')).toBe(
+            '<msg1@example.com> <msg2@example.com> <msg3@example.com>'
+        );
+        expect(getHeader(raw, 'In-Reply-To')).toBe('<msg3@example.com>');
+    });
+
+    it('falls back to inReplyTo when references is absent', () => {
+        const args = {
+            to: ['test@example.com'],
+            subject: 'Re: Fallback test',
+            body: 'Reply body',
+            inReplyTo: '<single@example.com>',
+        };
+        const raw = createEmailMessage(args);
+
+        expect(getHeader(raw, 'References')).toBe('<single@example.com>');
+    });
+
+    it('has no threading headers on new emails', () => {
+        const args = {
+            to: ['test@example.com'],
+            subject: 'New email',
+            body: 'Fresh email body',
+        };
+        const raw = createEmailMessage(args);
+
+        expect(getHeader(raw, 'References')).toBeNull();
+        expect(getHeader(raw, 'In-Reply-To')).toBeNull();
+    });
+});
+
+describe('Source verification', () => {
+    it('createEmailWithNodemailer uses references field with inReplyTo fallback', () => {
+        const source = fs.readFileSync(path.join(srcDir, 'utl.ts'), 'utf-8');
+        expect(source).toContain('references: validatedArgs.references || validatedArgs.inReplyTo');
+    });
+
+    it('handleEmailAction auto-resolves threading headers', () => {
+        const source = fs.readFileSync(path.join(srcDir, 'index.ts'), 'utf-8');
+        expect(source).toContain('validatedArgs.threadId && !validatedArgs.inReplyTo');
+        expect(source).toContain('gmail.users.threads.get');
+        expect(source).toContain('validatedArgs.inReplyTo = lastMessageId');
+        expect(source).toContain("validatedArgs.references = allMessageIds.join(' ')");
+    });
+
+    it('read_email returns Message-ID', () => {
+        const source = fs.readFileSync(path.join(srcDir, 'index.ts'), 'utf-8');
+        expect(source).toContain('message-id');
+        expect(source).toContain('rfcMessageId');
+        expect(source).toContain('Message-ID: ${rfcMessageId}');
+    });
+});

--- a/vendor/gmail-mcp-fork/src/utl.ts
+++ b/vendor/gmail-mcp-fork/src/utl.ts
@@ -1,0 +1,230 @@
+import fs from 'fs';
+import path from 'path';
+import { lookup as mimeLookup } from 'mime-types';
+import nodemailer from 'nodemailer';
+
+/**
+ * Upper bound on the decoded size of a base64 `content` inline image. Rejecting
+ * oversized payloads before nodemailer buffers them prevents host-process memory
+ * exhaustion. File-path images stream and are not subject to this check.
+ */
+export const MAX_INLINE_IMAGE_CONTENT_BYTES = 10 * 1024 * 1024;
+
+/**
+ * Helper function to encode email headers containing non-ASCII characters
+ * according to RFC 2047 MIME specification
+ */
+function encodeEmailHeader(text: string): string {
+    // Only encode if the text contains non-ASCII characters
+    if (/[^\x00-\x7F]/.test(text)) {
+        // Use MIME Words encoding (RFC 2047)
+        return '=?UTF-8?B?' + Buffer.from(text).toString('base64') + '?=';
+    }
+    return text;
+}
+
+export const validateEmail = (email: string): boolean => {
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    return emailRegex.test(email);
+};
+
+/**
+ * Sanitize a value destined for an email header to prevent CRLF injection.
+ * Strips \r, \n, and \0 characters that could inject additional headers.
+ */
+function sanitizeHeaderValue(value: string): string {
+    return value.replace(/[\r\n\0]/g, '');
+}
+
+export function createEmailMessage(validatedArgs: any): string {
+    const encodedSubject = encodeEmailHeader(sanitizeHeaderValue(validatedArgs.subject));
+    // Determine content type based on available content and explicit mimeType
+    let mimeType = validatedArgs.mimeType || 'text/plain';
+    
+    // If htmlBody is provided and mimeType isn't explicitly set to text/plain,
+    // use multipart/alternative to include both versions
+    if (validatedArgs.htmlBody && mimeType !== 'text/plain') {
+        mimeType = 'multipart/alternative';
+    }
+
+    // Generate a random boundary string for multipart messages
+    const boundary = `----=_NextPart_${Math.random().toString(36).substring(2)}`;
+
+    // Validate email addresses
+    (validatedArgs.to as string[]).forEach(email => {
+        if (!validateEmail(email)) {
+            throw new Error(`Recipient email address is invalid: ${email}`);
+        }
+    });
+
+    // Sanitize all user-supplied header values to prevent CRLF injection
+    const from = sanitizeHeaderValue(validatedArgs.from || 'me');
+    const to = (validatedArgs.to as string[]).map(sanitizeHeaderValue).join(', ');
+    const cc = validatedArgs.cc ? (validatedArgs.cc as string[]).map(sanitizeHeaderValue).join(', ') : '';
+    const bcc = validatedArgs.bcc ? (validatedArgs.bcc as string[]).map(sanitizeHeaderValue).join(', ') : '';
+    const inReplyTo = validatedArgs.inReplyTo ? sanitizeHeaderValue(validatedArgs.inReplyTo) : '';
+    const references = validatedArgs.references
+        ? sanitizeHeaderValue(validatedArgs.references)
+        : validatedArgs.inReplyTo ? sanitizeHeaderValue(validatedArgs.inReplyTo) : '';
+
+    // Common email headers
+    const emailParts = [
+        `From: ${from}`,
+        `To: ${to}`,
+        cc ? `Cc: ${cc}` : '',
+        bcc ? `Bcc: ${bcc}` : '',
+        `Subject: ${encodedSubject}`,
+        inReplyTo ? `In-Reply-To: ${inReplyTo}` : '',
+        references ? `References: ${references}` : '',
+        'MIME-Version: 1.0',
+    ].filter(Boolean);
+
+    // Construct the email based on the content type
+    if (mimeType === 'multipart/alternative') {
+        // Multipart email with both plain text and HTML
+        emailParts.push(`Content-Type: multipart/alternative; boundary="${boundary}"`);
+        emailParts.push('');
+        
+        // Plain text part
+        emailParts.push(`--${boundary}`);
+        emailParts.push('Content-Type: text/plain; charset=UTF-8');
+        emailParts.push('Content-Transfer-Encoding: 7bit');
+        emailParts.push('');
+        emailParts.push(validatedArgs.body);
+        emailParts.push('');
+        
+        // HTML part
+        emailParts.push(`--${boundary}`);
+        emailParts.push('Content-Type: text/html; charset=UTF-8');
+        emailParts.push('Content-Transfer-Encoding: 7bit');
+        emailParts.push('');
+        emailParts.push(validatedArgs.htmlBody || validatedArgs.body); // Use body as fallback
+        emailParts.push('');
+        
+        // Close the boundary
+        emailParts.push(`--${boundary}--`);
+    } else if (mimeType === 'text/html') {
+        // HTML-only email
+        emailParts.push('Content-Type: text/html; charset=UTF-8');
+        emailParts.push('Content-Transfer-Encoding: 7bit');
+        emailParts.push('');
+        emailParts.push(validatedArgs.htmlBody || validatedArgs.body);
+    } else {
+        // Plain text email (default)
+        emailParts.push('Content-Type: text/plain; charset=UTF-8');
+        emailParts.push('Content-Transfer-Encoding: 7bit');
+        emailParts.push('');
+        emailParts.push(validatedArgs.body);
+    }
+
+    return emailParts.join('\r\n');
+}
+
+
+export async function createEmailWithNodemailer(validatedArgs: any): Promise<string> {
+    // Validate email addresses
+    (validatedArgs.to as string[]).forEach(email => {
+        if (!validateEmail(email)) {
+            throw new Error(`Recipient email address is invalid: ${email}`);
+        }
+    });
+
+    // Create a nodemailer transporter (we won't actually send, just generate the message)
+    const transporter = nodemailer.createTransport({
+        streamTransport: true,
+        newline: 'unix',
+        buffer: true
+    });
+
+    // Inline images can only be referenced from an HTML body via cid: URLs.
+    const inlineImages = validatedArgs.inlineImages || [];
+    if (inlineImages.length > 0 && !validatedArgs.htmlBody) {
+        throw new Error('inlineImages require htmlBody — a cid: reference only resolves from HTML content');
+    }
+
+    // Prepare attachments for nodemailer
+    const attachments: any[] = [];
+    for (const filePath of (validatedArgs.attachments || [])) {
+        if (!fs.existsSync(filePath)) {
+            throw new Error(`File does not exist: ${filePath}`);
+        }
+
+        const fileName = path.basename(filePath);
+
+        attachments.push({
+            filename: fileName,
+            path: filePath
+        });
+    }
+
+    // Inline images: nodemailer emits a multipart/related container and sets
+    // Content-ID + Content-Disposition: inline for any attachment carrying a `cid`.
+    for (const img of inlineImages) {
+        // `cid` lands in a Content-ID header — strip CR/LF/NUL as defense in depth
+        // on top of the schema-level character restriction.
+        const cid = sanitizeHeaderValue(String(img.cid || ''));
+        if (!cid) {
+            throw new Error('Inline image cid must be a non-empty string');
+        }
+
+        const part: Record<string, unknown> = { cid };
+
+        if (img.path) {
+            if (!fs.existsSync(img.path)) {
+                throw new Error(`Inline image file does not exist: ${img.path}`);
+            }
+            part.path = img.path;
+            part.filename = img.filename || path.basename(img.path);
+        } else {
+            // Reject oversized base64 payloads before nodemailer buffers them in
+            // memory. Estimate decoded size from the base64 length (~3/4 ratio).
+            const estimatedBytes = Math.floor((String(img.content || '').length * 3) / 4);
+            if (estimatedBytes > MAX_INLINE_IMAGE_CONTENT_BYTES) {
+                throw new Error(
+                    `Inline image '${cid}' exceeds the ${MAX_INLINE_IMAGE_CONTENT_BYTES / (1024 * 1024)} MB size limit`,
+                );
+            }
+            part.content = img.content;
+            part.encoding = 'base64';
+            part.filename = img.filename || cid;
+        }
+
+        if (img.contentType) {
+            part.contentType = img.contentType;
+        }
+
+        attachments.push(part);
+    }
+
+    const mailOptions = {
+        from: validatedArgs.from || 'me', // Gmail API uses default send-as if 'me', or specified alias
+        to: validatedArgs.to.join(', '),
+        cc: validatedArgs.cc?.join(', '),
+        bcc: validatedArgs.bcc?.join(', '),
+        subject: validatedArgs.subject,
+        text: validatedArgs.body,
+        html: validatedArgs.htmlBody,
+        attachments: attachments,
+        inReplyTo: validatedArgs.inReplyTo,
+        references: validatedArgs.references || validatedArgs.inReplyTo
+    };
+
+    // Generate the raw message
+    const info = await transporter.sendMail(mailOptions);
+    const rawMessage = info.message.toString();
+
+    return rawMessage;
+}
+
+/**
+ * Decide which email builder to use. Messages carrying file attachments or
+ * inline images need the nodemailer-based raw builder (multipart/mixed and
+ * multipart/related); plain or simple HTML mail uses the lightweight
+ * createEmailMessage() builder.
+ */
+export function needsRawBuilder(args: any): boolean {
+    const hasAttachments = Array.isArray(args?.attachments) && args.attachments.length > 0;
+    const hasInlineImages = Array.isArray(args?.inlineImages) && args.inlineImages.length > 0;
+    return hasAttachments || hasInlineImages;
+}
+

--- a/vendor/gmail-mcp-fork/tsconfig.json
+++ b/vendor/gmail-mcp-fork/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": [
+      "node"
+    ]
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "src/**/*.test.ts"
+  ]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,13 @@ import { defineConfig, configDefaults } from 'vitest/config'
 // vitest defaults; only carve out the e2e directories.
 export default defineConfig({
   test: {
-    exclude: [...configDefaults.exclude, 'tests/smoke/**', 'tests/browser/**'],
+    // vendor/**: vendored third-party trees carry their OWN test files with
+    // their own dependencies (the gmail fork's tests import nodemailer etc.,
+    // which the root npm ci never installs) -- collecting them makes CI red
+    // with zero failing tests, just three unloadable files (Marveen, #1224).
+    // Running a vendor's suite is a separate workflow with the vendor's own
+    // install, never this one.
+    exclude: [...configDefaults.exclude, 'tests/smoke/**', 'tests/browser/**', 'vendor/**'],
     // vitest 4 enforces the 5s default testTimeout on tests that vitest 2 let
     // run long. Three subprocess-spawning tests (send-honesty-final,
     // send-honesty-round2) legitimately take 15-30s: they shell out to


### PR DESCRIPTION
Owner GO (21050) + Marveen plan approval (21071). The migration's first, reversible half:

- `vendor/gmail-mcp-fork/`: the fork's SOURCE at pinned commit `83e8daf` (stated visibly in VENDOR.md and the catalog authNote -- version bumps repeat the whole audit+build+verify path, never a silent bump). `dist/` is our own build from that source; `src/evals` dropped from audit scope.
- `run.sh` launcher: prod deps on first run, config defaults to `~/.gmail-mcp-v2/` -- the live `~/.gmail-mcp` is never touched, so token files cannot cross-write during the parallel phase and rollback stays one step.
- `mcp-catalog.json`: `gmail-v2` entry with `GMAIL_MCP_TOOL_PREFIX=v2_` for the parallel run.

NOT in this PR: the verification round (old tools AND v2_ tools measured working side by side) and the removal of the old gmail MCP -- the latter is Marveen-gated as the irreversible boundary.

Full vitest: 5033 passed / 1 skipped. Author is samu, independent verify welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)