### PR TITLE
fix(test): fallback control from a fixture, not the live checkout (CIDEVPIROS907)

### DIFF
--- a/src/__tests__/update-checker-branch.test.ts
+++ b/src/__tests__/update-checker-branch.test.ts
@@ -165,14 +165,23 @@ describe('branchOnRemote does not trust a branch the remote has never seen', () 
   })
 
   it('falls back to the default branch when the remote has no such branch', async () => {
+    // CIDEVPIROS907: the control must not be tied to the LIVE checkout. The
+    // old assertion compared against trackedBranch(), which on CI runs ON
+    // develop -- the very value the stub returned -- so the inequality
+    // structurally could never pass there (20/20 red develop runs). A
+    // synthetic fixture name proves the value came from the remote-default
+    // probe BY CONSTRUCTION: no real checkout can be named this, so the
+    // came-from-the-fallback property no longer depends on where the suite
+    // happens to run.
+    const FIXTURE_DEFAULT = 'fixture-default-branch-cidev907'
     const branch = await branchOnRemote(
       OURS, PROJECT_ROOT,
-      async () => 'develop',
+      async () => FIXTURE_DEFAULT,
       () => false,
       ownOrigin,
       () => true,
     )
-    expect(branch).toBe('develop')
+    expect(branch).toBe(FIXTURE_DEFAULT)
     expect(branch).not.toBe(trackedBranch())
   })
 


### PR DESCRIPTION
The develop `test` workflow was red 20/20 since 09-06 13:40 on ONE assertion: `update-checker-branch.test.ts` compared the fallback result against `trackedBranch()`, which reads the live checkout -- on develop-branch CI that IS the stub's value, so the inequality structurally cannot pass there. PR runs stayed green because a `pull_request` merge-ref checkout is detached and `trackedBranch()` falls back to `'main'` -- which is exactly why every merge gate saw green.

The stub now returns a synthetic fixture name (`fixture-default-branch-cidev907`), so the came-from-the-fallback property holds by construction, independent of where the suite runs. The intent of the control (the value must come from the remote-default probe) is preserved, not removed.

Mechanism reproduced before fixing (old shape + stub returning the live branch = identical failure on an attached branch); fixed file 21/21 locally. **The real readback is the develop workflow run after merge** -- I will verify and report it.

Step 3 of the card (what let this through for 1.5 days) measured separately: the develop branch workflow conclusion has NO consumer today (PR gates look at PR runs; the hermes soak runs build+node-check, not vitest). Proposal goes to Marveen with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)