### PR TITLE
fix(main-agent): stop reporting the running main agent as stopped (MSGWARN908)

### DIFF
--- a/src/__tests__/messages-main-agent-no-false-warning.test.ts
+++ b/src/__tests__/messages-main-agent-no-false-warning.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeAll } from 'vitest'
+import { EventEmitter } from 'node:events'
+import { initDatabase } from '../db.js'
+import { MAIN_AGENT_ID } from '../config.js'
+import { tryHandleMessages } from '../web/routes/messages.js'
+import type { RouteContext } from '../web/routes/types.js'
+
+// MSGWARN908: POST /api/messages warned "'<to>' nem fut -- ... elveszik" for
+// the MAIN agent on every send, because isAgentRunning() probes the
+// `agent-<name>` session and the main agent lives in `${MAIN_AGENT_ID}-channels`.
+// The claim was false twice over: the router never abandons a main-agent
+// message (pull model), so nothing is ever lost. On 2026-09-08 the false
+// "not running" state was relayed to the owner as a system-down report; the
+// reaction it invites -- starting a second main instance -- is exactly what
+// the pull model must never see. These tests run the real route handler: in a
+// test environment no tmux session exists at all, so isAgentRunning() is
+// false for EVERY name -- which is precisely the condition that used to
+// trigger the false warning for the main agent.
+
+function fakeCtx(body: unknown): { ctx: RouteContext; res: { statusCode: number; body: string } } {
+  const req = new EventEmitter() as unknown as RouteContext['req'] & { destroy(): void }
+  ;(req as unknown as { headers: Record<string, string> }).headers = {}
+  ;(req as { destroy(): void }).destroy = () => { /* readBody over-limit hook */ }
+  const state = { statusCode: 0, body: '' }
+  const res = {
+    writeHead(code: number) { state.statusCode = code; return res },
+    end(data?: unknown) { state.body = String(data ?? '') },
+    setHeader() { /* not used by json() */ },
+  } as unknown as RouteContext['res']
+  process.nextTick(() => {
+    ;(req as unknown as EventEmitter).emit('data', Buffer.from(JSON.stringify(body)))
+    ;(req as unknown as EventEmitter).emit('end')
+  })
+  const path = '/api/messages'
+  return { ctx: { req, res, path, method: 'POST', url: new URL(`http://localhost${path}`), fedPeer: null }, res: state }
+}
+
+async function post(body: unknown): Promise<{ statusCode: number; json: Record<string, unknown> }> {
+  const { ctx, res } = fakeCtx(body)
+  const handled = await tryHandleMessages(ctx)
+  expect(handled).toBe(true)
+  return { statusCode: res.statusCode, json: JSON.parse(res.body) }
+}
+
+beforeAll(() => {
+  process.env.NODE_ENV = 'test'
+  initDatabase(':memory:')
+})
+
+describe('POST /api/messages to the main agent (MSGWARN908)', () => {
+  it('never carries the "not running -- will be lost" warning', async () => {
+    const r = await post({ from: MAIN_AGENT_ID, to: MAIN_AGENT_ID, content: 'status probe' })
+    expect(r.statusCode).toBe(200)
+    expect(r.json.warning).toBeUndefined()
+    expect(r.json.targetRunning).toBeUndefined()
+    expect(r.json.to_agent).toBe(MAIN_AGENT_ID)
+  })
+
+  it('still warns for a genuinely stopped sub-agent (the gate is not loosened)', async () => {
+    // No tmux in the test env, so any sub-agent id reads as stopped -- the
+    // exemption must be main-only, not a blanket removal of the warning.
+    const r = await post({ from: MAIN_AGENT_ID, to: 'no-such-agent-session', content: 'ping' })
+    expect(r.statusCode).toBe(200)
+    expect(r.json.targetRunning).toBe(false)
+    expect(String(r.json.warning)).toContain('nem fut')
+  })
+})

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -1196,11 +1196,11 @@ export function sessionExistsOnHost(host: string | null, session: string): boole
   }
 }
 
