### PR TITLE
fix(profiles): the owner asked twice for these agents to be able to work (PROFILREGRESS908)

### DIFF
--- a/src/__tests__/profile-rule-syntax.test.ts
+++ b/src/__tests__/profile-rule-syntax.test.ts
@@ -45,17 +45,23 @@ describe('resolveProfilePlaceholders rule normalization', () => {
 })
 
 describe('web-reading profile posture (TMPLPERM908)', () => {
-  // Both profiles read web content (prompt-injection surface). strict is what
-  // makes the deny list enforceable at all: permissive launches with
-  // --dangerously-skip-permissions. The capability gaps that motivated the
-  // 2026-09 uncommitted permissive flip (skills read, notify.sh, agent-post.sh)
-  // are covered by explicit allow entries instead. Loosening the mode again is
-  // an owner decision, not a template edit -- see card TMPLPERM908.
+  // Both profiles read web content (prompt-injection surface), and strict is
+  // what makes the deny list enforceable: permissive launches with
+  // --dangerously-skip-permissions. The owner nevertheless chose permissive,
+  // twice -- 2026-09-07 (TG 14764, card PROFILSTRICT904) and again 2026-09-08
+  // (TG 15115, card PROFILREGRESS908) after this test's predecessor reverted
+  // the first, uncommitted flip. Measured reason: under strict the agent stops
+  // on a permission dialog at EVERY tool call, including read-only ones, and no
+  // one answers it in a non-interactive agent -- orsi filed two session-stuck
+  // alarms in 25 minutes and did zero work. The deny list still carries the
+  // real posture (SSH/AWS/.env, sudo, rm, curl -X POST, git push); it is simply
+  // advisory under permissive. Tightening the mode again is an OWNER decision,
+  // not a template edit, and it must land with the agents' work rerouted first.
   for (const id of ['marketer', 'researcher']) {
-    it(`${id} stays strict and carries the measured capability allows`, () => {
+    it(`${id} stays permissive (owner decision) and carries the measured capability allows`, () => {
       const p = loadProfileTemplate(id)
       expect(p.id).toBe(id) // guard against the default-profile fallback
-      expect(p.permissionMode).toBe('strict')
+      expect(p.permissionMode).toBe('permissive')
       expect(p.filesystem.allow).toContain('Read(${HOME}/.claude/skills/**)')
       expect(p.filesystem.allow).toContain('Bash(${PROJECT_ROOT}/scripts/notify.sh:*)')
       expect(p.filesystem.allow).toContain('Bash(${PROJECT_ROOT}/scripts/agent-post.sh:*)')

--- a/templates/profiles/marketer.json
+++ b/templates/profiles/marketer.json
@@ -1,8 +1,8 @@
 {
   "id": "marketer",
   "label": "Marketinges",
-  "description": "Email-vázlat, hírlevél, social tartalom. Mivel webes tartalmat olvas (prompt injection felület), szigorúan korlátozott: csak a saját mappájába írhat, SSH/AWS/.env tiltva, semmilyen Bash-pusztító parancs. A globális skillek olvasása és a notify.sh/agent-post.sh futtatása engedélyezett.",
-  "permissionMode": "strict",
+  "description": "Email-vazlat, hirlevel, social tartalom. Webes tartalmat olvas (prompt injection felulet), ezert a deny-lista (SSH/AWS/.env, sudo, rm, curl -X POST, git push) VALTOZATLANUL all. A permissionMode viszont permissive a gazda 2026-09-07-i dontese szerint (TG 14764): strict alatt az agens minden tool-hivasnal engedelykero parbeszedre allt meg, amire nem-interaktiv agensben senki nem valaszol. Csak a sajat mappajaba ir.",
+  "permissionMode": "permissive",
   "filesystem": {
     "allow": [
       "Read(${AGENT_DIR}/**)",

--- a/templates/profiles/researcher.json
+++ b/templates/profiles/researcher.json
@@ -1,8 +1,8 @@
 {
   "id": "researcher",
   "label": "Kutató",
-  "description": "Piackutatás, versenytárs-elemzés, webes források olvasása. Prompt injection szempontból ugyanúgy kiemelt mint a marketinges. Draft-only: riportot ír a mappájába, nem küld magától kifelé. A globális skillek olvasása és a notify.sh/agent-post.sh futtatása engedélyezett.",
-  "permissionMode": "strict",
+  "description": "Piackutatas, versenytars-elemzes, webes forrasok olvasasa. Prompt injection szempontbol kiemelt felulet, ezert a deny-lista (SSH/AWS/.env, sudo, rm, curl -X POST, git push) VALTOZATLANUL all. A permissionMode viszont permissive a gazda 2026-09-07-i dontese szerint (TG 14764): strict alatt az agens minden tool-hivasnal engedelykero parbeszedre allt meg, amire nem-interaktiv agensben senki nem valaszol, tehat egyaltalan nem tudott dolgozni. Draft-only marad: riportot ir a sajat mappajaba, nem kuld magatol kifele.",
+  "permissionMode": "permissive",
   "filesystem": {
     "allow": [
       "Read(${AGENT_DIR}/**)",


### PR DESCRIPTION
## What

`marketer` and `researcher` go back to `permissionMode: permissive`, and this time it is committed.

## Why this is not a new decision

On 2026-09-07 the owner decided (TG 14764, card PROFILSTRICT904): *"Lazitsd Orsi es Vera profiljat hogy dolgozni tudjanak es inditsd oket."* The execution edited these two templates in the working tree and **was never committed**. #1236 (`823907f4`, "keep web-reading profiles strict") then restored `strict` with a test asserting it, reversing a decision it could not see, because git had no record of it. That is on me, not on the author of #1236.

The owner confirmed the same direction again tonight (TG 15115) after being shown both sides.

## The measurement that forced it

`orsi` was restarted by the context guard at 14:27 and came up under the new template, so `agent-process.ts:1527` withheld `--dangerously-skip-permissions`. It then stopped on a permission dialog at **every** tool call, including read-only ones (a `sqlite3` SELECT, an `ls`), and filed two `session-stuck` alarms in 25 minutes while doing no work. `vera` has not been restarted since and still shows `bypass permissions on`; she would have hit the same wall on her next restart.

## What is not changed

The deny lists are untouched: `.ssh`, `.aws`, `.gnupg`, `**/.env`, `sudo`, `rm`, `curl -X POST`, `git push`. Under `permissive` Claude Code does not enforce them, and that is the trade the owner accepted knowingly. The descriptions were rewritten because the old text claimed "szigoruan korlatozott", which would no longer be true.

## Test

`src/__tests__/profile-rule-syntax.test.ts` now asserts `permissive` and carries both decisions plus the measurement in the comment, so the next round reads why rather than reverting it a third time. All other assertions in that block (capability allows, ssh deny, no `**` in Bash rules) are unchanged and still pass.

Run in a worktree (the suite refuses to run in the live install): 8 passed.

Cards: PROFILREGRESS908 (owner), TMPLPERM908, PROFILSTRICT904, MIOORSZEM831.

🤖 Generated with [Claude Code](https://claude.com/claude-code)