### PR TITLE
Schedule the recovery brief at the door, not at one caller

### DIFF
--- a/src/__tests__/recovery-brief-every-fresh-door.test.ts
+++ b/src/__tests__/recovery-brief-every-fresh-door.test.ts
@@ -1,0 +1,149 @@
+// The recovery brief was wired to ONE restart path: the channel monitor's
+// watchdog. Measured on develop @ 3877c61, three other paths also bring an
+// agent back on a fresh session and said nothing:
+//
+//   context-guard-runner.ts   restartAgentProcess(name, { fresh: true })
+//   auto-restart-runner.ts    restartAgentProcess(name, { fresh: mode === 'fresh' })
+//   routes/agents.ts          the dashboard's own restart/start with fresh
+//
+// An agent coming back through any of those sat at an empty prompt with its
+// uncommitted branch and its in_progress card waiting -- the exact gap card
+// 3a64403b describes, through a different door.
+//
+// The fix moves the decision to the one place all four pass through, so these
+// tests pin the RULE rather than the list of callers: a caller added tomorrow
+// inherits the behaviour instead of being forgotten.
+
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { shouldBriefAfterStart } from '../web/agent-process.js'
+import {
+  scheduleRecoveryBrief,
+  RECOVERY_BRIEF_DELAY_MS,
+  type RecoveryFacts,
+} from '../web/restart-recovery-brief.js'
+
+describe('who gets a brief', () => {
+  it('briefs a fresh start', () => {
+    expect(shouldBriefAfterStart({ fresh: true }, { ok: true })).toBe(true)
+  })
+
+  it('says nothing after a --continue resume', () => {
+    // The conversation survived, so the agent already knows what it was
+    // doing; a brief there repeats what is on its screen.
+    expect(shouldBriefAfterStart({ fresh: false }, { ok: true })).toBe(false)
+    expect(shouldBriefAfterStart({}, { ok: true })).toBe(false)
+  })
+
+  it('says nothing when the start failed', () => {
+    // Otherwise the brief is typed into whatever occupies that tmux target
+    // next -- and a failed start is exactly when something else might.
+    expect(shouldBriefAfterStart({ fresh: true }, { ok: false })).toBe(false)
+  })
+})
+
+describe('scheduleRecoveryBrief', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  const workInFlight = (): RecoveryFacts => ({
+    agent: 'devy',
+    branch: 'devy/some-task',
+    dirty: [{ code: ' M', path: 'src/web/thing.ts' }],
+    dirtyTruncated: false,
+    inProgress: [{ id: 'abc12345', title: 'Fix the thing' }],
+  })
+
+  it('types the brief into the session after the delay, not before', async () => {
+    vi.useFakeTimers()
+    const sent: { session: string; text: string }[] = []
+
+    scheduleRecoveryBrief(
+      'devy',
+      'agent-devy',
+      async (session, text) => {
+        sent.push({ session, text })
+        return { ok: true }
+      },
+      workInFlight,
+    )
+
+    // The restart path is still settling modals and the plugin probe here.
+    expect(sent).toEqual([])
+
+    await vi.advanceTimersByTimeAsync(RECOVERY_BRIEF_DELAY_MS + 1)
+
+    expect(sent).toHaveLength(1)
+    expect(sent[0]!.session).toBe('agent-devy')
+    expect(sent[0]!.text).toContain('abc12345')
+    expect(sent[0]!.text).toContain('devy/some-task')
+  })
+
+  it('stays quiet when the agent had nothing in flight', async () => {
+    vi.useFakeTimers()
+    const send = vi.fn(async () => ({ ok: true }))
+
+    scheduleRecoveryBrief('devy', 'agent-devy', send, () => ({
+      agent: 'devy',
+      branch: 'develop',
+      dirty: [],
+      dirtyTruncated: false,
+      inProgress: [],
+    }))
+    await vi.advanceTimersByTimeAsync(RECOVERY_BRIEF_DELAY_MS + 1)
+
+    // The scheduler consults the builder rather than sending unconditionally:
+    // an idle agent restarted for plugin reasons is never interrupted.
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it('never lets a failing sender escape into the restart path', async () => {
+    vi.useFakeTimers()
+    const boom = vi.fn(async () => {
+      throw new Error('tmux target vanished')
+    })
+
+    scheduleRecoveryBrief('devy', 'agent-devy', boom, workInFlight)
+    // No unhandled rejection, no throw out of the timer: a restart that
+    // worked must not be reported as failed because a courtesy message could
+    // not be typed.
+    await vi.advanceTimersByTimeAsync(RECOVERY_BRIEF_DELAY_MS + 1)
+
+    expect(boom).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The wiring itself
+// ---------------------------------------------------------------------------
+//
+// The tests above pass with the brief wired to NOTHING -- a mutation proved
+// it: deleting the call from startAgentProcess left all six green. That is the
+// same failure the card describes one level up (a module that exists and is
+// never reached), so the door is asserted here, at the source, the way
+// send-prompt-force-send-gate.test.ts asserts its own gate.
+
+describe('the brief is scheduled where fresh sessions are created', () => {
+  const AGENT_PROCESS = readFileSync(join(__dirname, '../web/agent-process.ts'), 'utf-8')
+
+  it('startAgentProcess schedules it, so every fresh caller inherits it', () => {
+    const start = AGENT_PROCESS.indexOf('export async function startAgentProcess(')
+    expect(start).toBeGreaterThan(0)
+    const body = AGENT_PROCESS.slice(start)
+    const call = body.indexOf('scheduleRecoveryBrief(')
+    expect(call, 'startAgentProcess no longer schedules the recovery brief').toBeGreaterThan(0)
+    // Gated, not unconditional: the predicate is what keeps a --continue
+    // resume and a failed start quiet.
+    expect(body.slice(0, call)).toContain('shouldBriefAfterStart(')
+  })
+
+  it('no restart path schedules it a second time', () => {
+    // It used to live at the channel monitor's call site. Leaving that behind
+    // after moving it here would type the brief twice on that one path.
+    const monitor = readFileSync(join(__dirname, '../web/channel-monitor.ts'), 'utf-8')
+    expect(monitor).not.toContain('scheduleRecoveryBrief(')
+  })
+})

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -27,6 +27,7 @@ import {
   stuckInputSignature,
   type FirstRunGateKind,
 } from '../pane-state.js'
+import { scheduleRecoveryBrief } from './restart-recovery-brief.js'
 import { agentDir, listAgentNames, readAgentModel, readAgentClaudeConfigDir, readAgentClaudePlan, readAgentChannelProvider, readAgentAuthMode, readAgentDisplayName, readAgentRemoteConfig, readAgentRemoteHost, readAgentRunAsUser, readAgentMemoryIsolation } from './agent-config.js'
 import { resolveAgentConfigDir } from './claude-plans.js'
 import { provisionMemoryBoundaryDir } from './memory-boundary.js'
@@ -1282,6 +1283,27 @@ function startRemoteAgentProcess(
   }
 }
 
+/**
+ * Does a start that just happened deserve a recovery brief?
+ *
+ * Only a FRESH start: a --continue resume still has the conversation, so the
+ * agent already knows what it was doing, and a brief there would repeat it.
+ * And only a start that actually succeeded -- briefing a session that never
+ * came up would type into whatever is on that tmux target next.
+ *
+ * Card 3a64403b covered the channel-monitor door. The measurement that
+ * followed found three more (context-guard restart, auto-restart in fresh
+ * mode, and the dashboard's own restart button), which is why the decision
+ * now lives here, at the one place all of them pass through, rather than at
+ * each caller.
+ */
+export function shouldBriefAfterStart(
+  opts: { fresh?: boolean },
+  result: { ok: boolean },
+): boolean {
+  return opts.fresh === true && result.ok
+}
+
 export async function startAgentProcess(name: string, opts: { fresh?: boolean } = {}): Promise<{ ok: boolean; pid?: number; error?: string }> {
   const dir = agentDir(name)
   if (!existsSync(dir)) return { ok: false, error: 'Agent not found' }
@@ -1719,6 +1741,16 @@ export async function startAgentProcess(name: string, opts: { fresh?: boolean } 
     // takes this path (it comes up via channels.sh) but guard defensively.
     if (hasChannel && name !== MAIN_AGENT_ID) {
       schedulePluginUnlockAfterRespawn(session, provider.type)
+    }
+
+    // A fresh session has no memory of what the agent was doing. Every fresh
+    // door passes here -- the channel monitor's watchdog, the context guard,
+    // auto-restart in fresh mode, and the dashboard button -- so the brief is
+    // scheduled once, at the door, instead of at each caller (card 3a64403b).
+    if (shouldBriefAfterStart(opts, { ok: true })) {
+      scheduleRecoveryBrief(name, session, (target, text) =>
+        sendPromptToSession(target, text, null, { lockMode: 'deliver' }),
+      )
     }
 
     return { ok: true }

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -9,7 +9,6 @@ import { MAIN_AGENT_ID, SERVICE_ID, BOT_NAME, CHANNEL_PROVIDER, PROJECT_ROOT, RE
 import { DISTRIBUTION_DEFAULT_AGENT_MODEL } from '../config-registry.js'
 import { agentDir, listAgentNames, readAgentChannelProvider } from './agent-config.js'
 import { listKanbanCards } from '../db.js'
-import { buildRecoveryBrief, parseGitStatusShort, type RecoveryFacts } from './restart-recovery-brief.js'
 import {
   agentHasChannel,
   agentSessionName,
@@ -1757,79 +1756,6 @@ function shouldEscalateMarveenDown(): boolean {
   return now - marveenSuspectFirstSeen >= MARVEEN_DOWN_CONFIRM_MS
 }
 
-// ---- recovery brief after a fresh restart (card 3a64403b) -------------------
-// A watchdog restart brings the agent back on a FRESH session: the plugin
-// reloads, the conversation does not. The agent then sits at an empty prompt
-// while its uncommitted branch and its in_progress card wait for it. These
-// three pieces close that gap; the decision of WHETHER to speak lives in the
-// pure buildRecoveryBrief (no facts -> no message, so an idle agent restarted
-// for plugin reasons is never interrupted).
-
-// How many changed files the brief lists before it says "and more". A restart
-// after a long spell can leave dozens; the brief is a pointer, not a diff.
-const RECOVERY_BRIEF_MAX_FILES = 12
-// Wait before typing the brief into the fresh session. The restart path
-// already schedules modal dismissal and the plugin-unlock probe; this sits
-// after both so the brief does not race a dialog or the probe's keystrokes.
-// sendPromptToSession still waits for idle on its own -- this delay is about
-// ORDER, not about hoping the session happens to be ready.
-const RECOVERY_BRIEF_DELAY_MS = 90_000
-
-// Collect what the fleet knew about an agent at restart time. Every failure is
-// swallowed into a null/empty field: a brief is a convenience, and a monitor
-// sweep must never fall over because a directory is missing or git is unhappy.
-function gatherRecoveryFacts(agent: string): RecoveryFacts {
-  let branch: string | null = null
-  let dirty: RecoveryFacts['dirty'] = []
-  let dirtyTruncated = false
-  try {
-    const dir = agentDir(agent)
-    if (existsSync(join(dir, '.git'))) {
-      try {
-        branch = execFileSync('git', ['-C', dir, 'rev-parse', '--abbrev-ref', 'HEAD'], { timeout: 5000 }).toString().trim() || null
-      } catch { /* detached HEAD or no repo -- the brief works without a branch */ }
-      const out = execFileSync('git', ['-C', dir, 'status', '--short'], { timeout: 5000 }).toString()
-      const parsed = parseGitStatusShort(out, RECOVERY_BRIEF_MAX_FILES)
-      dirty = parsed.dirty
-      dirtyTruncated = parsed.truncated
-    }
-  } catch (err) {
-    logger.debug({ err, agent }, 'recovery-brief: git facts unavailable')
-  }
-
-  let inProgress: RecoveryFacts['inProgress'] = []
-  try {
-    inProgress = listKanbanCards()
-      .filter((c) => c.assignee === agent && c.status === 'in_progress' && c.archived_at == null)
-      .map((c) => ({ id: c.id, title: c.title }))
-  } catch (err) {
-    logger.debug({ err, agent }, 'recovery-brief: kanban facts unavailable')
-  }
-
-  return { agent, branch, dirty, dirtyTruncated, inProgress }
-}
-
-// After a fresh restart, tell the new session what it was in the middle of.
-// Fire-and-forget: scheduled, never awaited by the sweep.
-export function scheduleRecoveryBrief(agent: string, session: string): void {
-  setTimeout(() => {
-    void (async () => {
-      try {
-        const facts = gatherRecoveryFacts(agent)
-        const brief = buildRecoveryBrief(facts)
-        if (!brief) {
-          logger.info({ agent, session }, 'recovery-brief: nothing in flight, staying quiet')
-          return
-        }
-        const res = await sendPromptToSession(session, brief, null, { lockMode: 'deliver' })
-        logger.info({ agent, session, res, cards: facts.inProgress.length, dirty: facts.dirty.length }, 'recovery-brief sent after restart')
-      } catch (err) {
-        logger.warn({ err, agent, session }, 'recovery-brief could not be delivered')
-      }
-    })()
-  }, RECOVERY_BRIEF_DELAY_MS)
-}
-
 export function startChannelPluginMonitor(): NodeJS.Timeout | null {
   // Respawn/keep-alive is production-only. On any non-production host (e.g. a
   // local dev checkout) we never respawn the main agent or auto-restart
@@ -2212,11 +2138,11 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
           // the --channels plugin MCP server, so the agent comes up with no plugin
           // and no poller (verified: continue -> "Plugin not found" in /mcp; fresh
           // -> plugin loads + poller attaches). Context is dropped, memory persists.
+          // startAgentProcess schedules the recovery brief itself for any
+          // fresh start (see agent-process): this path is no longer the only
+          // door onto a fresh session, so the brief lives at the door rather
+          // than at each caller.
           await startAgentProcess(t.agentName!, { fresh: true })
-          // The fresh session has no memory of what it was doing. If work was
-          // in flight, tell it -- once, after the modal/probe traffic settles,
-          // and only when there is something concrete to say.
-          scheduleRecoveryBrief(t.agentName!, t.session)
           agentLastRestart.set(t.agentName!, Date.now())
           agentDownSince.delete(t.session)
           agentBusyDeferAlerted.delete(t.session)

--- a/src/web/restart-recovery-brief.ts
+++ b/src/web/restart-recovery-brief.ts
@@ -18,6 +18,13 @@
 // a moment when the fleet's own state can be stale -- so the agent verifies
 // before acting, exactly as it would after any handoff.
 
+import { execFileSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { logger } from '../logger.js'
+import { listKanbanCards } from '../db.js'
+import { agentDir } from './agent-config.js'
+
 /** A file the agent left modified in its working directory. */
 export interface DirtyFile {
   /** git status --short XY code, e.g. ' M', '??', 'A '. */
@@ -100,4 +107,95 @@ export function parseGitStatusShort(out: string, max: number): { dirty: DirtyFil
     if (path) dirty.push({ code, path })
   }
   return { dirty, truncated: rows.length > max }
+}
+
+
+// How many changed files the brief lists before it says "and more". A restart
+// after a long spell can leave dozens; the brief is a pointer, not a diff.
+export const RECOVERY_BRIEF_MAX_FILES = 12
+
+// Wait before typing the brief into the fresh session. The restart paths
+// schedule modal dismissal and a plugin-unlock probe of their own; this sits
+// after both so the brief does not race a dialog or the probe's keystrokes.
+// The sender still waits for idle -- this delay is about ORDER, not hope.
+export const RECOVERY_BRIEF_DELAY_MS = 90_000
+
+/**
+ * Collect what the fleet knew about an agent at restart time.
+ *
+ * Every failure is swallowed into a null/empty field: a brief is a
+ * convenience, and a restart must never fail because a directory is missing
+ * or git is unhappy.
+ */
+export function gatherRecoveryFacts(agent: string): RecoveryFacts {
+  let branch: string | null = null
+  let dirty: RecoveryFacts['dirty'] = []
+  let dirtyTruncated = false
+  try {
+    const dir = agentDir(agent)
+    if (existsSync(join(dir, '.git'))) {
+      try {
+        branch = execFileSync('git', ['-C', dir, 'rev-parse', '--abbrev-ref', 'HEAD'], { timeout: 5000 }).toString().trim() || null
+      } catch { /* detached HEAD or no repo -- the brief works without a branch */ }
+      const out = execFileSync('git', ['-C', dir, 'status', '--short'], { timeout: 5000 }).toString()
+      const parsed = parseGitStatusShort(out, RECOVERY_BRIEF_MAX_FILES)
+      dirty = parsed.dirty
+      dirtyTruncated = parsed.truncated
+    }
+  } catch (err) {
+    logger.debug({ err, agent }, 'recovery-brief: git facts unavailable')
+  }
+
+  let inProgress: RecoveryFacts['inProgress'] = []
+  try {
+    inProgress = listKanbanCards()
+      .filter((c) => c.assignee === agent && c.status === 'in_progress' && c.archived_at == null)
+      .map((c) => ({ id: c.id, title: c.title }))
+  } catch (err) {
+    logger.debug({ err, agent }, 'recovery-brief: kanban facts unavailable')
+  }
+
+  return { agent, branch, dirty, dirtyTruncated, inProgress }
+}
+
+/** How the brief reaches the session. Injected so this module never has to
+ * import the process layer that calls it. */
+export type BriefSender = (session: string, text: string) => Promise<unknown>
+
+/**
+ * After a fresh restart, tell the new session what it was in the middle of.
+ *
+ * Fire-and-forget: scheduled, never awaited by the restart path, and every
+ * failure is logged rather than raised. A restart that succeeded must not be
+ * reported as failed because a courtesy message could not be typed.
+ */
+export function scheduleRecoveryBrief(
+  agent: string,
+  session: string,
+  send: BriefSender,
+  // Injected so a test can hand in facts instead of needing a real agent
+  // directory, a real git repo and a real database row. Without this seam the
+  // only reachable case is "no facts, no message", which cannot show that the
+  // send path works at all.
+  gather: (agent: string) => RecoveryFacts = gatherRecoveryFacts,
+): void {
+  setTimeout(() => {
+    void (async () => {
+      try {
+        const facts = gather(agent)
+        const brief = buildRecoveryBrief(facts)
+        if (!brief) {
+          logger.info({ agent, session }, 'recovery-brief: nothing in flight, staying quiet')
+          return
+        }
+        const res = await send(session, brief)
+        logger.info(
+          { agent, session, res, cards: facts.inProgress.length, dirty: facts.dirty.length },
+          'recovery-brief sent after restart',
+        )
+      } catch (err) {
+        logger.warn({ err, agent, session }, 'recovery-brief could not be delivered')
+      }
+    })()
+  }, RECOVERY_BRIEF_DELAY_MS).unref?.()
 }


### PR DESCRIPTION
## Mit talált a premissza-mérés

A `3a64403b` kártya csatorna-monitor ága **már kész volt** a developon (`3877c61`): a `restart-recovery-brief` modul áll, és a watchdog ág hívja. A mérés viszont **három további ajtót** talált, ami szintén friss sessiont nyit, és egyik sem szólt semmit:

| hol | mit hív |
|---|---|
| `context-guard-runner.ts:268` | `restartAgentProcess(name, { fresh: true })` |
| `auto-restart-runner.ts:110` | `restartAgentProcess(name, { fresh: cfg.mode === 'fresh' })` |
| `routes/agents.ts:1867,1961` | a dashboard saját start/restart gombja `fresh`-sel |

Az ezeken visszajövő agens pontosan azt csinálta, amiről a kártya szól: üres prompton ült, miközben a saját commitolatlan ága és az `in_progress` kártyája várta.

## A javítás helye

Nem három hívási pont, hanem **az egy ajtó, amin mind átmegy**: a `startAgentProcess`. A brief ütemezése odakerült, a channel-monitor saját hívása kikerült — különben azon az egy úton kétszer gépelné be. Egy holnap hozzáadott negyedik hívó így **örökli** a viselkedést, ahelyett hogy kimaradna.

Szerkezet:
- a gyűjtés és az ütemezés átkerült a `restart-recovery-brief` modulba, a már ott élő tiszta `buildRecoveryBrief` mellé
- a küldő **injektált** paraméter, így a modul nem importálja vissza a folyamat-réteget, ami hívja — nincs kör
- a gyűjtés is injektálható: enélkül teszteléskor **csak** a „nincs tény, nincs üzenet" ág érhető el, ami nem mutatja meg, hogy a küldés egyáltalán működik-e
- a döntés külön predikátum (`shouldBriefAfterStart`): csak `fresh`, és csak sikeres start. Egy `--continue` resume-nak megvan a beszélgetése; egy bukott startnál pedig abba a tmux célpontba gépelnénk, amit közben más foglal el.

## Mérés

| mutáció | melyik teszt bukott |
|---|---|
| nincs bekötés a `startAgentProcess`-ben | a forrás-szintű ajtó-teszt |
| a `--continue` is kap briefet | a predikátum-teszt |
| a bukott start is kap briefet | a predikátum-teszt |
| a scheduler feltétel nélkül küld | „stays quiet when nothing in flight" |
| a duplikált hívás visszakerül | „no restart path schedules it twice" |

**Az első a lényeg, és először átment.** A bekötést törölve mind a hat tesztem zöld maradt, mert csak a predikátumot és az ütemezőt mérték, magát az **ajtót** nem. Ez ugyanaz a hibaalak, mint amiről a kártya szól — egy modul, ami létezik és nincs elérve. Ezért áll most forrás-szintű állítás arra, hogy a `startAgentProcess` tényleg ütemezi, és hogy gate-elve teszi; a `send-prompt-force-send-gate.test.ts` ugyanezt a mintát használja a saját kapujára.

## Ellenőrzés

- `npx tsc --noEmit` -> tiszta
- Teljes suite: **380 fájl, 4907 passed, 1 skipped**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148rV8xMuHmpCgH1T8J1ZJz
