### PR TITLE
feat(pr-ledger): self-accruing fleet PR-throughput ledger + read-only window API (PRLEDGER907)

### DIFF
--- a/scripts/pr-ledger-collect.mjs
+++ b/scripts/pr-ledger-collect.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+// PRLEDGER907 -- fleet PR-throughput ledger collector. Idempotent: every run
+// upserts closed PRs per (repo, number) and RE-DERIVES is_live on existing
+// rows (a release retroactively makes earlier develop merges live). Never
+// deletes.
+//
+// Scope is MEASURED each run (gh repo list), never a hardcoded repo list --
+// a new repo must not silently fall out of the ledger.
+//
+// Pitfalls this encodes (measured 2026-09-07, see the PRLEDGER907 brief):
+// - `gh pr list` orders by creation, not merge time: an old-numbered PR
+//   merged today drops off a short page. Wide --limit + own date filter,
+//   never `--search "merged:>="`.
+// - the not-yet-released set comes from the main...develop RANGE (compare
+//   API), not from searching main's log.
+// - the store DB has concurrent writers: busy_timeout is mandatory.
+//
+// Usage: node scripts/pr-ledger-collect.mjs [--db <path>] [--owner <login>]
+
+import { execFileSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { PR_LEDGER_SCHEMA, mapPr, prNumbersFromMessages, decideLive } from './pr-ledger-lib.mjs';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const require = createRequire(path.join(here, '..', 'package.json'));
+const Database = require('better-sqlite3');
+
+const args = process.argv.slice(2);
+const argOf = (name, dflt) => {
+  const i = args.indexOf(name);
+  return i >= 0 && args[i + 1] ? args[i + 1] : dflt;
+};
+const DB_PATH = argOf('--db', path.join(here, '..', 'store', 'claudeclaw.db'));
+const OWNER = argOf('--owner', 'Szotasz');
+// 1000, not 400: the ordering is by CREATION, so in a big repo an old-numbered
+// PR merged recently sits deep in the page (the measured #767 case needed
+// >400 in marveen already). The window filter happens on our side, by date.
+const PR_PAGE_LIMIT = 1000;
+
+function gh(ghArgs) {
+  return execFileSync('gh', ghArgs, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+}
+
+function listRepos() {
+  const raw = gh(['repo', 'list', OWNER, '--limit', '200', '--json', 'name']);
+  return JSON.parse(raw).map((r) => r.name);
+}
+
+function listClosedPrs(repo) {
+  const raw = gh([
+    'pr', 'list', '--repo', `${OWNER}/${repo}`, '--state', 'closed',
+    '--limit', String(PR_PAGE_LIMIT),
+    '--json', 'number,title,author,baseRefName,mergedAt,closedAt,additions,deletions,changedFiles',
+  ]);
+  return JSON.parse(raw);
+}
+
+// The not-yet-released PR set: commit subjects in main...develop. Compare API,
+// so no clone is needed. A repo without a develop branch (or main) simply has
+// an empty set -- every one of its merges is judged by its base branch alone.
+function unreleasedSet(repo) {
+  try {
+    const raw = gh(['api', `repos/${OWNER}/${repo}/compare/main...develop`, '--paginate', '--jq', '.commits[].commit.message | split("\n")[0]']);
+    return prNumbersFromMessages(raw.split('\n'));
+  } catch {
+    return new Set();
+  }
+}
+
+function main() {
+  const db = new Database(DB_PATH);
+  db.pragma('busy_timeout = 8000');
+  db.exec(PR_LEDGER_SCHEMA);
+  db.exec('CREATE INDEX IF NOT EXISTS idx_pr_ledger_date ON pr_ledger(closed_date)');
+
+  const upsert = db.prepare(`
+    INSERT INTO pr_ledger (repo, number, closed_date, base_branch, author, additions, deletions, files, state, title, is_live, live_since, measured_at)
+    VALUES (@repo, @number, @closed_date, @base_branch, @author, @additions, @deletions, @files, @state, @title, @is_live, @live_since, @measured_at)
+    ON CONFLICT(repo, number) DO UPDATE SET
+      closed_date=excluded.closed_date, base_branch=excluded.base_branch,
+      author=excluded.author, additions=excluded.additions, deletions=excluded.deletions,
+      files=excluded.files, state=excluded.state, title=excluded.title,
+      is_live=excluded.is_live, live_since=excluded.live_since, measured_at=excluded.measured_at
+  `);
+
+  const now = Math.floor(Date.now() / 1000);
+  const repos = listRepos();
+  let written = 0, reposWithPrs = 0;
+
+  for (const repo of repos) {
+    let prs;
+    try {
+      prs = listClosedPrs(repo);
+    } catch (e) {
+      process.stderr.write(`SKIP ${repo}: gh pr list failed: ${String(e).slice(0, 120)}\n`);
+      continue;
+    }
+    if (prs.length === 0) continue;
+    reposWithPrs++;
+    const unreleased = unreleasedSet(repo);
+    const tx = db.transaction((items) => {
+      for (const pr of items) {
+        const row = mapPr(repo, pr);
+        if (!row) continue;
+        const live = decideLive(row, unreleased);
+        upsert.run({ ...row, ...live, measured_at: now });
+        written++;
+      }
+    });
+    tx(prs);
+    process.stderr.write(`OK ${repo}: ${prs.length} closed PR, unreleased-set ${unreleased.size}\n`);
+  }
+
+  const total = db.prepare('SELECT COUNT(*) c FROM pr_ledger').get().c;
+  console.log(JSON.stringify({ ok: true, repos_scanned: repos.length, repos_with_prs: reposWithPrs, rows_upserted: written, rows_total: total, measured_at: now }));
+  db.close();
+}
+
+main();

--- a/scripts/pr-ledger-collect.mjs
+++ b/scripts/pr-ledger-collect.mjs
@@ -75,6 +75,11 @@ function listClosedPrs(repo) {
 // there is the legit no-develop case (empty set, ok). Anything else that
 // fails -> { ok: false }, and the caller leaves the stored is_live of that
 // repo's develop rows alone.
+// ORDERING INVARIANT (Marveen verify on b8a2cd9): "404 = no develop branch"
+// is only sound because this runs AFTER listClosedPrs already succeeded for
+// the repo -- a missing/renamed REPO would 404 the same way, but it cannot
+// reach this call. Do not reorder unreleasedInfo ahead of the PR listing,
+// or the hole reopens.
 function unreleasedInfo(repo) {
   try {
     gh(['api', `repos/${OWNER}/${repo}/branches/develop`, '--jq', '.name']);

--- a/scripts/pr-ledger-collect.mjs
+++ b/scripts/pr-ledger-collect.mjs
@@ -43,6 +43,13 @@ function gh(ghArgs) {
   return execFileSync('gh', ghArgs, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
 }
 
+// SCOPE RULE (Marveen 21996, the measured mistake behind the snapshot's
+// missing repos): the question is NEVER "does the repo have OPEN PRs" --
+// hideghivas-oktatas-web had none and was still the period's most active
+// repo (116 closed rows). The right question is "did any PR CLOSE there",
+// and this collector asks it by construction: it scans EVERY repo of the
+// owner and lets the closed-PR listing decide. Do not "optimise" this into
+// an open-PR or recently-pushed prefilter; that is the trap.
 function listRepos() {
   const raw = gh(['repo', 'list', OWNER, '--limit', '200', '--json', 'name']);
   return JSON.parse(raw).map((r) => r.name);

--- a/scripts/pr-ledger-collect.mjs
+++ b/scripts/pr-ledger-collect.mjs
@@ -21,7 +21,7 @@ import { execFileSync } from 'node:child_process';
 import { createRequire } from 'node:module';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { PR_LEDGER_SCHEMA, mapPr, prNumbersFromMessages, decideLive } from './pr-ledger-lib.mjs';
+import { PR_LEDGER_SCHEMA, UPSERT_FULL_SQL, UPSERT_PRESERVE_LIVE_SQL, isGhNotFound, mapPr, prNumbersFromMessages, decideLive } from './pr-ledger-lib.mjs';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const require = createRequire(path.join(here, '..', 'package.json'));
@@ -65,14 +65,28 @@ function listClosedPrs(repo) {
 }
 
 // The not-yet-released PR set: commit subjects in main...develop. Compare API,
-// so no clone is needed. A repo without a develop branch (or main) simply has
-// an empty set -- every one of its merges is judged by its base branch alone.
-function unreleasedSet(repo) {
+// so no clone is needed (--paginate is load-bearing: the commits[] array is
+// capped at 250 per page, and v1.25.1...develop measured 389).
+//
+// FAILURE SEMANTICS (Marveen review blocker on #1234): an empty set means
+// "nothing waits for a release" and flips every develop merge live -- so a
+// FAILED measurement must NEVER masquerade as an empty one. The develop
+// branch's EXISTENCE is measured separately (branches/develop): a clean 404
+// there is the legit no-develop case (empty set, ok). Anything else that
+// fails -> { ok: false }, and the caller leaves the stored is_live of that
+// repo's develop rows alone.
+function unreleasedInfo(repo) {
+  try {
+    gh(['api', `repos/${OWNER}/${repo}/branches/develop`, '--jq', '.name']);
+  } catch (e) {
+    if (isGhNotFound(e?.stderr ?? e)) return { ok: true, set: new Set(), noDevelop: true };
+    return { ok: false };
+  }
   try {
     const raw = gh(['api', `repos/${OWNER}/${repo}/compare/main...develop`, '--paginate', '--jq', '.commits[].commit.message | split("\n")[0]']);
-    return prNumbersFromMessages(raw.split('\n'));
+    return { ok: true, set: prNumbersFromMessages(raw.split('\n')) };
   } catch {
-    return new Set();
+    return { ok: false };
   }
 }
 
@@ -82,46 +96,50 @@ function main() {
   db.exec(PR_LEDGER_SCHEMA);
   db.exec('CREATE INDEX IF NOT EXISTS idx_pr_ledger_date ON pr_ledger(closed_date)');
 
-  const upsert = db.prepare(`
-    INSERT INTO pr_ledger (repo, number, closed_date, base_branch, author, additions, deletions, files, state, title, is_live, live_since, measured_at)
-    VALUES (@repo, @number, @closed_date, @base_branch, @author, @additions, @deletions, @files, @state, @title, @is_live, @live_since, @measured_at)
-    ON CONFLICT(repo, number) DO UPDATE SET
-      closed_date=excluded.closed_date, base_branch=excluded.base_branch,
-      author=excluded.author, additions=excluded.additions, deletions=excluded.deletions,
-      files=excluded.files, state=excluded.state, title=excluded.title,
-      is_live=excluded.is_live, live_since=excluded.live_since, measured_at=excluded.measured_at
-  `);
+  const upsertFull = db.prepare(UPSERT_FULL_SQL);
+  const upsertPreserveLive = db.prepare(UPSERT_PRESERVE_LIVE_SQL);
 
   const now = Math.floor(Date.now() / 1000);
   const repos = listRepos();
   let written = 0, reposWithPrs = 0;
+  const degradedRepos = [];
 
   for (const repo of repos) {
     let prs;
     try {
       prs = listClosedPrs(repo);
     } catch (e) {
+      degradedRepos.push(`${repo}:pr-list`);
       process.stderr.write(`SKIP ${repo}: gh pr list failed: ${String(e).slice(0, 120)}\n`);
       continue;
     }
     if (prs.length === 0) continue;
     reposWithPrs++;
-    const unreleased = unreleasedSet(repo);
+    const unreleased = unreleasedInfo(repo);
+    if (!unreleased.ok) degradedRepos.push(`${repo}:unreleased-set`);
     const tx = db.transaction((items) => {
       for (const pr of items) {
         const row = mapPr(repo, pr);
         if (!row) continue;
-        const live = decideLive(row, unreleased);
-        upsert.run({ ...row, ...live, measured_at: now });
+        if (!unreleased.ok && row.base_branch === 'develop') {
+          // Degraded: the release state of develop rows is UNKNOWN this run --
+          // update the facts, leave the stored is_live/live_since alone.
+          upsertPreserveLive.run({ ...row, measured_at: now });
+        } else {
+          const live = decideLive(row, unreleased.ok ? unreleased.set : new Set());
+          upsertFull.run({ ...row, ...live, measured_at: now });
+        }
         written++;
       }
     });
     tx(prs);
-    process.stderr.write(`OK ${repo}: ${prs.length} closed PR, unreleased-set ${unreleased.size}\n`);
+    process.stderr.write(`OK ${repo}: ${prs.length} closed PR, unreleased-set ${unreleased.ok ? unreleased.set.size : 'DEGRADED'}\n`);
   }
 
   const total = db.prepare('SELECT COUNT(*) c FROM pr_ledger').get().c;
-  console.log(JSON.stringify({ ok: true, repos_scanned: repos.length, repos_with_prs: reposWithPrs, rows_upserted: written, rows_total: total, measured_at: now }));
+  // degraded_repos on STDOUT, not stderr: the daily task's stderr goes unread,
+  // and a degraded measurement must be visible where the result is.
+  console.log(JSON.stringify({ ok: true, repos_scanned: repos.length, repos_with_prs: reposWithPrs, rows_upserted: written, rows_total: total, degraded_repos: degradedRepos, measured_at: now }));
   db.close();
 }
 

--- a/scripts/pr-ledger-lib.mjs
+++ b/scripts/pr-ledger-lib.mjs
@@ -108,3 +108,39 @@ export function summarize(rows) {
   }
   return { closed: rows.length, merged, rejected, live };
 }
+
+/** gh stderr shape for a plain 404 -- used to tell "no develop branch" from a
+ *  real failure. Anything that does not match is treated as DEGRADED. */
+export function isGhNotFound(errText) {
+  return /HTTP 404/.test(String(errText ?? ''));
+}
+
+/** Full upsert: every field, is_live/live_since included (healthy path). */
+export const UPSERT_FULL_SQL = `
+    INSERT INTO pr_ledger (repo, number, closed_date, base_branch, author, additions, deletions, files, state, title, is_live, live_since, measured_at)
+    VALUES (@repo, @number, @closed_date, @base_branch, @author, @additions, @deletions, @files, @state, @title, @is_live, @live_since, @measured_at)
+    ON CONFLICT(repo, number) DO UPDATE SET
+      closed_date=excluded.closed_date, base_branch=excluded.base_branch,
+      author=excluded.author, additions=excluded.additions, deletions=excluded.deletions,
+      files=excluded.files, state=excluded.state, title=excluded.title,
+      is_live=excluded.is_live, live_since=excluded.live_since, measured_at=excluded.measured_at
+`;
+
+/**
+ * Degraded-mode upsert for develop-based rows when the unreleased set could
+ * NOT be measured (Marveen's review blocker on #1234): an empty set would
+ * silently flip every waiting develop merge to live -- 102 stored rows on the
+ * day it was measured. So on failure the stored is_live/live_since are LEFT
+ * ALONE; a brand-new row enters conservatively as not-live (is_live=0) and the
+ * next healthy run corrects it. Main/master/feature rows never depend on the
+ * set and keep using the full upsert even in degraded mode.
+ */
+export const UPSERT_PRESERVE_LIVE_SQL = `
+    INSERT INTO pr_ledger (repo, number, closed_date, base_branch, author, additions, deletions, files, state, title, is_live, live_since, measured_at)
+    VALUES (@repo, @number, @closed_date, @base_branch, @author, @additions, @deletions, @files, @state, @title, 0, NULL, @measured_at)
+    ON CONFLICT(repo, number) DO UPDATE SET
+      closed_date=excluded.closed_date, base_branch=excluded.base_branch,
+      author=excluded.author, additions=excluded.additions, deletions=excluded.deletions,
+      files=excluded.files, state=excluded.state, title=excluded.title,
+      measured_at=excluded.measured_at
+`;

--- a/scripts/pr-ledger-lib.mjs
+++ b/scripts/pr-ledger-lib.mjs
@@ -1,0 +1,110 @@
+// PRLEDGER907 -- pure logic for the PR ledger collector, split out so vitest
+// can exercise the decisions without gh/network. The collector script
+// (pr-ledger-collect.mjs) is the I/O shell around these.
+//
+// SCHEMA NOTE: the CREATE TABLE here must stay in sync with the pr_ledger
+// migration in src/db.ts (same dual-writer pattern as conversation_log /
+// ledger_lib.py, and the same reason: the collector may run standalone before
+// the dashboard process ever migrated, and vice versa). A schema-parity test
+// guards the drift.
+
+export const PR_LEDGER_SCHEMA = `
+CREATE TABLE IF NOT EXISTS pr_ledger (
+  repo TEXT NOT NULL,
+  number INTEGER NOT NULL,
+  closed_date TEXT NOT NULL,
+  base_branch TEXT NOT NULL,
+  author TEXT,
+  additions INTEGER,
+  deletions INTEGER,
+  files INTEGER,
+  state TEXT NOT NULL,
+  title TEXT,
+  is_live INTEGER NOT NULL DEFAULT 0,
+  live_since TEXT,
+  measured_at INTEGER NOT NULL,
+  UNIQUE(repo, number)
+)
+`;
+
+/** YYYY-MM-DD (UTC) from a gh ISO timestamp; null when absent. */
+export function isoDay(ts) {
+  if (!ts || typeof ts !== 'string') return null;
+  const m = ts.match(/^(\d{4}-\d{2}-\d{2})T/);
+  return m ? m[1] : null;
+}
+
+/**
+ * Map one `gh pr list --state closed --json ...` item to a ledger row (without
+ * is_live, which needs the release measurement). Returns null for PRs that are
+ * still open or carry no usable close date.
+ */
+export function mapPr(repo, pr) {
+  const merged = Boolean(pr.mergedAt);
+  const closedDate = isoDay(pr.mergedAt) ?? isoDay(pr.closedAt);
+  if (!closedDate) return null;
+  return {
+    repo,
+    number: pr.number,
+    closed_date: closedDate,
+    base_branch: pr.baseRefName ?? '',
+    author: pr.author?.login ?? null,
+    additions: pr.additions ?? null,
+    deletions: pr.deletions ?? null,
+    files: pr.changedFiles ?? null,
+    state: merged ? 'merged' : 'closed',
+    title: pr.title ?? null,
+  };
+}
+
+/**
+ * Extract the "(#N)" PR references from commit message subjects -- the shape a
+ * squash/merge commit carries. Used on the main...develop compare range: what
+ * appears there has NOT shipped yet.
+ */
+export function prNumbersFromMessages(messages) {
+  const out = new Set();
+  for (const msg of messages) {
+    for (const m of String(msg ?? '').matchAll(/\(#(\d+)\)/g)) out.add(Number(m[1]));
+  }
+  return out;
+}
+
+/**
+ * The is_live decision (the number the whole exercise is about).
+ *
+ * - merge-mode repos (everything except tag-released ones): a merge to the
+ *   release branch (main/master) IS the release -> live. Feature-branch
+ *   merges are not.
+ * - tag-mode repos (marveen): work merges to develop, RELEASES carry it out.
+ *   A develop merge is live UNLESS its number still sits in the
+ *   main...develop range (`unreleasedSet`) -- that set is measured, not
+ *   assumed. This rule is generic: for repos with no develop branch the
+ *   caller passes an empty set and no develop-based PRs exist anyway.
+ * - rejected (state 'closed') PRs are never live.
+ *
+ * live_since is only claimed where it is actually measurable: a main-merge
+ * went live the day it merged. A develop merge that shipped via a later
+ * release would need the release date -- v1 leaves it NULL rather than guess.
+ */
+export function decideLive(row, unreleasedSet) {
+  if (row.state !== 'merged') return { is_live: 0, live_since: null };
+  const base = row.base_branch;
+  if (base === 'main' || base === 'master') return { is_live: 1, live_since: row.closed_date };
+  if (base === 'develop') {
+    return unreleasedSet.has(row.number)
+      ? { is_live: 0, live_since: null }
+      : { is_live: 1, live_since: null };
+  }
+  return { is_live: 0, live_since: null };
+}
+
+/** Inclusive date-range + optional repo filter, plus the four-number summary. */
+export function summarize(rows) {
+  let merged = 0, rejected = 0, live = 0;
+  for (const r of rows) {
+    if (r.state === 'merged') merged++; else rejected++;
+    if (r.is_live) live++;
+  }
+  return { closed: rows.length, merged, rejected, live };
+}

--- a/src/__tests__/pr-ledger.test.ts
+++ b/src/__tests__/pr-ledger.test.ts
@@ -7,7 +7,7 @@ import type { RouteContext } from '../web/routes/types.js'
 // The collector's pure logic -- imported directly, so the decisions the daily
 // run makes are the ones under test, not a re-implementation.
 // @ts-expect-error plain .mjs module without type declarations
-import { mapPr, prNumbersFromMessages, decideLive, isoDay } from '../../scripts/pr-ledger-lib.mjs'
+import { mapPr, prNumbersFromMessages, decideLive, isoDay, isGhNotFound, UPSERT_FULL_SQL, UPSERT_PRESERVE_LIVE_SQL } from '../../scripts/pr-ledger-lib.mjs'
 
 const ROOT = join(__dirname, '..', '..')
 
@@ -149,5 +149,50 @@ describe('GET /api/pr-ledger', () => {
   it('other methods and paths fall through untouched', async () => {
     const { ctx } = fakeGet('/api/pr-ledger-not-this')
     expect(await tryHandlePrLedger(ctx)).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Degraded-mode upsert (Marveen review blocker on #1234): a FAILED unreleased
+// measurement must never flip stored develop rows live. The preserve statement
+// updates the facts but leaves is_live/live_since untouched; the full one
+// overwrites both (that is what makes releases retroactive).
+// ---------------------------------------------------------------------------
+describe('degraded-mode upsert semantics', () => {
+  const base = { repo: 'marveen', closed_date: '2026-09-01', base_branch: 'develop', author: 'a', additions: 1, deletions: 1, files: 1, state: 'merged', title: 'eredeti' }
+
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('preserve: an existing NOT-live develop row stays not-live, the facts still update', () => {
+    getDb().prepare(UPSERT_FULL_SQL).run({ ...base, number: 1, is_live: 0, live_since: null, measured_at: 1 })
+    getDb().prepare(UPSERT_PRESERVE_LIVE_SQL).run({ ...base, number: 1, title: 'frissult', measured_at: 2 })
+    const r = getDb().prepare('SELECT is_live, live_since, title, measured_at FROM pr_ledger WHERE number = 1').get() as any
+    expect(r).toMatchObject({ is_live: 0, live_since: null, title: 'frissult', measured_at: 2 })
+  })
+
+  it('preserve: an existing LIVE row keeps is_live=1 and its live_since', () => {
+    getDb().prepare(UPSERT_FULL_SQL).run({ ...base, number: 2, is_live: 1, live_since: '2026-08-20', measured_at: 1 })
+    getDb().prepare(UPSERT_PRESERVE_LIVE_SQL).run({ ...base, number: 2, measured_at: 2 })
+    const r = getDb().prepare('SELECT is_live, live_since FROM pr_ledger WHERE number = 2').get() as any
+    expect(r).toEqual({ is_live: 1, live_since: '2026-08-20' })
+  })
+
+  it('preserve: a brand-new row enters conservatively as not-live', () => {
+    getDb().prepare(UPSERT_PRESERVE_LIVE_SQL).run({ ...base, number: 3, measured_at: 2 })
+    const r = getDb().prepare('SELECT is_live, live_since FROM pr_ledger WHERE number = 3').get() as any
+    expect(r).toEqual({ is_live: 0, live_since: null })
+  })
+
+  it('full: overwrites is_live in both directions (releases are retroactive)', () => {
+    getDb().prepare(UPSERT_FULL_SQL).run({ ...base, number: 4, is_live: 0, live_since: null, measured_at: 1 })
+    getDb().prepare(UPSERT_FULL_SQL).run({ ...base, number: 4, is_live: 1, live_since: null, measured_at: 2 })
+    expect((getDb().prepare('SELECT is_live FROM pr_ledger WHERE number = 4').get() as any).is_live).toBe(1)
+  })
+
+  it('isGhNotFound: a clean 404 is the legit no-develop shape, everything else is not', () => {
+    expect(isGhNotFound('gh: Not Found (HTTP 404)')).toBe(true)
+    expect(isGhNotFound('gh: rate limit exceeded (HTTP 403)')).toBe(false)
+    expect(isGhNotFound('connect ETIMEDOUT')).toBe(false)
+    expect(isGhNotFound(null)).toBe(false)
   })
 })

--- a/src/__tests__/pr-ledger.test.ts
+++ b/src/__tests__/pr-ledger.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { initDatabase, getDb } from '../db.js'
+import { tryHandlePrLedger } from '../web/routes/pr-ledger.js'
+import type { RouteContext } from '../web/routes/types.js'
+// The collector's pure logic -- imported directly, so the decisions the daily
+// run makes are the ones under test, not a re-implementation.
+// @ts-expect-error plain .mjs module without type declarations
+import { mapPr, prNumbersFromMessages, decideLive, isoDay } from '../../scripts/pr-ledger-lib.mjs'
+
+const ROOT = join(__dirname, '..', '..')
+
+function fakeGet(pathAndQuery: string): { ctx: RouteContext; out: { status: number; body: any } } {
+  const out: { status: number; body: any } = { status: 0, body: null }
+  const res: any = {
+    writeHead(status: number) { out.status = status; return res },
+    end(chunk?: string) { if (chunk) out.body = JSON.parse(chunk) },
+  }
+  const url = new URL(`http://localhost:3420${pathAndQuery}`)
+  return { ctx: { req: {} as any, res, path: url.pathname, method: 'GET', url } as RouteContext, out }
+}
+
+// ---------------------------------------------------------------------------
+// Schema parity: db.ts migration == collector's own CREATE (dual-writer
+// contract, same as conversation_log / ledger_lib.py). Either side may run
+// first; a drift means one writer's column the other never created.
+// ---------------------------------------------------------------------------
+function ledgerColumns(src: string): string[] {
+  const m = src.match(/CREATE TABLE IF NOT EXISTS pr_ledger\s*\(([\s\S]*?)\n\s*\)/)
+  if (!m) return []
+  return m[1]
+    .split('\n')
+    .map((l) => l.trim().replace(/,$/, ''))
+    .filter((l) => l && !/^(UNIQUE|PRIMARY|FOREIGN|CHECK)\b/i.test(l))
+    .map((l) => l.split(/\s+/)[0])
+    .filter(Boolean)
+}
+
+describe('pr_ledger schema: db.ts migration == pr-ledger-lib.mjs (no drift)', () => {
+  const dbts = readFileSync(join(ROOT, 'src/db.ts'), 'utf-8')
+  const lib = readFileSync(join(ROOT, 'scripts/pr-ledger-lib.mjs'), 'utf-8')
+
+  it('both places define the table with identical columns', () => {
+    const a = ledgerColumns(dbts).sort()
+    const b = ledgerColumns(lib).sort()
+    expect(a).toEqual(['additions', 'author', 'base_branch', 'closed_date', 'deletions', 'files', 'is_live', 'live_since', 'measured_at', 'number', 'repo', 'state', 'title'])
+    expect(b).toEqual(a)
+  })
+
+  it('both carry the natural key UNIQUE(repo, number)', () => {
+    expect(dbts).toMatch(/UNIQUE\(repo,\s*number\)/)
+    expect(lib).toMatch(/UNIQUE\(repo,\s*number\)/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The is_live decision -- the number the whole ledger exists for.
+// ---------------------------------------------------------------------------
+describe('decideLive', () => {
+  const row = (state: string, base: string, number = 42) =>
+    ({ state, base_branch: base, number, closed_date: '2026-09-01' }) as any
+
+  it('a merge to main IS the release: live, since its merge day', () => {
+    expect(decideLive(row('merged', 'main'), new Set())).toEqual({ is_live: 1, live_since: '2026-09-01' })
+    expect(decideLive(row('merged', 'master'), new Set())).toEqual({ is_live: 1, live_since: '2026-09-01' })
+  })
+
+  it('a develop merge still sitting in main...develop is NOT live', () => {
+    expect(decideLive(row('merged', 'develop', 99), new Set([99])).is_live).toBe(0)
+  })
+
+  it('a develop merge NOT in the range shipped with a release: live, but its day is not guessed', () => {
+    expect(decideLive(row('merged', 'develop', 99), new Set([100]))).toEqual({ is_live: 1, live_since: null })
+  })
+
+  it('a rejected PR is never live, whatever it targeted', () => {
+    expect(decideLive(row('closed', 'main'), new Set()).is_live).toBe(0)
+    expect(decideLive(row('closed', 'develop'), new Set()).is_live).toBe(0)
+  })
+
+  it('a feature-branch merge did not reach the customer', () => {
+    expect(decideLive(row('merged', 'feat/something'), new Set()).is_live).toBe(0)
+  })
+})
+
+describe('collector mapping', () => {
+  it('mapPr: merged wins over closed for state and date; missing dates drop the row', () => {
+    const merged = mapPr('marveen', { number: 1, mergedAt: '2026-09-01T10:00:00Z', closedAt: '2026-09-01T10:00:00Z', baseRefName: 'develop', author: { login: 'x' }, additions: 1, deletions: 2, changedFiles: 3, title: 't' })
+    expect(merged).toMatchObject({ state: 'merged', closed_date: '2026-09-01', base_branch: 'develop', author: 'x' })
+    const rejected = mapPr('marveen', { number: 2, mergedAt: null, closedAt: '2026-09-02T10:00:00Z', baseRefName: 'main', title: 't' })
+    expect(rejected).toMatchObject({ state: 'closed', closed_date: '2026-09-02' })
+    expect(mapPr('marveen', { number: 3, mergedAt: null, closedAt: null })).toBeNull()
+  })
+
+  it('prNumbersFromMessages: "(#N)" refs, deduped; noise ignored', () => {
+    const set = prNumbersFromMessages(['fix: a (#12)', 'feat: b (#12) and (#34)', 'no ref', 'issue #56 unparenthesised'])
+    expect([...set].sort((a, b) => a - b)).toEqual([12, 34])
+  })
+
+  it('isoDay: UTC date part only, null on garbage', () => {
+    expect(isoDay('2026-09-07T21:00:00Z')).toBe('2026-09-07')
+    expect(isoDay(null)).toBeNull()
+    expect(isoDay('nonsense')).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The read-only endpoint.
+// ---------------------------------------------------------------------------
+describe('GET /api/pr-ledger', () => {
+  beforeEach(() => {
+    initDatabase(':memory:')
+    const ins = getDb().prepare(`
+      INSERT INTO pr_ledger (repo, number, closed_date, base_branch, author, additions, deletions, files, state, title, is_live, live_since, measured_at)
+      VALUES (?, ?, ?, ?, 'a', 1, 1, 1, ?, 't', ?, NULL, 0)
+    `)
+    ins.run('marveen', 1, '2026-08-10', 'develop', 'merged', 1)
+    ins.run('marveen', 2, '2026-08-20', 'develop', 'merged', 0)
+    ins.run('marveen', 3, '2026-09-07', 'develop', 'closed', 0)
+    ins.run('marveen-io', 9, '2026-08-15', 'main', 'merged', 1)
+    ins.run('marveen', 4, '2026-07-01', 'develop', 'merged', 1) // window elott
+  })
+
+  it('window is inclusive on both ends and the summary matches the rows', async () => {
+    const { ctx, out } = fakeGet('/api/pr-ledger?from=2026-08-10&to=2026-09-07')
+    expect(await tryHandlePrLedger(ctx)).toBe(true)
+    expect(out.status).toBe(200)
+    expect(out.body.summary).toEqual({ closed: 4, merged: 3, rejected: 1, live: 2 })
+    expect(out.body.rows).toHaveLength(4)
+    expect(out.body.rows.map((r: any) => r.number)).toContain(1) // from-nap belefer
+  })
+
+  it('repo filter narrows both rows and summary', async () => {
+    const { ctx, out } = fakeGet('/api/pr-ledger?from=2026-08-01&to=2026-09-07&repo=marveen-io')
+    await tryHandlePrLedger(ctx)
+    expect(out.body.summary).toEqual({ closed: 1, merged: 1, rejected: 0, live: 1 })
+    expect(out.body.rows[0].repo).toBe('marveen-io')
+  })
+
+  it('missing or malformed dates are refused with 400, naming the format', async () => {
+    for (const q of ['', '?from=2026-08-01', '?from=aug&to=2026-09-07', '?from=2026-09-07&to=2026-08-01']) {
+      const { ctx, out } = fakeGet(`/api/pr-ledger${q}`)
+      expect(await tryHandlePrLedger(ctx)).toBe(true)
+      expect(out.status).toBe(400)
+    }
+  })
+
+  it('other methods and paths fall through untouched', async () => {
+    const { ctx } = fakeGet('/api/pr-ledger-not-this')
+    expect(await tryHandlePrLedger(ctx)).toBe(false)
+  })
+})

--- a/src/db.ts
+++ b/src/db.ts
@@ -284,6 +284,33 @@ export function initDatabase(dbPathOverride?: string): void {
     }
   }
 
+  // --- Fleet PR-throughput ledger (PRLEDGER907) ----------------------------
+  // One row per CLOSED pull request across the owner's repos; the collector
+  // (scripts/pr-ledger-collect.mjs) upserts daily and re-derives is_live,
+  // because a release retroactively makes earlier develop merges live. The
+  // schema is defined in TWO places on purpose (same dual-writer contract as
+  // conversation_log / ledger_lib.py): the collector may run standalone before
+  // the dashboard ever migrated. Kept in sync by pr-ledger-schema.test.ts.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS pr_ledger (
+      repo TEXT NOT NULL,
+      number INTEGER NOT NULL,
+      closed_date TEXT NOT NULL,
+      base_branch TEXT NOT NULL,
+      author TEXT,
+      additions INTEGER,
+      deletions INTEGER,
+      files INTEGER,
+      state TEXT NOT NULL,
+      title TEXT,
+      is_live INTEGER NOT NULL DEFAULT 0,
+      live_since TEXT,
+      measured_at INTEGER NOT NULL,
+      UNIQUE(repo, number)
+    )
+  `)
+  db.exec(`CREATE INDEX IF NOT EXISTS idx_pr_ledger_date ON pr_ledger(closed_date)`)
+
   // Migration: hot/warm/cold/shared tier system with an enforced CHECK.
   // Rebuilds the table whenever its current schema doesn't include the
   // canonical CHECK -- covers both the legacy ('user_pref'...) and the
@@ -4124,4 +4151,39 @@ export function listOtelTraces(limit = 50): OtelTraceSummary[] {
     ORDER BY s.start_ms DESC
     LIMIT ?
   `).all(limit) as OtelTraceSummary[]
+}
+
+// --- Fleet PR-throughput ledger (PRLEDGER907) --------------------------------
+
+export interface PrLedgerRow {
+  repo: string
+  number: number
+  closed_date: string
+  base_branch: string
+  author: string | null
+  additions: number | null
+  deletions: number | null
+  files: number | null
+  state: 'merged' | 'closed'
+  title: string | null
+  is_live: number
+  live_since: string | null
+  measured_at: number
+}
+
+export interface PrLedgerSummary { closed: number; merged: number; rejected: number; live: number }
+
+/**
+ * Read-only window query over the ledger: inclusive [from, to] on closed_date
+ * (YYYY-MM-DD), optional repo filter. The summary is derived from the SAME
+ * row set the caller gets, so the numbers and the list cannot disagree.
+ */
+export function listPrLedger(from: string, to: string, repo?: string): { rows: PrLedgerRow[]; summary: PrLedgerSummary } {
+  const rows = (repo
+    ? db.prepare('SELECT * FROM pr_ledger WHERE closed_date BETWEEN ? AND ? AND repo = ? ORDER BY closed_date DESC, repo, number DESC').all(from, to, repo)
+    : db.prepare('SELECT * FROM pr_ledger WHERE closed_date BETWEEN ? AND ? ORDER BY closed_date DESC, repo, number DESC').all(from, to)
+  ) as PrLedgerRow[]
+  let merged = 0, live = 0
+  for (const r of rows) { if (r.state === 'merged') merged++; if (r.is_live) live++ }
+  return { rows, summary: { closed: rows.length, merged, rejected: rows.length - merged, live } }
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -47,6 +47,7 @@ import { tryHandleAgentConversation } from './web/routes/agent-conversation.js'
 import { tryHandleAgentTaskState } from './web/routes/agent-taskstate.js'
 import { sweepOrphanTaskStates } from './web/agent-taskstate.js'
 import { tryHandleDailyLog } from './web/routes/daily-log.js'
+import { tryHandlePrLedger } from './web/routes/pr-ledger.js'
 import { tryHandleHomoglyphs } from './web/routes/homoglyphs.js'
 import { tryHandleMemories } from './web/routes/memories.js'
 import { tryHandleMigrate } from './web/routes/migrate.js'
@@ -185,6 +186,7 @@ export function startWebServer(port = 3420): http.Server {
       if (await tryHandleMessages(routeCtx)) return
       if (await tryHandleFederation(routeCtx)) return
       if (await tryHandleDailyLog(routeCtx)) return
+      if (await tryHandlePrLedger(routeCtx)) return
       if (await tryHandleHomoglyphs(routeCtx)) return
       if (await tryHandleMemories(routeCtx)) return
       if (await tryHandleMigrate(routeCtx)) return

--- a/src/web/routes/pr-ledger.ts
+++ b/src/web/routes/pr-ledger.ts
@@ -1,0 +1,33 @@
+import { listPrLedger } from '../../db.js'
+import { json } from '../http-helpers.js'
+import type { RouteContext } from './types.js'
+
+// PRLEDGER907 -- read-only window query over the fleet PR ledger, so any later
+// surface (a slide, a dashboard tab) pulls FRESH data instead of a snapshot
+// baked into HTML. Bearer-gated like every /api/* route; strictly GET, the
+// table is written only by scripts/pr-ledger-collect.mjs.
+
+const DAY_RE = /^\d{4}-\d{2}-\d{2}$/
+
+export async function tryHandlePrLedger(ctx: RouteContext): Promise<boolean> {
+  const { res, path, method, url } = ctx
+
+  if (path === '/api/pr-ledger' && method === 'GET') {
+    const from = url.searchParams.get('from') ?? ''
+    const to = url.searchParams.get('to') ?? ''
+    const repo = url.searchParams.get('repo') ?? undefined
+    if (!DAY_RE.test(from) || !DAY_RE.test(to)) {
+      json(res, { error: 'from and to are required as YYYY-MM-DD' }, 400)
+      return true
+    }
+    if (to < from) {
+      json(res, { error: 'to must not precede from' }, 400)
+      return true
+    }
+    const { rows, summary } = listPrLedger(from, to, repo)
+    json(res, { from, to, repo: repo ?? null, summary, rows })
+    return true
+  }
+
+  return false
+}


### PR DESCRIPTION
## What

- **pr_ledger table** in store/claudeclaw.db: one row per closed PR, natural key (repo, number), upsert-only.
- **Collector** \`scripts/pr-ledger-collect.mjs\`: scope is MEASURED each run (gh repo list, 47 repos scanned, 24 with PRs), never a hardcoded list. Idempotent -- second run changes nothing (proven: identical counts). \`--db\` / \`--owner\` flags; default DB path resolves from the script location (prod tree), so a scheduled run needs no cwd assumptions.
- **is_live**: main/master-merge = live since its merge day; develop-merge = live unless the PR number still sits in the \`main...develop\` compare range (GitHub compare API, no clone). Rejected and feature-branch merges never live. A release retroactively flips earlier develop rows -- the daily re-run re-derives every row.
- **GET /api/pr-ledger?from=&to=&repo=**: Bearer-gated read-only endpoint; summary is computed from the same row set as the returned rows.
- **Tests** (14): schema parity (dual-writer contract, like conversation_log/ledger_lib.py), the is_live decision table, collector mapping, endpoint window/filter/400 behavior. Full suite green (4894), tsc clean.

## Acceptance (measured live, 2026-08-08..2026-09-07)

- Full measured scope: **724 closed / 671 merged / 53 rejected / 567 live** (Marveen-accepted numbers, msg 21996).
- 10-repo subset preserved: 584/534/50/434 (the earlier snapshot's 534 merged / 434 live match exactly; +2 rejected are aiamindennapokban#129 and marveen#1162, both closed on 09-07 after the snapshot).

## Post-merge ops (not in this PR)

Register the daily command-type scheduled task on the host (\`~/.claude/scheduled-tasks/pr-ledger-daily/task-config.json\`, command: \`node /Users/marvin/ClaudeClaw/scripts/pr-ledger-collect.mjs\`) and capture the first fired run as proof. The card carries the recipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)