### PR TITLE
feat(scheduler): ejszakai idozar 22:00-05:00 (IDOZAR909)

### DIFF
--- a/src/__tests__/schedule-night-lock.test.ts
+++ b/src/__tests__/schedule-night-lock.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import {
+  isNightLocked,
+  schedulerLocalHour,
+  NIGHT_LOCK_START_HOUR,
+  NIGHT_LOCK_END_HOUR,
+} from '../web/schedule-runner.js'
+
+describe('night lock (idozar 22-05)', () => {
+  it('locks the whole window, boundaries included as asked', () => {
+    expect(isNightLocked(22)).toBe(true)
+    expect(isNightLocked(23)).toBe(true)
+    expect(isNightLocked(0)).toBe(true)
+    expect(isNightLocked(4)).toBe(true)
+  })
+
+  it('opens at 05:00 and stays open all day', () => {
+    expect(isNightLocked(5)).toBe(false)
+    expect(isNightLocked(12)).toBe(false)
+    expect(isNightLocked(21)).toBe(false)
+  })
+
+  it('keeps the configured bounds', () => {
+    expect(NIGHT_LOCK_START_HOUR).toBe(22)
+    expect(NIGHT_LOCK_END_HOUR).toBe(5)
+  })
+
+  it('reads the hour in the scheduler zone, not the host default', () => {
+    // 2026-09-09T21:30:00Z is 23:30 in Budapest (CEST) but 21:30 in UTC:
+    // the same instant is locked on one clock and open on the other.
+    const ms = Date.parse('2026-09-09T21:30:00Z')
+    expect(schedulerLocalHour(ms, 'Europe/Budapest')).toBe(23)
+    expect(schedulerLocalHour(ms, 'UTC')).toBe(21)
+    expect(isNightLocked(schedulerLocalHour(ms, 'Europe/Budapest'))).toBe(true)
+    expect(isNightLocked(schedulerLocalHour(ms, 'UTC'))).toBe(false)
+  })
+
+  it('midnight maps to 0, not 24', () => {
+    const ms = Date.parse('2026-09-09T22:10:00Z') // 00:10 Budapest
+    expect(schedulerLocalHour(ms, 'Europe/Budapest')).toBe(0)
+  })
+
+  it('falls back to the host clock on an unusable zone instead of locking blindly', () => {
+    const ms = Date.parse('2026-09-09T12:00:00Z')
+    expect(schedulerLocalHour(ms, 'Nem/Letezik')).toBe(new Date(ms).getHours())
+  })
+})

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -9,6 +9,7 @@ import {
   PROJECT_ROOT,
   MAIN_AGENT_ID,
   BOT_NAME,
+  APP_TZ,
   APP_TZ_INVALID,
   CHANNEL_PROVIDER,
 } from '../config.js'
@@ -594,6 +595,36 @@ export function quotaWorkClass(task: Pick<ScheduledTask, 'type'>): QuotaWorkClas
   if (task.type === 'command') return 'free'
   if (task.type === 'heartbeat') return 'background'
   return 'owner-facing'
