### PR TITLE
fix(kanban): normalise non-integer card timestamps so a row cannot drop out of every sweep

### DIFF
--- a/src/__tests__/kanban-timestamp-type-gate.test.ts
+++ b/src/__tests__/kanban-timestamp-type-gate.test.ts
@@ -1,0 +1,120 @@
+// The 2026-09-07 lelet: kanban_cards.created_at / updated_at were not all the
+// same TYPE. Twelve cards and fifteen comments from one evening carried
+// '2026-08-29 18:29:48' -- the output of datetime('now') -- in columns declared
+// INTEGER NOT NULL, because SQLite's INTEGER affinity converts a numeric string
+// but leaves a datetime string as TEXT.
+//
+// Why that is worth a trigger: SQLite compares TEXT with INTEGER by type order,
+// not by value, so a TEXT row lands on the same side of EVERY sweep and audit
+// comparison. It always looks fresh, never looks stuck, and drops out of the
+// stale-card detectors with no exception and no log line. The measured proof of
+// the mechanism is pinned below, so the reason for the gate cannot be forgotten
+// and quietly reverted.
+//
+// Shape follows the two triggers already on this table: self-healing, NOT a
+// CHECK constraint -- agents write here with raw sqlite3 and rarely inspect
+// exit codes, so a rejected INSERT would lose the card silently.
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { initDatabase, getDb } from '../db.js'
+
+beforeEach(() => {
+  initDatabase(':memory:')
+})
+
+const NOW = Math.floor(Date.now() / 1000)
+
+function types(id: string): { created: string; updated: string; created_at: number; updated_at: number } {
+  const row = getDb()
+    .prepare(`SELECT typeof(created_at) c, typeof(updated_at) u, created_at, updated_at FROM kanban_cards WHERE id = ?`)
+    .get(id) as { c: string; u: string; created_at: number; updated_at: number }
+  return { created: row.c, updated: row.u, created_at: row.created_at, updated_at: row.updated_at }
+}
+
+describe('why the gate exists: a TEXT timestamp is not merely ugly', () => {
+  it('compares on the wrong side of every sweep -- text always outranks a number', () => {
+    const db = getDb()
+    // The exact comparison every stale-card detector makes.
+    const stale = db.prepare(`SELECT ('2026-08-29 18:29:48' < strftime('%s','now','-8 minutes')) AS looksStale`)
+      .get() as { looksStale: number }
+    expect(stale.looksStale).toBe(0)   // an eight-day-old row does NOT look stale
+    const realStale = db.prepare(`SELECT (? < strftime('%s','now','-8 minutes')) AS looksStale`)
+      .get(NOW - 86400) as { looksStale: number }
+    expect(realStale.looksStale).toBe(1) // the same age as an integer does
+  })
+})
+
+describe('kanban_cards_timestamp_type_gate triggers', () => {
+  it('known positive on INSERT: a datetime(\'now\')-shaped write is normalised to an integer', () => {
+    getDb().prepare(
+      `INSERT INTO kanban_cards (id, title, status, priority, created_at, updated_at)
+       VALUES ('ts-1', 'raw sql card', 'planned', 'normal', datetime('now'), datetime('now'))`
+    ).run()
+
+    const t = types('ts-1')
+    expect(t.created).toBe('integer')
+    expect(t.updated).toBe('integer')
+    // and it is the RIGHT integer: datetime('now') is UTC, so it must land
+    // within a few seconds of now, not off by a timezone or a Julian day.
+    expect(Math.abs(t.created_at - NOW)).toBeLessThan(120)
+  })
+
+  it('known positive on UPDATE: an ad-hoc `SET updated_at = datetime(\'now\')` is normalised too', () => {
+    const db = getDb()
+    db.prepare(
+      `INSERT INTO kanban_cards (id, title, status, priority, created_at, updated_at)
+       VALUES ('ts-2', 'card', 'planned', 'normal', ?, ?)`
+    ).run(NOW, NOW)
+    db.prepare(`UPDATE kanban_cards SET updated_at = datetime('now') WHERE id = 'ts-2'`).run()
+
+    const t = types('ts-2')
+    expect(t.updated).toBe('integer')
+    expect(Math.abs(t.updated_at - NOW)).toBeLessThan(120)
+  })
+
+  it('known negative: an ordinary integer write is left byte-identical, no trigger, no drift', () => {
+    const db = getDb()
+    db.prepare(
+      `INSERT INTO kanban_cards (id, title, status, priority, created_at, updated_at)
+       VALUES ('ts-3', 'card', 'planned', 'normal', ?, ?)`
+    ).run(1788721449, 1788721449)
+    const after = types('ts-3')
+    expect(after).toMatchObject({ created: 'integer', updated: 'integer', created_at: 1788721449, updated_at: 1788721449 })
+
+    // A number must never be handed to strftime: read as a Julian day it would
+    // become a date tens of thousands of years out, which is the failure mode
+    // a naive "just normalise everything" gate would introduce.
+    db.prepare(`UPDATE kanban_cards SET updated_at = ? WHERE id = 'ts-3'`).run(1788800000)
+    expect(types('ts-3').updated_at).toBe(1788800000)
+  })
+
+  it('a numeric STRING was never the problem -- affinity already converts it', () => {
+    getDb().prepare(
+      `INSERT INTO kanban_cards (id, title, status, priority, created_at, updated_at)
+       VALUES ('ts-4', 'card', 'planned', 'normal', strftime('%s','now'), strftime('%s','now'))`
+    ).run()
+    expect(types('ts-4').created).toBe('integer')
+  })
+
+  it('unparseable text falls back to now() rather than to NULL, which the column would reject', () => {
+    getDb().prepare(
+      `INSERT INTO kanban_cards (id, title, status, priority, created_at, updated_at)
+       VALUES ('ts-5', 'card', 'planned', 'normal', 'not a date at all', 'not a date at all')`
+    ).run()
+    const t = types('ts-5')
+    expect(t.created).toBe('integer')
+    expect(Math.abs(t.created_at - NOW)).toBeLessThan(120)
+  })
+
+  it('does not fight the status trigger: a status flip still bumps updated_at exactly once', () => {
+    const db = getDb()
+    db.prepare(
+      `INSERT INTO kanban_cards (id, title, status, priority, created_at, updated_at)
+       VALUES ('ts-6', 'card', 'planned', 'normal', ?, ?)`
+    ).run(NOW - 5000, NOW - 5000)
+    db.prepare(`UPDATE kanban_cards SET status = 'done' WHERE id = 'ts-6'`).run()
+    const t = types('ts-6')
+    expect(t.updated).toBe('integer')
+    expect(Math.abs(t.updated_at - NOW)).toBeLessThan(120)
+  })
+})

