### PR TITLE
fix(kartya-eszkoz): a letrehozo agon is KIMONDOTT a felado (KARTYAKULDO908)

### DIFF
--- a/scripts/__tests__/kartya-ertesites-felado.test.py
+++ b/scripts/__tests__/kartya-ertesites-felado.test.py
@@ -117,11 +117,39 @@ def main():
     check('2 felado az --author-bol == boni', POSTED and POSTED[0]['from'] == 'boni',
           f'kapott: {POSTED[0]["from"] if POSTED else "semmi"}')
 
+    # 3. A CSENDES 'marveen' ALAPERTELMEZES SZANDEKOSAN MEGSZUNT (KARTYAKULDO908, 2026-09-08).
+    #    EZ AZ ELLENORZES KORABBAN AZ ELLENKEZOJET ALLITOTTA, es a megfordulasa DONTES, nem elirás:
+    #    2026-09-07-ig a --author es --from nelkuli futas felado nelkul is kikuldte az ertesitest,
+    #    a koordinator (marveen) neveben. Mira merte (21680), mi ennek az ara: Tomi olyan
+    #    feladat-kiosztast kapott, ami ugy nezett ki, mintha a FO-AGENS adta volna, holott a
+    #    kartya Mirae volt -- es visszakerdezni is a koordinatornak kerdezett volna vissza.
+    #    A hiba iranya a rossz: FELFELE attribual, tehat SULYT ad egy kerésnek, amit nem az
+    #    kuldott, akinek latszik.
+    #    A KOMMENT-AGON ezt a #1237 mar lezarta; ez a sor a LETREHOZO ag ugyanezen kapuja.
+    #    A ket agat szandekosan ket PR zarta: a regi viselkedest EZ a sor rogzitette
+    #    regresszio-kontrollkent, es egy ilyen szerzodest nem irunk at egy masik javitas
+    #    mellekhatasakent. Ha valaki a jovoben visszaallitana az alapertelmezest, ELOSZOR
+    #    ezt a kommentet olvassa el: a csend nem kenyelem, hanem rossz nevre kuldott uzenet.
     POSTED.clear()
-    p = run('KULDOC906', 'samu', 'Kartya: KULDOC906 -- alapertelmezes valtozatlan.', port)
-    check('3 lefutott', p.returncode == 0, p.stdout + p.stderr)
-    check('3 alapertelmezett felado marveen (regresszio-kontroll)',
-          POSTED and POSTED[0]['from'] == 'marveen')
+    p = run('KULDOC906', 'samu', 'Kartya: KULDOC906 -- kimondott felado nelkul.', port)
+    check('3 MEGTAGADVA kimondott felado nelkul (2026-09-08 ota)', p.returncode != 0,
+          f'exit={p.returncode} out={p.stdout + p.stderr!r}')
+    check('3 a megtagadas megnevezi a ket kapcsolot',
+          '--author' in (p.stdout + p.stderr) and '--from' in (p.stdout + p.stderr),
+          p.stdout + p.stderr)
+    check('3 semmit nem kuldott ki', not POSTED)
+    db = sqlite3.connect(DB_PATH)
+    n3 = db.execute('SELECT count(*) FROM kanban_cards WHERE id=?', ('KULDOC906',)).fetchone()[0]
+    db.close()
+    check('3 a kartya sem jott letre', n3 == 0)
+    # NEGATIV KONTROLL a megfordult ellenorzes melle: enelkul a 3. attol is zold lenne, ha a kapu
+    # MINDEN letrehozo futast megtagadna. Ugyanaz a hivas, csak kimondott szerzovel -> zold.
+    POSTED.clear()
+    p = run('KULDOC2906', 'samu', 'Kartya: KULDOC2906 -- kimondott szerzovel.', port,
+            extra=('--author', 'Boni'))
+    check('3 kimondott szerzovel ugyanaz a futas zold', p.returncode == 0, p.stdout + p.stderr)
+    check('3 es a felado boni, nem marveen', POSTED and POSTED[0]['from'] == 'boni',
+          f'kapott: {POSTED[0]["from"] if POSTED else "semmi"}')
 
     # 4. ONHUROK: felado == felelos -> a koordinatorhoz megy, es ki is mondja.
     POSTED.clear()

--- a/scripts/__tests__/kartya-mezomozgatas.test.py
+++ b/scripts/__tests__/kartya-mezomozgatas.test.py
@@ -23,6 +23,11 @@ FAILS = []
 SANDBOX_ROOT = tempfile.mkdtemp(prefix='kartya-sandbox-')
 
 
