### PR TITLE
Poll the VoiceMailAI schema verdict, and treat a long silence as the finding

### DIFF
--- a/src/__tests__/schema-watch.test.ts
+++ b/src/__tests__/schema-watch.test.ts
@@ -1,0 +1,215 @@
+// A verdict nobody polls is the same silence in a new place.
+//
+// The VoiceMailAI backend checks its own schema at boot and publishes the
+// result at GET /health/schema. These pin the fleet-side half: that `missing`
+// alerts at once, that `unknown` does NOT alert on its own, and -- the case
+// the card was actually written for -- that an endpoint which stays unknown
+// for days DOES alert, because a permanently silent check is indistinguishable
+// from a permanently healthy one.
+//
+// The staleness cases move a timestamp rather than waiting, and they sit ON
+// the boundary: a value comfortably inside the window passes with or without
+// the rule, which is how a broken threshold survives its own test.
+
+import { describe, it, expect } from 'vitest'
+import {
+  parseSchemaProbe,
+  decideSchemaVerdict,
+  nextSchemaWatchState,
+  formatSchemaAlert,
+  SCHEMA_UNKNOWN_STALE_MS,
+  type SchemaProbe,
+  type SchemaWatchState,
+} from '../web/schema-watch.js'
+
+const DAY_MS = 24 * 60 * 60 * 1000
+const NOW = 1_760_000_000_000
+
+function decide(
+  probe: SchemaProbe,
+  over: { lastMeaningfulAt?: number | null; watchingSince?: number | null; now?: number } = {},
+) {
+  return decideSchemaVerdict({
+    probe,
+    lastMeaningfulAt: over.lastMeaningfulAt ?? null,
+    watchingSince: over.watchingSince ?? null,
+    now: over.now ?? NOW,
+    staleAfterMs: SCHEMA_UNKNOWN_STALE_MS,
+  })
+}
+
+// The shape below is the one measured against production on 2026-09-07:
+// {"state":"ok","summary":"schema complete","missing_tables":[],"missing_columns":[]}
+const OK_BODY = { state: 'ok', summary: 'schema complete', missing_tables: [], missing_columns: [] }
+
+describe('parseSchemaProbe', () => {
+  it('reads the production ok payload as ok', () => {
+    const probe = parseSchemaProbe(200, OK_BODY, JSON.stringify(OK_BODY))
+    expect(probe.state).toBe('ok')
+    expect(probe.summary).toBe('schema complete')
+  })
+
+  it('reads a missing payload and carries its lists through untouched', () => {
+    // This shape comes from the backend's own tests, not from a live
+    // observation, so nothing here rewrites or re-orders it.
+    const body = {
+      state: 'missing',
+      summary: 'missing tables: app_sessions; missing columns: email_accounts.provider_account_id',
+      missing_tables: ['app_sessions'],
+      missing_columns: ['email_accounts.provider_account_id'],
+    }
+    const probe = parseSchemaProbe(200, body, JSON.stringify(body))
+    expect(probe.state).toBe('missing')
+    expect(probe.missingTables).toEqual(['app_sessions'])
+    expect(probe.missingColumns).toEqual(['email_accounts.provider_account_id'])
+  })
+
+  it('treats a call that never completed as unknown, never as missing', () => {
+    // Our own network being down says nothing about their database.
+    const probe = parseSchemaProbe(0, null)
+    expect(probe.state).toBe('unknown')
+    expect(probe.missingTables).toEqual([])
+  })
+
+  it('treats a non-200 answer as unknown and names the status', () => {
+    const probe = parseSchemaProbe(502, null, '<html>bad gateway</html>')
+    expect(probe.state).toBe('unknown')
+    expect(probe.summary).toContain('502')
+    expect(probe.raw).toContain('bad gateway')
+  })
+
+  it('does not guess at an unrecognised state, and keeps the body verbatim', () => {
+    // Only the `ok` shape has been seen in production. Anything else is
+    // reported as-is for a human to read, rather than being flattened into a
+    // verdict this file invented.
+    const body = { state: 'degraded', summary: 'partial' }
+    const probe = parseSchemaProbe(200, body, JSON.stringify(body))
+    expect(probe.state).toBe('unknown')
+    expect(probe.raw).toContain('degraded')
+  })
+
+  it('does not read a body without a state field as healthy', () => {
+    const probe = parseSchemaProbe(200, { summary: 'schema complete' }, '{}')
+    expect(probe.state).toBe('unknown')
+  })
+})
+
+describe('decideSchemaVerdict', () => {
+  const ok = parseSchemaProbe(200, OK_BODY)
+  const missing = parseSchemaProbe(200, {
+    state: 'missing',
+    summary: 'missing tables: app_sessions',
+    missing_tables: ['app_sessions'],
+    missing_columns: [],
+  })
+  const unknown = parseSchemaProbe(0, null)
+
+  it('stays silent on ok', () => {
+    expect(decide(ok, { lastMeaningfulAt: NOW - DAY_MS })).toMatchObject({ verdict: 'ok', alert: false })
+  })
+
+  it('alerts immediately on missing', () => {
+    expect(decide(missing, { lastMeaningfulAt: NOW - 1000 })).toMatchObject({ verdict: 'missing', alert: true })
+  })
+
+  it('does not alert on a single unknown', () => {
+    // Mid-deploy, a network blip, a maintenance window. Paging here teaches
+    // the reader to ignore this watcher.
+    const d = decide(unknown, { lastMeaningfulAt: NOW - DAY_MS })
+    expect(d).toMatchObject({ verdict: 'unknown-recent', alert: false })
+    expect(d.unknownForMs).toBe(DAY_MS)
+  })
+
+  it('alerts once unknown has lasted the whole window', () => {
+    // ON the boundary, not inside it: at exactly the threshold a rule that
+    // compares with > instead of >= is still wrong, and only this input says so.
+    const d = decide(unknown, { lastMeaningfulAt: NOW - SCHEMA_UNKNOWN_STALE_MS })
+    expect(d).toMatchObject({ verdict: 'unknown-stale', alert: true })
+  })
+
+  it('stays quiet one millisecond before the boundary', () => {
+    const d = decide(unknown, { lastMeaningfulAt: NOW - SCHEMA_UNKNOWN_STALE_MS + 1 })
+    expect(d).toMatchObject({ verdict: 'unknown-recent', alert: false })
+  })
+
+  it('ages from when watching began when the endpoint has NEVER answered', () => {
+    // The nastiest case: a URL that was wrong from the first day. With the
+    // clock running only from the last meaningful answer, there would never be
+    // one, and the watcher would stay silent for ever.
+    const d = decide(unknown, { lastMeaningfulAt: null, watchingSince: NOW - SCHEMA_UNKNOWN_STALE_MS })
+    expect(d).toMatchObject({ verdict: 'unknown-stale', alert: true })
+  })
+
+  it('does not alert on the very first reading of all', () => {
+    // One reading is not a duration.
+    expect(decide(unknown, { lastMeaningfulAt: null, watchingSince: null })).toMatchObject({
+      verdict: 'unknown-recent',
+      alert: false,
+    })
+  })
+
+  it('prefers the last meaningful answer over the start of watching', () => {
+    // Watching began long ago, but the endpoint answered an hour ago: that is
+    // a healthy watcher having one bad reading, not a stale one.
+    const d = decide(unknown, {
+      lastMeaningfulAt: NOW - 60 * 60 * 1000,
+      watchingSince: NOW - 30 * DAY_MS,
+    })
+    expect(d).toMatchObject({ verdict: 'unknown-recent', alert: false })
+  })
+})
+
+describe('nextSchemaWatchState', () => {
+  const ok = parseSchemaProbe(200, OK_BODY)
+  const unknown = parseSchemaProbe(0, null)
+  const base: SchemaWatchState = {
+    lastMeaningfulAt: NOW - 10 * DAY_MS,
+    watchingSince: NOW - 30 * DAY_MS,
+    lastState: 'ok',
+    alert: null,
+  }
+
+  it('advances the meaningful clock on ok', () => {
+    expect(nextSchemaWatchState(base, ok, NOW, false).lastMeaningfulAt).toBe(NOW)
+  })
+
+  it('does NOT advance it on unknown', () => {
+    // The whole staleness rule rests on this: if an unreachable endpoint
+    // refreshed the clock, "unknown for days" could never be reached.
+    expect(nextSchemaWatchState(base, unknown, NOW, false).lastMeaningfulAt).toBe(base.lastMeaningfulAt)
+  })
+
+  it('keeps the original watchingSince across runs', () => {
+    expect(nextSchemaWatchState(base, unknown, NOW, false).watchingSince).toBe(base.watchingSince)
+  })
+
+  it('starts watching now when there is no prior state', () => {
+    expect(nextSchemaWatchState(null, unknown, NOW, false).watchingSince).toBe(NOW)
+  })
+
+  it('records a sent alert so the cooldown has something to measure', () => {
+    expect(nextSchemaWatchState(base, unknown, NOW, true).alert).toEqual({ lastSentAt: NOW, suppressed: 0 })
+  })
+})
+
+describe('formatSchemaAlert', () => {
+  it('names the missing tables and columns', () => {
+    const probe = parseSchemaProbe(200, {
+      state: 'missing',
+      summary: 'missing tables: app_sessions',
+      missing_tables: ['app_sessions'],
+      missing_columns: ['email_accounts.provider_account_id'],
+    })
+    const text = formatSchemaAlert(decide(probe, { lastMeaningfulAt: NOW }), probe)
+    expect(text).toContain('app_sessions')
+    expect(text).toContain('email_accounts.provider_account_id')
+  })
+
+  it('says how long the silence has lasted, and shows the raw answer', () => {
+    const probe = parseSchemaProbe(502, null, '<html>bad gateway</html>')
+    const decision = decide(probe, { lastMeaningfulAt: NOW - 3 * DAY_MS })
+    const text = formatSchemaAlert(decision, probe)
+    expect(text).toContain('3 napja')
+    expect(text).toContain('bad gateway')
+  })
+})