--- a/src/__tests__/kanban-timestamp-type-gate.test.ts
+++ b/src/__tests__/kanban-timestamp-type-gate.test.ts
@@ -118,3 +118,55 @@ describe('kanban_cards_timestamp_type_gate triggers', () => {
     expect(Math.abs(t.updated_at - NOW)).toBeLessThan(120)
   })
 })
+
+// The same defect from the same evening lived in kanban_comments too: fifteen
+// TEXT rows beside the twelve card rows. Gating only the cards would leave the
+// protection half-built -- and a comment timestamp is what orders a card's
+// history, so a TEXT one sorts above every integer sibling and the "newest"
+// comment becomes whichever one went in wrong.
+describe('kanban_comments_timestamp_type_gate triggers', () => {
+  function commentType(id: number): { t: string; created_at: number } {
+    const row = getDb().prepare('SELECT typeof(created_at) t, created_at FROM kanban_comments WHERE id = ?')
+      .get(id) as { t: string; created_at: number }
+    return row
+  }
+
+  it('known positive on INSERT: a datetime(\'now\')-shaped comment is normalised', () => {
+    const info = getDb().prepare(
+      `INSERT INTO kanban_comments (card_id, author, content, created_at)
+       VALUES ('c-1', 'agent', 'raw sql comment', datetime('now'))`
+    ).run()
+    const row = commentType(Number(info.lastInsertRowid))
+    expect(row.t).toBe('integer')
+    expect(Math.abs(row.created_at - NOW)).toBeLessThan(120)
+  })
+
+  it('known positive on UPDATE, and known negative: an integer comment is left alone', () => {
+    const db = getDb()
+    const info = db.prepare(
+      `INSERT INTO kanban_comments (card_id, author, content, created_at) VALUES ('c-2', 'agent', 'x', ?)`
+    ).run(1788721449)
+    const id = Number(info.lastInsertRowid)
+    expect(commentType(id)).toMatchObject({ t: 'integer', created_at: 1788721449 })
+
+    db.prepare(`UPDATE kanban_comments SET created_at = datetime('now') WHERE id = ?`).run(id)
+    const after = commentType(id)
+    expect(after.t).toBe('integer')
+    expect(Math.abs(after.created_at - NOW)).toBeLessThan(120)
+  })
+
+  // The ordering consequence, pinned: this is WHY a comment timestamp's type
+  // matters, not just that it is untidy.
+  it('a TEXT comment would sort above every integer sibling -- the gate is what stops it', () => {
+    const db = getDb()
+    db.prepare(`INSERT INTO kanban_comments (card_id, author, content, created_at) VALUES ('c-3', 'a', 'old', ?)`)
+      .run(NOW - 100)
+    db.prepare(`INSERT INTO kanban_comments (card_id, author, content, created_at) VALUES ('c-3', 'a', 'raw', datetime('now', '-30 days'))`)
+      .run()
+    const newest = db.prepare(
+      `SELECT content FROM kanban_comments WHERE card_id = 'c-3' ORDER BY created_at DESC LIMIT 1`
+    ).get() as { content: string }
+    // Without the gate the 30-day-old raw row would win this ordering.
+    expect(newest.content).toBe('old')
+  })
+})

