### PR TITLE
feat(ledger): record which message an inbound Telegram reply quoted

### DIFF
--- a/scripts/__tests__/conversation-ledger.test.sh
+++ b/scripts/__tests__/conversation-ledger.test.sh
@@ -97,6 +97,21 @@ print(json.dumps(payload))
 PYEOF
 }
 
+# Emit an inbound payload that quotes an earlier message (reply_to_message_id).
+emit_inbound_replyto() { # chat_id message_id text reply_to_message_id [cwd]
+    python3 - "$@" <<'PYEOF'
+import json, sys
+chat_id, message_id, text, reply_to = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
+block = (f'<channel source="plugin:telegram:telegram" chat_id="{chat_id}" '
+         f'message_id="{message_id}" user="x" reply_to_message_id="{reply_to}" '
+         f'ts="2026-06-02T14:20:25.000Z">\n{text}\n</channel>')
+payload = {"hook_event_name": "UserPromptSubmit", "prompt": block}
+if len(sys.argv) > 5:
+    payload["cwd"] = sys.argv[5]
+print(json.dumps(payload))
+PYEOF
+}
+
 # Emit a Telegram reply PostToolUse payload.
 emit_reply() { # chat_id text [cwd]
     python3 - "$@" <<'PYEOF'
@@ -185,6 +200,15 @@ assert_eq "inbound capture: message_id" "1054" \
     "$(db_scalar "$DB_A" "SELECT message_id FROM conversation_log")"
 assert_eq "inbound capture: text recorded" "Jok a Fokusz e-mail cimek" \
     "$(db_scalar "$DB_A" "SELECT text FROM conversation_log")"
+assert_eq "inbound capture: no quote -> reply_to_message_id is NULL" "NULL" \
+    "$(db_scalar "$DB_A" "SELECT reply_to_message_id FROM conversation_log")"
+
+# A message that quotes an earlier one records which message_id it quoted
+# (df3b48a7) -- and never the quoted text itself, only the id.
+DB_A2="$TMPDIR_BASE/a2.db"
+emit_inbound_replyto 10000000001 2001 "lezarhato" 1999 | run_hook ledger-capture.py "$DB_A2"
+assert_eq "inbound capture: reply_to_message_id recorded" "1999" \
+    "$(db_scalar "$DB_A2" "SELECT reply_to_message_id FROM conversation_log")"
 
 # ---------------------------------------------------------------------------
 # (b) OUTBOUND CAPTURE -> conversation_log direction='out'

--- a/scripts/hooks/ledger-capture.py
+++ b/scripts/hooks/ledger-capture.py
@@ -95,11 +95,17 @@ def main():
         # carries the transcript in the body instead, so nothing is stored then).
         att_kind = _attr(attrs, "attachment_kind")
         att_file_id = _attr(attrs, "attachment_file_id")
+        # Which earlier message (if any) the sender quoted. Only the id is
+        # captured, never reply_to_excerpt (df3b48a7): the excerpt is a copy of
+        # that other row's own text, and storing it twice would drift the
+        # moment either side is edited/redacted.
+        reply_to_message_id = _attr(attrs, "reply_to_message_id")
         if chat_id and message_id:
             try:
                 ledger_lib.log_inbound(
                     agent_id, chat_id, message_id, text.strip(), ts,
                     attachment_kind=att_kind, attachment_file_id=att_file_id,
+                    reply_to_message_id=reply_to_message_id,
                 )
                 stored += 1
             except Exception as exc:

--- a/scripts/hooks/ledger_lib.py
+++ b/scripts/hooks/ledger_lib.py
@@ -30,6 +30,7 @@ CREATE TABLE IF NOT EXISTS conversation_log (
   created_at INTEGER NOT NULL,
   attachment_kind TEXT,
   attachment_file_id TEXT,
+  reply_to_message_id TEXT,
   UNIQUE(agent_id, chat_id, direction, message_id)
 )
 """
@@ -41,6 +42,7 @@ INDEX = "CREATE INDEX IF NOT EXISTS idx_convlog_agent ON conversation_log(agent_
 _MIGRATION_COLUMNS = (
     ("attachment_kind", "TEXT"),
     ("attachment_file_id", "TEXT"),
+    ("reply_to_message_id", "TEXT"),
 )
 
 RECENT_LIMIT = 20
@@ -245,21 +247,28 @@ def connect():
 
 
 def log_inbound(agent_id, chat_id, message_id, text, ts,
-                attachment_kind=None, attachment_file_id=None):
+                attachment_kind=None, attachment_file_id=None,
+                reply_to_message_id=None):
     """Record an inbound user message. Idempotent on (agent_id, chat_id, in, message_id).
 
     attachment_kind/file_id: set for voice / video_note messages that arrived
     WITHOUT a transcript, so a respawned session can still download and
-    transcribe the audio instead of losing the message content forever."""
+    transcribe the audio instead of losing the message content forever.
+
+    reply_to_message_id: the message_id this inbound quoted (Telegram
+    ctx.message.reply_to_message), when the sender replied to a specific
+    earlier message instead of writing standalone. Only the id is kept, not an
+    excerpt -- the quoted text is a copy of that other row's own `text` and is
+    already recoverable via a lookup on message_id (df3b48a7)."""
     con = connect()
     try:
         con.execute(
             "INSERT OR IGNORE INTO conversation_log"
             " (agent_id, chat_id, direction, message_id, text, ts, created_at,"
-            "  attachment_kind, attachment_file_id)"
-            " VALUES (?, ?, 'in', ?, ?, ?, ?, ?, ?)",
+            "  attachment_kind, attachment_file_id, reply_to_message_id)"
+            " VALUES (?, ?, 'in', ?, ?, ?, ?, ?, ?, ?)",
             (str(agent_id), str(chat_id), str(message_id), text, ts, int(time.time()),
-             attachment_kind, attachment_file_id),
+             attachment_kind, attachment_file_id, reply_to_message_id),
         )
         con.commit()
     finally:

