### PR TITLE
feat(graph-mail): file attachments, with a drop directory and a size cap

### DIFF
--- a/scripts/graph-mail.ts
+++ b/scripts/graph-mail.ts
@@ -4,13 +4,52 @@
 //
 //   tsx scripts/graph-mail.ts verify
 //   tsx scripts/graph-mail.ts list [--unread] [--top N] [--folder inbox|sentitems]
-//   tsx scripts/graph-mail.ts send --to a@b.hu[,c@d.hu] --subject "..." --body "..." [--cc ...] [--html]
+//   tsx scripts/graph-mail.ts send --to a@b.hu[,c@d.hu] --subject "..." --body "..." [--cc ...] [--html] [--attach FILE]
+//
+// --attach does NOT take an arbitrary path. The file must sit inside the
+// attachment drop directory (GRAPH_MAIL_ATTACH_DIR, default
+// <repo>/store/mail-attachments); anything outside it is refused. Putting a
+// file there is the deliberate act that authorises sending it.
 //
 // Credentials come from the gitignored marveen-mail-ugyfelkod file (override
 // with MARVEEN_MAIL_CREDS). Send is intentionally CLI-explicit; the sub-agent
 // email-send-gate hook still applies to any programmatic use elsewhere.
 
 import { listMessages, sendMail, verifyAccess } from '../src/graph-mail.js'