--- a/src/db.ts
+++ b/src/db.ts
@@ -582,6 +582,35 @@ export function initDatabase(dbPathOverride?: string): void {
     ${tsGateBody}
   `)
 
+  // Same defect, same evening, same writer: kanban_comments.created_at carried
+  // fifteen TEXT rows next to the twelve card rows -- one agent's ad-hoc
+  // sqlite3 session, not an application path. Gating only the cards would leave
+  // the protection half-built against a hazard that is demonstrably table-wide,
+  // and a comment timestamp is what orders a card's history and dates its
+  // entries; a TEXT one sorts above every integer sibling, so the newest
+  // comment on such a card is whichever one went in wrong.
+  //
+  // Comments have no updated_at, so the gate is single-column; everything else
+  // (self-healing over CHECK, loop safety, CAST for REAL, now() fallback over
+  // NULL) is the argument written above, unchanged.
+  const commentTsGateBody = `
+    BEGIN
+      UPDATE kanban_comments SET created_at = ${tsNormalise('created_at')} WHERE id = NEW.id;
+    END
+  `
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS kanban_comments_timestamp_type_gate_insert
+    AFTER INSERT ON kanban_comments
+    FOR EACH ROW WHEN typeof(NEW.created_at) != 'integer'
+    ${commentTsGateBody}
+  `)
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS kanban_comments_timestamp_type_gate_update
+    AFTER UPDATE OF created_at ON kanban_comments
+    FOR EACH ROW WHEN typeof(NEW.created_at) != 'integer'
+    ${commentTsGateBody}
+  `)
+
   // --- Kanban labels (tags) -----------------------------------------------
   // Labels are a separate registry (not hardcoded per-card strings) so the
   // same label can be reused across many cards and recolored in one place.

--- a/src/db.ts
+++ b/src/db.ts
@@ -518,6 +518,70 @@ export function initDatabase(dbPathOverride?: string): void {
     ${titleGateBody}
   `)
 