+}
+
+// NIGHT LOCK (idozar, kert 2026-09-09). Between these hours no scheduled task
+// is started at all: the owner asked for a window where the fleet initiates
+// nothing. 22 is inclusive, 5 is exclusive, so 22:00-04:59 local is locked and
+// 05:00 opens the gate.
+//
+// The bound is the SCHEDULER's zone (APP_TZ), not the process default -- the
+// cron matcher already runs in APP_TZ, and a gate on a different clock would
+// let a task through at 22:30 whenever the host zone drifted from the
+// configured one.
+export const NIGHT_LOCK_START_HOUR = 22
+export const NIGHT_LOCK_END_HOUR = 5
+
+// Pure, so the boundary hours are testable without a clock.
+export function isNightLocked(hourLocal: number): boolean {
+  return hourLocal >= NIGHT_LOCK_START_HOUR || hourLocal < NIGHT_LOCK_END_HOUR
+}
+
+export function schedulerLocalHour(nowMs: number, tz: string = APP_TZ): number {
+  try {
+    return Number(
+      new Intl.DateTimeFormat('en-US', { hour: 'numeric', hour12: false, timeZone: tz })
+        .format(new Date(nowMs)),
+    ) % 24
+  } catch {
+    // An unusable zone must not silently lock (or unlock) the whole night:
+    // fall back to the host clock, which is what cron would use anyway.
+    return new Date(nowMs).getHours()
+  }
 }
 
 export function runPreCheck(task: ScheduledTask): { skip: boolean; prefix?: string } {
@@ -1671,6 +1702,23 @@ export function startScheduleRunner(): NodeJS.Timeout {
         targetAgents = [MAIN_AGENT_ID, ...running]
       } else {
         targetAgents = [task.agent || MAIN_AGENT_ID]
+      }
+
+      // NIGHT LOCK. Nothing is started inside the window. The skip is
+      // RECORDED (never silent) for the same reason as the desktop gate: a
+      // dropped tick with no trace looks exactly like "there was nothing to
+      // do". lastRun is stamped so the morning catch-up does not replay the
+      // whole night at 05:00 -- the owner asked for the rounds to be skipped,
+      // not deferred into a burst.
+      if (isNightLocked(schedulerLocalHour(now))) {
+        logger.info(
+          { task: task.name, hour: schedulerLocalHour(now), tz: APP_TZ },
+          `Schedule skipped: night lock ${NIGHT_LOCK_START_HOUR}:00-0${NIGHT_LOCK_END_HOUR}:00`,
+        )
+        scheduleLastRun.set(task.name, now)
+        persistScheduleLastRun()
+        for (const agentName of targetAgents) appendTaskRun(task.name, agentName, 'skipped-night-lock')
+        continue
       }
 
       // Quota gate. Every heartbeat across the fleet spends from the same


### PR DESCRIPTION
A gazda ejszakai idozarat kert: 22:00 es 05:00 kozott semmilyen tevekenyseg ne induljon el.

## Mit csinal

Uj kapu a `schedule-runner` tick-ciklusaban, a kvota-kapu ELOTT (a legolcsobb dontes szuletik meg eloszor). A zart oraban a task nem indul el egyetlen agensnel sem.

- A skip **rogzul**: `skipped-night-lock` statusszal megy a `task_runs`-ba. Egy nyom nelkul eldobott tick megkulonboztethetetlen attol, hogy nem volt teendo, es pont igy tunik el egy elveszett kor. Ugyanaz a minta, mint a desktop-kapunal.
- A `lastRun` is stampelodik, kulonben a catch-up ablak 05:00-kor egyben visszajatszana az egesz ejszakat. A keres a kihagyas volt, nem a halasztas.
- Az ora a scheduler zonajabol (`APP_TZ`) jon, nem a process alapertelmezettjebol. A cron mar `APP_TZ`-ben illeszkedik; egy masik orara kotott kapu 22:30-kor atengedne egy feladatot, valahanyszor a host zona elcsuszik a konfiguralttol. Hasznalhatatlan zona eseten a host orajara esik vissza, mert egy nema egesz-ejszakas zar (vagy nyitas) rosszabb, mint a cron sajat viselkedese.

Hatarok: 22 inkluziv, 5 exkluziv. 22:00-04:59 zarva, 05:00 nyit.

## Teszt

`src/__tests__/schedule-night-lock.test.ts`, 6 teszt: hatarorak, a zona-fuggoseg (ugyanaz a pillanat Budapesten zarva, UTC-ben nyitva), az ejfel 0-ra kepzese, es a fallback.

`npx vitest run src/__tests__/schedule-night-lock.test.ts src/__tests__/schedule-runner-precheck.test.ts` zold, `tsc --noEmit` tiszta.

## Kovetkezmeny, amit a gazda fele jeleztem

Ket ejszakai feladat a zarba esik es igy elmarad: `dream-engine` (02:07) es `auto-update` (szerda 04:00). A dream-engine a memoria-konszolidacio, a reggeli napindito erre epul. Az athelyezesuk (05:30 / szerda 05:40) kulon dontes, nincs ebben a PR-ben.

🤖 Generated with [Claude Code](https://claude.com/claude-code)