-export function getAgentRunningSince(name: string): number | null {
+export function getAgentRunningSince(name: string, session: string = agentSessionName(name)): number | null {
   try {
     const target = agentTmuxTarget(name)
     const host = target.host
-    const out = captureTmux(target, ['display-message', '-p', '-t', agentSessionName(name), '#{session_created}']).trim()
+    const out = captureTmux(target, ['display-message', '-p', '-t', session, '#{session_created}']).trim()
     const ts = parseInt(out, 10)
     return Number.isFinite(ts) ? ts : null
   } catch {

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -468,15 +468,26 @@ function getAgentSummary(name: string): AgentSummary {
   // never blocks on a sleeping laptop's ssh timeout. `running` is derived from
   // it; `unreachable` reads as not-running but is surfaced distinctly so the UI
   // does not show a still-alive remote agent as "stopped".
+  //
+  // MSGWARN908: the MAIN agent lives in `${MAIN_AGENT_ID}-channels` (launchd /
+  // channels.sh), not `agent-<name>` -- agentRunState() on its id always said
+  // 'stopped', so this roster reported a running Marveen as down, and on
+  // 2026-09-08 that false state was relayed to the owner as a system-down
+  // report. Probe the channels session instead (same source the activity
+  // endpoint already uses).
+  const isMain = isMainChannelsAgent(name)
   const remote = readAgentRemoteConfig(name)
-  const runState = agentRunStateCached(name, remote.host != null)
+  const mainSessionName = isMain ? MAIN_CHANNELS_SESSION : agentSessionName(name)
+  const runState: AgentRunState = isMain
+    ? (capturePane(MAIN_CHANNELS_SESSION) !== null ? 'running' : 'stopped')
+    : agentRunStateCached(name, remote.host != null)
   const running = runState === 'running'
-  const session = running ? agentSessionName(name) : undefined
-  const runningSince = running ? getAgentRunningSince(name) : null
+  const session = running ? mainSessionName : undefined
+  const runningSince = running ? getAgentRunningSince(name, mainSessionName) : null
 
   // Reauth badge: only meaningful for a running session (a stopped agent has
   // no pane to inspect). One capture-pane per running agent on the list poll.
-  const reauth = running ? detectReauthNeeded(capturePane(agentSessionName(name))) : { needsReauth: false }
+  const reauth = running ? detectReauthNeeded(capturePane(mainSessionName)) : { needsReauth: false }
 
   return {
     name,

--- a/src/web/routes/messages.ts
+++ b/src/web/routes/messages.ts
@@ -12,7 +12,7 @@ import { logger } from '../../logger.js'
 import { COORDINATOR_AGENT_ID } from '../../channel-coordinator/ingest.js'
 import { sanitizeAgentIdent } from '../../prompt-safety.js'
 import { isKnownAgent } from '../agent-config.js'
-import { OWNER_NAME, SYSTEM_SENDER_IDS, parseSystemSenderIds } from '../../config.js'
+import { MAIN_AGENT_ID, OWNER_NAME, SYSTEM_SENDER_IDS, parseSystemSenderIds } from '../../config.js'
 import { isAgentRunning } from '../agent-process.js'
 import { readBody, json, jsonMaybeGzip } from '../http-helpers.js'
 import { normalizeKanbanRefs } from '../kanban-ref-normalize.js'
@@ -214,7 +214,17 @@ export async function tryHandleMessages(ctx: RouteContext): Promise<boolean> {
     // error at creation time (see above) -- give the local path the same
     // courtesy, as a non-breaking warning field rather than a status change, so
     // existing callers keep working.
-    if (!storedTo.includes('/') && !isAgentRunning(sanitizeAgentIdent(storedTo))) {
+    // The MAIN agent is exempt (MSGWARN908): its session is
+    // `${MAIN_AGENT_ID}-channels`, so isAgentRunning() -- which probes
+    // `agent-<name>` -- always says stopped, and the router never abandons a
+    // main-agent message anyway (pull model: the main agent drains its own
+    // inbox each turn). The warning below was therefore always false for it,
+    // and on 2026-09-08 the false "not running" state reached the owner as a
+    // system-down report. The worst reaction it invites -- starting a second
+    // main instance -- is exactly what the pull model must never see.
+    if (!storedTo.includes('/')
+        && sanitizeAgentIdent(storedTo) !== sanitizeAgentIdent(MAIN_AGENT_ID)
+        && !isAgentRunning(sanitizeAgentIdent(storedTo))) {
       logger.warn({ id: msg.id, to: msg.to_agent }, 'Agent message queued for a STOPPED agent -- likely to be abandoned')
       json(res, {
         ...msg,


### PR DESCRIPTION
## Mi volt a hiba

A fő-ágens a `${MAIN_AGENT_ID}-channels` sessionben él, nem `agent-<name>`-ben, ezért az `isAgentRunning()` rá mindig 'stopped'-ot mondott. Két hamis, ember felé is eljutó kimenet:

- **POST /api/messages**: minden fő-ágensnek szóló küldés "nem fut -- ... elveszik" figyelmeztetést kapott, holott a router a fő-ágens üzenetét SOHA nem abandonálja (pull-modell) -- semmi nem veszik el.
- **/api/agents**: a roster a futó Marveent stopped-nak listázta; 2026-09-08-án ez a hamis állapot a gazdáig jutott rendszer-leállás jelentésként. A figyelmeztetés által sugallt reakció (második fő-instance indítása) a pull-modell mellett kifejezetten káros.

## A javítás (a review-ban kimondott hatókörrel)

A két fogyasztói helyen, NEM a központi `agentRunState`-ben (annak átbillentése a stop/start lifecycle-őröket is átírná):
- `messages.ts`: a veszteség-figyelmeztetés kapuja kivételezi a MAIN_AGENT_ID-t
- `routes/agents.ts` `getAgentSummary`: a fő-ágens runState/session/runningSince/reauth a `MAIN_CHANNELS_SESSION`-t méri (ugyanaz a forrás, amit az activity-endpoint már használ); `getAgentRunningSince` opcionális session-paramétert kapott

## Mérés

- Runtime-teszt a valódi route-handlerrel (in-memory DB): fő-ágensre nincs warning, leállt sub-agentre TOVÁBBRA IS van (a kapu nem lazult)
- Mutáció-próba: a kivétel törlésével pont a fő-ágens-assert megy pirosra
- tsc tiszta, teljes suite: **4918 passed / 1 skipped**
- Deploy után élő verify: `/api/agents` marveen-sora running=true + session=marveen-channels (rollout-lépés, a kártyán)

Kártya: MSGWARN908 (F4F0838D, high -- a mai Zara-incidens után emelve)

🤖 Generated with [Claude Code](https://claude.com/claude-code)