--- a/src/web.ts
+++ b/src/web.ts
@@ -23,6 +23,7 @@ import { startChannelPluginMonitor } from './web/channel-monitor.js'
 import { startInboundProber } from './web/inbound-probe.js'
 import { startChannelHealthMonitor } from './web/channel-health-monitor.js'
 import { startChannelIntakeMonitor } from './web/channel-intake-monitor.js'
+import { startSchemaWatch } from './web/schema-watch.js'
 import { startStuckInputWatcher } from './web/stuck-input-watcher.js'
 import { startInboxNudgeWatcher } from './web/inbox-nudge-watcher.js'
 import { startStuckToolCallWatcher } from './web/stuck-tool-call-watcher.js'
@@ -418,6 +419,14 @@ export function startWebServer(port = 3420): http.Server {
   const channelIntakeInterval = webOnly ? undefined : startChannelIntakeMonitor(PROJECT_ROOT)
   if (!webOnly) logger.info('Channel intake monitor started (5min poll, 100s offset)')
 
+  // The VoiceMailAI backend checks its own schema at boot and publishes the
+  // verdict at GET /health/schema. It cannot push the result here (it runs on
+  // Railway, this runs on localhost), so the fleet asks -- once a day, and it
+  // only speaks up for a real `missing`, or for an endpoint that has stayed
+  // unreadable long enough that its silence has stopped being informative.
+  const schemaWatchInterval = webOnly ? undefined : startSchemaWatch()
+  if (!webOnly) logger.info('Schema watch started (daily poll of /health/schema)')
+
   // CostOps: reflect the local config's fixed costs into the ledger once at boot + every
   // 10 minutes. Deliberately NOT done inside the GET /api/costs/summary handler -- a read
   // endpoint must not write (was flagged in review); this is the one place that does.
@@ -616,6 +625,7 @@ setInterval(() => { try { sweepExpiredDesktopLock() } catch { /* never kill the 
     if (workerLivenessInterval) clearInterval(workerLivenessInterval)
     clearInterval(channelHealthInterval)
     if (channelIntakeInterval) clearInterval(channelIntakeInterval)
+    if (schemaWatchInterval) clearInterval(schemaWatchInterval)
     if (costsSyncInterval) clearInterval(costsSyncInterval)
     clearInterval(stuckInputInterval)
     clearInterval(stuckToolCallInterval)

--- a/src/web/schema-watch.ts
+++ b/src/web/schema-watch.ts
@@ -1,0 +1,355 @@
+/**
+ * Schema watcher: the fleet-side half of the VoiceMailAI schema preflight.
+ *
+ * On 2026-09-06 two migrations had never been run against production. Nothing
+ * said so, and the sign-in failed earlier on another branch, so the missing
+ * column and the missing table stayed invisible for a day. The backend now
+ * checks its own schema at boot and publishes the verdict at
+ * `GET /health/schema` -- but a verdict nobody polls is the same silence in a
+ * new place, which is what this closes.
+ *
+ * WHY A POLL AND NOT A PUSH
+ * The original request was for the backend to send an inter-agent message when
+ * the check fails. It cannot: the backend runs on Railway, the dashboard runs
+ * on the owner's machine at localhost:3420, and the container can neither
+ * reach it nor hold a token for it. Writing that call anyway would have put a
+ * never-succeeding HTTP request on the startup path -- exactly the kind of
+ * quiet lie the whole card exists to prevent. So the backend answers, and this
+ * asks.
+ *
+ * THREE STATES, AND THE THIRD IS THE DANGEROUS ONE
+ * `ok`, `missing`, `unknown`. `unknown` is never an alert on its own: the
+ * endpoint may be mid-deploy, the network may be down, and paging on that
+ * would train the owner to ignore this. But an endpoint that stays unreachable
+ * for DAYS must alert, because otherwise a permanently silent check reads
+ * exactly like a permanently healthy one -- the same failure shape one level
+ * up. So staleness is measured, not assumed, and the clock runs from the last
+ * MEANINGFUL answer (ok or missing), not from the last request.
+ *
+ * WHAT THIS DELIBERATELY DOES NOT DO
+ * It does not interpret a non-`ok` payload. The `ok` shape was measured
+ * against production on 2026-09-07; the `missing` and `unknown` shapes were
+ * not -- they exist only in the backend's own tests. So anything that is not a
+ * recognised `ok` is carried through verbatim into the alert, and a human
+ * reads the actual body. A watcher that recognises only the healthy shape and
+ * flattens everything else would be at its least precise exactly where it
+ * matters.
+ */
+
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { logger } from '../logger.js'
+import { STORE_DIR } from '../config.js'
+import { atomicWriteFileSync } from './atomic-write.js'
+import { createAgentMessage } from '../db.js'
+import { decideRoutineAlert, routineAlertSuffix, type RoutineAlertState } from './routine-alert.js'
+
+const MINUTE_MS = 60 * 1000
+const HOUR_MS = 60 * MINUTE_MS
+const DAY_MS = 24 * HOUR_MS
+
+/** Where the verdict is published. Unauthenticated by design; carries no data. */
+export const SCHEMA_HEALTH_URL =
+  process.env['VOICEMAILAI_SCHEMA_HEALTH_URL']
+  ?? 'https://voicemailai-production.up.railway.app/health/schema'
+
+/** Who hears about it. */
+export const SCHEMA_WATCH_SENDER = 'schema-watch'
+export const SCHEMA_WATCH_RECIPIENT = 'jarvis'
+
+/**
+ * How long `unknown` may persist before it becomes the finding.
+ *
+ * Two days rather than one: a single day of silence is still explainable by a
+ * deploy or a maintenance window, and an alert the owner can dismiss with "it
+ * was deploying" is an alert they will dismiss next time too.
+ */
+export const SCHEMA_UNKNOWN_STALE_MS = 2 * DAY_MS
+
+/** Once a day. The schema does not change within an hour. */
+export const SCHEMA_CHECK_INTERVAL_MS = DAY_MS
+
+/** Matches the fleet's re-alert cadence for standing conditions. */
+export const SCHEMA_ALERT_COOLDOWN_MS = 3 * HOUR_MS
+
+const PROBE_TIMEOUT_MS = 10_000
+const INITIAL_DELAY_MS = 4 * MINUTE_MS
+
+export type SchemaState = 'ok' | 'missing' | 'unknown'
+
+export interface SchemaProbe {
+  state: SchemaState
+  /** The endpoint's own words, or ours when it never answered. */
+  summary: string
+  missingTables: string[]
+  missingColumns: string[]
+  /**
+   * The body as received, kept for anything that is not a recognised `ok`.
+   * Null when there was no body to keep. This is what makes the alert
+   * readable without this file having to guess the payload's shape.
+   */
+  raw: string | null
+}
+
+export type SchemaVerdict = 'ok' | 'missing' | 'unknown-recent' | 'unknown-stale'
+
+export interface SchemaDecision {
+  verdict: SchemaVerdict
+  alert: boolean
+  /** How long we have been without a meaningful answer; null while we have one. */
+  unknownForMs: number | null
+}
+
+interface SchemaHealthBody {
+  state?: unknown
+  summary?: unknown
+  missing_tables?: unknown
+  missing_columns?: unknown
+}
+
+function stringList(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((v): v is string => typeof v === 'string') : []
+}
+
+/**
+ * Turn one `GET /health/schema` response into a probe reading.
+ *
+ * `status === 0` is the caller's marker for "the HTTP call never completed".
+ * That is `unknown`, never `missing`: our own network being down says nothing
+ * about the database.
+ *
+ * Only the exact `state: "ok"` payload is treated as healthy. Every other
+ * answer -- a different state, a missing field, a proxy's HTML error page --
+ * comes back as `missing` when the endpoint says so, and `unknown` otherwise,
+ * with the body preserved in `raw` either way.
+ */
+export function parseSchemaProbe(status: number, body: unknown, rawText: string | null = null): SchemaProbe {
+  if (status === 0) {
+    return { state: 'unknown', summary: 'a végpont nem válaszolt', missingTables: [], missingColumns: [], raw: rawText }
+  }
+  if (status !== 200) {
+    return {
+      state: 'unknown',
+      summary: `a végpont ${status} státusszal válaszolt`,
+      missingTables: [],
+      missingColumns: [],
+      raw: rawText,
+    }
+  }
+
+  const parsed = (body ?? {}) as SchemaHealthBody
+  const summary = typeof parsed.summary === 'string' ? parsed.summary : ''
+
+  if (parsed.state === 'ok') {
+    return { state: 'ok', summary: summary || 'schema complete', missingTables: [], missingColumns: [], raw: null }
+  }
+  if (parsed.state === 'missing') {
+    return {
+      state: 'missing',
+      summary: summary || 'a séma hiányos',
+      missingTables: stringList(parsed.missing_tables),
+      missingColumns: stringList(parsed.missing_columns),
+      raw: rawText,
+    }
+  }
+  return {
+    state: 'unknown',
+    summary: summary || 'a válasz nem az ismert alakban jött',
+    missingTables: stringList(parsed.missing_tables),
+    missingColumns: stringList(parsed.missing_columns),
+    raw: rawText,
+  }
+}
+
+/**
+ * Pure verdict for one reading.
+ *
+ * `lastMeaningfulAt` is when the endpoint last answered `ok` or `missing`.
+ * While it is null the clock runs from `watchingSince` instead, so an endpoint
+ * that has NEVER answered since this watcher started still ages into an alert
+ * rather than sitting quiet for ever.
+ */
+export function decideSchemaVerdict(opts: {
+  probe: SchemaProbe
+  lastMeaningfulAt: number | null
+  watchingSince: number | null
+  now: number
+  staleAfterMs: number
+}): SchemaDecision {
+  const { probe, lastMeaningfulAt, watchingSince, now, staleAfterMs } = opts
+
+  if (probe.state === 'ok') return { verdict: 'ok', alert: false, unknownForMs: null }
+  if (probe.state === 'missing') return { verdict: 'missing', alert: true, unknownForMs: null }
+
+  const since = lastMeaningfulAt ?? watchingSince
+  // Nothing to measure against yet: this is the first reading of all, and one
+  // reading is not a duration.
+  if (since == null) return { verdict: 'unknown-recent', alert: false, unknownForMs: null }
+
+  const unknownForMs = Math.max(0, now - since)
+  if (unknownForMs >= staleAfterMs) return { verdict: 'unknown-stale', alert: true, unknownForMs }
+  return { verdict: 'unknown-recent', alert: false, unknownForMs }
+}
+
+export function formatSchemaAlert(decision: SchemaDecision, probe: SchemaProbe): string {
+  if (decision.verdict === 'missing') {
+    const tables = probe.missingTables.length ? `\nHiányzó táblák: ${probe.missingTables.join(', ')}` : ''
+    const columns = probe.missingColumns.length ? `\nHiányzó oszlopok: ${probe.missingColumns.join(', ')}` : ''
+    // The summary is the backend's own sentence, not ours.
+    return `❌ VoiceMailAI séma: a backend HIÁNYT jelez.\n${probe.summary}${tables}${columns}\n\nEz azt jelenti, hogy egy migráció nem futott le élesben. Ugyanaz az alakzat, ami 2026-09-06-án egy napig láthatatlan maradt.`
+  }
+  const days = decision.unknownForMs == null ? '?' : Math.floor(decision.unknownForMs / DAY_MS)
+  const raw = probe.raw ? `\n\nA kapott válasz: ${probe.raw.slice(0, 400)}` : ''
+  return `⚠️ VoiceMailAI séma: ${days} napja NEM tudjuk ellenőrizni (${probe.summary}).\n\nEz nem azt jelenti, hogy baj van, hanem hogy nem tudjuk megmondani. Egy tartósan néma ellenőrzés pontosan úgy néz ki, mint egy tartósan egészséges.${raw}`
+}
+
+// ---------------------------------------------------------------------------
+// Persisted state
+// ---------------------------------------------------------------------------
+
+export interface SchemaWatchState {
+  /** Last `ok` or `missing` answer. Null until the endpoint answers once. */
+  lastMeaningfulAt: number | null
+  /** First time this watcher ran at all, so "never answered" still ages. */
+  watchingSince: number
+  lastState: SchemaState | null
+  alert: RoutineAlertState | null
+}
+
+export function schemaWatchStatePath(storeDir: string = STORE_DIR): string {
+  return join(storeDir, '.schema-watch.json')
+}
+
+export function readSchemaWatchState(path: string): SchemaWatchState | null {
+  if (!existsSync(path)) return null
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf-8')) as Partial<SchemaWatchState>
+    if (typeof parsed.watchingSince !== 'number') return null
+    return {
+      lastMeaningfulAt: typeof parsed.lastMeaningfulAt === 'number' ? parsed.lastMeaningfulAt : null,
+      watchingSince: parsed.watchingSince,
+      lastState:
+        parsed.lastState === 'ok' || parsed.lastState === 'missing' || parsed.lastState === 'unknown'
+          ? parsed.lastState
+          : null,
+      alert:
+        parsed.alert && typeof parsed.alert.lastSentAt === 'number'
+          ? { lastSentAt: parsed.alert.lastSentAt, suppressed: Number(parsed.alert.suppressed) || 0 }
+          : null,
+    }
+  } catch {
+    // A corrupt state file must not silence the watcher; losing the timestamps
+    // costs one staleness window, keeping the watcher dead costs everything.
+    return null
+  }
+}
+
+export function writeSchemaWatchState(path: string, state: SchemaWatchState): void {
+  atomicWriteFileSync(path, JSON.stringify(state, null, 2))
+}
+
+/**
+ * Fold one reading into the stored state.
+ *
+ * Pure, so the "unknown for days" case is producible by moving a timestamp
+ * rather than by waiting two days.
+ */
+export function nextSchemaWatchState(
+  prev: SchemaWatchState | null,
+  probe: SchemaProbe,
+  now: number,
+  sent: boolean,
+): SchemaWatchState {
+  const base: SchemaWatchState = prev ?? {
+    lastMeaningfulAt: null,
+    watchingSince: now,
+    lastState: null,
+    alert: null,
+  }
+  const meaningful = probe.state === 'ok' || probe.state === 'missing'
+  const alert: RoutineAlertState | null = sent
+    ? { lastSentAt: now, suppressed: 0 }
+    : base.alert
+      ? { ...base.alert, suppressed: base.alert.suppressed + (probe.state === 'ok' ? 0 : 1) }
+      : null
+  return {
+    lastMeaningfulAt: meaningful ? now : base.lastMeaningfulAt,
+    watchingSince: base.watchingSince,
+    lastState: probe.state,
+    alert,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Runtime
+// ---------------------------------------------------------------------------
+
+async function probeSchemaHealth(url: string): Promise<SchemaProbe> {
+  try {
+    const res = await fetch(url, { signal: AbortSignal.timeout(PROBE_TIMEOUT_MS) })
+    const text = await res.text()
+    let body: unknown = null
+    try {
+      body = JSON.parse(text)
+    } catch {
+      // A proxy or an error page. parseSchemaProbe keeps the text in `raw`.
+    }
+    return parseSchemaProbe(res.status, body, text.slice(0, 1000))
+  } catch (err) {
+    return parseSchemaProbe(0, null, err instanceof Error ? err.message : null)
+  }
+}
+
+export async function checkSchemaOnce(opts: {
+  url?: string
+  statePath?: string
+  now?: number
+} = {}): Promise<SchemaDecision> {
+  const url = opts.url ?? SCHEMA_HEALTH_URL
+  const statePath = opts.statePath ?? schemaWatchStatePath()
+  const now = opts.now ?? Date.now()
+
+  const probe = await probeSchemaHealth(url)
+  const prev = readSchemaWatchState(statePath)
+  const decision = decideSchemaVerdict({
+    probe,
+    lastMeaningfulAt: prev?.lastMeaningfulAt ?? null,
+    watchingSince: prev?.watchingSince ?? null,
+    now,
+    staleAfterMs: SCHEMA_UNKNOWN_STALE_MS,
+  })
+
+  let sent = false
+  if (decision.alert) {
+    const throttle = decideRoutineAlert(prev?.alert ?? undefined, now, SCHEMA_ALERT_COOLDOWN_MS)
+    if (throttle.send) {
+      const text = formatSchemaAlert(decision, probe) + routineAlertSuffix(throttle.repeats, SCHEMA_ALERT_COOLDOWN_MS)
+      try {
+        createAgentMessage(SCHEMA_WATCH_SENDER, SCHEMA_WATCH_RECIPIENT, text)
+        sent = true
+      } catch (err) {
+        logger.error({ err }, 'schema-watch: could not queue the alert')
+      }
+    }
+  }
+
+  writeSchemaWatchState(statePath, nextSchemaWatchState(prev, probe, now, sent))
+  logger.info(
+    { verdict: decision.verdict, state: probe.state, unknownForMs: decision.unknownForMs, alerted: sent },
+    'schema-watch: probe',
+  )
+  return decision
+}
+
+/** Daily poll. Returns the interval so the caller can clear it on shutdown. */
+export function startSchemaWatch(): NodeJS.Timeout {
+  setTimeout(() => {
+    void checkSchemaOnce().catch((err) => logger.error({ err }, 'schema-watch: check failed'))
+  }, INITIAL_DELAY_MS).unref?.()
+
+  const interval = setInterval(() => {
+    void checkSchemaOnce().catch((err) => logger.error({ err }, 'schema-watch: check failed'))
+  }, SCHEMA_CHECK_INTERVAL_MS)
+  interval.unref?.()
+  return interval
+}


### PR DESCRIPTION
## Mit csinál

A PR #157 (VoiceMailAI) másik fele, flotta-oldalról. A backend indulásnál ellenőrzi a saját sémáját és közzéteszi a verdiktet a `GET /health/schema` végponton -- de **egy verdikt, amit senki nem kérdez meg, ugyanaz a csend egy új helyen**.

Kártya: `90b67570`.

## Miért pull, és nem push

Az eredeti kérés az volt, hogy a backend küldjön inter-agent üzenetet, ha az ellenőrzés bukik. **Nem tudja**: a backend a Railwayen fut, a dashboard a tulajdonos gépén `localhost:3420`-on, a konténer nem lát rá és nincs hozzá tokenje. Egy odaírt hívás sosem sikerülne az indulási úton -- pont az a fajta csendes hazugság, ami ellen az egész kártya szól. Tehát a backend válaszol, és a flotta kérdez.

## Három állapot, és a harmadik a veszélyes

| állapot | mit tesz |
|---|---|
| `ok` | csend |
| `missing` | azonnali inter-agent üzenet Jarvisnak |
| `unknown` | **önmagában nem riasztás** (lehet deploy, hálózat, karbantartás), **de ha napokig tart, igen** |

Az `unknown` kezelése a kártya lényege: különben egy tartósan elérhetetlen végpont **csendben zölddé válik**, és pontosan azt a hibaalakot kapjuk vissza egy szinttel feljebb, ami ellen az egész készült.

Ezért az avulás **mérve** van, nem feltételezve:
- az óra az utolsó **értelmes** választól (`ok` vagy `missing`) fut, nem az utolsó kéréstől -- ha egy elérhetetlen végpont frissítené az órát, a "napok óta unknown" állapot sosem állna elő
- ha a végpont **még soha** nem válaszolt, az óra a figyelés kezdetétől fut, különben egy első naptól rossz URL örökre néma maradna
- a küszöb 2 nap: egy nap kimaradás még elmegy deploynak, és egy riasztás, amit "épp deployolt"-tal el lehet intézni, olyan riasztás, amit legközelebb is el fognak intézni

## Amit szándékosan NEM tesz

**Nem értelmezi a nem-`ok` választ.** Az `ok` alakot 2026-09-07-en élesben megmértük; a `missing` és az `unknown` alakját nem -- azok csak a backend saját tesztjeiben léteznek. Ezért minden, ami nem a felismert `ok`, **nyersen** megy tovább a riasztásba, és ember olvassa el a valódi testet. Egy figyelő, ami csak az egészséges alakot ismeri fel biztosan és minden mást egy kalap alá vesz, pont a riasztási ágon lenne pontatlan -- ott, ahol számít.

## Mérés

Hat mutációs próba, mind piros:

| mutáció | melyik teszt bukott |
|---|---|
| a stale-ág törölve | "ages from when watching began when the endpoint has NEVER answered" |
| `>=` helyett `>` | ugyanaz a határ-teszt |
| az `unknown` is frissíti a meaningful órát | "does NOT advance it on unknown" |
| ismeretlen `state`-et `ok`-ként olvas | "does not read a body without a state field as healthy" |
| nem öregszik a `watchingSince`-ről | a soha-nem-válaszolt eset |
| a nyers testet eldobja | "says how long the silence has lasted, and shows the raw answer" |

A határ-teszt **pontosan a küszöbön** áll, plusz egy ezredmásodperccel előtte: egy ablakon belül kényelmesen elhelyezett bemenet mindkét implementációt átengedi, és pont ezen a hibán csúsztam el korábban egy 24 órás TTL-nél.

## Ellenőrzés

- `npx tsc --noEmit` -> tiszta
- Teljes suite: **379 fájl, 4901 passed, 1 skipped**
- A napi poll a `web.ts`-ben indul (`webOnly` módban nem), és leálláskor törlődik, a többi monitor mintájára

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148rV8xMuHmpCgH1T8J1ZJz