+# AZ --author MINDEN LETREHOZO HIVASBAN KIMONDOTT (KARTYAKULDO908, 2026-09-08). Nem stilus:
+# 2026-09-08 ota a letrehozo ag kimondott feladot kovetel, es kimondott szerzo NELKUL ezek a
+# futasok MAR A FELADO-KAPUN halnanak el. A tesztek tovabbra is zoldek maradnanak (a legtobbjuk
+# megtagadast var), csak MAS OKBOL -- vagyis a homoglifa-, horgony- es felelos-kapuk, amiket
+# merni akarnak, SOSEM futnanak le. Egy teszt, ami a rossz kapun zold, rosszabb, mint egy piros.
 def check(name, cond, detail=''):
     print(('PASS  ' if cond else 'FAIL  ') + name + (('  -- ' + detail) if detail and not cond else ''))
     if not cond:
@@ -156,7 +161,7 @@ def main():
     env['KARTYA_DB'] = DB_PATH
     env['CLAUDECLAW_ROOT'] = SANDBOX_ROOT
     env['KARTYA_API'] = 'http://127.0.0.1:1/api/messages'
-    p = subprocess.run([sys.executable, SCRIPT, '--id', 'UJKARTYA906', '--assignee', 'marveen',
+    p = subprocess.run([sys.executable, SCRIPT, '--id', 'UJKARTYA906', '--assignee', 'marveen', '--author', 'Boni',
                         '--title', 'UJKARTYA906 uj kartya teszt', '--no-msg'],
                        capture_output=True, text=True, env=env, timeout=30)
     check('7 letrehozo ag lefutott', p.returncode == 0, p.stdout + p.stderr)
@@ -167,7 +172,7 @@ def main():
     d = tempfile.mkdtemp(prefix='kartya-m3-')
     mf = os.path.join(d, 'm.txt')
     open(mf, 'w', encoding='utf-8').write('Kartya ELLENT906: ellentmondo kapcsolok.')
-    p = subprocess.run([sys.executable, SCRIPT, '--id', 'ELLENT906', '--assignee', 'marveen',
+    p = subprocess.run([sys.executable, SCRIPT, '--id', 'ELLENT906', '--assignee', 'marveen', '--author', 'Boni',
                         '--title', 'ellentmondas teszt', '--msg-file', mf, '--no-msg'],
                        capture_output=True, text=True, env=env, timeout=30)
     # A puszta nem-nulla exit itt NEM eleg: a kapu nelkul is elbukna az uzenetkuldesen (a
@@ -310,7 +315,7 @@ def main():
     env = dict(os.environ)
     env['KARTYA_DB'] = DB_PATH; env['CLAUDECLAW_ROOT'] = SANDBOX_ROOT
     env['KARTYA_API'] = 'http://127.0.0.1:1/api/messages'
-    p = subprocess.run([sys.executable, SCRIPT, '--id', 'HORGONYUJ906', '--assignee', 'marveen',
+    p = subprocess.run([sys.executable, SCRIPT, '--id', 'HORGONYUJ906', '--assignee', 'marveen', '--author', 'Boni',
                         '--title', 'cim azonosito nelkul', '--no-msg'],
                        capture_output=True, text=True, env=env, timeout=30)
     check('22 a letrehozo ag is megtagadja a horgony nelkuli cimet',
@@ -338,7 +343,7 @@ def main():
 
     # 24. Az --assignee-uj a LETREHOZO agon ertelmetlen -- egy nem hato kapcsolo pont az a
     #     hibaosztaly, amit ez az eszkoz ket kore zar (a --status csendes elvesztese).
-    p = subprocess.run([sys.executable, SCRIPT, '--id', 'UJFLAG906', '--assignee', 'marveen',
+    p = subprocess.run([sys.executable, SCRIPT, '--id', 'UJFLAG906', '--assignee', 'marveen', '--author', 'Boni',
                         '--title', 'UJFLAG906 teszt', '--no-msg', '--assignee-uj'],
                        capture_output=True, text=True, env=env, timeout=30)
     check('24 megtagadva az --assignee-uj a letrehozo agon',
@@ -347,7 +352,7 @@ def main():
 
     # 25. A LETREHOZO AG IS MEGORZI a kulso nev kis/nagybetujet (a kozos feloldas kovetkezmenye).
     #     Korabban a feltetel nelkuli .lower() mas erteket irt volna, mint ami a tablan all.
-    p = subprocess.run([sys.executable, SCRIPT, '--id', 'KULSONEV906', '--assignee', 'UjSzerzo',
+    p = subprocess.run([sys.executable, SCRIPT, '--id', 'KULSONEV906', '--assignee', 'UjSzerzo', '--author', 'Boni',
                         '--title', 'KULSONEV906 kulso szerzo kartyaja', '--no-msg'],
                        capture_output=True, text=True, env=env, timeout=30)
     check('25 a letrehozo ag lefutott', p.returncode == 0, p.stdout + p.stderr)
@@ -374,7 +379,7 @@ def main():
 
     # 27. UGYANAZ A LETREHOZO AGON. A kapu a KOZOS feloldasban all, nem a ket hivonal --
     #     pont ez a megoszlas hasadt el egyszer mar.
-    p = subprocess.run([sys.executable, SCRIPT, '--id', 'HOMOGB906', '--assignee', hamis_nev,
+    p = subprocess.run([sys.executable, SCRIPT, '--id', 'HOMOGB906', '--assignee', hamis_nev, '--author', 'Boni',
                         '--title', 'HOMOGB906 homoglifa a letrehozo agon', '--no-msg'],
                        capture_output=True, text=True, env=env, timeout=30)
     check('27 megtagadva a homoglifas felelos (letrehozo ag)',

--- a/scripts/kartya-es-ertesites.py
+++ b/scripts/kartya-es-ertesites.py
@@ -16,7 +16,9 @@ Amit garantal:
 
 Hasznalat:
   kartya-es-ertesites.py --id X905 --assignee boni --title "..." --desc-file /path
-      --msg-file /path [--priority normal] [--status planned] [--dry-run]
+      --msg-file /path --author Boni [--priority normal] [--status planned] [--dry-run]
+A felado MINDKET modban KIMONDOTT (KARTYAKULDO908, 2026-09-08): a letrehozo agon --author vagy
+--from kell, kulonben megtagadas. Korabban csendben 'marveen' lett belole.
 Az onmagunknak (marveen) vagy a gazdanak (szabolcs) szolo kartya ertesites nelkul is mehet:
 ott a --no-msg kapcsolo kell, KIMONDVA.
 
@@ -464,14 +466,22 @@ def main():
     # UGYANAZ A KANONIKUS ALAK, mint a mozgato agon -- kulonben a ket ut ugyanarra a nevre
     # KET KULONBOZO erteket irna a tablara.
     who = _felelos_feloldas(a.assignee)
-    # A FELADO: kimondva (--from), vagy a szerzobol. Az alapertelmezes az --author kisbetusitve,
-    # tehat a korabbi viselkedes (--author nelkul: 'marveen') valtozatlan marad.
-    # A 'Marveen' MOST ITT all, es nem az argparse default-jaban: a komment-ag szerzo-kapuja
-    # csak ugy tud kulonbseget tenni a kimondott es a nem-adott ertek kozott, ha a default
-    # None. A LETREHOZO agon SZANDEKOSAN nem szigoritunk: a kartya-ertesites-felado teszt 3.
-    # ellenorzese ezt a viselkedest REGRESSZIO-KONTROLLKENT rogziti (--author es --from nelkul
-    # a felado marveen). Ha ez valtozik, az szerzodes-valtas, es a teszttel egyutt kell donteni.
-    frm = (a.from_agent or a.author or 'Marveen').strip().lower()
+    # A FELADO KIMONDOTT (KARTYAKULDO908, 2026-09-08). Korabban itt egy 'Marveen' tartalek allt:
+    # --author es --from nelkul az ertesites CSENDBEN a koordinator neveben ment ki. Mira merte
+    # 2026-09-07-en (21680), mi tortenik ilyenkor: Tomi olyan feladat-kiosztast kapott, ami ugy
+    # nezett ki, mintha a FO-AGENS adta volna, holott a kartya Mirae volt. Az attribucios hiba
+    # iranya a rossz: FELFELE mutat, tehat SULYT ad egy kerésnek, amit nem a koordinator kuldott,
+    # es a cimzett neki is valaszolna vissza.
+    # A #1237 ezt a komment-agon mar lezarta; ez a kapu ugyanaz a LETREHOZO agon. A ket agat
+    # SZANDEKOSAN kulon PR zarja: a regi viselkedest egy KIADOTT teszt rogzitette
+    # regresszio-kontrollkent (kartya-ertesites-felado, 3. ellenorzes), es egy ilyen szerzodest
+    # nem irunk at egy masik javitas mellekhatasakent -- kulon dontesbol, a teszttel egyutt.
+    if not a.from_agent and not a.author:
+        sys.exit('MEGTAGADVA: a letrehozo agon is KIMONDOTT a felado: add meg az --author-t\n'
+                 '(a kartya szerzoje) vagy a --from-ot (az ertesites feladoja).\n'
+                 'Korabban ez csendben "marveen"-re esett vissza, tehat a cimzett ugy latta,\n'
+                 'mintha a koordinator kerte volna -- es neki is valaszolt volna vissza.')
+    frm = (a.from_agent or a.author).strip().lower()
     if frm not in KULDOK:
         sys.exit(f'MEGTAGADVA: ismeretlen felado ("{frm}"). Ervenyes: {", ".join(sorted(KULDOK))}.\n'
                  f'Ha az --author nem agens-nev (pl. "Marveen (Boni lelete)"), add meg kimondva: --from <agens>.')


### PR DESCRIPTION
Folytatasa a #1237-nek. Az ott lezart komment-agi szerzo-kapu parja a **letrehozo agon**.
Kulon PR, szandekosan: a regi viselkedest egy KIADOTT teszt rogzitette regresszio-kontrollkent,
es egy ilyen szerzodest nem irunk at egy masik javitas mellekhatasakent.

## A hiba, amit zar

`--author` es `--from` nelkul az ertesites **csendben a koordinator (marveen) neveben** ment ki.
Mira merte 2026-09-07-en (21680), mi ennek az ara: Tomi olyan feladat-kiosztast kapott, ami ugy
nezett ki, mintha a **fo-agens** adta volna, holott a kartya Mirae volt -- es visszakerdezni is a
koordinatornak kerdezett volna vissza.

Az attribucios hiba iranya a rossz: **felfele** mutat, tehat sulyt ad egy kerésnek, amit nem az
kuldott, akinek latszik.

## A teszt 3. ellenorzese megfordult, es ki is mondja, hogy dontes

Nem csak atallt. A fole irt komment megnevezi, **mi volt** a regi viselkedes, **mikortol** nem az,
**miert** szunt meg, es hogy a ket agat szandekosan ket PR zarta. Egy atirt assert onmagaban nem
mondja meg a kovetkezo olvasonak, hogy dontes volt-e vagy elirás.

Melle **negativ kontroll** kerult: ugyanaz a hivas kimondott szerzovel zold, es a felado `boni`,
nem `marveen`. Enelkul a 3. attol is zold lenne, ha a kapu MINDEN letrehozo futast megtagadna --
pontosan ezt mutatta meg a masodik mutacio.

## Minden hivot megmertem, nem csak azt, amelyik a hibat hordozta

A harom teszt-fajlban **het** letrehozo-hivas allt kimondott szerzo nelkul: egy a felado-tesztben
(a 3., ez a targy) es **hat** a mezomozgatas-tesztben.

Ez a hat **megtagadast var** (homoglifa-, horgony- es felelos-kapuk), tehat az uj kapu alatt is
**zold maradt volna -- csak mas okbol**, es a merni kivant kapuk sosem futottak volna le. Egy teszt,
ami a rossz kapun zold, rosszabb, mint egy piros. Ezert mind a hat kimondott `--author`-t kapott,
es a fajl tetejen all, hogy miert.

A repoban es a flotta-dokumentumokban egyeb hivo nincs (megmerve: egyetlen hivatkozas a
`kanban-audit` SKILL.md-ben, az komment-mod, mar `--author`-ral).

## Mutacios kontroll

A fajl a vegen byte-azonos a mutaciok elottivel (ellenorizve):

| mutacio | eredmeny |
|---|---|
| a kapu kiiktatva, vissza a csendes `'marveen'`-re | felado-teszt **3. PIROS**, es a mutacio alatt az uzenet-sor pontosan a regi alakban all elo: `('marveen', 'samu')` |
| a kapu tulzottan szeles (minden letrehozo futast megtagad) | **14 allitas PIROS**, koztuk a 3. negativ kontrollja |

Mind a harom teszt-fajl zold a javitassal: paritas 10/10, mezomozgatas, felado.

Kartya: KARTYADRYRUN907 (kovetkezmeny-PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)