### PR TITLE
fix(kartya-eszkoz): dry-run paritas + kimondott komment-szerzo, tesztekkel (KARTYADRYRUN907)

### DIFF
--- a/scripts/__tests__/kartya-dryrun-paritas.test.py
+++ b/scripts/__tests__/kartya-dryrun-paritas.test.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Dry-run / live parity for scripts/kartya-es-ertesites.py (KARTYADRYRUN907).
+
+Mira's finding (2026-09-07): `--dry-run` returned OK for a card id that ALREADY
+EXISTED, while the same command without `--dry-run` was refused. The exact use the
+flag exists for -- "would this go through?" -- was the one that broke. A dry-run
+that is MORE PERMISSIVE than the live path is worse than none: it returns green for
+what the system rejects.
+
+The assertion here is PARITY, not "dry-run refuses": both directions must agree, so
+a future divergence on either side goes red.
+
+Drives the script as a subprocess against an isolated DB (KARTYA_DB). Run:
+    python3 scripts/__tests__/kartya-dryrun-paritas.test.py
+Exit 0 = all pass; non-zero = a failure.
+"""
+import os, sqlite3, subprocess, sys, tempfile, time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(os.path.dirname(HERE))
+SCRIPT = os.path.join(ROOT, 'scripts', 'kartya-es-ertesites.py')
+FAILS = []
+
+# KET SANDBOX-GYOKER, mert az egyik or eppen a token HIANYAT meri:
+#   TOKEN_ROOT  -- van store/.dashboard-token
+#   NOTOKEN_ROOT -- nincs
+TOKEN_ROOT = tempfile.mkdtemp(prefix='kartya-dry-tok-')
+NOTOKEN_ROOT = tempfile.mkdtemp(prefix='kartya-dry-notok-')
+os.makedirs(os.path.join(TOKEN_ROOT, 'store'))
+os.makedirs(os.path.join(NOTOKEN_ROOT, 'store'))
+with open(os.path.join(TOKEN_ROOT, 'store', '.dashboard-token'), 'w') as f:
+    f.write('teszt-token')
+DB_PATH = os.path.join(TOKEN_ROOT, 'store', 'claudeclaw.db')
+
+
+def check(name, cond, detail=''):
+    print(('PASS  ' if cond else 'FAIL  ') + name + (('  -- ' + detail) if detail and not cond else ''))
+    if not cond:
+        FAILS.append(name)
+
+
+def fresh_db():
+    db = sqlite3.connect(DB_PATH)
+    db.executescript('''
+      CREATE TABLE kanban_cards (id TEXT PRIMARY KEY, title TEXT NOT NULL, description TEXT,
+        status TEXT NOT NULL DEFAULT 'planned'
+          CHECK(status IN ('planned','in_progress','testing','waiting','done')),
+        assignee TEXT,
+        priority TEXT NOT NULL DEFAULT 'normal'
+          CHECK(priority IN ('low','normal','high','urgent')),
+        project TEXT, due_date INTEGER, sort_order REAL NOT NULL DEFAULT 0,
+        created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL, archived_at INTEGER,
+        parent_id TEXT, dispatched_at INTEGER);
+      CREATE TABLE kanban_comments (id INTEGER PRIMARY KEY AUTOINCREMENT, card_id TEXT NOT NULL,
+        author TEXT NOT NULL, content TEXT NOT NULL, created_at INTEGER NOT NULL);
+      CREATE TABLE agent_messages (id INTEGER PRIMARY KEY AUTOINCREMENT, from_agent TEXT NOT NULL,
+        to_agent TEXT NOT NULL, content TEXT NOT NULL, status TEXT NOT NULL DEFAULT 'pending',
+        result TEXT, created_at INTEGER NOT NULL, delivered_at INTEGER, completed_at INTEGER);
+    ''')
+    db.commit(); db.close()
+
+
+def seed(card_id):
+    db = sqlite3.connect(DB_PATH)
+    now = int(time.time())
+    db.execute('INSERT INTO kanban_cards (id,title,status,assignee,priority,created_at,updated_at)'
+               ' VALUES (?,?,?,?,?,?,?)', (card_id, f'teszt {card_id}', 'planned', 'boni', 'normal', now, now))
+    db.commit(); db.close()
+
+
+def exists(card_id):
+    db = sqlite3.connect(DB_PATH)
+    r = db.execute('SELECT 1 FROM kanban_cards WHERE id=?', (card_id,)).fetchone()
+    db.close()
+    return r is not None
+
+
+def run(card_id, extra=(), root=TOKEN_ROOT):
+    env = dict(os.environ)
+    env['KARTYA_DB'] = DB_PATH
+    env['CLAUDECLAW_ROOT'] = root
+    return subprocess.run(
+        # A --author KIMONDVA megy, holott a LETREHOZO agon nem kotelezo: enelkul a felado
+        # csendben 'marveen' lenne, es a teszt sorai MAS agens neveben mennenek ki. (A teszt
+        # egy korabbi valtozata azt allitotta, hogy az --author a letrehozo agon KOTELEZO --
+        # 2026-09-08-an visszamerve ez NEM igaz: a kotelezoseg CSAK a komment-modra all, es a
+        # letrehozo ag alapertelmezeset a kartya-ertesites-felado teszt 3. ellenorzese
+        # regresszio-kontrollkent rogziti.)
+        # A CIM HORGONYA (KARTYAHORGONY906): a cimnek tartalmaznia kell a kartya sajat ID-jet,
+        # kulonben a futas MAR A HORGONY-KAPUN elhal, es a teszt a ROSSZ OKBOL lenne piros.
+        # Ez a kapu UJABB, mint a teszt elso valtozata -- merve 2026-09-08-an: mind az ot
+        # "paritas" ellenorzes ezen bukott, nem a merni kivant viselkedesen.
+        [sys.executable, SCRIPT, '--id', card_id, '--assignee', 'boni',
+         '--title', f'{card_id} paritas teszt',
+         '--author', 'Boni', *extra],
+        capture_output=True, text=True, env=env, timeout=30)
+
+
+def msgfile(card_id):
+    d = tempfile.mkdtemp(prefix='kartya-dry-msg-')
+    p = os.path.join(d, 'm.txt')
+    with open(p, 'w', encoding='utf-8') as f:
+        f.write(f'Kartya: {card_id} -- teszt uzenet.\n')
+    return p
+
+
+fresh_db()
+
+# --- 1. A LELET MAGA: letezo ID-n a ket ag EGYETERT (mindketto megtagad) ---
+seed('LETEZO1')
+dry = run('LETEZO1', ('--no-msg', '--dry-run'))
+live = run('LETEZO1', ('--no-msg',))
+check('1 dry-run megtagadja a letezo ID-t', dry.returncode != 0, f'exit={dry.returncode} out={dry.stdout!r}')
+check('2 az eles ag is megtagadja', live.returncode != 0, f'exit={live.returncode}')
+check('3 PARITAS: a ket ag ugyanazt az okot mondja',
+      'MAR LETEZIK' in (dry.stdout + dry.stderr) and 'MAR LETEZIK' in (live.stdout + live.stderr),
+      f'dry={dry.stdout + dry.stderr!r}')
+
+# --- 2. A JO UT NEM TORT EL: uj ID-n a dry-run zold, ES nem ir semmit ---
+dry_uj = run('UJKARTYA1', ('--no-msg', '--dry-run'))
+check('4 uj ID-n a dry-run tovabbra is zold', dry_uj.returncode == 0, f'exit={dry_uj.returncode} err={dry_uj.stderr!r}')
+check('5 a dry-run NEM hozta letre a kartyat', not exists('UJKARTYA1'))
+
+# --- 3. TOKEN-OR: uzenettel, token nelkul az eles ag RESZLEGESEN irna (kartya igen, uzenet nem) ---
+mf = msgfile('TOKENUJ1')
+dry_notok = run('TOKENUJ1', ('--msg-file', mf, '--dry-run'), root=NOTOKEN_ROOT)
+check('6 token nelkul + uzenettel a dry-run megtagad', dry_notok.returncode != 0, f'exit={dry_notok.returncode}')
+check('7 es kimondja, hogy a kartya eles futasban MAR LETREJONNE',
+      'LETREJONNE' in (dry_notok.stdout + dry_notok.stderr), f'{dry_notok.stdout + dry_notok.stderr!r}')
+check('8 a megtagadott dry-run semmit nem irt', not exists('TOKENUJ1'))
+
+# --- 4. NEGATIV KONTROLL: az or NEM tulzottan szeles ---
+dry_tok = run('TOKENUJ2', ('--msg-file', msgfile('TOKENUJ2'), '--dry-run'), root=TOKEN_ROOT)
+check('9 letezo tokennel ugyanaz a futas zold', dry_tok.returncode == 0, f'exit={dry_tok.returncode} err={dry_tok.stderr!r}')
+dry_nomsg = run('TOKENUJ3', ('--no-msg', '--dry-run'), root=NOTOKEN_ROOT)
+check('10 token nelkul, de --no-msg mellett zold (az or az UZENET-utra szol)',
+      dry_nomsg.returncode == 0, f'exit={dry_nomsg.returncode} err={dry_nomsg.stderr!r}')
+
+print()
+if FAILS:
+    print(f'BUKOTT: {len(FAILS)} -- {", ".join(FAILS)}', file=sys.stderr)
+    sys.exit(1)
+print('minden teszt atment')

--- a/scripts/__tests__/kartya-mezomozgatas.test.py
+++ b/scripts/__tests__/kartya-mezomozgatas.test.py
@@ -411,6 +411,44 @@ def main():
     check('31 a megtagadas felajanlja a letezo TisztaNev-et', 'TisztaNev' in (p.stdout + p.stderr),
           p.stdout + p.stderr)
 
+    # 32. A SZERZO KIMONDOTT (KARTYADRYRUN907, 2026-09-08). Komment-modban az --author korabban
+    #     CSENDBEN 'Marveen'-re esett: a kimenet OK-t mondott, a kartyan pedig MAS neve allt.
+    #     A javitas 2026-09-07-en egy VERZIOKOVETETLEN peldanyba ment, es a v1.37.0 kiadas
+    #     nemán visszaallitotta -- ezert all ITT, a repoban, egy teszt: enelkul a kovetkezo
+    #     kiadas ugyanugy vissza tudja hozni, es semmi nem szol rola.
+    seed('SZERZO907', assignee='samu')
+    d = tempfile.mkdtemp(prefix='kartya-m-')
+    cf = os.path.join(d, 'c.txt')
+    with open(cf, 'w', encoding='utf-8') as f:
+        f.write('Kartya SZERZO907: szerzo nelkuli komment.')
+    p = subprocess.run([sys.executable, SCRIPT, '--id', 'SZERZO907', '--comment-file', cf],
+                       capture_output=True, text=True, env=env, timeout=30)
+    check('32 --author nelkul a komment MEGTAGADVA',
+          p.returncode != 0 and '--author' in (p.stdout + p.stderr), p.stdout + p.stderr)
+    check('32 a komment nem irodott be', comments('SZERZO907') == [])
+    # A MEZOMOZGATAS SEM CSUSZHAT AT a szerzo-kapun: a kapu a komment-ag ELEJEN all, tehat a
+    # statusz-valtas is elhal vele. Enelkul a kartya nyom nelkul mozdulna el.
+    p = subprocess.run([sys.executable, SCRIPT, '--id', 'SZERZO907', '--comment-file', cf,
+                        '--status', 'done'], capture_output=True, text=True, env=env, timeout=30)
+    check('32 a mezomozgatas sem ment at szerzo nelkul', p.returncode != 0, p.stdout + p.stderr)
+    check('32 a statusz valtozatlan', card('SZERZO907')[0] == 'planned', f'kapott: {card("SZERZO907")}')
+
+    # 33. NEGATIV KONTROLL: az or nem tulzottan szeles -- KIMONDOTT szerzovel ugyanaz a futas zold,
+    #     es a fejlec ES a kanban_comments.author is AZT a nevet hordozza, nem a koordinatoret.
+    p = comment('SZERZO907', 'Kartya SZERZO907: kimondott szerzovel.')
+    check('33 kimondott --author-ral zold', p.returncode == 0, p.stdout + p.stderr)
+    c = comments('SZERZO907')
+    check('33 a fejlec Boni-t nevezi, nem Marveent',
+          c and c[-1].startswith('[Boni '), f'kapott: {c[-1][:40] if c else None!r}')
+    # A FEJLEC ES AZ OSZLOP KET KULON HELY: 2026-09-07-en MINDKETTO 'Marveen'-re esett, tehat
+    # egy fejlec-only ellenorzes zold maradna, ha csak az oszlop romlana el.
+    _db = sqlite3.connect(DB_PATH)
+    _szerzo = _db.execute("SELECT author FROM kanban_comments WHERE card_id='SZERZO907'"
+                          ' ORDER BY id DESC LIMIT 1').fetchone()
+    _db.close()
+    check('33 a kanban_comments.author oszlop is Boni', _szerzo and _szerzo[0] == 'Boni',
+          f'kapott: {_szerzo!r}')
+
     os.remove(DB_PATH)
     if FAILS:
         sys.stderr.write('\nBUKOTT: ' + ', '.join(FAILS) + '\n')

--- a/scripts/kartya-es-ertesites.py
+++ b/scripts/kartya-es-ertesites.py
@@ -10,7 +10,9 @@ Amit garantal:
   - megnevezett flotta-gazdas kartya NEM jon letre ertesites nelkul (a szkript megtagadja);
   - mindket iras VISSZA VAN OLVASVA (a kartya SELECT-tel, az uzenet a visszakapott id-vel);
   - a 300 karakteres cim-kaput ELORE jelzi, nem utolag a trigger;
-  - --dry-run: mindent ellenoriz, semmit nem ir.
+  - --dry-run: mindent ellenoriz, semmit nem ir -- ES UGYANAZOKAT A KAPUKAT futtatja, mint az
+    eles ag (letezes, token). Egy dry-run, ami megengedobb az eles futasnal, rosszabb, mint
+    a semmi: zoldet ad arra, amit a rendszer megtagad. Ezt a kartya-dryrun-paritas teszt meri.
 
 Hasznalat:
   kartya-es-ertesites.py --id X905 --assignee boni --title "..." --desc-file /path
@@ -27,7 +29,9 @@ KOORDINATORHOZ (marveen) -- kimondva, a kimeneten es az uzenet elso soraban is.
 
 KOMMENT-ONLY MOD (KARTYAIRASESZKOZ905, 2026-09-05): komment egy MEGLEVO kartyara,
 ERTESITES NELKUL, ugyanazokkal a kapukkal es kotelezo visszaolvasassal:
-  kartya-es-ertesites.py --id X905 --comment-file /path [--author Samu] [--dry-run]
+  kartya-es-ertesites.py --id X905 --comment-file /path --author Samu [--dry-run]
+Az --author itt KOTELEZO (KARTYADRYRUN907, 2026-09-08): korabban csendben 'Marveen'-re esett,
+tehat a kartyan MAS neve allt, mint aki irta. A letrehozo agon az alapertelmezes valtozatlan.
 MEZOMOZGATAS (KARTYASTATUSZ906, Boni lelete 2026-09-06): komment-modban a lenti mezok MEGLEVO
 kartyat mozgatnak, elotte-pillanatkeppel es FUGGETLEN visszaolvasassal:
   kartya-es-ertesites.py --id X905 --status waiting --comment-file /path --author Boni
@@ -87,6 +91,30 @@ def _db_kapu():
                  f'(gyoker: {ROOT})\nEz jellemzoen egy korabbi rossz ut-feloldas hagyta ott. Mondd ki:\n'
                  f'CLAUDECLAW_ROOT=<a fo fa> vagy KARTYA_DB=<a db utvonala>.')
     return DB
+def _token_kapu(dry_run):
+    """A dashboard-token feloldasa, EGY helyen -- hogy a dry-run ES az eles ag UGYANAZT a
+    kaput fussa. A ket ag CSAK a mondatban ter el, mert a KOVETKEZMENY ter el: az eles agon
+    a kartya EKKOR MAR LETREJOTT (a token-kapu az 5. lepesben all, a 4. lepes irasa utan),
+    a dry-run agon meg semmi nem irodott -- ezert ott felteteles modban mondjuk ki, hogy
+    eles futasban MAR LETREJONNE. Ez a hianyzo mondat volt a dry-run legdragabb hazugsaga:
+    zoldet adott arra a futasra, aminek a vege pontosan az az allapot, amit az egesz eszkoz
+    megelozni hivatott -- a NEMA KARTYA."""
+    tok = os.environ.get('KARTYA_TOKEN')
+    if tok is not None:
+        return tok
+    tokpath = os.path.join(ROOT, 'store', '.dashboard-token')
+    if not os.path.exists(tokpath):
+        elozmeny = ('MEGTAGADVA (dry-run): eles futasban A KARTYA MAR LETREJONNE, DE AZ UZENET NEM MENNE KI:'
+                    if dry_run else
+                    'A KARTYA LETREJOTT, DE AZ UZENET NEM MENT KI:')
+        sys.exit(f'{elozmeny} nincs dashboard-token itt:\n'
+                 f'  {tokpath}\n(gyoker: {ROOT}). Mondd ki: CLAUDECLAW_ROOT=<a fo fa> vagy KARTYA_TOKEN=<token>.\n'
+                 + ('A dry-run ezert PIROS: az eles futas reszlegesen irna (kartya igen, uzenet nem).'
+                    if dry_run else
+                    'Kuldd el kezzel az uzenetet, kulonben a kartya nema marad.'))
+    return open(tokpath).read().strip()
+
+
 FLEET = {'samu','zara','boni','iris','dani','geri','deeper','qwen','mira','tomi','jumanji','hidli'}
 COORDINATOR = 'marveen'
 GAZDA = 'szabolcs'
@@ -230,6 +258,19 @@ GEPI_FEJLEC_RX = re.compile(r'^\s*\[[^\]\n]*\d{1,2}:\d{2}, rendszerora\]\s*\n?')
 
 def komment_mod(a):
     """Komment egy MEGLEVO kartyara, ertesites nelkul. Kapuk + kotelezo visszaolvasas."""
+    # SZERZO-KAPU (KARTYADRYRUN907, 2026-09-08). Boni es Zara egymastol fuggetlenul
+    # merte 2026-09-07-en (21700, 21701), hogy --author nelkul a fejlec ES a
+    # kanban_comments.author mezo CSENDBEN 'Marveen'-re esett. A javitas akkor egy
+    # VERZIOKOVETETLEN peldanyba ment, es a v1.37.0 kiadas nemán visszaallitotta a hibat
+    # (a kartya kozben done-on allt, tehat senki nem olvasta ujra). Ezert all itt fail-closed
+    # kapu FELSZOLITAS helyett: a kapu akkor is vedd, ha senki nem olvassa el a korlevelet.
+    # MIERT NEM ELEG A HELYES ALAPERTELMEZES: a komment SZERZOJE attribucio, nem kenyelem --
+    # a rossz nev irANYA is rossz, mert FELFELE, a koordinatorra mutat, tehat SULYT ad egy
+    # mondatnak, amit nem o irt.
+    if a.author is None:
+        sys.exit('MEGTAGADVA: komment-modban a szerzo KIMONDOTT: add meg az --author-t\n'
+                 '(pl. --author Boni). Korabban ez csendben "Marveen"-re esett vissza, tehat\n'
+                 'a kartyan MAS neve allt, mint aki irta -- es a kimenet kozben OK-t mondott.')
     text = open(a.comment_file, encoding='utf-8').read().strip()
     if not text:
         sys.exit('MEGTAGADVA: ures komment-fajl.')
@@ -387,7 +428,12 @@ def main():
     p.add_argument('--comment-file', help='KOMMENT-ONLY mod: komment meglevo kartyara, ertesites nelkul')
     p.add_argument('--assignee-uj', action='store_true', dest='assignee_uj',
                    help='komment-mod: kimondva uj (a tablan meg nem szereplo) felelos-nev')
-    p.add_argument('--author', default='Marveen', help='komment-mod: a komment szerzoje')
+    # NINCS CSENDES ALAPERTELMEZES (KARTYADRYRUN907, 2026-09-08). Korabban itt
+    # default='Marveen' allt, tehat egy --author nelkuli komment SZO NELKUL a
+    # koordinatort nevezte meg szerzokent -- a kimenet OK-t mondott, a kartyan pedig
+    # MAS neve allt. A None azert kell, hogy a komment-ag meg tudja KULONBOZTETNI a
+    # kimondott erteket a nem-adottol; a letrehozo ag alapertelmezese lentebb, KIMONDVA all.
+    p.add_argument('--author', default=None, help='a komment szerzoje (komment-modban KOTELEZO)')
     p.add_argument('--from', dest='from_agent', default=None,
                    help='az ertesites feladoja (alapertelmezes: az --author kisbetusitve)')
     p.add_argument('--dry-run', action='store_true')
@@ -420,7 +466,12 @@ def main():
     who = _felelos_feloldas(a.assignee)
     # A FELADO: kimondva (--from), vagy a szerzobol. Az alapertelmezes az --author kisbetusitve,
     # tehat a korabbi viselkedes (--author nelkul: 'marveen') valtozatlan marad.
-    frm = (a.from_agent or a.author).strip().lower()
+    # A 'Marveen' MOST ITT all, es nem az argparse default-jaban: a komment-ag szerzo-kapuja
+    # csak ugy tud kulonbseget tenni a kimondott es a nem-adott ertek kozott, ha a default
+    # None. A LETREHOZO agon SZANDEKOSAN nem szigoritunk: a kartya-ertesites-felado teszt 3.
+    # ellenorzese ezt a viselkedest REGRESSZIO-KONTROLLKENT rogziti (--author es --from nelkul
+    # a felado marveen). Ha ez valtozik, az szerzodes-valtas, es a teszttel egyutt kell donteni.
+    frm = (a.from_agent or a.author or 'Marveen').strip().lower()
     if frm not in KULDOK:
         sys.exit(f'MEGTAGADVA: ismeretlen felado ("{frm}"). Ervenyes: {", ".join(sorted(KULDOK))}.\n'
                  f'Ha az --author nem agens-nev (pl. "Marveen (Boni lelete)"), add meg kimondva: --from <agens>.')
@@ -466,8 +517,30 @@ def main():
             sys.exit(f'MEGTAGADVA: vegyes irasrendszeru szo a(z) {cimke}-ban: {h[:5]}')
 
     if a.dry_run:
-        _db_kapu()
-        print(f'DRY-RUN OK (DB: {DB}): minden ellenorzes atment.\n  id={a.id} gazda={who} statusz={a.status} '
+        # PARITAS-KAPU (KARTYADRYRUN907; Mira lelete 2026-09-07, UJRA ELO 2026-09-08 a kiadott
+        # peldanyban). A dry-run KORABBAN ITT tert vissza: a 4. lepes letezes-ellenorzese ES az
+        # 5. lepes token-kapuja ELOTT. Ezert zoldet adott ket olyan futasra, amit az eles ag
+        # megtagad vagy elront:
+        #   - LETEZO id-re "minden ellenorzes atment" (az eles ag: MEGTAGADVA, MAR LETEZIK);
+        #   - token nelkul, uzenettel szinten zold (az eles ag: a kartya letrejon, az uzenet nem).
+        # Egy dry-run, ami MEGENGEDOBB az eles agnal, rosszabb, mintha nem lenne: pont az a
+        # hasznalat dol be, amiert a kapcsolo letezik ("atmenne-e?"). A kapcsolo erteke a
+        # PARITAS, nem a szigor -- ezert a lenti ket kapu ugyanaz, mint az eles agon, es ezert
+        # meri a kartya-dryrun-paritas teszt MINDKET IRANYT (a hamis zoldet es a hamis pirosat is).
+        # IRNI TOVABBRA SEM IR: a letezes-ellenorzes READ-ONLY kapcsolaton megy, igy a dry-run
+        # meg egy hianyzo DB-fajlt sem hozhat letre.
+        dbro = sqlite3.connect(f'file:{_db_kapu()}?mode=ro', uri=True)
+        letezik = dbro.execute('SELECT 1 FROM kanban_cards WHERE id=?', (a.id,)).fetchone()
+        dbro.close()
+        if letezik:
+            # SZO SZERINT ugyanaz a mondat, mint az eles agon (a paritas-teszt 3. ellenorzese
+            # pont ezt meri): ha a ket ag MAS okot mond ugyanarra, az olvasoja nem tudja
+            # eldonteni, hogy ugyanaz a kapu fogta-e meg.
+            sys.exit(f'MEGTAGADVA: a(z) {a.id} kartya MAR LETEZIK.')
+        if msg:
+            _token_kapu(dry_run=True)
+        print(f'DRY-RUN OK (DB: {DB}): minden ellenorzes atment (a letezes- es a token-kaput is'
+              f' beleertve).\n  id={a.id} gazda={who} statusz={a.status} '
               f'prio={a.priority}\n  cim {len(a.title)} kar | leiras {len(desc)} kar | uzenet {len(msg)} kar')
         return
 
@@ -503,14 +576,7 @@ def main():
 
     # A token a gyokerbol jon, tehat ugyanaz a feloldas vonatkozik ra. KARTYA_TOKEN: teszt-horog
     # es kimondott felulbiralas, ugyanabban az alakban, mint a KARTYA_DB/KARTYA_API.
-    tokpath = os.path.join(ROOT, 'store', '.dashboard-token')
-    tok = os.environ.get('KARTYA_TOKEN')
-    if tok is None:
-        if not os.path.exists(tokpath):
-            sys.exit(f'A KARTYA LETREJOTT, DE AZ UZENET NEM MENT KI: nincs dashboard-token itt:\n'
-                     f'  {tokpath}\n(gyoker: {ROOT}). Mondd ki: CLAUDECLAW_ROOT=<a fo fa> vagy KARTYA_TOKEN=<token>.\n'
-                     f'Kuldd el kezzel az uzenetet, kulonben a kartya nema marad.')
-        tok = open(tokpath).read().strip()
+    tok = _token_kapu(dry_run=False)
     req = urllib.request.Request(API,
         data=json.dumps({'from': frm, 'to': cimzett, 'content': msg}).encode(),
         headers={'Content-Type': 'application/json', 'Authorization': 'Bearer ' + tok}, method='POST')


### PR DESCRIPTION
## Miert all ujra nyitva egy 2026-09-07-en lezart kartya

A KARTYADRYRUN907 javitasa egy **untracked** peldanyba ment a prod fan. A #1204 kozben
bevitte ugyanezt az eszkozt a repoba egy javitas ELOTTI valtozatban, es a v1.37.0 promote
utani checkout a kiadott peldanyt tette a helyere. A hiba **nemán visszaallt**, a kartya
kozben `done`-on allt, tehat senki nem olvasta ujra. A 13230-as komment sajat maga leirta
a kockazatot: "a fajl NINCS verziokovetve ... nincs diff, amihez visszalapozhatnank".

Ez a PR a repoba teszi a javitast, es melle a tesztet, ami a kovetkezo kiadast megfogja.

## 1. Dry-run paritas

A dry-run korai return-je **megelozte** a letezes-kaput es a token-kaput is:

| futas | dry-run (elotte) | eles ag |
|---|---|---|
| letezo ID | `DRY-RUN OK`, exit 0 | `MEGTAGADVA: MAR LETEZIK`, exit 1 |
| token nelkul + uzenet | `DRY-RUN OK`, exit 0 | a **kartya letrejon**, az uzenet nem megy ki, exit 1 |

A masodik a sulyosabb: a dry-run pont arra a futasra mondott zoldet, aminek a vege a
**nema kartya** -- az az allapot, amit az egesz eszkoz megelozni hivatott.

A dry-run mostantol mindket kaput futtatja, es tovabbra sem ir: a letezes-ellenorzes
READ-ONLY kapcsolaton megy. A token-feloldas egy helyre kerult (`_token_kapu`), hogy a
ket ag ne tudjon szetcsuszni; a dry-run mondata felteteles modban mondja ki, hogy eles
futasban a kartya MAR LETREJONNE.

## 2. Kimondott komment-szerzo

Az `--author` argparse-alapertelmezese `'Marveen'` volt, tehat egy `--author` nelkuli
komment **csendben a koordinatort** nevezte meg szerzokent -- a fejlecben ES a
`kanban_comments.author` oszlopban is. Az attribucio iranya a rossz: felfele mutat, tehat
sulyt ad egy mondatnak, amit nem o irt. Komment-modban az `--author` mostantol **kotelezo**.

**A letrehozo agon szandekosan nincs szigoritas.** Ott a `kartya-ertesites-felado` teszt
3. ellenorzese regresszio-kontrollkent rogziti, hogy `--author` es `--from` nelkul a felado
`marveen`. Az a szerzodes kulon dontes, nem ennek a PR-nek a targya -- a `'Marveen'`
alapertelmezes ezert a hivas helyere kerult, kimondva, nem az argparse-ba.

## 3. A teszt a lenyeg, nem a melleklet

A `kartya-dryrun-paritas.test.py` eddig **sehol nem volt verziokovetve**. Ez az egyetlen
darab, ami tulelte a kiadast, es csak azert, mert semmi nem irta felul. Most be van
commitolva. Ket dolgot igazitottam rajta, mindkettot merve:

- a **cim-horgony** kapu ujabb, mint a teszt, ezert a cimekbe bekerult a kartya ID-je
  (enelkul mind az ot "paritas" ellenorzes a rossz okbol volt piros);
- a fejlec-komment azt allitotta, hogy az `--author` a letrehozo agon kotelezo --
  visszamerve ez **nem igaz**, ezert helyesbitettem.

A `kartya-mezomozgatas.test.py` ket uj esettel bovult (32, 33): szerzo nelkul a komment ES
a mezomozgatas is megtagadva; kimondott szerzovel a fejlec ES az oszlop is a valodi szerzot
hordozza. A ket hely 2026-09-07-en egyutt romlott el, tehat egy fejlec-only ellenorzes zold
maradna.

## Mutacios kontroll

Mind a harom kapu kulon elrontva, majd visszaallitva (a fajl a vegen byte-azonos):

| mutacio | eredmeny |
|---|---|
| dry-run letezes-kapu kiiktatva | paritas **1, 3 PIROS** |
| dry-run token-kapu kiiktatva | paritas **6, 7 PIROS** |
| szerzo-kapu vissza a csendes `'Marveen'`-re | mezomozgatas **32 PIROS**, es a mutacio alatt a statusz szo nelkul `done`-ra mozdult (pont a regi hiba alakja) |

Javitassal mind a harom teszt-fajl zold: paritas 10/10, mezomozgatas, felado.

## Ami NEM fert bele

A harom lokalis valtozat (486/215/235 sor) egyedi tartalma **elveszett**: a mentes helye
(egy session-scratchpad) eltunt, es a 22 munkafan sincs meg. Amit a kiadottbol hianyzonak
mertem, az ebben a PR-ben bent van; ami esetleg meg volt bennuk, azt nem tudom megmondani,
mert nincs mihez hasonlitani.

Kartya: KARTYADRYRUN907

🤖 Generated with [Claude Code](https://claude.com/claude-code)