### PR TITLE
fix(watchdog): stale upper bound + round-scoped answer attribution (TGORPHAN908)

### DIFF
--- a/scripts/__tests__/telegram-watchdog-wedged.test.sh
+++ b/scripts/__tests__/telegram-watchdog-wedged.test.sh
@@ -159,6 +159,106 @@ assert_eq "rewrites placeholder into a generic error" "1" "$(count editMessageTe
 assert_eq "error text used" "yes" "$(body_has "Valami elakadt")"
 
 # ---------------------------------------------------------------------------
+# TGORPHAN908 cases: stale upper bound + round-scoped answer attribution.
+# ---------------------------------------------------------------------------
+
+# Build a case whose transcript carries TIMESTAMPED user prompts (real format).
+# layout = delivered | undelivered | foreign
+#   delivered:   round-1 prompt @ marker time, answer text + reply call WITH
+#                result; then a later internal round with monologue text.
+#   undelivered: round-1 prompt @ marker time, answer text, NO reply call;
+#                then a later internal round with monologue text.
+#   foreign:     only a later round's prompt (nothing at/before marker time).
+make_ts_case() { # name layout age_seconds
+    local name="$1" layout="$2" age="$3"
+    local pdir="$TMP/root/agents/$name/.claude/channels/telegram/progress"
+    local sdir="$TMP/root/agents/$name/.claude/channels/telegram"
+    mkdir -p "$pdir"
+    printf 'TELEGRAM_BOT_TOKEN=TESTTOKEN\n' > "$sdir/.env"
+    local tr="$sdir/transcript.jsonl"
+    python3 - "$tr" "$layout" "$age" <<'PY'
+import datetime, json, sys, time
+tr, layout, age = sys.argv[1], sys.argv[2], int(sys.argv[3])
+now = time.time()
+def iso(t):
+    return datetime.datetime.fromtimestamp(t, datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.000Z')
+t1, t2 = now - age, now - age / 2
+ev = []
+if layout in ("delivered", "undelivered"):
+    ev.append({"type": "user", "timestamp": iso(t1),
+               "message": {"role": "user", "content": "csatorna-kerdes"}})
+    blocks = [{"type": "text", "text": "VALODI_T1_VALASZ a csatornanak"}]
+    if layout == "delivered":
+        blocks.append({"type": "tool_use", "id": "tuR1",
+                       "name": "mcp__plugin_telegram_telegram__reply"})
+    ev.append({"type": "assistant", "message": {"role": "assistant", "content": blocks}})
+    if layout == "delivered":
+        ev.append({"type": "user", "message": {"role": "user",
+                   "content": [{"type": "tool_result", "tool_use_id": "tuR1"}]}})
+ev.append({"type": "user", "timestamp": iso(t2),
+           "message": {"role": "user", "content": "belso scheduled kor"}})
+ev.append({"type": "assistant", "message": {"role": "assistant",
+           "content": [{"type": "text", "text": "BELSO_NAPLO Szabinak nem kuldtem semmit"}]}})
+with open(tr, "w") as f:
+    for e in ev:
+        f.write(json.dumps(e) + "\n")
+PY
+    printf '[{"chat_id":"%s","message_id":555,"transcript_path":"%s"}]\n' "$CHAT" "$tr" \
+        > "$pdir/SID.json"
+    python3 - "$pdir/SID.json" "$age" <<'PY'
+import os, sys, time
+os.utime(sys.argv[1], (time.time()-int(sys.argv[2]),)*2)
+PY
+    echo "$pdir"
+}
+
+echo ""
+echo "(f) Stale (28 days): dropped silently, no API call at all"
+PF="$(make_case wf hung $((28 * 86400)))"
+run_wd 1 1
+assert_eq "no real-answer send for a dead round" "0" "$(count sendMessage)"
+assert_eq "no error edit for a dead round" "0" "$(count editMessageText)"
+assert_eq "no delete attempt past Telegram's 48h window" "0" "$(count deleteMessage)"
+assert_eq "state file removed (cleanup, not collection)" "no" "$(pend_exists "$PF")"
+
+echo ""
+echo "(g) Stale but <48h: placeholder deleted, nothing delivered"
+PG="$(make_case wg hung 100000)"   # ~27.7h: > 24h stale, < 47h delete window
+run_wd 1 1
+assert_eq "no real-answer send" "0" "$(count sendMessage)"
+assert_eq "no error edit" "0" "$(count editMessageText)"
+assert_eq "placeholder deleted while still possible" "1" "$(count deleteMessage)"
+assert_eq "state file removed" "no" "$(pend_exists "$PG")"
+
+echo ""
+echo "(h) Round's reply already delivered: silent clear, NO resend of anything"
+PH="$(make_ts_case wh delivered 1000)"
+run_wd 1 1
+assert_eq "no resend (answer already reached the channel)" "0" "$(count sendMessage)"
+assert_eq "no error edit" "0" "$(count editMessageText)"
+assert_eq "internal monologue never sent" "no" "$(body_has "BELSO_NAPLO")"
+assert_eq "placeholder cleaned up" "1" "$(count deleteMessage)"
+assert_eq "state file removed" "no" "$(pend_exists "$PH")"
+
+echo ""
+echo "(i) Answer scoped to the marker's round, not the transcript's last text"
+PI="$(make_ts_case wi undelivered 1000)"
+run_wd 1 1
+assert_eq "backstop fires: one delivery" "1" "$(count sendMessage)"
+assert_eq "delivers the marker round's own text" "yes" "$(body_has "VALODI_T1_VALASZ")"
+assert_eq "later internal turn's text NOT sent" "no" "$(body_has "BELSO_NAPLO")"
+assert_eq "state file removed" "no" "$(pend_exists "$PI")"
+
+echo ""
+echo "(j) Timestamped transcript with no prompt at the marker: unattributable"
+PJ="$(make_ts_case wj foreign 1000)"
+run_wd 1 1
+assert_eq "no text delivery (nothing attributable)" "0" "$(count sendMessage)"
+assert_eq "internal text NOT leaked" "no" "$(body_has "BELSO_NAPLO")"
+assert_eq "falls back to generic error" "1" "$(count editMessageText)"
+assert_eq "state file removed" "no" "$(pend_exists "$PJ")"
+
+# ---------------------------------------------------------------------------
 echo ""
 echo "=============================="
 TOTAL=$((PASS + FAIL))

--- a/scripts/hooks/telegram_progress_watchdog.py
+++ b/scripts/hooks/telegram_progress_watchdog.py
@@ -31,12 +31,20 @@ Detection (per pending placeholder, keyed by its session state file):
   - agent UP with no hung-reply signal but the placeholder is older than
     WEDGED_SEC -> fire (blunt backstop for genuinely stuck turns; generous so
     long legit tasks aren't cut short).
+  - placeholder older than STALE_SEC (default 24h) -> DEAD round: deliver
+    nothing, drop the marker (and the placeholder message while Telegram still
+    allows deletion). TGORPHAN908: without this bound a post-outage scan walked
+    28-day orphans into the backstop and sent internal work logs to the owner.
+
+The recovered answer is scoped to the round that posted the placeholder (see
+read_transcript): the transcript keeps growing after that round, so its last
+text may be a later internal turn's monologue -- never deliverable here.
 
 Standalone: scans every agent's per-agent telegram state dir. No marveen src
 dependency; only Python stdlib + the `tmux` binary. Bot API base is overridable
 via TELEGRAM_API_BASE (tests point it at a local stub).
 """
-import os, glob, json, time, subprocess, urllib.request
+import datetime, os, glob, json, time, subprocess, urllib.request
 
 # State dirs to scan: per-agent dirs under the fleet, plus the default dir.
 # No hardcoded user paths -- derive from $HOME (override with MARVEEN_ROOT).
@@ -47,6 +55,19 @@ SCAN_GLOBS = [
 ]
 DOWN_GRACE_SEC = 120        # agent down + placeholder older than this -> fire
 WEDGED_SEC = 15 * 60        # agent up, no hung-reply signal, this old -> fire (backstop)
+# UPPER age bound (TGORPHAN908): a marker older than this marks a DEAD round,
+# not a stuck one -- there is no question behind it that needs an answer today.
+# Deliver NOTHING; drop the marker. Without this bound, a fleet restart after a
+# long outage walked 20-28 day old markers into the wedged-backstop branch and
+# sent six internal work logs to the owner's channel (2026-09-08).
+DEFAULT_STALE_SEC = 24 * 3600
+# Telegram refuses deleteMessage on messages older than 48h; don't burn an API
+# call (and an error log line) on a delete that cannot succeed.
+TELEGRAM_DELETE_WINDOW_SEC = 47 * 3600
+# A marker is written by the SAME submit hook that logs the user event into the
+# transcript, so the round's opening user-prompt sits within seconds of the
+# marker mtime. The slack absorbs clock/write-order jitter.
+TURN_ANCHOR_SLACK_SEC = 120
 # agent up + a HUNG reply detected + placeholder older than this -> fire FAST.
 # Far below WEDGED_SEC because the hung-reply signal is precise. Env-tunable so
 # a live install can adjust without a code change.
@@ -69,6 +90,10 @@ def _env_int(name, default):
 
 def wedged_up_sec():
     return _env_int("TELEGRAM_WATCHDOG_WEDGED_UP_SEC", DEFAULT_WEDGED_UP_SEC)
+
+
+def stale_sec():
+    return _env_int("TELEGRAM_WATCHDOG_STALE_SEC", DEFAULT_STALE_SEC)
 
 
 def token(state_dir):
@@ -137,21 +162,40 @@ def _is_reply_tool(name):
     return "telegram" in n and "reply" in n
 
 
-def read_transcript(transcript_path):
-    """Return (last_assistant_text, reply_is_hung).
+def _ev_epoch(ev):
+    ts = ev.get("timestamp")
+    if not ts or not isinstance(ts, str):
+        return None
+    try:
+        return datetime.datetime.fromisoformat(ts.replace("Z", "+00:00")).timestamp()
+    except Exception:
+        return None
 
-    last_assistant_text: the agent's final user-facing answer (last non-empty
-    assistant text block) -- the same source the Stop hook's fallback uses.
 
-    reply_is_hung: True iff the MOST RECENT tool call is the Telegram `reply`
-    tool and it has no matching tool_result yet -- i.e. the agent tried to reply
-    and the call never returned (dropped MCP). Keyed on the LAST tool_use so a
-    stale dangling reply from an already-handled earlier turn can't misfire.
-    """
-    text = ""
-    results = set()               # tool_use_ids that have a tool_result
-    last_tool_use = None          # (id, is_reply) of the most recent tool_use
-    for ev in _iter_events(transcript_path):
+def _is_user_prompt(ev):
+    """A real inbound prompt (starts a turn) -- NOT a tool_result carrier."""
+    msg = ev.get("message") or {}
+    role = msg.get("role") or ev.get("role")
+    if not (ev.get("type") == "user" or role == "user"):
+        return False
+    content = msg.get("content", ev.get("content"))
+    if isinstance(content, str):
+        return bool(content.strip())
+    if isinstance(content, list):
+        return any(isinstance(b, dict) and b.get("type") != "tool_result"
+                   for b in content)
+    return False
+
+
+class _Acc:
+    """Accumulator for one scan window of the transcript."""
+    def __init__(self):
+        self.text = ""
+        self.results = set()      # tool_use_ids that have a tool_result
+        self.reply_ids = set()    # tool_use_ids of Telegram reply calls
+        self.last_tool_use = None  # (id, is_reply) of the most recent tool_use
+
+    def feed(self, ev):
         msg = ev.get("message") or {}
         role = msg.get("role") or ev.get("role")
         content = msg.get("content", ev.get("content"))
@@ -162,21 +206,77 @@ def read_transcript(transcript_path):
                     continue
                 bt = b.get("type")
                 if bt == "tool_use":
-                    last_tool_use = (b.get("id"), _is_reply_tool(b.get("name")))
+                    is_reply = _is_reply_tool(b.get("name"))
+                    self.last_tool_use = (b.get("id"), is_reply)
+                    if is_reply and b.get("id") is not None:
+                        self.reply_ids.add(b.get("id"))
                 elif bt == "tool_result":
                     tid = b.get("tool_use_id")
                     if tid is not None:
-                        results.add(tid)
+                        self.results.add(tid)
                 elif bt == "text" and is_assistant:
                     t = (b.get("text") or "").strip()
                     if t:
-                        text = t
+                        self.text = t
         elif isinstance(content, str) and is_assistant:
             if content.strip():
-                text = content.strip()
-    reply_is_hung = bool(last_tool_use and last_tool_use[1]
-                         and last_tool_use[0] not in results)
-    return text, reply_is_hung
+                self.text = content.strip()
+
+    def reply_hung(self):
+        return bool(self.last_tool_use and self.last_tool_use[1]
+                    and self.last_tool_use[0] not in self.results)
+
+    def reply_delivered(self):
+        return bool(self.reply_ids & self.results)
+
+
+def read_transcript(transcript_path, turn_start=None):
+    """Return (last_assistant_text, reply_is_hung, reply_delivered).
+
+    last_assistant_text: the agent's final user-facing answer (last non-empty
+    assistant text block) -- the same source the Stop hook's fallback uses.
+
+    reply_is_hung: True iff the most recent tool call in scope is the Telegram
+    `reply` tool with no matching tool_result yet (dropped MCP).
+
+    reply_delivered: True iff a Telegram reply call in scope DID get a result
+    -- the round's answer already reached the channel, so nothing may be resent.
+
+    Scope (TGORPHAN908): a transcript outlives the round that posted the
+    placeholder -- later scheduled/internal turns keep appending, so the LAST
+    text of the whole file may be internal monologue that was never meant for
+    the channel (six such leaked to the owner on 2026-09-08). When `turn_start`
+    (the marker mtime) is given and the transcript carries timestamped user
+    prompts, only the round active at turn_start is read: from the last user
+    prompt at/before turn_start+slack to the next user prompt. A timestamped
+    transcript with no prompt at/before the marker is unattributable -> no
+    answer (generic-error path), never a foreign turn's text. Transcripts
+    without timestamped prompts (older format) keep the whole-file behavior.
+    """
+    whole = _Acc()
+    scoped = _Acc()
+    have_ts_prompt = False
+    anchor_seen = False
+    in_window = False
+    for ev in _iter_events(transcript_path):
+        if _is_user_prompt(ev):
+            e = _ev_epoch(ev)
+            if e is not None:
+                have_ts_prompt = True
+                if turn_start is not None and e <= turn_start + TURN_ANCHOR_SLACK_SEC:
+                    scoped = _Acc()  # a later prompt supersedes: window restarts
+                    anchor_seen = True
+                    in_window = True
+                elif in_window:
+                    in_window = False  # the marker's round ended here
+        whole.feed(ev)
+        if in_window:
+            scoped.feed(ev)
+    if turn_start is not None and have_ts_prompt:
+        if not anchor_seen:
+            return "", False, False
+        return scoped.text, scoped.reply_hung(), scoped.reply_delivered()
+    return whole.text, whole.reply_hung(), False
 
 
 def log(progress_dir, msg):
@@ -225,6 +325,7 @@ def handle_dir(progress_dir):
             pass
     tok = None
     up_sec = wedged_up_sec()
+    max_age = stale_sec()
     for path in glob.glob(os.path.join(progress_dir, "*.json")):
         try:
             age = now - os.path.getmtime(path)
@@ -237,15 +338,43 @@ def handle_dir(progress_dir):
         if not pend:
             continue
 
+        # UPPER age bound (TGORPHAN908): a marker this old marks a DEAD round.
+        # Whatever answer might be scraped from its transcript, nobody is
+        # waiting for it today -- deliver NOTHING, drop the marker. The
+        # placeholder message is cleaned up only while Telegram still allows
+        # deletion (<48h); past that the delete can only fail (HTTP 400).
+        if age > max_age:
+            if age < TELEGRAM_DELETE_WINDOW_SEC:
+                if tok is None:
+                    tok = token(state_dir)
+                if tok:
+                    for p in pend:
+                        try:
+                            api(tok, "deleteMessage",
+                                {"chat_id": p.get("chat_id"),
+                                 "message_id": p.get("message_id")})
+                        except Exception as e:
+                            log(progress_dir,
+                                f"stale placeholder delete failed "
+                                f"(mid={p.get('message_id')}): {e}")
+            try:
+                os.remove(path)
+            except Exception:
+                pass
+            log(progress_dir, f"orphan dropped (stale): {os.path.basename(path)} "
+                              f"age={int(age)}s delivered=none")
+            continue
+
         # The transcript path is stamped onto the pending entries by the submit
         # hook (same for the whole turn); read the agent's answer + hung-reply
-        # signal once.
+        # signal once, scoped to the round that posted this marker.
         transcript_path = ""
         for p in pend:
             if p.get("transcript_path"):
                 transcript_path = p["transcript_path"]
                 break
-        answer, reply_hung = read_transcript(transcript_path)
+        answer, reply_hung, reply_delivered = read_transcript(
+            transcript_path, turn_start=now - age)
 
         # Fire decision.
         if not agent_up:
@@ -267,6 +396,30 @@ def handle_dir(progress_dir):
             tok = token(state_dir)
         if not tok:
             continue
+
+        # The round's own reply already reached the channel (a reply call in
+        # this round's window has a result): the marker is leftover bookkeeping
+        # from a missed Stop hook. Resending would duplicate the answer -- and
+        # the transcript's LAST text may belong to a later, internal turn.
+        # Clear silently.
+        if reply_delivered and not reply_hung:
+            for p in pend:
+                try:
+                    api(tok, "deleteMessage",
+                        {"chat_id": p.get("chat_id"),
+                         "message_id": p.get("message_id")})
+                except Exception as e:
+                    log(progress_dir,
+                        f"placeholder delete failed (mid={p.get('message_id')}): {e}")
+            try:
+                os.remove(path)
+            except Exception:
+                pass
+            log(progress_dir, f"orphan cleared (reply-already-delivered): "
+                              f"{os.path.basename(path)} agent_up={agent_up} "
+                              f"age={int(age)}s delivered=none")
+            continue
+
         modes = []
         for p in pend:
             modes.append(deliver(tok, p.get("chat_id"), p.get("message_id"),


### PR DESCRIPTION
## Mi történt (a kártyáról)

Ma 08:28-kor a flotta-újraindulás utáni szken hat 20-28 napos árva jelölőt vitt a `wedged-backstop` ágra, és hat belső munkanaplót küldött ki a gazda Telegram-csatornájára.

## A három kért lépés -- mindhárom benne van

1. **Felső korhatár** a backstopra: `STALE_SEC` (alapból 24h, env: `TELEGRAM_WATCHDOG_STALE_SEC`). Ami ennél öregebb: SEMMI kézbesítés, jelölő törölve; a placeholder-üzenet csak a Telegram 48 órás törlési ablakán belül kap deleteMessage-t (azon túl a hívás csak HTTP 400-at tudna adni -- a kártya buktatója).
2. **Takarítás gyűjtés helyett**: az 1. pontból következik -- minden szken eltakarítja a lejárt jelölőket, tehát nem halmozódnak.
3. **A 3. pont OLCSÓN mérhetőnek bizonyult, nem kell külön kártya.** A `read_transcript` mostantól a jelölőt létrehozó KÖRRE szűkít: az utolsó timestampes user-prompt a jelölő mtime-ja előtt/körül nyitja az ablakot, a következő prompt zárja. Következmények:
   - egy későbbi belső kör szövege SOHA nem kézbesíthető;
   - ha a kör saját reply-hívása kapott tool_result-ot (a válasz már kiment), a jelölő NÉMÁN takarítódik, nincs újraküldés;
   - timestampes transzkript, amiben nincs prompt a jelölő idejénél: nem attribuálható -> generikus hiba, nem idegen szöveg;
   - timestamp nélküli (régi formátumú) transzkript: marad a teljes-fájl viselkedés.

## Mérés

Contract-teszt 5 új esettel (28 napos stale; stale a 48h ablakon belül; már-kézbesített kör; kör-szűkített válasz vs. későbbi belső szöveg; nem-attribuálható): **36/36 zöld**, a régi (a)-(e) esetek érintetlenül.

## DEPLOY -- a merge önmagában NEM élesít

Az élő watchdog egy MÁSOLAT: `~/.claude/hooks/telegram_progress_watchdog.py` (jelenleg aug. 4-i!), a `com.marveen.telegram-progress-watchdog` launchd job futtatja. Merge után az `install-telegram-progress-hook.sh`-t újra kell futtatni, különben a fix a repóban ül és a hiba élőben marad.

🤖 Generated with [Claude Code](https://claude.com/claude-code)