### PR TITLE
fix(profiles): keep web-reading profiles strict; make permission rules actually match (TMPLPERM908)

### DIFF
--- a/src/__tests__/profile-rule-syntax.test.ts
+++ b/src/__tests__/profile-rule-syntax.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+import { loadProfileTemplate, resolveProfilePlaceholders } from '../web/profiles.js'
+import { PROJECT_ROOT } from '../config.js'
+
+// TMPLPERM908: the permission-rule shapes below were MEASURED against Claude
+// Code's engine on 2026-09-08 (strict launch, -p probes T1-T9):
+//   - Read(/abs/path/**)  -> single leading '/' is project-relative, NEVER matches
+//   - Read(//abs/path/**) -> matches (allow and deny)
+//   - Read(~/path/**)     -> matches (allow and deny)
+//   - Bash(/abs/**/x.sh:*) -> '**' has no glob meaning in Bash rules; only a
+//                             literal command prefix matches
+// These tests pin the normalization + template posture so a future edit cannot
+// silently regress to the never-matching shapes.
+
+const ctx = { HOME: '/Users/testuser', AGENT_DIR: '/Users/testuser/ClaudeClaw/agents/tester' }
+
+describe('resolveProfilePlaceholders rule normalization', () => {
+  it('rewrites a single-slash absolute Read rule to the // absolute form', () => {
+    expect(resolveProfilePlaceholders('Read(${HOME}/.ssh/**)', ctx))
+      .toBe('Read(//Users/testuser/.ssh/**)')
+  })
+
+  it('rewrites Edit and Write rules the same way', () => {
+    expect(resolveProfilePlaceholders('Edit(${AGENT_DIR}/**)', ctx))
+      .toBe('Edit(//Users/testuser/ClaudeClaw/agents/tester/**)')
+    expect(resolveProfilePlaceholders('Write(/tmp/**)', ctx)).toBe('Write(//tmp/**)')
+  })
+
+  it('leaves already-absolute (//), home (~) and relative (**) rules untouched', () => {
+    expect(resolveProfilePlaceholders('Read(//tmp/**)', ctx)).toBe('Read(//tmp/**)')
+    expect(resolveProfilePlaceholders('Read(~/.claude/skills/**)', ctx)).toBe('Read(~/.claude/skills/**)')
+    expect(resolveProfilePlaceholders('Read(**/.env)', ctx)).toBe('Read(**/.env)')
+  })
+
+  it('never touches Bash rules (command-prefix matching, not paths)', () => {
+    expect(resolveProfilePlaceholders('Bash(sudo:*)', ctx)).toBe('Bash(sudo:*)')
+    expect(resolveProfilePlaceholders('Bash(${PROJECT_ROOT}/scripts/notify.sh:*)', ctx))
+      .toBe(`Bash(${PROJECT_ROOT}/scripts/notify.sh:*)`)
+  })
+
+  it('resolves ${PROJECT_ROOT}', () => {
+    expect(resolveProfilePlaceholders('${PROJECT_ROOT}/scripts/x.sh', ctx))
+      .toBe(`${PROJECT_ROOT}/scripts/x.sh`)
+  })
+})
+
+describe('web-reading profile posture (TMPLPERM908)', () => {
+  // Both profiles read web content (prompt-injection surface). strict is what
+  // makes the deny list enforceable at all: permissive launches with
+  // --dangerously-skip-permissions. The capability gaps that motivated the
+  // 2026-09 uncommitted permissive flip (skills read, notify.sh, agent-post.sh)
+  // are covered by explicit allow entries instead. Loosening the mode again is
+  // an owner decision, not a template edit -- see card TMPLPERM908.
+  for (const id of ['marketer', 'researcher']) {
+    it(`${id} stays strict and carries the measured capability allows`, () => {
+      const p = loadProfileTemplate(id)
+      expect(p.id).toBe(id) // guard against the default-profile fallback
+      expect(p.permissionMode).toBe('strict')
+      expect(p.filesystem.allow).toContain('Read(${HOME}/.claude/skills/**)')
+      expect(p.filesystem.allow).toContain('Bash(${PROJECT_ROOT}/scripts/notify.sh:*)')
+      expect(p.filesystem.allow).toContain('Bash(${PROJECT_ROOT}/scripts/agent-post.sh:*)')
+      expect(p.filesystem.deny).toContain('Read(${HOME}/.ssh/**)')
+    })
+  }
+
+  it('no template carries a Bash rule with a ** glob (prefix matching cannot glob)', () => {
+    for (const id of ['marketer', 'researcher', 'developer-junior', 'developer-senior', 'applier', 'sub-dev', 'default']) {
+      const p = loadProfileTemplate(id)
+      for (const rule of [...p.filesystem.allow, ...p.filesystem.deny]) {
+        if (rule.startsWith('Bash(')) expect(rule).not.toContain('**')
+      }
+    }
+  })
+})