+  // Timestamp TYPE gate. SQLite's INTEGER affinity converts a numeric string
+  // ('1788721449') on the way in, so strftime('%s','now') lands as an integer
+  // and nobody notices the difference -- but datetime('now') yields
+  // '2026-08-29 18:29:48', which is not a well-formed integer, so it is stored
+  // AS TEXT in a column declared INTEGER NOT NULL.
+  //
+  // Why that is not cosmetic: every sweep and every audit detector on this
+  // table compares a timestamp with an integer (`updated_at < strftime(...)`),
+  // and SQLite compares a TEXT value with an INTEGER by TYPE ORDER, not by
+  // value -- text always sorts above numbers. So a TEXT row silently lands on
+  // the same side of EVERY such comparison: it always looks fresh, never looks
+  // stuck, and quietly drops out of the stale-card sweeps and the audit
+  // instead of raising anything. The failure has no exception and no log line,
+  // which is why it survived from 2026-08-29 to 2026-09-07 unnoticed.
+  //
+  // The write path cannot be fixed at a call site: the application writers all
+  // pass Date.now()/1000, and the rows that went wrong were written by an
+  // agent's own ad-hoc `sqlite3 ... INSERT` with datetime('now') -- measured
+  // 2026-09-07, twelve cards and fifteen comments from one evening, all
+  // carrying UTC datetime strings. The writer is "anyone with a shell", so the
+  // guard belongs to the table.
+  //
+  // Self-healing rather than a CHECK constraint, for the reason already stated
+  // above the title gate: agents write this table with raw sqlite3 and rarely
+  // inspect exit codes, so a rejected INSERT would lose the card silently.
+  // Normalising keeps the row AND makes it comparable.
+  //
+  // Loop safety, same argument as the title gate: the corrective UPDATE writes
+  // integers, so the re-fired WHEN clause is false even with
+  // PRAGMA recursive_triggers=ON.
+  //
+  // A REAL is cast, not parsed: strftime() would read a bare number as a
+  // Julian day and turn 1788721449 into a date in the year 4.8 million. Text
+  // that strftime cannot parse falls back to now() rather than to NULL, which
+  // the NOT NULL column would reject -- losing the whole write to save a
+  // timestamp.
+  const tsNormalise = (col: string) => `
+    CASE typeof(NEW.${col})
+      WHEN 'integer' THEN NEW.${col}
+      WHEN 'real' THEN CAST(NEW.${col} AS INTEGER)
+      ELSE CAST(COALESCE(strftime('%s', NEW.${col}), strftime('%s','now')) AS INTEGER)
+    END`
+  const tsGateWhen = `typeof(NEW.created_at) != 'integer' OR typeof(NEW.updated_at) != 'integer'`
+  const tsGateBody = `
+    BEGIN
+      UPDATE kanban_cards SET
+        created_at = ${tsNormalise('created_at')},
+        updated_at = ${tsNormalise('updated_at')}
+      WHERE id = NEW.id;
+    END
+  `
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS kanban_cards_timestamp_type_gate_insert
+    AFTER INSERT ON kanban_cards
+    FOR EACH ROW WHEN ${tsGateWhen}
+    ${tsGateBody}
+  `)
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS kanban_cards_timestamp_type_gate_update
+    AFTER UPDATE OF created_at, updated_at ON kanban_cards
+    FOR EACH ROW WHEN ${tsGateWhen}
+    ${tsGateBody}
+  `)
+
   // --- Kanban labels (tags) -----------------------------------------------
   // Labels are a separate registry (not hardcoded per-card strings) so the
   // same label can be reused across many cards and recolored in one place.


### PR DESCRIPTION
## A változtatás típusa / Type of change
- [x] Hibajavítás (bugfix)