--- a/src/__tests__/conversation-ledger-schema.test.ts
+++ b/src/__tests__/conversation-ledger-schema.test.ts
@@ -32,7 +32,7 @@ describe('conversation_log schema: db.ts migration == ledger_lib.py (no drift)',
   it('the column sets are identical and complete', () => {
     const a = logColumns(dbts).sort()
     const b = logColumns(lib).sort()
-    expect(a).toEqual(['agent_id', 'attachment_file_id', 'attachment_kind', 'chat_id', 'created_at', 'direction', 'id', 'message_id', 'text', 'ts'])
+    expect(a).toEqual(['agent_id', 'attachment_file_id', 'attachment_kind', 'chat_id', 'created_at', 'direction', 'id', 'message_id', 'reply_to_message_id', 'text', 'ts'])
     expect(b).toEqual(a)
   })
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -270,14 +270,17 @@ export function initDatabase(dbPathOverride?: string): void {
       created_at INTEGER NOT NULL,
       attachment_kind TEXT,
       attachment_file_id TEXT,
+      reply_to_message_id TEXT,
       UNIQUE(agent_id, chat_id, direction, message_id)
     )
   `)
   db.exec(`CREATE INDEX IF NOT EXISTS idx_convlog_agent ON conversation_log(agent_id, created_at)`)
   // Migration for pre-existing DBs: transcript-less voice/video_note inbounds
   // keep their attachment identity so a respawned session can still download
-  // and transcribe them (mirrors _MIGRATION_COLUMNS in scripts/hooks/ledger_lib.py).
-  for (const col of ['attachment_kind', 'attachment_file_id']) {
+  // and transcribe them; reply_to_message_id lets an inbound quote be
+  // retraced after the fact (df3b48a7) (mirrors _MIGRATION_COLUMNS in
+  // scripts/hooks/ledger_lib.py).
+  for (const col of ['attachment_kind', 'attachment_file_id', 'reply_to_message_id']) {
     const cols = db.prepare("PRAGMA table_info(conversation_log)").all() as { name: string }[]
     if (!cols.some(c => c.name === col)) {
       db.exec(`ALTER TABLE conversation_log ADD COLUMN ${col} TEXT`)


### PR DESCRIPTION
When a user replies to a specific earlier message on Telegram, the agent cannot
see which message it was, so a one-word answer attaches to the wrong thread.

**It caused a real error here, 2026-09-04.** A colleague quote-replied
"lezárható" ("you can close it") to one concrete message. The agent had several
open threads with him, could not see the quote, guessed the wrong one, and
closed the wrong card -- a business decision was recorded incorrectly. His
actual answer arrived 42 seconds later and said something different. His words
were: *"nem értem, hogy miért nem látod, azt hogy ha egy üzenetre válaszolok
konkrétan, hogy lezárhatod akkor miért más témához írod?"*

**Root cause.** The Telegram Bot API update carries `message.reply_to_message`,
and the channel plugin already uses it for another purpose, but the inbound
`<channel>` notification never passed it to the model. The outbound direction
could already quote (the reply tool takes `reply_to`); only the inbound half was
missing.

**What this commit does** is the persistence half: a nullable
`reply_to_message_id` column on `conversation_log`, and the write path that
fills it. That makes the association recoverable afterwards, not just visible in
the moment.

Deliberately NOT stored: the quoted text excerpt. It is a copy of someone else's
message, and it is retrievable from the message id.

Verified on this branch: `tsc` clean, the schema test 5/5, and the ledger shell
suite 52/52. Two real quoted replies have been captured live at our install
since the change went in.