--- a/src/web/profiles.ts
+++ b/src/web/profiles.ts
@@ -49,8 +49,16 @@ export function loadProfileTemplate(id: string): ProfileTemplate {
 }
 
 export function resolveProfilePlaceholders(value: string, ctx: { HOME: string; AGENT_DIR: string }): string {
-  return value
+  const resolved = value
     .replace(/\$\{HOME\}/g, ctx.HOME)
     .replace(/\$\{AGENT_DIR\}/g, ctx.AGENT_DIR)
     .replace(/\$\{WORKDIR\}/g, ctx.AGENT_DIR)
+    .replace(/\$\{PROJECT_ROOT\}/g, PROJECT_ROOT)
+  // File-permission rules (Read/Edit/Write) treat a single leading '/' as
+  // PROJECT-RELATIVE (gitignore semantics): Read(/Users/x/.ssh/**) silently
+  // never matches, so every ${HOME}-based deny in the strict profiles was
+  // inert (measured 2026-09-08, TMPLPERM908). A true absolute path needs
+  // '//'. Normalize here so template authors keep writing ${HOME}/${AGENT_DIR}
+  // naturally; Bash rules are command-prefix matches and must stay untouched.
+  return resolved.replace(/^(Read|Edit|Write)\(\/(?!\/)/, '$1(//')
 }

--- a/templates/profiles/marketer.json
+++ b/templates/profiles/marketer.json
@@ -1,8 +1,8 @@
 {
   "id": "marketer",
   "label": "Marketinges",
-  "description": "Email-vázlat, hírlevél, social tartalom. Mivel webes tartalmat olvas (prompt injection felület), szigorúan korlátozott: csak a saját mappájába írhat, SSH/AWS/.env tiltva, semmilyen Bash-pusztító parancs.",
-  "permissionMode": "strict",
+  "description": "Email-vazlat, hirlevel, social tartalom. Webes tartalmat olvas, tehat prompt-injekcios felulet: a fajl-tiltasok (ssh/aws/env) a permissive mod miatt NEM ervenyesulnek, a vedelmet a hookok adjak (email-kapu, egress-kapu, self-pace kapu) es a sajat mappaja.",
+  "permissionMode": "permissive",
   "filesystem": {
     "allow": [
       "Read(${AGENT_DIR}/**)",
@@ -12,7 +12,10 @@
       "Bash(ls:*)",
       "Bash(cat:*)",
       "WebFetch(*)",
-      "WebSearch(*)"
+      "WebSearch(*)",
+      "Read(${HOME}/.claude/skills/**)",
+      "Bash(${HOME}/**/scripts/agent-post.sh:*)",
+      "Bash(${HOME}/**/scripts/notify.sh:*)"
     ],
     "deny": [
       "Read(${HOME}/.ssh/**)",

--- a/templates/profiles/marketer.json
+++ b/templates/profiles/marketer.json
@@ -1,12 +1,11 @@
 {
   "id": "marketer",
   "label": "Marketinges",
-  "description": "Email-vazlat, hirlevel, social tartalom. Webes tartalmat olvas, tehat prompt-injekcios felulet: a fajl-tiltasok (ssh/aws/env) a permissive mod miatt NEM ervenyesulnek, a vedelmet a hookok adjak (email-kapu, egress-kapu, self-pace kapu) es a sajat mappaja.",
-  "permissionMode": "permissive",
+  "description": "Email-vázlat, hírlevél, social tartalom. Mivel webes tartalmat olvas (prompt injection felület), szigorúan korlátozott: csak a saját mappájába írhat, SSH/AWS/.env tiltva, semmilyen Bash-pusztító parancs. A globális skillek olvasása és a notify.sh/agent-post.sh futtatása engedélyezett.",
+  "permissionMode": "strict",
   "filesystem": {
     "allow": [
       "Read(${AGENT_DIR}/**)",
-      "Write(${AGENT_DIR}/**)",
       "Edit(${AGENT_DIR}/**)",
       "Read(${HOME}/Downloads/**)",
       "Bash(ls:*)",
@@ -14,8 +13,8 @@
       "WebFetch(*)",
       "WebSearch(*)",
       "Read(${HOME}/.claude/skills/**)",
-      "Bash(${HOME}/**/scripts/agent-post.sh:*)",
-      "Bash(${HOME}/**/scripts/notify.sh:*)"
+      "Bash(${PROJECT_ROOT}/scripts/agent-post.sh:*)",
+      "Bash(${PROJECT_ROOT}/scripts/notify.sh:*)"
     ],
     "deny": [
       "Read(${HOME}/.ssh/**)",

--- a/templates/profiles/researcher.json
+++ b/templates/profiles/researcher.json
@@ -1,8 +1,8 @@
 {
   "id": "researcher",
   "label": "Kutató",
-  "description": "Piackutatás, versenytárs-elemzés, webes források olvasása. Prompt injection szempontból ugyanúgy kiemelt mint a marketinges. Draft-only: riportot ír a mappájába, nem küld magától kifelé.",
-  "permissionMode": "strict",
+  "description": "Piackutatas, versenytars-elemzes, webes forrasok olvasasa. Prompt-injekcio szempontjabol ugyanugy kiemelt, mint a marketinges. A fajl-tiltasok a permissive mod miatt NEM ervenyesulnek, a vedelmet a hookok adjak (email-kapu, egress-kapu, self-pace kapu).",
+  "permissionMode": "permissive",
   "filesystem": {
     "allow": [
       "Read(${AGENT_DIR}/**)",
@@ -12,7 +12,10 @@
       "Bash(ls:*)",
       "Bash(cat:*)",
       "WebFetch(*)",
-      "WebSearch(*)"
+      "WebSearch(*)",
+      "Read(${HOME}/.claude/skills/**)",
+      "Bash(${HOME}/**/scripts/agent-post.sh:*)",
+      "Bash(${HOME}/**/scripts/notify.sh:*)"
     ],
     "deny": [
       "Read(${HOME}/.ssh/**)",

--- a/templates/profiles/researcher.json
+++ b/templates/profiles/researcher.json
@@ -1,12 +1,11 @@
 {
   "id": "researcher",
   "label": "Kutató",
-  "description": "Piackutatas, versenytars-elemzes, webes forrasok olvasasa. Prompt-injekcio szempontjabol ugyanugy kiemelt, mint a marketinges. A fajl-tiltasok a permissive mod miatt NEM ervenyesulnek, a vedelmet a hookok adjak (email-kapu, egress-kapu, self-pace kapu).",
-  "permissionMode": "permissive",
+  "description": "Piackutatás, versenytárs-elemzés, webes források olvasása. Prompt injection szempontból ugyanúgy kiemelt mint a marketinges. Draft-only: riportot ír a mappájába, nem küld magától kifelé. A globális skillek olvasása és a notify.sh/agent-post.sh futtatása engedélyezett.",
+  "permissionMode": "strict",
   "filesystem": {
     "allow": [
       "Read(${AGENT_DIR}/**)",
-      "Write(${AGENT_DIR}/**)",
       "Edit(${AGENT_DIR}/**)",
       "Read(${HOME}/Downloads/**)",
       "Bash(ls:*)",
@@ -14,8 +13,8 @@
       "WebFetch(*)",
       "WebSearch(*)",
       "Read(${HOME}/.claude/skills/**)",
-      "Bash(${HOME}/**/scripts/agent-post.sh:*)",
-      "Bash(${HOME}/**/scripts/notify.sh:*)"
+      "Bash(${PROJECT_ROOT}/scripts/agent-post.sh:*)",
+      "Bash(${PROJECT_ROOT}/scripts/notify.sh:*)"
     ],
     "deny": [
       "Read(${HOME}/.ssh/**)",


### PR DESCRIPTION
## Summary

Two commits, in order:
1. **Rescue** (a1400dc0): verbatim capture of the uncommitted strict->permissive flip found on the prod checkout (marketer+researcher), so the diff exists in version control and the next update.sh cannot silently destroy it.
2. **Fix** (8897f210): the measurement Marveen asked for on card TMPLPERM908 -- and its consequence.

## What was measured (strict-launch `claude -p` probes against the live permissions engine, 2026-09-08)

| Probe | Rule shape | Result |
|---|---|---|
| T1 | `Bash(${HOME}/**/scripts/notify.sh:*)` | **blocked** -- Bash rules are command-prefix matches, `**` has no glob meaning |
| T2 | `Read(/Users/.../.claude/skills/**)` | **blocked** -- single leading `/` is project-relative |
| T3 | `Read(**/.env)` deny | denies correctly |
| T4 | unallowed `touch` (control) | blocked -- strict does enforce |
| T5 | `Bash(/abs/literal/notify.sh:*)` | **works** |
| T6/T7 | `Read(//abs/...)` allow / deny | **works both ways** |
| T8 | `Read(/abs/...)` deny | **silently inert** -- i.e. every ${HOME}-based .ssh/.aws/.gnupg deny in every strict profile never matched |
| T9 | `Read(~/...)` allow / deny | **works both ways** |

**Conclusion: strict + correctly written allows covers all three capability gaps (skills read, notify.sh, agent-post.sh). The permissive flip is not needed, so the posture question does not need to go to Szabi.**

## The fix

- marketer + researcher back to `strict`, original (accented) descriptions restored, three capability allows in working shapes: `Read(${HOME}/.claude/skills/**)`, `Bash(${PROJECT_ROOT}/scripts/notify.sh:*)`, `Bash(${PROJECT_ROOT}/scripts/agent-post.sh:*)`
- `resolveProfilePlaceholders`: new `${PROJECT_ROOT}` placeholder + normalization of single-slash absolute Read/Edit/Write rules to `//` -- this makes the deny lists of ALL templates (developer-junior included) enforceable with zero template churn, and fixes the same bug for any customer install's shipped templates via code alone
- dead `Write()` allow entries dropped (the engine only matches Edit rules for file edits; they produced a warning at every strict launch)
- new test pins the normalization and the strict posture of both web-reading profiles, so the next silent flip fails CI

Full suite in the worktree: **4907 passed, 1 skipped**.

## Rollout note

The profile is applied at agent (re)spawn (`writeAgentSettingsFromProfile`), so orsi and qwen pick up strict on their next restart -- no immediate behavior change on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)