### PR TITLE
fix(messages): stamp the heartbeat digest header clock at persistence (HBORACSUSZAS908)

### DIFF
--- a/src/__tests__/heartbeat-header-stamp.test.ts
+++ b/src/__tests__/heartbeat-header-stamp.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { stampHeartbeatHeader } from '../web/heartbeat-header-stamp.js'
+
+// 2026-09-08T13:00:28Z == 15:00 in Europe/Budapest (CEST, UTC+2)
+const NOW = new Date('2026-09-08T13:00:28Z')
+
+describe('stampHeartbeatHeader', () => {
+  it('replaces a drifted header clock with the server time (the measured +3h case)', () => {
+    const content = '## Heartbeat 2026-09-08 18:00 (Europe/Budapest)\n\n### Calendar (next 2h)\n- x'
+    expect(stampHeartbeatHeader(content, NOW)).toBe(
+      '## Heartbeat 2026-09-08 15:00 (Europe/Budapest)\n\n### Calendar (next 2h)\n- x',
+    )
+  })
+
+  it('restamps an already-correct header to the same value (idempotent surface)', () => {
+    const content = '## Heartbeat 2026-09-08 15:00 (Europe/Budapest)\n\nbody'
+    expect(stampHeartbeatHeader(content, NOW)).toBe(content)
+  })
+
+  it('corrects the date too, not only the hour (a midnight-crossing drift)', () => {
+    const content = '## Heartbeat 2026-09-09 01:00 (Europe/Budapest)\n\nbody'
+    expect(stampHeartbeatHeader(content, NOW)).toContain('## Heartbeat 2026-09-08 15:00')
+  })
+
+  it('leaves a digest quoted after other text untouched (historical label)', () => {
+    const content = 'Nézd ezt a digestet:\n## Heartbeat 2026-09-08 18:00 (Europe/Budapest)\nbody'
+    expect(stampHeartbeatHeader(content, NOW)).toBe(content)
+  })
+
+  it('leaves non-digest content untouched', () => {
+    const content = 'Feladat KÉSZ. PR: https://example.com/1'
+    expect(stampHeartbeatHeader(content, NOW)).toBe(content)
+  })
+
+  it('leaves a header without the timestamp shape untouched', () => {
+    const content = '## Heartbeat woke up\nbody'
+    expect(stampHeartbeatHeader(content, NOW)).toBe(content)
+  })
+
+  it('stamps in Europe/Budapest local time, not UTC', () => {
+    const content = '## Heartbeat 2026-09-08 13:00 (Europe/Budapest)'
+    // 13:00Z must become 15:00 local, proving the timezone conversion happens.
+    expect(stampHeartbeatHeader(content, NOW)).toBe('## Heartbeat 2026-09-08 15:00 (Europe/Budapest)')
+  })
+})

--- a/src/web/heartbeat-header-stamp.ts
+++ b/src/web/heartbeat-header-stamp.ts
@@ -1,0 +1,27 @@
+// Restamps the clock in a heartbeat-digest header with the server's own time
+// at persistence. The digest is composed by an LLM agent, and a session-start
+// `date` is no anchor for the rest of that session: on 2026-09-08 the header
+// drifted monotonically (0,0,0,0,0,+1h,+3h against created_at) and a "18:00"
+// label nearly released the owner's evening decision batch at 15:05
+// (HBORACSUSZAS908). The scheduler fires on time; only the written label lies.
+// Same principle as the kanban header clock: the machine stamps it, the
+// author never types it.
+//
+// The matcher is intentionally narrow: only the FIRST line, only the exact
+// `## Heartbeat YYYY-MM-DD HH:MM` shape. A digest quoted mid-message keeps
+// its original (historical) label; any first-line match is by definition a
+// digest being published now, so "now" is the only truthful value.
+
+const HEADER_RE = /^## Heartbeat \d{4}-\d{2}-\d{2} \d{2}:\d{2}/
+
+// sv-SE gives `YYYY-MM-DD HH:mm` directly; the digest header is Budapest-local.
+const BUDAPEST_STAMP = new Intl.DateTimeFormat('sv-SE', {
+  timeZone: 'Europe/Budapest',
+  year: 'numeric', month: '2-digit', day: '2-digit',
+  hour: '2-digit', minute: '2-digit',
+})
+
+export function stampHeartbeatHeader(content: string, now: Date = new Date()): string {
+  if (!content.startsWith('## Heartbeat ')) return content
+  return content.replace(HEADER_RE, `## Heartbeat ${BUDAPEST_STAMP.format(now)}`)
+}