## Rövid leírás / Summary
HU: A `kanban_cards.created_at` / `updated_at` oszlop `INTEGER NOT NULL`, de az SQLite INTEGER-affinitása
csak a SZÁMOT TARTALMAZÓ szöveget konvertálja. A `strftime('%s','now')` ezért integerként landol, és senki
nem veszi észre a különbséget -- a `datetime('now')` viszont `'2026-08-29 18:29:48'` alakot ad, ami TEXT-ként
marad bent.

Ez nem kozmetika. A tábla minden söprése és minden audit-detektora időbélyeget hasonlít integerhez, az SQLite
pedig a TEXT-et és az INTEGER-t TÍPUS-SORREND szerint hasonlítja, nem érték szerint: a szöveg mindig a szám
fölé kerül. Egy TEXT sor így MINDEN ilyen összehasonlításnál ugyanarra az oldalra esik: mindig frissnek
látszik, soha nem látszik beakadtnak, és némán kiesik a beakadt-kártya detektorokból. Nincs kivétel, nincs
naplósor.

MÉRVE: egy nyolc napos TEXT időbélyeg 0-t ad arra a pontos "beakadt-e" összehasonlításra, amit a detektorok
végeznek, míg ugyanaz a kor integerként 1-et. A teszt ezt a mechanizmust rögzíti, hogy a kapu indoka ne
felejtődjön el és ne lehessen csendben visszavonni.

EN: The columns are declared `INTEGER NOT NULL`, but SQLite's INTEGER affinity only converts a NUMERIC
string. `strftime('%s','now')` lands as an integer; `datetime('now')` stays TEXT. Every sweep and audit
detector compares a timestamp against an integer, and SQLite compares TEXT with INTEGER by type order rather
than value -- text always outranks a number. A TEXT row lands on the same side of every such comparison: it
always looks fresh, never looks stuck, and drops out of the stale-card detectors with no exception and no log
line. The test pins that mechanism so the reason for the gate cannot be quietly reverted.

## Az ÍRÓ ÚT, mérve / The write path, measured
Nem javítható hívási helyen. Minden alkalmazás-oldali író `Date.now()/1000`-t ad át (`createKanbanCard`).
A hibás sorok egy ágens SAJÁT ad-hoc `sqlite3 ... INSERT`-jéből származnak `datetime('now')`-val: EGY este,
12 kártya és 15 komment, mind UTC datetime-sztringgel, miközben a szomszédos, API-n át írt sorok integerek.
Az író tehát "bárki, akinek van shellje" -- ezért a védelem a TÁBLÁÉ, nem egy kódúté.

Not fixable at a call site: every application writer passes `Date.now()/1000`; the bad rows came from an
agent's own ad-hoc `sqlite3` INSERT with `datetime('now')` (one evening, 12 cards and 15 comments, all UTC
datetime strings, next to API-written integer rows). The writer is "anyone with a shell", so the guard
belongs to the table.

## Az alak, és miért ez / The shape, and why
Ön-gyógyító trigger, NEM `CHECK` constraint -- ugyanaz az indok, ami a cím-kapu fölött már le van írva a
`db.ts`-ben: az ágensek nyers `sqlite3`-mal írnak ide, és ritkán néznek exit kódot, tehát egy elutasított
INSERT NÉMÁN elveszítené a kártyát. A normalizálás megtartja a sort ÉS összehasonlíthatóvá teszi.

- **Loop-biztonság** a cím-kapu érve: a javító UPDATE integert ír, tehát az újra-kiértékelt `WHEN` hamis.
- **A REAL-t CAST-oljuk, nem parse-oljuk:** a `strftime()` a csupasz számot Julián-napként olvasná, és egy
  normál epoch-ból évmilliós dátum lenne.
- **Az értelmezhetetlen szöveg `now()`-ra esik vissza, nem NULL-ra:** a NOT NULL oszlop a NULL-t elutasítaná,
  és az egész írást vinné magával egy időbélyegért.

