### PR TITLE
fix(kanban-audit): a hard owner blocker never reaches Telegram, and your own comment hides the card

### DIFF
--- a/seed-scheduled-tasks/kanban-audit/SKILL.md
+++ b/seed-scheduled-tasks/kanban-audit/SKILL.md
@@ -267,9 +267,48 @@ for c in json.load(sys.stdin):
 7. **Telegram csak akkor írj ha**:
    - 3+ beakadt task van (kritikus)
    - Új blokker (waiting > 48h)
+   - **TULAJDONOSRA VÁRÓ KEMÉNY BLOKKOLÓ, státusztól és kortól függetlenül.**
+     A fenti két küszöb szűk, mert mindkettő ÁLLAPOTOT vagy KORT néz, a
+     blokkoló viszont lehet friss és lehet `planned` is. 2026-08-11: egy
+     kártya arról, hogy elfogyott egy szolgáltató előrefizetett kerete és
+     minden hívás 429-cel tér vissza, `planned` státuszban, 100 perce
+     létezett, tehát SEM a "3+ beakadt", SEM a "waiting > 48h" nem fogta meg.
+     Közben négy szálat állított meg, és csak a tulajdonos tudta feloldani,
+     mert számlázás.
+     A szabály: ha egy kártya (a) kemény megállást ír le, (b) az assignee-je a
+     tulajdonos, vagy a leírása szerint csak ő tudja elvégezni, és (c) nem
+     látszik, hogy szólt volna neki bárki, akkor kimegy Telegramon.
+     A (c) ellenőrzése: nézd meg, kérte-e valaki inter-agent üzenetben a
+     továbbítást, és fusd át a saját kimenő üzeneteidet. Ha kétséges, inkább
+     szólj: a kétszer elmondott blokkoló olcsóbb, mint a négy órát álló flotta.
    - Egyébként csendben (heartbeat-stílus)
 
 ## Buktatók
+- **A saját kommentelésed elrejti a kártyát a kor-alapú metrikák elől.** Egy
+  komment (és minden kártya-írás) frissíti az `updated_at`-et, tehát a
+  `waiting > 48h` lista ÜRESRE válthat attól, hogy az előző körben te magad
+  írtál a kártyára. 2026-08-11, saját mérés: egy kártya 307 órája várt, 12:00-kor
+  kommenteltem rá, és a 16:00-s auditon már 0 volt a `waiting > 48h` -- nem
+  azért, mert megoldódott, hanem mert én nyúltam hozzá. A hiba iránya
+  megnyugtató, és ettől veszélyes: néma nulla, ami sikernek látszik.
+  Ha "0 blokkolót" mérsz, nézd meg, mozgott-e a kártya az előző audit óta ÉS ki
+  mozgatta:
+  ```bash
+  python3 -c "
+  import sqlite3
+  c=sqlite3.connect('store/claudeclaw.db')
+  r=c.execute(\"select author from kanban_comments where card_id=? order by created_at desc limit 1\", ('<id>',)).fetchone()
+  print(r[0] if r else '(nincs komment)')"
+  ```
+  Az `updated_at` az utolsó ÍRÁS ideje, nem a munka utolsó valódi mozgásáé.
+  **A VALÓS kort a `created_at`-tel vesd össze, ha az `updated_at` a te írásod.**
+  2026-08-25: egy kártya 162,5 órásnak mérődött, de az `updated_at` egy héttel
+  korábbi saját kommentem volt; a kártya 14 napja készült. A kétszeres eltérés
+  eldönti, halasztható-e még egy napot, ezért a jelentésben a valós kort mondd,
+  a mérttel együtt.
+  Ebből következik egy tartózkodás is: **ne kommentelj a kártyára pusztán azért,
+  hogy rögzítsd, hogy megnézted.** Ha csak ellenőriztél, a csatornán jelezd, ne a
+  táblán. Kommentet akkor írj, ha MÉRTÉL valamit, ami a kártyán maradandó.
 - **NE `sqlite3` CLI-t és NE `jq`-t használj.** Egyik sincs telepítve egy átlagos Linux
   gépen (a telepítő függőségei: ffmpeg, git, tmux, lsof, curl, python3, pipx, unzip), és a
   hívás ott `exit 127`-tel elhal -- ez a lépés némán kimarad, miközben az audit sikeresnek


### PR DESCRIPTION
Two gaps in the shipped `kanban-audit` recipe, both measured on a live install. Each one makes the audit report a clean board while something is actually stuck, and the failure direction is reassuring in both cases, which is what makes them worth shipping.

### 1. A hard owner blocker never reaches Telegram

The two Telegram triggers are "3+ stuck tasks" and "new blocker (waiting > 48h)". Both key on **state** or **age**, so a blocker that is neither old nor stuck stays silent forever.

Measured 2026-08-11: a card saying a provider's prepaid credit had run out and every call was returning 429 sat in `planned`, 100 minutes old. Neither threshold caught it. It had stopped four threads, and only the owner could clear it, because it was billing.

The PR adds a third trigger next to the existing two: an owner-blocking card goes out regardless of status and age, with the "has anyone told them yet" check spelled out, and with the reason to err loud stated: a blocker said twice is cheaper than a fleet idle for four hours.

### 2. Your own comment hides the card from the age-based metric

Every card write bumps `updated_at`, so the `waiting > 48h` list can go **empty** simply because the previous round commented on a card.

Measured 2026-08-11: a card that had waited 307 hours was commented on at 12:00, and the 16:00 audit reported 0 blockers. Not because it resolved, but because the audit itself had touched it. A silent zero that reads as success.

The pitfall added to `## Buktatók` says to check **who** last wrote the card, to compare the real age against `created_at` when `updated_at` is your own write (measured 2026-08-25: 162.5 hours by the metric, 14 days in reality), and not to comment merely to record that you looked.

### Notes

- Both sections are in Hungarian, matching the surrounding file.
- They use `python3` and the dashboard API, so `shipped-recipes-no-sqlite-cli` stays green; no new binary dependency.
- Docs only, one file, +39 lines. No code paths touched.
- The two dirs `scheduled-tasks/` and `seed-scheduled-tasks/` hold disjoint task sets and `kanban-audit` lives only in the latter, so this is the single place the change belongs. (Checking that was on my list as a possible second bug; it is not one.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y8H1SBfHP69wQJEXV57GXb