+import { readFileSync, realpathSync, statSync } from 'node:fs'
+import { basename, resolve, sep } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const REPO_ROOT = resolve(fileURLToPath(new URL('..', import.meta.url)))
+
+/**
+ * Resolve --attach against the attachment drop directory and refuse anything
+ * outside it. Symlinks are resolved first (realpath on both sides), so a link
+ * planted inside the directory cannot reach out of it, and the separator on
+ * the prefix check keeps a sibling like `<dir>-evil` from matching.
+ */
+function readAttachment(rawPath: string): { name: string; contentBytes: string } {
+  const dir = realpathSync(
+    resolve(process.env.GRAPH_MAIL_ATTACH_DIR ?? resolve(REPO_ROOT, 'store/mail-attachments')),
+  )
+  let file: string
+  try {
+    file = realpathSync(resolve(dir, rawPath))
+  } catch {
+    throw new Error(`graph-mail: attachment not found: ${rawPath}`)
+  }
+  if (file !== dir && !file.startsWith(dir + sep)) {
+    throw new Error(
+      `graph-mail: refusing to attach a file outside the drop directory.\n` +
+        `  requested: ${file}\n  allowed:   ${dir}\n` +
+        'Copy the file into the drop directory (or set GRAPH_MAIL_ATTACH_DIR) and retry.',
+    )
+  }
+  if (!statSync(file).isFile()) {
+    throw new Error(`graph-mail: attachment is not a regular file: ${file}`)
+  }
+  return { name: basename(file), contentBytes: readFileSync(file).toString('base64') }
+}
 
 function flag(name: string): string | undefined {
   const i = process.argv.indexOf(`--${name}`)
@@ -47,6 +86,8 @@ async function main(): Promise<void> {
       break
     }
     case 'send': {
+      const attachPath = flag('attach')
+      const attachments = attachPath ? [readAttachment(attachPath)] : undefined
       const to = flag('to')
       const subject = flag('subject')
       const body = flag('body')
@@ -55,6 +96,7 @@ async function main(): Promise<void> {
         process.exit(2)
       }
       await sendMail({
+        attachments,
         to: to.split(','),
         subject,
         body,

--- a/src/graph-mail.ts
+++ b/src/graph-mail.ts
@@ -50,7 +50,21 @@ export interface SendMailOptions {
   contentType?: 'Text' | 'HTML'
   /** Persist the sent message to the mailbox Sent Items. Default true. */
   saveToSentItems?: boolean
+  /**
+   * File attachments. `contentBytes` is base64, as Graph expects it.
+   * The combined base64 size is capped at MAX_TOTAL_ATTACHMENT_BASE64_BYTES
+   * and rejected here, before the request is built -- Graph's own limit on a
+   * simple /sendMail would otherwise surface as an opaque request failure.
+   */
+  attachments?: { name: string; contentBytes: string; contentType?: string }[]
 }
+
+/**
+ * Ceiling for the combined base64 payload of all attachments on one message.
+ * Graph caps a simple /sendMail request at a few MB total; this sits under it
+ * so the failure is ours, named and local, rather than a Graph-side reject.
+ */
+export const MAX_TOTAL_ATTACHMENT_BASE64_BYTES = 3 * 1024 * 1024
 
 export interface ListMessagesOptions {
   /** How many messages to return (Graph $top). Default 10, capped at 50. */
@@ -227,6 +241,22 @@ export async function sendMail(options: SendMailOptions): Promise<void> {
     toRecipients: toRecipientList(options.to),
   }
   if (options.cc) message.ccRecipients = toRecipientList(options.cc)
+  if (options.attachments?.length) {
+    const total = options.attachments.reduce((n, a) => n + a.contentBytes.length, 0)
+    if (total > MAX_TOTAL_ATTACHMENT_BASE64_BYTES) {
+      throw new Error(
+        `graph-mail: attachments too large (${total} base64 bytes across ` +
+          `${options.attachments.length} file(s); limit ${MAX_TOTAL_ATTACHMENT_BASE64_BYTES}). ` +
+          'Send fewer or smaller files, or share a link instead.',
+      )
+    }
+    message.attachments = options.attachments.map((a) => ({
+      '@odata.type': '#microsoft.graph.fileAttachment',
+      name: a.name,
+      contentType: a.contentType ?? 'application/octet-stream',
+      contentBytes: a.contentBytes,
+    }))
+  }
   const res = await graphFetch(`${mailboxPath()}/sendMail`, {
     method: 'POST',
     body: JSON.stringify({ message, saveToSentItems: options.saveToSentItems ?? true }),


### PR DESCRIPTION
Split out of #900 at your request, and reworked rather than resubmitted. Reviewing the original diff against your two questions, both already had answers in the code, and both were gaps rather than defences. So this PR carries the fixes instead of an explanation.

**"What stops it reading and sending an arbitrary path?"** Previously: nothing. The `--attach` value went straight into `readFileSync`.

Now `--attach` resolves inside an attachment drop directory (`GRAPH_MAIL_ATTACH_DIR`, default `<repo>/store/mail-attachments`) and anything outside it is refused. Both sides are `realpath`'d before the comparison, so a symlink planted inside the directory cannot reach out of it, and the prefix check includes the separator so a sibling like `<dir>-evil` does not match. Directories and other non-regular files are refused too. Putting a file in the drop directory is the deliberate act that authorises sending it.

**"What happens at the 3MB Graph limit?"** Previously: the limit was a doc comment on the interface field and nothing enforced it, so Graph would have been the thing that failed.

Now the combined base64 payload is capped at `MAX_TOTAL_ATTACHMENT_BASE64_BYTES` (3 MiB) and rejected in `sendMail` before the request is built. The cap sits in the library rather than the CLI so every caller inherits it, and the error names the measured size and the limit.

**"Should an attachment be allowed from a non-interactive caller at all?"** That one is a policy call, not a code question, so I have left it to you. The drop directory narrows it usefully either way: a non-interactive caller can only send what someone already placed there. If you would rather gate it harder, say how and I will add it.

**Verification.** Run, not inspected. A file inside the directory is accepted and proceeds to the credentials step; an absolute path outside, a traversal that resolves to a real file (`/etc/hosts`), a symlink pointing out of the directory, a sibling directory sharing the name prefix, and a directory argument are each refused. The size cap was exercised in both directions: 4 MiB is rejected by the check, 1 MiB passes it and fails later at credentials, so the check distinguishes rather than blocking everything.

#900 now contains only the alias and memory half and is unaffected by this.