## Ellenőrzés / Verification
- **NEGATÍV KONTROLL egy ÉLES ADATBÁZIS PILLANATKÉPÉN** (a kártya külön kikötése), mindkét táblára: a
  migráció lefut a valódi sémán, feltelepíti mind a 7 triggert, majd egy `datetime('now')`-os ad-hoc INSERT
  `typeof()`-ja **integer** lett, a helyes epoch értékkel (nem Julián-nap műtermék).
- Ugyanezen a pillanatképen a meglévő sorok VÁLTOZATLANOK maradtak. A trigger `AFTER INSERT` / `AFTER UPDATE`,
  tehát a régi sorok javítása KÜLÖN, kimondott adatírás, nem a telepítés mellékhatása.
- A pillanatkép `sqlite3 .backup`-pal készült, nem `cp`-vel: az adatbázis WAL módban van, és egy nyers
  fájlmásolat a WAL-ban álló, még be nem olvasztott írásokat KIHAGYJA -- egy `cp`-vel készült masolat mérve
  12 sorral elmaradt a valóságtól.
- Known-negative: egy közönséges integer írás bájtazonos marad, és egy státusz-váltás továbbra is pontosan
  egyszer bumpolja az `updated_at`-ot (a meglévő státusz-trigger nem ütközik ezzel).

## A kommentek is / Comments too
HU: Ugyanaz a hiba, ugyanabbol az estebol, ugyanabbol az ad-hoc `sqlite3` menetbol: a
`kanban_comments.created_at` 15 TEXT sort hordozott a 12 kartya-sor mellett. Csak a kartyakat kapuzni annyi
lett volna, mint egy tabla-szintu veszely FELET megfogni -- eppen az az alak, ami ellen ez a kor szol.

Es nem csak rendezettseg: a komment idobelyege az, ami a kartya tortenetet SORBA rakja. Az SQLite a TEXT-et
minden integer fole rendezi, tehat egy ilyen kartyan a "legujabb" komment az, amelyik ROSSZUL ment be. Ezt a
kovetkezmenyt teszt rogziti, nem leiras: egy 30 napos, nyers SQL-lel bevitt komment NEM nyerheti meg az
`ORDER BY created_at DESC`-et egy friss, integer sor ellen.

A kommenteknek nincs `updated_at`-juk, ezert ez a kapu egyoszlopos; minden mas ervelés (ongyogyitas a CHECK
helyett, loop-biztonsag, CAST a REAL-re, `now()` a NULL helyett) valtozatlan.

EN: Same defect, same evening, same ad-hoc session: `kanban_comments.created_at` carried fifteen TEXT rows
beside the twelve card rows. Gating only the cards would stop one half of a table-wide hazard. A comment
timestamp is what orders a card's history, and SQLite sorts TEXT above every integer, so the "newest" comment
on such a card is whichever one went in wrong -- pinned by a test, not described.

## Kapcsolódó issue / Related issue
Nincs nyitott GitHub issue -- kanban #1248.

## Ellenőrzőlista / Checklist
- [x] `npm run typecheck` zöld.
- [x] `npm test` zöld: 379 fájl, 4890 teszt (1 skipped).
- [x] `npm run syntax-check` zöld.
- [x] Új teszt: `src/__tests__/kanban-timestamp-type-gate.test.ts` (10 eset), köztük a MECHANIZMUS két
      bizonyítéka: a TEXT időbélyeg 0-t ad a "beakadt-e" kérdésre (az integer 1-et), és egy TEXT komment
      megnyerné az `ORDER BY created_at DESC`-et egy frissebb integer sor ellen.
- [x] Negatív kontroll éles DB-másolaton lefuttatva.
- [x] docs/ frissítés: nem szükséges (a döntés indoka a `db.ts`-ben, a két testvér-trigger mellett áll).
- [x] Nincs beégetett szenzitív adat.
- [x] Saját, beszédes nevű branch: fix/kanban-timestamp-type-gate