--- a/src/web/routes/messages.ts
+++ b/src/web/routes/messages.ts
@@ -16,6 +16,7 @@ import { MAIN_AGENT_ID, OWNER_NAME, SYSTEM_SENDER_IDS, parseSystemSenderIds } fr
 import { isAgentRunning } from '../agent-process.js'
 import { readBody, json, jsonMaybeGzip } from '../http-helpers.js'
 import { normalizeKanbanRefs } from '../kanban-ref-normalize.js'
+import { stampHeartbeatHeader } from '../heartbeat-header-stamp.js'
 import { parseQualifiedId, formatQualifiedId } from '../federation/address.js'
 import { getFederationConfig } from '../federation/config.js'
 import type { RouteContext } from './types.js'
@@ -201,7 +202,12 @@ export async function tryHandleMessages(ctx: RouteContext): Promise<boolean> {
     // human-facing `#<seq>` form before persistence, so the dashboard and
     // every downstream consumer sees the canonical reference even when a
     // sub-agent forgets the CLAUDE.md rule (#75 Cuzcoo dispatch).
-    const normalizedContent = normalizeKanbanRefs(content.trim(), getKanbanSeqByIdPrefix)
+    // HBORACSUSZAS908: the digest header clock is machine-stamped at
+    // persistence -- an agent-typed hour drifts forward as its session fills
+    // (measured 0,0,0,0,0,+1h,+3h on 2026-09-08) and the digest is the surface
+    // the whole fleet reads time from. Same code-side-enforcement pattern as
+    // normalizeKanbanRefs below.
+    const normalizedContent = normalizeKanbanRefs(stampHeartbeatHeader(content.trim()), getKanbanSeqByIdPrefix)
     // Card 06f062e4: optional attributability tag, self-declared like `from`
     // itself -- capped short so it stays a label, not a second content field.
     const trimmedOriginNote = origin_note?.trim().slice(0, 120) || null


### PR DESCRIPTION
## What

The heartbeat digest header hour is now machine-stamped at POST /api/messages: a first-line `## Heartbeat YYYY-MM-DD HH:MM` header is rewritten with the server's Europe/Budapest clock before persistence.

## Why

The header was typed by the composing agent, and a session-start `date` is no anchor for the rest of that session. Measured 2026-09-08 (label vs `created_at`): five exact digests, then +1h at 14:00, +3h at 15:00. The drifted "18:00" label nearly released the owner's evening decision batch at 15:05. The scheduler fires on time; only the written label lied. The digest is the surface the whole fleet reads time from, so the label must come from the machine (same principle as the kanban header clock, and the same code-side-enforcement pattern as `normalizeKanbanRefs` right next to it).

## Scope guard

Only the FIRST line, only the exact header shape. A digest quoted after intro text keeps its historical label. Content without the header passes through byte-identical.

## Verify

- 7 new unit tests (drifted case, idempotence, date rollover, quoted digest, non-digest, shape mismatch, TZ conversion) -- green
- adjacent suites green: kanban-ref-normalize, messages-post-sender-guards, messages-main-agent-no-false-warning (16 tests)
- `tsc --noEmit` clean

Post-deploy check (from the card): label vs `created_at` diff must be 0 on EVERY digest row a day back, not only the first fifty.

Card: HBORACSUSZAS908

🤖 Generated with [Claude Code](https://claude.com/claude-code)