### PR TITLE
fix(main-agent): every respawn path decides the config dir, and says so

### DIFF
--- a/scripts/stuck-modal-guard.sh
+++ b/scripts/stuck-modal-guard.sh
@@ -270,7 +270,40 @@ run_guard() {
   CLAUDE_Q="$(printf '%q' "$CLAUDE")"
   # W2: %q-quote the (config-overridable) plugin id, same treatment as the model.
   local PLUGIN_Q; PLUGIN_Q="$(printf '%q' "$RESPAWN_PLUGIN")"
-  local RESPAWN_CMD="export PATH=\"/opt/homebrew/bin:\$HOME/.bun/bin:/home/linuxbrew/.linuxbrew/bin:\$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin\" && $CLAUDE_Q --dangerously-skip-permissions ${MODEL_FLAG}--channels $PLUGIN_Q"
+
+  # CFGDIR686: the main-agent isolated-config decision belongs on EVERY respawn
+  # path, not just the watchdog's. PR #686 fixed the 401 outage by giving
+  # channel-watchdog.sh a CFG_ENV -- this script was the other respawner and was
+  # missed, so a respawn from here silently dropped the main agent back onto the
+  # shared ~/.claude. That is the very outage shape the channels.sh guard exists
+  # to shout about, and it would fire at the worst moment: the session is
+  # already stuck, and the operator simply stops getting answers.
+  # Mirrors channel-watchdog.sh:186-201 exactly, including reading the fleet
+  # token via $(cat ...) at spawn time so the secret never lands in the
+  # RESPAWN_CMD string handed to tmux (visible via ps/pane history otherwise).
+  local CFG_ENV=""
+  local NODE_BIN; NODE_BIN="$(command -v node || true)"
+  if [ -n "$NODE_BIN" ] && [ -f "$INSTALL_DIR/dist/web/agent-process.js" ]; then
+    # The helper keys the isolated dir by PROVIDER; here the configured value is
+    # a full plugin id (plugin:<provider>@<owner>), so take the provider out of it
+    # rather than hard-coding 'telegram' -- a renamed install would otherwise get
+    # a config dir that belongs to a different channel.
+    local _prov="${RESPAWN_PLUGIN#plugin:}"; _prov="${_prov%%@*}"
+    local _cfg_line _cfg_mode _cfg_dir
+    _cfg_line="$("$NODE_BIN" "$INSTALL_DIR/scripts/main-agent-isolated-config.mjs" "$_prov" 2>>"$STORE/channels-failures.log" || true)"
+    _cfg_mode="${_cfg_line%%	*}"
+    _cfg_dir="${_cfg_line#*	}"
+    if [ -n "$_cfg_line" ] && [ -d "$_cfg_dir" ]; then
+      if [ "$_cfg_mode" = "explicit" ]; then
+        CFG_ENV="export CLAUDE_CONFIG_DIR='$_cfg_dir' && "
+      else
+        CFG_ENV="export CLAUDE_CONFIG_DIR='$_cfg_dir' && export CLAUDE_CODE_OAUTH_TOKEN=\"\$(cat '$INSTALL_DIR/store/.claude-oauth-token')\" && "
+      fi
+      log "main-agent $_cfg_mode CLAUDE_CONFIG_DIR=$_cfg_dir"
+    fi
+  fi
+
+  local RESPAWN_CMD="export PATH=\"/opt/homebrew/bin:\$HOME/.bun/bin:/home/linuxbrew/.linuxbrew/bin:\$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin\" && ${CFG_ENV}$CLAUDE_Q --dangerously-skip-permissions ${MODEL_FLAG}--channels $PLUGIN_Q"
 
   log "stuck modal not cleared by Escape -- respawn-pane $SESSION (respawn #$((count+1)))"
   # G: alert ONLY after the respawn-pane actually succeeds, so a failed respawn

--- a/src/__tests__/channel-deafness-recovery.test.ts
+++ b/src/__tests__/channel-deafness-recovery.test.ts
@@ -9,12 +9,17 @@ import {
   shouldEscalateAfterResume,
   POST_RESUME_GUARD_DELAY_MS,
 } from '../web/channel-monitor.js'
+// The respawn builder now demands a MainConfigDecision, and the production
+// factory REPORTS as it resolves. These cases are about the command STRING, so
+// they use the reporting-free factory on purpose -- and that use is exactly what
+// main-config-guard-wiring.test.ts forbids in production modules.
+import { mainConfigDecisionForTest } from '../web/main-config-decision.js'
 
 // CONTRACT: the respawn command MUST carry the .bun/bin PATH export -- without
 // it the respawned bun telegram bridge can't be located and the session comes
 // up channel-less. Lock it so a future refactor can't silently drop it.
 describe('buildMainSessionRespawnCmd', () => {
-  const base = { claudePath: '/usr/local/bin/claude', pluginId: 'telegram@claude-plugins-official', model: "claude-opus-4-8[1m]" }
+  const base = { claudePath: '/usr/local/bin/claude', pluginId: 'telegram@claude-plugins-official', model: "claude-opus-4-8[1m]", config: mainConfigDecisionForTest() }
 
   it('always exports a PATH that includes $HOME/.bun/bin', () => {
     const cmd = buildMainSessionRespawnCmd({ ...base, continueSession: false })
@@ -57,13 +62,13 @@ describe('buildMainSessionRespawnCmd', () => {
   // session -- it silently fell back to ~/.claude/.credentials.json. The
   // fleetToken leg closes that: token export WITHOUT a config-dir override.
   it('exports the fleet token (no CLAUDE_CONFIG_DIR) when fleetToken is set and isolation is off', () => {
-    const cmd = buildMainSessionRespawnCmd({ ...base, continueSession: false, fleetToken: true })
+    const cmd = buildMainSessionRespawnCmd({ ...base, continueSession: false, config: mainConfigDecisionForTest({ fleetToken: true }) })
     expect(cmd).toContain('export CLAUDE_CODE_OAUTH_TOKEN="$(cat ')
     expect(cmd).not.toContain('CLAUDE_CONFIG_DIR')
   })
 
   it('exports BOTH the isolated config dir and the token when isolation is on (unchanged macOS contract)', () => {
-    const cmd = buildMainSessionRespawnCmd({ ...base, continueSession: false, isolatedConfigDir: '/tmp/iso', fleetToken: true })
+    const cmd = buildMainSessionRespawnCmd({ ...base, continueSession: false, config: mainConfigDecisionForTest({ isolatedConfigDir: '/tmp/iso', fleetToken: true }) })
     expect(cmd).toContain("export CLAUDE_CONFIG_DIR='/tmp/iso'")
     expect(cmd).toContain('export CLAUDE_CODE_OAUTH_TOKEN="$(cat ')
   })

--- a/src/__tests__/main-config-dir-parity.test.ts
+++ b/src/__tests__/main-config-dir-parity.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = join(__dirname, '..', '..')
+const SCRIPTS = join(REPO_ROOT, 'scripts')
+
+// CFGDIR686 structural locks -- the sibling of the RESPAWNMODEL807 describe in
+// main-model-resolution-parity.test.ts, on the OTHER axis.
+//
+// The main agent's isolated CLAUDE_CONFIG_DIR is the fix for the 2026-07-23/27
+// 401 outages: without it the agent re-authenticates from whatever refreshes the
+// shared ~/.claude, that credential expires, and the main bot goes silent until
+// someone runs /login by hand.
+//
+// PR #686 put that decision on ONE of the two shell respawn paths. The other,
+// stuck-modal-guard.sh, was written in PR #264 and never had it -- so a respawn
+// from there dropped the agent back onto the shared root, silently, and at the
+// worst possible moment (the session is already stuck, so the owner is already
+// not getting answers and has no way to tell the two causes apart).
+//
+// The same shape had already happened on the model axis, which is why the model
+// test locks all its paths at once. This file does it for the config-dir axis:
+// the point is not that these two files are correct today, but that a THIRD
+// respawner cannot be added without either carrying the decision or failing here.
+const SHELL_RESPAWNERS = ['channel-watchdog.sh', 'stuck-modal-guard.sh'] as const
+
+const read = (name: string) => readFileSync(join(SCRIPTS, name), 'utf-8')
+
+describe('every shell respawn path carries the main-agent config decision (CFGDIR686)', () => {
+  it.each(SHELL_RESPAWNERS)('%s asks the one helper for the config dir', (name) => {
+    const src = read(name)
+    expect(src).toContain('main-agent-isolated-config.mjs')
+    // The helper's two modes must BOTH be handled: an `explicit` dir carries its
+    // own credentials (injecting the fleet token there would swap the identity),
+    // an `isolated` one needs the token. A script that only handles one of them
+    // is half-fixed, and the half it misses is the half that authenticates.
+    expect(src).toContain('explicit')
+    expect(src).toContain('CLAUDE_CODE_OAUTH_TOKEN')
+  })
+
+  it.each(SHELL_RESPAWNERS)('%s interpolates ${CFG_ENV} into the respawn command it hands tmux', (name) => {
+    const src = read(name)
+    // Building CFG_ENV is not the guarantee -- USING it is. A variable that is
+    // computed, logged and then left out of RESPAWN_CMD looks correct in review
+    // and changes nothing at runtime.
+    const cmdLines = src.split('\n').filter((l) => /RESPAWN_CMD="/.test(l))
+    expect(cmdLines.length).toBe(1)
+    expect(cmdLines[0]).toContain('${CFG_ENV}')
+  })
+
+  it('the shell respawners are EXACTLY these two -- a third one fails here first', () => {
+    // toBe, not toBeGreaterThanOrEqual: an at-least assertion is exactly what
+    // let #686 look complete with one of two paths fixed. The number is the
+    // point, so a new respawner must come here and be listed.
+    const respawners = readdirSync(SCRIPTS)
+      .filter((f) => f.endsWith('.sh'))
+      .filter((f) => /respawn-pane/.test(readFileSync(join(SCRIPTS, f), 'utf-8')))
+      .sort()
+    expect(respawners).toEqual([...SHELL_RESPAWNERS].sort())
+    expect(respawners.length).toBe(SHELL_RESPAWNERS.length)
+  })
+
+  it('POSITIVE CONTROL: the assertions can fail -- a script without the decision is detectable', () => {
+    // Without this, every assertion above would also pass on a file that simply
+    // contains the words for unrelated reasons. channels.sh is the LAUNCH path:
+    // it carries the config decision too, but it is not a respawner, so it must
+    // NOT appear in the list the previous test locks.
+    const launcher = read('channels.sh')
+    expect(launcher).toContain('CLAUDE_CONFIG_DIR')
+    expect([...SHELL_RESPAWNERS]).not.toContain('channels.sh')
+    // And a file that genuinely lacks the decision reads as lacking it:
+    const unrelated = read('main-agent-isolated-config.mjs')
+    expect(unrelated).not.toContain('RESPAWN_CMD')
+  })
+})

--- a/src/__tests__/main-config-guard-wiring.test.ts
+++ b/src/__tests__/main-config-guard-wiring.test.ts
@@ -125,18 +125,39 @@ describe('NO PRODUCTION MODULE MAY BUILD A DECISION WITHOUT REPORTING IT', () =>
     expect(offenders).toEqual([])
   })
 
-  it('the respawn module does not cast its way around the brand either', () => {
+  it('no src/web module casts its way around the brand either', () => {
     // The brand makes forgetting impossible, not bypassing. A cast is the one
-    // remaining way through, so it is spelled out here rather than left to be
-    // discovered later.
-    const src = readFileSync(join(__dirname, '..', 'web', 'channel-monitor.ts'), 'utf-8')
-    expect(src).not.toContain('as MainConfigDecision')
+    // remaining way through.
+    //
+    // This walks the directory for the same reason (2) does. It used to name
+    // channel-monitor.ts alone -- true today, because the type has exactly two
+    // mentions, but the FIRST new caller falls outside a one-file check, and a
+    // hand-maintained list of places to look is the very shape this file rejects
+    // two paragraphs above its own assertion.
+    const dir = join(__dirname, '..', 'web')
+    const offenders = readdirSync(dir)
+      .filter((f) => f.endsWith('.ts') && f !== 'main-config-decision.ts')
+      .filter((f) => readFileSync(join(dir, f), 'utf-8').includes('as MainConfigDecision'))
+    expect(offenders).toEqual([])
   })
 
-  it('POSITIVE CONTROL: the forbidden token IS findable where it legitimately lives', () => {
-    // Without this, a typo in the token would make both assertions above pass
-    // while searching for a string that occurs nowhere at all.
-    const own = readFileSync(join(__dirname, '..', 'web', 'main-config-decision.ts'), 'utf-8')
-    expect(own).toContain('mainConfigDecisionForTest')
+  it('POSITIVE CONTROL: BOTH forbidden tokens are findable in CODE where they legitimately live', () => {
+    // Without this, a typo in either token would make the bans above pass while
+    // searching for a string that occurs nowhere at all. Both are covered: the
+    // factory ban and the cast ban fail silently in exactly the same way, and
+    // covering only one of them leaves the other's typo undetectable.
+    //
+    // COMMENTS ARE STRIPPED FIRST, and that is the whole point of this version.
+    // Measured while writing it: renaming BOTH real casts still left the control
+    // green, because the module's own header PROSE spells the token out. A
+    // positive control satisfied by a sentence about the code is not a control --
+    // it is the same false green it exists to prevent.
+    const raw = readFileSync(join(__dirname, '..', 'web', 'main-config-decision.ts'), 'utf-8')
+    const code = raw
+      .split('\n')
+      .filter((l) => !/^\s*(\/\/|\*|\/\*)/.test(l))
+      .join('\n')
+    expect(code).toContain('mainConfigDecisionForTest')
+    expect(code).toContain('as MainConfigDecision')
   })
 })

--- a/src/__tests__/main-config-guard-wiring.test.ts
+++ b/src/__tests__/main-config-guard-wiring.test.ts
@@ -1,0 +1,142 @@
+// A guard that decides correctly and is never called is indistinguishable, from
+// the outside, from no guard at all.
+//
+// THIS IS THE OTHER AXIS (kanban card `guard-respawn-vak`). Its sibling file
+// main-shared-config-guard.test.ts pins the DECISION -- which of the two
+// shared-root regressions a given state is. Everything there stays green if the
+// decision is never consulted. That is not a hypothetical: on 2026-09-04 the
+// router fix had four mutations red on its predicate and a fifth, which deleted
+// the CALL, green on all seven assertions.
+//
+// So this file measures two things the decision test cannot see:
+//   1. that resolving actually WRITES -- on the healthy launch too, because a
+//      guard that only speaks when unhappy has an ambiguous silence, and that
+//      ambiguity is precisely what hid the 2026-08-04 outage for four hours;
+//   2. that no production module builds a decision through the reporting-free
+//      test factory.
+//
+// WHY (2) IS NOT A LIST OF CALL SITES. The obvious version of this assertion
+// enumerates the known callers and checks each one. That list is itself a thing
+// somebody has to remember to update -- the same shape as the bug the card is
+// about. Instead the assertion forbids ONE TOKEN in production modules, so it
+// holds for callers that do not exist yet.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, readFileSync, existsSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+let ROOT = ''
+const sent: Array<[string, string, string]> = []
+
+vi.mock('../config.js', async (orig) => ({
+  ...(await orig<Record<string, unknown>>()),
+  MAIN_AGENT_ID: 'boss',
+  get PROJECT_ROOT() { return ROOT },
+}))
+vi.mock('../db.js', async (orig) => ({
+  ...(await orig<Record<string, unknown>>()),
+  createAgentMessage: (from: string, to: string, content: string) => { sent.push([from, to, content]); return 1 },
+}))
+
+/** State the resolver reads. Only the two lookups are faked -- the verdict
+ *  itself runs for real, so a wrong decision still fails here. */
+let fakeState = { isolatedConfigDir: null as string | null, fleetToken: false, isolatedDirExists: false }
+vi.mock('../web/agent-process.js', async (orig) => ({
+  ...(await orig<Record<string, unknown>>()),
+  ensureMainAgentIsolatedConfigDir: () => fakeState.isolatedConfigDir,
+  readMainSharedConfigState: (dir: string | null) => ({ ...fakeState, isolatedConfigDir: dir }),
+}))
+
+const { resolveMainConfigDecision } = await import('../web/main-config-decision.js')
+
+function log(): string {
+  const p = join(ROOT, 'store', 'channels-failures.log')
+  return existsSync(p) ? readFileSync(p, 'utf-8') : ''
+}
+
+beforeEach(() => {
+  ROOT = mkdtempSync(join(tmpdir(), 'mcguard-'))
+  require('node:fs').mkdirSync(join(ROOT, 'store'), { recursive: true })
+  sent.length = 0
+  fakeState = { isolatedConfigDir: null, fleetToken: false, isolatedDirExists: false }
+})
+afterEach(() => { rmSync(ROOT, { recursive: true, force: true }) })
+
+describe('THE HEALTHY LAUNCH LEAVES A TRACE TOO', () => {
+  it('records the isolated dir when isolation is working', () => {
+    // Without this line the guard's silence would mean either "all well" or
+    // "never ran", and on 2026-08-04 it meant the second while looking like the
+    // first for four hours.
+    fakeState = { isolatedConfigDir: '/srv/m/.channels-config', fleetToken: true, isolatedDirExists: true }
+    const d = resolveMainConfigDecision()
+    expect(d.trigger).toBeNull()
+    expect(log()).toContain('isolated CLAUDE_CONFIG_DIR=/srv/m/.channels-config')
+    expect(sent).toHaveLength(0)
+  })
+
+  it('records the stock install too, and stays quiet in the inbox', () => {
+    const d = resolveMainConfigDecision()
+    expect(d.trigger).toBeNull()
+    expect(log()).toContain('shared ~/.claude')
+    expect(sent).toHaveLength(0)
+  })
+})
+
+describe('THE REGRESSION LAUNCH BOTH LOGS AND TELLS SOMEBODY', () => {
+  it('warns in the log AND messages the main agent when isolation was lost', () => {
+    fakeState = { isolatedConfigDir: null, fleetToken: true, isolatedDirExists: true }
+    const d = resolveMainConfigDecision()
+    expect(d.trigger).toBe('isolation-lost')
+    expect(log()).toContain('WARN isolation-lost')
+    expect(sent).toHaveLength(1)
+    expect(sent[0][0]).toBe('respawn-guard')
+    expect(sent[0][1]).toBe('boss')
+    expect(sent[0][2]).toContain('[GUARD]')
+  })
+
+  it('warns for an unused fleet token as well', () => {
+    fakeState = { isolatedConfigDir: null, fleetToken: true, isolatedDirExists: false }
+    expect(resolveMainConfigDecision().trigger).toBe('fleet-token-unused')
+    expect(sent).toHaveLength(1)
+  })
+
+  it('a second respawn inside the cooldown still LOGS but does not message again', () => {
+    // The hard restart can fire repeatedly on a wedged session. One notice per
+    // attempt would bury the first -- the shape of the 2026-08-10 handoff chain.
+    // The log line is not suppressed: it costs nothing and it is the series.
+    fakeState = { isolatedConfigDir: null, fleetToken: true, isolatedDirExists: true }
+    resolveMainConfigDecision()
+    resolveMainConfigDecision()
+    expect(sent).toHaveLength(1)
+    expect(log().match(/WARN isolation-lost/g) ?? []).toHaveLength(2)
+    expect(log()).toContain('notice suppressed')
+  })
+})
+
+describe('NO PRODUCTION MODULE MAY BUILD A DECISION WITHOUT REPORTING IT', () => {
+  it('the reporting-free factory appears in no src/web module but its own', () => {
+    // Not a list of call sites -- a forbidden token. It therefore holds for
+    // callers nobody has written yet, which a list never does.
+    const dir = join(__dirname, '..', 'web')
+    const offenders = readdirSync(dir)
+      .filter((f) => f.endsWith('.ts') && f !== 'main-config-decision.ts')
+      .filter((f) => readFileSync(join(dir, f), 'utf-8').includes('mainConfigDecisionForTest'))
+    expect(offenders).toEqual([])
+  })
+
+  it('the respawn module does not cast its way around the brand either', () => {
+    // The brand makes forgetting impossible, not bypassing. A cast is the one
+    // remaining way through, so it is spelled out here rather than left to be
+    // discovered later.
+    const src = readFileSync(join(__dirname, '..', 'web', 'channel-monitor.ts'), 'utf-8')
+    expect(src).not.toContain('as MainConfigDecision')
+  })
+
+  it('POSITIVE CONTROL: the forbidden token IS findable where it legitimately lives', () => {
+    // Without this, a typo in the token would make both assertions above pass
+    // while searching for a string that occurs nowhere at all.
+    const own = readFileSync(join(__dirname, '..', 'web', 'main-config-decision.ts'), 'utf-8')
+    expect(own).toContain('mainConfigDecisionForTest')
+  })
+})

--- a/src/__tests__/main-shared-config-guard.test.ts
+++ b/src/__tests__/main-shared-config-guard.test.ts
@@ -1,0 +1,84 @@
+// The main agent coming up on the SHARED ~/.claude must be said out loud --
+// from every launch path, not just the one that happens to run in daylight.
+//
+// WHY THIS FILE EXISTS (kanban card `guard-respawn-vak`). scripts/channels.sh
+// has carried a loud regression guard since 2026-07: two triggers, both meaning
+// "this boot resolved to the shared root, so the main bot rides a rotating
+// credential and can 401 into a silent channel". But channels.sh is only ONE of
+// the ways the main session starts. The nightly 03:00 respawn, the stage-3
+// recovery resume and the hard restart all go through tmux respawn-pane and
+// never touch channels.sh -- so the guard could not fire on any of them.
+//
+// The cost was measured, not imagined: on 2026-08-04 the main agent came up on
+// the shared root at 03:00 and the outage ran until 07:58. Nothing was broken
+// except the reporting. The store/channels-failures.log had no line for that
+// morning, and the absence looked exactly like health.
+//
+// THIS FILE MEASURES THE DECISION ONLY, AND SAYS SO. A green decision test is
+// not evidence that anybody calls it -- that lesson cost a full round on the
+// router fix the same week (four mutations red on the predicate, a fifth that
+// deleted the CALL and left all seven assertions green). The wiring assertions
+// live with the call sites; what is pinned here is that the decision itself is
+// right, and in particular that it stays SILENT on a stock install.
+
+import { describe, it, expect } from 'vitest'
+import { mainSharedConfigTrigger } from '../web/agent-process.js'
+
+/** The three facts the decision reads, with the quiet default install as base. */
+const stock = { isolatedConfigDir: null, fleetToken: false, isolatedDirExists: false }
+
+describe('the guard stays silent where silence is correct', () => {
+  it('says nothing on a stock install: no isolation, no token, no dir', () => {
+    // The common case by a wide margin. A guard that speaks here is noise on
+    // every install that never asked for isolation, and noise is how a real
+    // warning stops being read.
+    expect(mainSharedConfigTrigger(stock)).toBeNull()
+  })
+
+  it('says nothing while isolation is actually working', () => {
+    // The resolved dir is the whole point of the guard; having it means the
+    // thing we are afraid of did not happen.
+    expect(mainSharedConfigTrigger({
+      isolatedConfigDir: '/srv/marveen/.channels-config',
+      fleetToken: true,
+      isolatedDirExists: true,
+    })).toBeNull()
+  })
+})
+
+describe('the two triggers, and which one wins when both could apply', () => {
+  it('a fleet token with no isolation is a MISSING SETTING, not a declined one', () => {
+    // Issue #835's shape: the token is the thing isolation is gated on, so an
+    // install that carries one and still lands on the shared root is
+    // misconfigured rather than deliberately plain.
+    expect(mainSharedConfigTrigger({ ...stock, fleetToken: true })).toBe('fleet-token-unused')
+  })
+
+  it('an existing .channels-config dir means isolation worked here once and was LOST', () => {
+    // No token required: the dir on disk is the evidence. channels.sh trigger 2
+    // fires on the same condition, deliberately, for the same reason.
+    expect(mainSharedConfigTrigger({ ...stock, isolatedDirExists: true })).toBe('isolation-lost')
+  })
+
+  it('PRECEDENCE: the dir on disk wins over the token, because it points at the right fix', () => {
+    // Both conditions hold on an install that lost its setting but kept its
+    // token -- the likeliest real failure. Reporting that as a fresh install
+    // would send the operator to "turn isolation on" when the truth is "your
+    // setting disappeared", which is a different investigation.
+    expect(mainSharedConfigTrigger({
+      isolatedConfigDir: null, fleetToken: true, isolatedDirExists: true,
+    })).toBe('isolation-lost')
+  })
+})
+
+describe('POSITIVE CONTROL', () => {
+  it('not every input is null -- an always-silent stub cannot pass this file', () => {
+    // Without this, a decision that returned null for everything would satisfy
+    // both silence tests above and look like a working guard.
+    const speaks = [
+      mainSharedConfigTrigger({ ...stock, fleetToken: true }),
+      mainSharedConfigTrigger({ ...stock, isolatedDirExists: true }),
+    ].filter((t) => t !== null)
+    expect(speaks).toHaveLength(2)
+  })
+})

--- a/src/__tests__/model-id-injection.test.ts
+++ b/src/__tests__/model-id-injection.test.ts
@@ -9,6 +9,7 @@ import { MODEL_ID_RE, isValidModelId, InvalidModelIdError } from '../model-id.js
 import { writeAgentModel } from '../web/agent-config.js'
 import { shSingleQuote } from '../web/agent-process.js'
 import { buildMainSessionRespawnCmd } from '../web/channel-monitor.js'
+import { mainConfigDecisionForTest } from '../web/main-config-decision.js'
 import { execFileSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
 import { join, dirname } from 'node:path'
@@ -163,7 +164,7 @@ describe('the launch string the fix produces is safe end-to-end', () => {
 // escape is the only guard on this path. (The other four sinks live in agent-process/ssh-tmux/
 // agent-worker and use shSingleQuote/shQuote/shArg; this one was the last raw-quoted holdout.)
 describe('the real launch builder escapes the model AT the sink (not only at the validator)', () => {
-  const OPTS = { claudePath: 'claude', pluginId: 'telegram', continueSession: false }
+  const OPTS = { claudePath: 'claude', pluginId: 'telegram', continueSession: false, config: mainConfigDecisionForTest() }
 
   it('buildMainSessionRespawnCmd single-quote-escapes a hostile model id at --model', () => {
     const hostile = "x'; touch PWNED #"

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -396,6 +396,75 @@ export function readExtraChannelPluginIds(): string[] {
   }
 }
 
+/**
+ * Which shared-root regression this main-agent launch is, if any.
+ *
+ * THE SHAPE THIS ANSWERS, AND WHY IT IS A FUNCTION AND NOT AN `if`. The same two
+ * triggers already live in scripts/channels.sh (the LOUD REGRESSION GUARD, two
+ * blocks): that path shouts when the main agent comes up on the shared
+ * ~/.claude. Every OTHER way the main session starts -- the nightly respawn, the
+ * stage-3 recovery resume, the hard restart -- bypasses channels.sh entirely and
+ * was therefore silent, which is what kanban card `guard-respawn-vak` is about.
+ * The 2026-08-04 outage ran from 03:00 to 07:58 unnoticed for exactly that
+ * reason: the one path that runs at night with nobody watching is the one path
+ * that could not speak.
+ *
+ * Deliberately PURE and state-injected: the caller reads the three facts, this
+ * decides. That keeps it testable without a filesystem, and -- more to the point
+ * -- keeps the DECISION in one place while the EMISSION stays at the call site,
+ * so a test of the decision can never be mistaken for proof that anyone acts on
+ * it.
+ *
+ * `null` means "nothing to warn about", which covers TWO different situations:
+ * isolation is on and working, OR this is a plain default install that never
+ * ran isolated and holds no fleet token. The second is the common case and must
+ * stay silent, or the guard becomes noise on every stock install.
+ */
+export type MainSharedConfigTrigger =
+  /** A fleet setup-token exists but the resolution came back empty: the setting
+   *  is missing, not declined. Shape of issue #835; the isolation-lost trigger
+   *  is structurally blind to it because there is no .channels-config dir yet. */
+  | 'fleet-token-unused'
+  /** This install HAS run isolated (its .channels-config is still on disk), yet
+   *  this launch resolved to the shared root -- so the setting was LOST, e.g.
+   *  store/config-overrides.json deleted with no .env key behind it. */
+  | 'isolation-lost'
+  | null
+
+export function mainSharedConfigTrigger(state: {
+  /** The resolved isolated CLAUDE_CONFIG_DIR, or null for the shared root. */
+  isolatedConfigDir: string | null
+  /** store/.claude-oauth-token present and non-empty. */
+  fleetToken: boolean
+  /** PROJECT_ROOT/.channels-config exists on disk. */
+  isolatedDirExists: boolean
+}): MainSharedConfigTrigger {
+  // Running isolated -- the whole point of the guard is already satisfied.
+  if (state.isolatedConfigDir) return null
+  // Order matters, and it mirrors channels.sh: the dir on disk is the stronger
+  // evidence (isolation demonstrably worked here once), so it wins when both
+  // could apply. Swapping these would report a LOST setting as a fresh install
+  // and send the operator to the wrong fix.
+  if (state.isolatedDirExists) return 'isolation-lost'
+  if (state.fleetToken) return 'fleet-token-unused'
+  return null
+}
+
+/** Reads the three facts mainSharedConfigTrigger decides on. Separate from the
+ *  decision so the decision needs no filesystem, and separate from the emitter
+ *  so the emitter can be swapped in a test. */
+export function readMainSharedConfigState(isolatedConfigDir: string | null): {
+  isolatedConfigDir: string | null
+  fleetToken: boolean
+  isolatedDirExists: boolean
+} {
+  return {
+    isolatedConfigDir,
+    fleetToken: hasFleetOauthToken(),
+    isolatedDirExists: existsSync(join(PROJECT_ROOT, '.channels-config')),
+  }
+}
+
 // An EXPLICIT config dir for the main channels agent (MAIN_AGENT_CONFIG_DIR),
 // for the operator who already keeps a separate Claude login for the main bot --
 // e.g. a personal subscription for the bot and a different one for the fleet.

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -32,6 +32,7 @@ import {
 } from './agent-process.js'
 import { sendSystemDirective } from './system-directive.js'
 import { isRestartInFlight, beginRestart, endRestart } from './restart-lock.js'
+import { resolveMainConfigDecision, type MainConfigDecision } from './main-config-decision.js'
 import { withSessionSendLock } from './session-send-lock.js'
 import { reapChannelOrphans, reapDetachedChannelClaudes, collectPollerEvidence } from './channel-poller-reap.js'
 import { probeTelegramConflict } from './channel-conflict-probe.js'
@@ -756,23 +757,18 @@ export function buildMainSessionRespawnCmd(opts: {
   model: string
   continueSession: boolean
   /**
-   * When set (macOS main-agent isolation on), the respawn exports this isolated
-   * CLAUDE_CONFIG_DIR plus the fleet setup-token -- parity with channels.sh CFG_ENV.
-   * Without it the RECOVERY respawn brings the main agent up on the shared
-   * ~/.claude, which on macOS authenticates from the rotating Keychain OAuth
-   * session and periodically 401s ("Please run /login"). null/undefined => keep
-   * the shared root (unchanged behaviour for installs with isolation off).
+   * What this launch does about CLAUDE_CONFIG_DIR, and whether that is worth
+   * shouting about. REQUIRED, and obtainable in production only from
+   * resolveMainConfigDecision(), which reports as it resolves -- see
+   * main-config-decision.ts for why the guard is wired as a value rather than a
+   * callback. `isolatedConfigDir` set => export the isolated dir plus the fleet
+   * setup-token (parity with channels.sh CFG_ENV); null with `fleetToken` =>
+   * export the token alone, which is what keeps a wizard-entered token reaching
+   * a respawned main session at all (2026-07-15 bootcamp, bug 2 latent path);
+   * null with no token => the shared root, unchanged for installs with
+   * isolation off.
    */
-  isolatedConfigDir?: string | null
-  /**
-   * When true (fleet setup-token file present) and there is NO isolated config
-   * dir, the respawn still exports CLAUDE_CODE_OAUTH_TOKEN from the fleet token
-   * file. On Linux the isolatedConfigDir is always null (macOS-only), so before
-   * this leg a wizard-entered token never reached a respawned main session at
-   * all -- it fell back to ~/.claude/.credentials.json (2026-07-15 bootcamp,
-   * bug 2 latent path). Keeps main + sub-agents on the SAME auth source.
-   */
-  fleetToken?: boolean
+  config: MainConfigDecision
   /**
    * Secondary plugin ids to co-listen on alongside `pluginId`, from
    * readExtraChannelPluginIds(). Omitting them is what silently half-mutes every
@@ -793,9 +789,9 @@ export function buildMainSessionRespawnCmd(opts: {
     '&& export MCP_SERVER_CONNECTION_BATCH_SIZE=10 MCP_CONNECTION_NONBLOCKING=1 MCP_TIMEOUT=60000',
     // macOS main-agent config isolation -- parity with channels.sh CFG_ENV. The
     // token is read at launch via $(cat) so the secret never lands in argv/`ps`.
-    ...(opts.isolatedConfigDir
-      ? [`&& export CLAUDE_CONFIG_DIR='${opts.isolatedConfigDir}' && export CLAUDE_CODE_OAUTH_TOKEN="$(cat '${FLEET_OAUTH_TOKEN_PATH}')"`]
-      : opts.fleetToken
+    ...(opts.config.isolatedConfigDir
+      ? [`&& export CLAUDE_CONFIG_DIR='${opts.config.isolatedConfigDir}' && export CLAUDE_CODE_OAUTH_TOKEN="$(cat '${FLEET_OAUTH_TOKEN_PATH}')"`]
+      : opts.config.fleetToken
         ? [`&& export CLAUDE_CODE_OAUTH_TOKEN="$(cat '${FLEET_OAUTH_TOKEN_PATH}')"`]
         : []),
     '&&', opts.claudePath,
@@ -849,8 +845,7 @@ export function respawnMainSessionFresh(): void {
     // The main session always starts a new conversation -- this is the whole
     // point of the nightly restart (drop the accumulated context).
     continueSession: false,
-    isolatedConfigDir: ensureMainAgentIsolatedConfigDir(),
-    fleetToken: hasFleetOauthToken(),
+    config: resolveMainConfigDecision(),
   })
   execFileSync(tmuxBin(), ['respawn-pane', '-k', '-t', MAIN_CHANNELS_SESSION, claudeCmd], { timeout: 15000 })
   // Stamp IMMEDIATELY after the respawn, before the scheduling follow-ups.
@@ -921,8 +916,7 @@ export async function resumeMarveenSession(): Promise<boolean> {
       // isolated CLAUDE_CONFIG_DIR (macOS), else it re-authenticates from the
       // rotating Keychain and 401s. Returns null when isolation is off/no token,
       // preserving the prior shared-root behaviour.
-      isolatedConfigDir: ensureMainAgentIsolatedConfigDir(),
-      fleetToken: hasFleetOauthToken(),
+      config: resolveMainConfigDecision(),
     })
     execFileSync(tmuxBin(), ['respawn-pane', '-k', '-t', MAIN_CHANNELS_SESSION, claudeCmd], { timeout: 15000 })
 
@@ -1175,8 +1169,7 @@ function respawnMarveenSessionFresh(): boolean {
       // Same channels.sh-bypass concern as resumeMarveenSession: this fresh
       // respawn also skips channels.sh, so it must carry the isolated config
       // itself or it 401s on the rotating macOS Keychain. null when off/no token.
-      isolatedConfigDir: ensureMainAgentIsolatedConfigDir(),
-      fleetToken: hasFleetOauthToken(),
+      config: resolveMainConfigDecision(),
     })
     execFileSync(tmuxBin(), ['respawn-pane', '-k', '-t', MAIN_CHANNELS_SESSION, claudeCmd], { timeout: 15000 })
     logger.warn({ provider: provider.type }, 'Hard restart: marveen session respawned fresh (no --continue)')

--- a/src/web/main-config-decision.ts
+++ b/src/web/main-config-decision.ts
@@ -1,0 +1,149 @@
+// The main agent's config-dir decision, made ONCE and reported on the way past.
+//
+// WHAT THIS MODULE IS FOR (kanban card `guard-respawn-vak`). scripts/channels.sh
+// shouts when the main agent comes up on the shared ~/.claude. Every other way
+// the main session starts -- the nightly 03:00 respawn, the stage-3 recovery
+// resume, the hard restart -- goes through tmux respawn-pane and never touches
+// channels.sh, so none of them could shout. On 2026-08-04 that cost four hours
+// of silence between 03:00 and 07:58: nothing was broken except the reporting,
+// and the missing log line looked exactly like a healthy morning.
+//
+// WHY A BRANDED TYPE AND NOT A CALLBACK. The obvious fix is to hand
+// buildMainSessionRespawnCmd a reporter function. It works, and it is what we
+// first agreed -- but it leaves the failure mode this card is ABOUT still
+// reachable: a new call site can pass a no-op and go quiet, and the only thing
+// standing between us and that is a test that enumerates the known call sites.
+// A hand-maintained list of callers is the same shape as the bug (a guard whose
+// scope has to be remembered), so it was rejected deliberately.
+//
+// Instead, buildMainSessionRespawnCmd takes a MainConfigDecision, and the only
+// way to obtain one in production is resolveMainConfigDecision(), which reports
+// as it resolves. A caller cannot forget the guard, because it cannot build the
+// argument without it. Forgetting becomes impossible; DELIBERATELY bypassing
+// still is not -- a `as MainConfigDecision` cast or the test factory would do
+// it -- but both are loud, greppable, and reviewable, which "I forgot" is not.
+//
+// THE RESIDUAL GAP, STATED RATHER THAN PAPERED OVER: one resolve could in
+// principle be reused across several respawns, which would emit one trace for
+// many launches. Nothing does that today; every call site resolves inline.
+import { appendFileSync, existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { MAIN_AGENT_ID, PROJECT_ROOT } from '../config.js'
+import { logger } from '../logger.js'
+import { createAgentMessage } from '../db.js'
+import {
+  ensureMainAgentIsolatedConfigDir,
+  readMainSharedConfigState,
+  mainSharedConfigTrigger,
+  type MainSharedConfigTrigger,
+} from './agent-process.js'
+
+declare const MAIN_CONFIG_DECISION: unique symbol
+
+/**
+ * What the main agent's next launch will do about CLAUDE_CONFIG_DIR, plus the
+ * verdict on whether that is worth shouting about. The brand is what makes this
+ * unforgeable by accident -- see the module header.
+ */
+export type MainConfigDecision = {
+  readonly [MAIN_CONFIG_DECISION]: true
+  readonly isolatedConfigDir: string | null
+  readonly fleetToken: boolean
+  readonly trigger: MainSharedConfigTrigger
+}
+
+/** The same file scripts/channels.sh writes to, on purpose: an operator looking
+ *  into a silent-channel morning should find every launch path in ONE place. */
+const FAILURES_LOG = join(PROJECT_ROOT, 'store', 'channels-failures.log')
+/** Suppresses only the MESSAGE, never the log line -- see noteState(). */
+const WARN_STAMP = join(PROJECT_ROOT, 'store', '.main-config-guard-warned')
+const WARN_COOLDOWN_MS = 6 * 60 * 60 * 1000
+
+const HU_ADVICE: Record<Exclude<MainSharedConfigTrigger, null>, string> = {
+  'fleet-token-unused':
+    '[GUARD] A fo agens most a KOZOS ~/.claude alol indult ujra, pedig van flotta setup-token (store/.claude-oauth-token). A MAIN_AGENT_ISOLATED_CONFIG nincs beallitva, ezert az auth a rotalodo megosztott credentialbol megy: ez lejarhat, 401-be all a TUI, es a csatorna NEMAN elerhetetlen lesz. Teendo: MAIN_AGENT_ISOLATED_CONFIG=1 beallitasa, majd a fo session ujrainditasa.',
+  'isolation-lost':
+    '[GUARD] A fo agens most a KOZOS ~/.claude alol indult ujra, pedig letezik izolalt config dir (.channels-config). A MAIN_AGENT_ISOLATED_CONFIG beallitas valoszinuleg elveszett (store/config-overrides.json torlodott es nincs .env kulcs). Az auth a rotalodo shared sessionbol megy, 401-veszely. Teendo: MAIN_AGENT_ISOLATED_CONFIG=1 visszaallitasa, majd a fo session ujrainditasa.',
+}
+
+function line(text: string): void {
+  const ts = new Date().toLocaleString('sv-SE').replace('T', ' ')
+  appendFileSync(FAILURES_LOG, `${ts} ${text}\n`)
+}
+
+/** True at most once per WARN_COOLDOWN_MS. The hard restart can fire in a loop
+ *  on a wedged session, and a notice per attempt would bury the first one --
+ *  the same shape as the handoff-failure chain of 2026-08-10. */
+function warnDueNow(): boolean {
+  try {
+    const prev = Number(readFileSync(WARN_STAMP, 'utf-8').trim())
+    if (Number.isFinite(prev) && Date.now() - prev < WARN_COOLDOWN_MS) return false
+  } catch { /* no stamp yet -> due */ }
+  try { writeFileSync(WARN_STAMP, String(Date.now())) } catch { /* best effort */ }
+  return true
+}
+
+/**
+ * Writes the trace for this launch. A line goes out on EVERY launch, healthy or
+ * not: scripts/channels.sh does the same unconditionally (its status line at
+ * :477), and that is precisely what made the ABSENCE of a line evidence on
+ * 2026-08-04. A guard that only writes when it is unhappy has an ambiguous
+ * silence -- "nothing wrong" and "never ran" look identical -- which is the
+ * condition this card exists to end.
+ */
+function noteState(d: Omit<MainConfigDecision, typeof MAIN_CONFIG_DECISION>): void {
+  try {
+    if (!d.trigger) {
+      line(d.isolatedConfigDir
+        ? `main-agent respawn: isolated CLAUDE_CONFIG_DIR=${d.isolatedConfigDir}`
+        : 'main-agent respawn: shared ~/.claude (no isolation configured, no fleet token) -- expected for a stock install')
+      return
+    }
+    line(`main-agent respawn: WARN ${d.trigger} -- starting on SHARED ~/.claude`)
+    if (!warnDueNow()) {
+      line(`main-agent respawn: notice suppressed (a ${d.trigger} notice went out within the last 6h)`)
+      return
+    }
+    createAgentMessage('respawn-guard', MAIN_AGENT_ID, HU_ADVICE[d.trigger])
+  } catch (err) {
+    // A guard must never be the reason a restart fails. Losing the trace is bad;
+    // losing the session because the trace could not be written is worse.
+    logger.warn({ err }, 'main-config guard: could not record the launch state (continuing)')
+  }
+}
+
+/**
+ * Resolve the main agent's config dir AND report what came out. The only
+ * production source of a MainConfigDecision.
+ */
+export function resolveMainConfigDecision(): MainConfigDecision {
+  const state = readMainSharedConfigState(ensureMainAgentIsolatedConfigDir())
+  // isolatedDirExists is an INPUT to the verdict, not part of it: carrying it
+  // along would invite a later reader to re-derive the trigger from the
+  // decision and quietly disagree with mainSharedConfigTrigger.
+  const d = {
+    isolatedConfigDir: state.isolatedConfigDir,
+    fleetToken: state.fleetToken,
+    trigger: mainSharedConfigTrigger(state),
+  }
+  noteState(d)
+  return d as MainConfigDecision
+}
+
+/**
+ * A decision WITHOUT the reporting, for tests that are about the respawn command
+ * string rather than the guard. Named so an assertion can forbid it in
+ * production modules -- if this token appears under src/web/ outside this file,
+ * somebody built a decision that never reported.
+ */
+export function mainConfigDecisionForTest(
+  partial: Partial<Omit<MainConfigDecision, typeof MAIN_CONFIG_DECISION>> = {},
+): MainConfigDecision {
+  const isolatedConfigDir = partial.isolatedConfigDir ?? null
+  const fleetToken = partial.fleetToken ?? false
+  return {
+    isolatedConfigDir,
+    fleetToken,
+    trigger: partial.trigger ?? mainSharedConfigTrigger({ isolatedConfigDir, fleetToken, isolatedDirExists: false }),
+  } as MainConfigDecision
+}

--- a/src/web/main-config-decision.ts
+++ b/src/web/main-config-decision.ts
@@ -53,10 +53,12 @@ export type MainConfigDecision = {
 }
 
 /** The same file scripts/channels.sh writes to, on purpose: an operator looking
- *  into a silent-channel morning should find every launch path in ONE place. */
-const FAILURES_LOG = join(PROJECT_ROOT, 'store', 'channels-failures.log')
+ *  into a silent-channel morning should find every launch path in ONE place.
+ *  Resolved per call, not at module load: a path captured at import time is one
+ *  a test can never redirect, and an untestable emitter is how we got here. */
+const failuresLog = () => join(PROJECT_ROOT, 'store', 'channels-failures.log')
 /** Suppresses only the MESSAGE, never the log line -- see noteState(). */
-const WARN_STAMP = join(PROJECT_ROOT, 'store', '.main-config-guard-warned')
+const warnStamp = () => join(PROJECT_ROOT, 'store', '.main-config-guard-warned')
 const WARN_COOLDOWN_MS = 6 * 60 * 60 * 1000
 
 const HU_ADVICE: Record<Exclude<MainSharedConfigTrigger, null>, string> = {
@@ -68,7 +70,7 @@ const HU_ADVICE: Record<Exclude<MainSharedConfigTrigger, null>, string> = {
 
 function line(text: string): void {
   const ts = new Date().toLocaleString('sv-SE').replace('T', ' ')
-  appendFileSync(FAILURES_LOG, `${ts} ${text}\n`)
+  appendFileSync(failuresLog(), `${ts} ${text}\n`)
 }
 
 /** True at most once per WARN_COOLDOWN_MS. The hard restart can fire in a loop
@@ -76,10 +78,10 @@ function line(text: string): void {
  *  the same shape as the handoff-failure chain of 2026-08-10. */
 function warnDueNow(): boolean {
   try {
-    const prev = Number(readFileSync(WARN_STAMP, 'utf-8').trim())
+    const prev = Number(readFileSync(warnStamp(), 'utf-8').trim())
     if (Number.isFinite(prev) && Date.now() - prev < WARN_COOLDOWN_MS) return false
   } catch { /* no stamp yet -> due */ }
-  try { writeFileSync(WARN_STAMP, String(Date.now())) } catch { /* best effort */ }
+  try { writeFileSync(warnStamp(), String(Date.now())) } catch { /* best effort */ }
   return true
 }
 


### PR DESCRIPTION
Every path that starts the main channels session decides which `CLAUDE_CONFIG_DIR` to
come up under. Only one of them said so out loud.

`scripts/channels.sh` has a loud regression guard: it shouts when the main agent comes
up on the shared `~/.claude`. Every other way the session starts -- the nightly respawn,
the stage-3 recovery resume, the hard restart -- bypasses `channels.sh` entirely and was
therefore silent. That is the path that runs at night with nobody watching.

## What changes

**A pure decision, in one place.** `mainSharedConfigTrigger()` names which of the two
shared-root regressions a launch is: a fleet setup-token that exists but resolved to
nothing (the setting is missing, not declined), or an install that HAS run isolated --
its `.channels-config` is still on disk -- yet resolved to the shared root. `null` covers
both "isolation is working" and "plain default install", because a stock install must
stay silent or the guard becomes noise everywhere.

**The decision cannot be skipped by forgetting.** `buildMainSessionRespawnCmd` now takes a
branded `MainConfigDecision` whose only production source is `resolveMainConfigDecision()`,
which reports as it resolves. A callback would have worked too, but then the guard would be
a hand-maintained list of call sites -- the same shape as the bug.

**The healthy launch writes a line as well.** A guard that only speaks when unhappy has an
ambiguous silence: "nothing wrong" and "never ran" look identical from the outside.

**And the second shell respawner gets the same decision.** There are two scripts that
respawn the main session with their own command string. PR #686 gave `channel-watchdog.sh`
a `CFG_ENV`; `stuck-modal-guard.sh`, added in #264, never had one, so a respawn from there
brought the main agent back up on the shared root -- at the worst possible moment, since
that script only fires when the session is already stuck. The provider comes out of the
configured plugin id rather than being hard-coded, so a renamed install does not inherit
another channel's directory.

## Evidence

Two measured cases, on the install where this was written:

1. **The failure.** 2026-08-04: the main agent came up on the shared root at 03:00 and the
   outage ran until 07:58 unnoticed. Nothing in that path could speak.
2. **The fix, in production.** After deploying this on 2026-09-08 08:22, the scheduled
   fresh respawn on 2026-09-09 at 03:00:33 left this line:
   `main-agent respawn: isolated CLAUDE_CONFIG_DIR=...`
   It comes from the SUCCESSFUL branch of `noteState()`, which is the point: the healthy
   path is what proves the silence is no longer ambiguous.

That is one observed run of the fixed path, and the claim stops there. The log file it
landed in holds two lines and has no rotated predecessor, so it cannot support a stronger
statement about how many respawns happened since the deploy.

## Tests, and what they measure

`main-shared-config-guard` pins the DECISION; `main-config-guard-wiring` pins that anything
acts on it, because every assertion in the first file stays green if the decision is never
consulted. `main-config-dir-parity` locks the count of shell respawners with `toBe`, since
an at-least assertion is precisely what let #686 read as complete with one of two paths
fixed.

Mutations run against them: removing the `noteState` call turns the wiring file red while
the decision file stays green; swapping the two triggers turns three assertions red; a cast
around the brand in any `src/web` module is caught by directory walk rather than by naming
one file.

## Scope, and what was left out

Six commits, nine files. Two cherry-picks needed re-application on `develop`: an insertion
collision in `agent-process.ts` (upstream's `readExtraChannelPluginIds` and this change's
function landed in the same place -- both kept, upstream's byte-identical) and an import
collision in `channel-monitor.ts`.

Deliberately not included: the install-specific operational parts of the same work --
nothing from `store/`, no agent directories, no absolute paths.

`npm run typecheck` is clean on top of `develop`, and the five affected test files pass
(72 tests). The full suite was NOT run on this base; it was run on our own line, where it
has a small number of pre-existing environment-dependent failures unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
