### PR TITLE
fix(migrate): chunk long sections instead of truncating them at 2000 chars (GH #1024)

### DIFF
--- a/src/__tests__/migrate-chunking.test.ts
+++ b/src/__tests__/migrate-chunking.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import { chunkText } from '../web/routes/migrate.js'
+
+// The contract the importer depends on: chunking is lossless. GH #1024 measured
+// 30.4% of the source text disappearing on a 20 file run because each section
+// was cut at 2000 characters instead of being split.
+const nonSpace = (s: string) => s.replace(/\s+/g, '')
+
+describe('chunkText', () => {
+  it('returns a short text unchanged, as a single chunk', () => {
+    expect(chunkText('  rövid szöveg  ', 2000)).toEqual(['rövid szöveg'])
+  })
+
+  it('drops nothing: the chunks hold every non-whitespace character', () => {
+    const paragraph = 'A kockázatfelmérés során az alkusz feltérképezi a jármű jellemzőit. '
+    const source = paragraph.repeat(200) // ~13k characters
+    const chunks = chunkText(source, 2000)
+
+    expect(chunks.length).toBeGreaterThan(5)
+    expect(nonSpace(chunks.join(''))).toBe(nonSpace(source))
+  })
+
+  it('keeps every chunk within the limit, apart from a merged short tail', () => {
+    const source = 'mondat vége. '.repeat(500)
+    for (const chunk of chunkText(source, 2000)) {
+      expect(chunk.length).toBeLessThanOrEqual(2000 + 20)
+    }
+  })
+
+  it('prefers a paragraph break over a mid-sentence cut', () => {
+    const first = 'a'.repeat(1500)
+    const second = 'b'.repeat(1500)
+    const [head] = chunkText(`${first}\n\n${second}`, 2000)
+    expect(head).toBe(first)
+  })
+
+  it('falls back to a sentence end when there is no paragraph break', () => {
+    const source = `${'sok szó '.repeat(200)}. ${'még több szó '.repeat(200)}`
+    const [head] = chunkText(source, 2000)
+    expect(head.endsWith('.')).toBe(true)
+  })
+
+  it('hard cuts only when the window holds no boundary at all', () => {
+    const oneLongWord = 'x'.repeat(5000)
+    const chunks = chunkText(oneLongWord, 2000)
+    expect(chunks).toHaveLength(3)
+    expect(chunks[0]).toHaveLength(2000)
+    expect(chunks.join('')).toBe(oneLongWord)
+  })
+
+  it('merges a very short tail into the previous chunk instead of emitting a fragment row', () => {
+    const source = `${'y'.repeat(2000)} vég`
+    const chunks = chunkText(source, 2000)
+    expect(chunks).toHaveLength(1)
+    expect(chunks[0]).toContain('vég')
+  })
+
+  it('returns nothing for empty or whitespace-only input', () => {
+    expect(chunkText('', 2000)).toEqual([])
+    expect(chunkText('   \n\n  ', 2000)).toEqual([])
+  })
+
+  it('reproduces the issue scenario: a 6000 character heading-free section survives whole', () => {
+    // The install measured in GH #1024 had 217 of 360 files over 2000 characters
+    // and only 40 with any `##` heading, so most files became one section.
+    const section = 'Ez egy hosszú, tagolatlan memóriafájl tartalma. '.repeat(130)
+    const chunks = chunkText(section, 2000)
+    expect(nonSpace(chunks.join(''))).toBe(nonSpace(section))
+    expect(chunks.length).toBeGreaterThan(2)
+  })
+})

--- a/src/web/routes/migrate.ts
+++ b/src/web/routes/migrate.ts
@@ -6,6 +6,80 @@ import { logger } from '../../logger.js'
 import { readBody, json } from '../http-helpers.js'
 import type { RouteContext } from './types.js'
 
+// Longest run of characters a single memory row may hold. Anything longer is
+// split into several rows; it is never cut short. See CHUNK_MIN_TAIL for the
+// one case where a chunk is allowed to exceed this.
+const MEMORY_CHUNK_CHARS = 2000
+const DOCUMENT_CHUNK_CHARS = 3000
+
+// A section shorter than this is not worth its own memory row. It is the
+// threshold the importer has always used; it is applied to the SOURCE section,
+// before chunking, so a long section never loses its tail to it.
+const SECTION_MIN_CHARS = 20
+
+// A trailing chunk shorter than this is appended to the chunk before it rather
+// than becoming a memory row of its own. That makes the last chunk longer than
+// maxLen by up to this much, which is the deliberate trade: a slightly long row
+// beats a row holding half a sentence, and beats dropping the tail.
+const CHUNK_MIN_TAIL = 20
+
+// Never cut before this fraction of the window. Without a floor, a paragraph
+// break early in the window would produce a stream of tiny chunks.
+const BOUNDARY_FLOOR = 0.6
+
+/**
+ * Split `text` into chunks of at most `maxLen` characters, preferring to cut at
+ * a paragraph break, then a sentence end, then any whitespace. Falls back to a
+ * hard cut only when the window holds no boundary at all (one very long word).
+ *
+ * The contract that matters: the concatenation of the result contains every
+ * non-whitespace character of the input. Nothing is discarded. This is the fix
+ * for the importer truncating each section at 2000 characters (GH #1024, which
+ * measured 30.4% of the source text lost on a 20 file run, with no sign of it
+ * in the response).
+ */
+export function chunkText(text: string, maxLen: number): string[] {
+  const trimmed = text.trim()
+  if (!trimmed) return []
+  if (trimmed.length <= maxLen) return [trimmed]
+
+  const chunks: string[] = []
+  const floor = Math.floor(maxLen * BOUNDARY_FLOOR)
+  let rest = trimmed
+
+  while (rest.length > maxLen) {
+    const window = rest.slice(0, maxLen)
+    let cut = window.lastIndexOf('\n\n')
+
+    if (cut < floor) {
+      const sentence = Math.max(
+        window.lastIndexOf('. '), window.lastIndexOf('.\n'),
+        window.lastIndexOf('! '), window.lastIndexOf('!\n'),
+        window.lastIndexOf('? '), window.lastIndexOf('?\n'),
+      )
+      cut = sentence >= floor ? sentence + 1 : -1
+    }
+    if (cut < floor) {
+      const space = window.lastIndexOf(' ')
+      // A hard cut at maxLen is the last resort, not the default.
+      cut = space >= floor ? space : maxLen
+    }
+
+    chunks.push(rest.slice(0, cut).trim())
+    rest = rest.slice(cut).trim()
+  }
+
+  if (rest) {
+    if (chunks.length > 0 && rest.length < CHUNK_MIN_TAIL) {
+      chunks[chunks.length - 1] = `${chunks[chunks.length - 1]}\n${rest}`
+    } else {
+      chunks.push(rest)
+    }
+  }
+
+  return chunks
+}
+
 export async function tryHandleMigrate(ctx: RouteContext): Promise<boolean> {
   const { req, res, path, method } = ctx
 
@@ -100,33 +174,53 @@ export async function tryHandleMigrate(ctx: RouteContext): Promise<boolean> {
     const stats = { hot: 0, warm: 0, cold: 0, shared: 0 }
     const details: string[] = []
 
-    for (const f of findings.filter(fi => fi.type === 'personality')) {
-      try {
-        const content = readFileSync(f.path, 'utf-8').slice(0, 3000)
-        saveAgentMemory(agentId, `[Importált személyiség] ${content}`, 'warm', 'személyiség, soul, import', true)
+    // Character accounting. The old importer reported the number of rows it
+    // wrote, which says nothing about how much of the source arrived: it was
+    // possible (and measured, GH #1024) to lose 30% of the text and still read
+    // a clean success. These two totals go back in the response so the caller
+    // can see the difference instead of having to measure the database.
+    let sourceChars = 0
+    let importedChars = 0
+    let skippedShortChars = 0
+
+    // Saves one source document as however many rows it needs, labelling the
+    // parts when there is more than one so a reader can tell they belong together.
+    const saveDocument = (label: string, content: string, keywords: string) => {
+      const parts = chunkText(content, DOCUMENT_CHUNK_CHARS)
+      parts.forEach((part, i) => {
+        const suffix = parts.length > 1 ? ` (${i + 1}/${parts.length})` : ''
+        saveAgentMemory(agentId, `[${label}${suffix}] ${part}`, 'warm', keywords, true)
         stats.warm++
         imported++
-        details.push(`Személyiség: ${f.name}`)
+        importedChars += part.length
+      })
+      return parts.length
+    }
+
+    for (const f of findings.filter(fi => fi.type === 'personality')) {
+      try {
+        const content = readFileSync(f.path, 'utf-8')
+        sourceChars += content.trim().length
+        const parts = saveDocument('Importált személyiség', content, 'személyiség, soul, import')
+        details.push(`Személyiség: ${f.name}${parts > 1 ? ` (${parts} részben)` : ''}`)
       } catch {}
     }
 
     for (const f of findings.filter(fi => fi.type === 'profile')) {
       try {
-        const content = readFileSync(f.path, 'utf-8').slice(0, 3000)
-        saveAgentMemory(agentId, `[Importált felhasználói profil] ${content}`, 'warm', 'felhasználó, profil, import', true)
-        stats.warm++
-        imported++
-        details.push(`Profil: ${f.name}`)
+        const content = readFileSync(f.path, 'utf-8')
+        sourceChars += content.trim().length
+        const parts = saveDocument('Importált felhasználói profil', content, 'felhasználó, profil, import')
+        details.push(`Profil: ${f.name}${parts > 1 ? ` (${parts} részben)` : ''}`)
       } catch {}
     }
 
     for (const f of findings.filter(fi => fi.type === 'heartbeat')) {
       try {
-        const content = readFileSync(f.path, 'utf-8').slice(0, 2000)
-        saveAgentMemory(agentId, `[Importált heartbeat konfig] ${content}`, 'warm', 'heartbeat, konfig, import', true)
-        stats.warm++
-        imported++
-        details.push(`Heartbeat: ${f.name}`)
+        const content = readFileSync(f.path, 'utf-8')
+        sourceChars += content.trim().length
+        const parts = saveDocument('Importált heartbeat konfig', content, 'heartbeat, konfig, import')
+        details.push(`Heartbeat: ${f.name}${parts > 1 ? ` (${parts} részben)` : ''}`)
       } catch {}
     }
 
@@ -135,9 +229,20 @@ export async function tryHandleMigrate(ctx: RouteContext): Promise<boolean> {
     )
 
     const chunks: string[] = []
+
+    // Every section that clears SECTION_MIN_CHARS is chunked, never truncated.
+    // The length test stays on the source section: a 6000 character section is
+    // long enough to keep, and it keeps all 6000, in three rows.
+    const addSection = (text: string) => {
+      const section = text.trim()
+      if (section.length <= SECTION_MIN_CHARS) { skippedShortChars += section.length; return }
+      chunks.push(...chunkText(section, MEMORY_CHUNK_CHARS))
+    }
+
     for (const f of memoryFindings) {
       try {
         const content = readFileSync(f.path, 'utf-8')
+        sourceChars += content.trim().length
         const ext = f.name.split('.').pop()?.toLowerCase()
         if (ext === 'json') {
           try {
@@ -145,32 +250,40 @@ export async function tryHandleMigrate(ctx: RouteContext): Promise<boolean> {
             if (Array.isArray(data)) {
               for (const item of data) {
                 const text = typeof item === 'object' ? (item.content || item.text || JSON.stringify(item)) : String(item)
-                if (String(text).trim().length > 20) chunks.push(String(text).slice(0, 2000))
+                addSection(String(text))
               }
             } else if (typeof data === 'object') {
               for (const [k, v] of Object.entries(data)) {
-                const text = `${k}: ${v}`
-                if (text.length > 20) chunks.push(text.slice(0, 2000))
+                addSection(`${k}: ${v}`)
               }
             }
-          } catch { if (content.trim().length > 20) chunks.push(content.slice(0, 2000)) }
+          } catch { addSection(content) }
         } else {
           const sections = ext === 'md' ? content.split(/\n(?=##?\s)/) : content.split(/\n\n+/)
-          for (const section of sections) {
-            if (section.trim().length > 20) chunks.push(section.trim().slice(0, 2000))
-          }
+          for (const section of sections) addSection(section)
         }
       } catch {}
     }
 
     if (chunks.length > 0) {
       let categorizeModel: string | null = null
+      // Why the reason is carried and not just the null: an install whose only
+      // Ollama model is an embedding model (needed for vector search) gets no
+      // categoriser, so every row lands in `warm` with empty keywords. That is
+      // a real degradation of the import and it used to happen in silence
+      // (GH #1024, second finding).
+      let categorizeUnavailable: string | null = null
       try {
         const modelsResp = await fetch(`${OLLAMA_URL}/api/tags`, { signal: AbortSignal.timeout(3000) })
         const modelsData = await modelsResp.json() as { models?: { name: string }[] }
         const available = (modelsData.models || []).filter(m => !m.name.includes('embed')).map(m => m.name)
         categorizeModel = available.find(m => m.includes('gemma4')) || available[0] || null
-      } catch {}
+        if (!categorizeModel) {
+          categorizeUnavailable = 'nincs kategorizálásra alkalmas Ollama modell (csak embedding modell érhető el)'
+        }
+      } catch {
+        categorizeUnavailable = 'az Ollama nem válaszolt'
+      }
 
       for (const chunk of chunks) {
         try {
@@ -200,6 +313,7 @@ export async function tryHandleMigrate(ctx: RouteContext): Promise<boolean> {
           saveAgentMemory(agentId, chunk, tier, keywords, true)
           stats[tier as keyof typeof stats]++
           imported++
+          importedChars += chunk.length
 
           if (chunks.indexOf(chunk) < chunks.length - 1) {
             await new Promise(r => setTimeout(r, 200))
@@ -208,14 +322,31 @@ export async function tryHandleMigrate(ctx: RouteContext): Promise<boolean> {
           saveAgentMemory(agentId, chunk, 'warm', '', true)
           stats.warm++
           imported++
+          importedChars += chunk.length
         }
       }
 
       details.push(`${chunks.length} memória chunk feldolgozva`)
+      if (categorizeUnavailable) {
+        details.push(`Kategorizálás kimaradt (${categorizeUnavailable}), ezért minden sor warm lett, kulcsszavak nélkül`)
+      }
     }
 
-    logger.info({ agentId, imported, stats }, 'Költöztetés kész')
-    json(res, { ok: true, imported, stats, details })
+    // What the difference means, so the number is readable: source is every
+    // character in the selected files, imported is every character written to
+    // `memories`. The gap is structural (JSON syntax, blank lines between
+    // sections, markdown heading separators) plus the sections below the
+    // minimum length, which are counted separately. After the chunking fix no
+    // kept section loses its tail, so a large unexplained gap is a bug report,
+    // not normal operation.
+    const chars = { source: sourceChars, imported: importedChars, skippedShortSections: skippedShortChars }
+    if (sourceChars > 0) {
+      const pct = Math.round((importedChars / sourceChars) * 1000) / 10
+      details.push(`Karakterek: ${importedChars} / ${sourceChars} importálva (${pct}%), rövid szekciókból kihagyva: ${skippedShortChars}`)
+    }
+
+    logger.info({ agentId, imported, stats, chars }, 'Költöztetés kész')
+    json(res, { ok: true, imported, stats, details, chars })
     return true
   }
 


### PR DESCRIPTION
Fixes #1024.

## What was measured, before anything was changed

The bug lives on `develop` at 8f96248d. `src/web/routes/migrate.ts` splits each memory file into sections and then calls `.slice(0, 2000)` on every section. There is no second chunk, so the tail is discarded, and the response reports the number of rows written, which is a different quantity from the amount of text imported.

The reporter measured 30.4% loss on a 20 file run. I reproduced the class independently on an unrelated 252 file memory directory (2,910,887 characters), running the old and the new path over the same input:

| | characters imported | rows | lost |
|---|---|---|---|
| old (`slice(0, 2000)`) | 2,288,921 (78.6%) | 1,494 | **621,966 (21.4%)** |
| new (`chunkText`) | 2,906,711 (99.9%) | 2,167 | 4,176 (0.1%) |

The remaining 0.1% is sections below the minimum length plus the whitespace between sections. It is not silent any more: it is counted and returned.

That directory has 174 of 252 files over 2000 characters and only 87 with any `##` heading, which matches what the reporter saw on their install (217 of 360, and 40). Where a file has no heading it becomes one section, and one section used to become one truncated row.

## What changed

- **`chunkText(text, maxLen)`** splits a section into as many chunks as it needs, preferring a paragraph break, then a sentence end, then any whitespace, and hard cutting only when the window holds no boundary at all (one very long word). The contract the tests assert: the concatenation of the chunks holds every non-whitespace character of the input.
- **The personality, profile and heartbeat branches** truncated the same way at 3000/3000/2000 characters. They now save as many rows as the document needs, labelled `(1/3)`, `(2/3)`.
- **The minimum-length test stays on the source section**, not on the chunk. A 6000 character section is long enough to keep, and it keeps all 6000, in three rows.
- **The response carries `chars: { source, imported, skippedShortSections }`** plus a details line with the percentage. The number matters less than the fact that a gap can no longer pass unnoticed.

## Second finding from the same report

An install whose only Ollama model is an embedding model (which the vector search needs) ends up with `categorizeModel = null`, so every imported row lands in `warm` with empty keywords and nothing says so. The response now names the reason.

## Verification

- `npx vitest run` in a clean worktree: 392 files, 5050 passed, 1 skipped, 0 failed.
- `npx tsc --noEmit`: clean.
- New suite `src/__tests__/migrate-chunking.test.ts`, 9 tests, including the losslessness property, the boundary preference order, the long-word hard cut and the short-tail merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
