### PR TITLE
fix(schedules): a deleted default scheduled task no longer reappears (#796)

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -1259,11 +1259,18 @@ if [ -d "$SEED_SCHED_DIR" ]; then
   mkdir -p "$SCHED_TARGET_DIR"
   SCHED_NEW=0
   SCHED_SKIP=0
+  SCHED_TOMBSTONE="$SCHED_TARGET_DIR/.removed-defaults"
   for tpl in "$SEED_SCHED_DIR"/*/; do
     [ -d "$tpl" ] || continue
     task_name=$(basename "$tpl")
     [[ "$task_name" == "bumblebee-hygiene-scan" ]] && continue
     target="$SCHED_TARGET_DIR/$task_name"
+    # #796: a reinstall over an existing box must honor the dashboard's record
+    # of a deleted default (.removed-defaults); a UI re-create clears it.
+    if [ -f "$SCHED_TOMBSTONE" ] && grep -qxF "$task_name" "$SCHED_TOMBSTONE" 2>/dev/null; then
+      SCHED_SKIP=$((SCHED_SKIP + 1))
+      continue
+    fi
     if [ -d "$target" ]; then
       SCHED_SKIP=$((SCHED_SKIP + 1))
       continue

--- a/src/__tests__/scheduled-task-deletion-tombstone.test.ts
+++ b/src/__tests__/scheduled-task-deletion-tombstone.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { mkdtempSync, rmSync, existsSync, statSync, readdirSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+// #796: a deleted DEFAULT scheduled task reappeared after an update, because
+// seeding (ensureDefaultScheduledTasks on every dashboard start, and the shell
+// seed loops) is skip-if-missing and nothing recorded the deletion. The fix is
+// a tombstone (.removed-defaults) the DELETE route writes and all seed points
+// read. os.homedir() reads $HOME on POSIX, so we point HOME at a temp dir
+// BEFORE importing the modules (SCHEDULED_TASKS_DIR is computed at import) and
+// exercise the real exported functions, not a re-implementation.
+const tmpHome = mkdtempSync(join(tmpdir(), 'tombstone-home-'))
+const realHome = process.env.HOME
+process.env.HOME = tmpHome
+process.env.MAIN_AGENT_ID = process.env.MAIN_AGENT_ID || 'marveen'
+
+let io: typeof import('../web/scheduled-tasks-io.js')
+let scaffold: typeof import('../web/agent-scaffold.js')
+let dir: string
+
+beforeAll(async () => {
+  io = await import('../web/scheduled-tasks-io.js')
+  scaffold = await import('../web/agent-scaffold.js')
+  dir = io.SCHEDULED_TASKS_DIR
+})
+
+afterAll(() => {
+  process.env.HOME = realHome
+  rmSync(tmpHome, { recursive: true, force: true })
+})
+
+const taskDirs = () =>
+  existsSync(dir)
+    ? readdirSync(dir).filter(f => { try { return statSync(join(dir, f)).isDirectory() } catch { return false } })
+    : []
+
+describe('deleted default scheduled task stays deleted (#796)', () => {
+  it('seeds the shipped defaults on first run', () => {
+    scaffold.ensureDefaultScheduledTasks()
+    const seeded = taskDirs()
+    expect(seeded).toContain('memoria-heartbeat')
+  })
+
+  it('does not re-seed a default the operator deleted', () => {
+    const victim = 'memoria-heartbeat'
+    rmSync(join(dir, victim), { recursive: true, force: true })
+    io.markDefaultTaskRemoved(victim)
+    expect([...io.readRemovedDefaultTasks()]).toContain(victim)
+    // a restart re-runs the seeder:
+    scaffold.ensureDefaultScheduledTasks()
+    expect(taskDirs()).not.toContain(victim)
+  })
+
+  it('keeps the tombstone as a plain file that listScheduledTasks ignores', () => {
+    expect(statSync(join(dir, '.removed-defaults')).isFile()).toBe(true)
+    expect(io.listScheduledTasks().some(t => t.name === '.removed-defaults')).toBe(false)
+  })
+
+  it('lifts the tombstone when the task is re-created, and it then survives re-seed', () => {
+    const victim = 'memoria-heartbeat'
+    io.writeScheduledTask(victim, { description: 'x', prompt: 'y', schedule: '0 0 * * *', agent: 'marveen' })
+    expect(io.readRemovedDefaultTasks().size).toBe(0)
+    scaffold.ensureDefaultScheduledTasks()
+    expect(taskDirs()).toContain(victim)
+  })
+})

--- a/src/web/agent-scaffold.ts
+++ b/src/web/agent-scaffold.ts
@@ -1,4 +1,5 @@
 import { readFileSync, writeFileSync, existsSync, mkdirSync, copyFileSync, readdirSync, statSync, rmSync, watchFile, unwatchFile } from 'node:fs'
+import { readRemovedDefaultTasks } from './scheduled-tasks-io.js'
 import { join } from 'node:path'
 import { homedir } from 'node:os'
 import { PROJECT_ROOT, OWNER_NAME, MAIN_AGENT_ID, HEARTBEAT_AGENT_ID, BOT_NAME, CHANNEL_PROVIDER, WEB_PORT, OWNER_DRIVE_FOLDER, APP_TZ, DASHBOARD_PUBLIC_URL, AGENT_API_ORIGIN, STORE_DIR } from '../config.js'
@@ -1270,10 +1271,16 @@ export function ensureDefaultScheduledTasks(): void {
   const destRoot = join(homedir(), '.claude', 'scheduled-tasks')
   mkdirSync(destRoot, { recursive: true })
 
+  // #796: an operator who deleted a shipped default must not have it silently
+  // re-seeded on the next dashboard start. The DELETE route records the removal
+  // in this tombstone; honor it here (a later re-create via the UI clears it).
+  const removed = readRemovedDefaultTasks()
+
   for (const taskName of readdirSync(repoTasks)) {
     const src = join(repoTasks, taskName)
     const dest = join(destRoot, taskName)
     if (!statSync(src).isDirectory()) continue
+    if (removed.has(taskName)) continue
     if (existsSync(dest)) continue
     mkdirSync(dest, { recursive: true })
     for (const file of readdirSync(src)) {

--- a/src/web/routes/schedules.ts
+++ b/src/web/routes/schedules.ts
@@ -15,7 +15,7 @@ import { listAgentNames } from '../agent-config.js'
 import { readFileOr } from '../agent-config.js'
 import {
   SCHEDULED_TASKS_DIR, MAX_SCHEDULED_TASK_PROMPT_LEN,
-  listScheduledTasks, writeScheduledTask,
+  listScheduledTasks, writeScheduledTask, markDefaultTaskRemoved,
 } from '../scheduled-tasks-io.js'
 import { runScheduledTaskNow } from '../schedule-runner.js'
 import type { RouteContext } from './types.js'
@@ -218,6 +218,10 @@ Az eredmeny CSAK a kibovitett prompt szovege legyen, semmi mas. Ne hasznalj code
     const { name, dir } = resolved
     if (!existsSync(dir)) { json(res, { error: 'Schedule not found' }, 404); return true }
     rmSync(dir, { recursive: true, force: true })
+    // #796: remember the removal so a shipped default is not re-seeded on the
+    // next restart/update. Harmless for a user-authored task (the seeders only
+    // ever revisit shipped names); a later re-create with this name clears it.
+    markDefaultTaskRemoved(name)
     logger.info({ name }, 'Scheduled task deleted')
     json(res, { ok: true })
     return true

--- a/src/web/scheduled-tasks-io.ts
+++ b/src/web/scheduled-tasks-io.ts
@@ -13,6 +13,41 @@ export const SCHEDULED_TASKS_DIR = join(homedir(), '.claude', 'scheduled-tasks')
 // legitimate schedule prompt -- real ones are usually <1k chars.
 export const MAX_SCHEDULED_TASK_PROMPT_LEN = 50_000
 
+// #796: a deleted DEFAULT scheduled task must stay deleted. Seeding is
+// skip-if-missing at three points -- ensureDefaultScheduledTasks() on every
+// dashboard start, and the install/update shell seed loops -- so without a
+// record of the deletion, a shipped task the operator removed reappears on the
+// next restart or update. This tombstone is a newline-separated list of task
+// names that all three seed points consult; the DELETE route appends to it and
+// (re)creating a task clears its entry. Kept as a plain dotfile in the tasks
+// dir (not a subdirectory) so listScheduledTasks -- which filters to dirs --
+// never treats it as a task, and the shell seeders can read it with grep.
+export const REMOVED_DEFAULTS_FILE = join(SCHEDULED_TASKS_DIR, '.removed-defaults')
+
+export function readRemovedDefaultTasks(): Set<string> {
+  try {
+    return new Set(
+      readFileSync(REMOVED_DEFAULTS_FILE, 'utf-8')
+        .split('\n').map(l => l.trim()).filter(l => l.length > 0),
+    )
+  } catch { return new Set<string>() }
+}
+
+export function markDefaultTaskRemoved(taskName: string): void {
+  const names = readRemovedDefaultTasks()
+  if (names.has(taskName)) return
+  names.add(taskName)
+  mkdirSync(SCHEDULED_TASKS_DIR, { recursive: true })
+  atomicWriteFileSync(REMOVED_DEFAULTS_FILE, [...names].sort().join('\n') + '\n')
+}
+
+export function clearDefaultTaskRemoved(taskName: string): void {
+  const names = readRemovedDefaultTasks()
+  if (!names.delete(taskName)) return
+  const body = [...names].sort().join('\n')
+  atomicWriteFileSync(REMOVED_DEFAULTS_FILE, body.length > 0 ? body + '\n' : '')
+}
+
 export interface ScheduledTask {
   name: string
   description: string
@@ -179,6 +214,9 @@ export function writeScheduledTask(
 ): void {
   const dir = join(SCHEDULED_TASKS_DIR, taskName)
   mkdirSync(dir, { recursive: true })
+  // (Re)creating a task with this name is a deliberate act -- lift any tombstone
+  // so a later restart's seeding treats it as present, not as removed (#796).
+  clearDefaultTaskRemoved(taskName)
 
   const skillPath = join(dir, 'SKILL.md')
   const configPath = join(dir, 'task-config.json')

--- a/update.sh
+++ b/update.sh
@@ -806,10 +806,18 @@ if [ -d "$SEED_SCHED_DIR" ]; then
     # content (SKILL.md + task-config.json). Task RUN-STATE lives in store/ (not
     # in the task dir), so it is preserved across a force-reseed. Tasks the user
     # authored themselves have no seed-scheduled-tasks/ source -> never visited.
+    SCHED_TOMBSTONE="$SCHED_TARGET_DIR/.removed-defaults"
     for tpl in "$SEED_SCHED_DIR"/*/; do
       [ -d "$tpl" ] || continue
       task_name=$(basename "$tpl")
       target="$SCHED_TARGET_DIR/$task_name"
+      # #796: an operator who deleted a shipped default must not have it
+      # re-seeded here. The dashboard records deletions in .removed-defaults;
+      # a UI re-create clears the entry. Honored even under --reseed-fleet
+      # (resurrection is a deliberate UI action, not a content refresh).
+      if [ -f "$SCHED_TOMBSTONE" ] && grep -qxF "$task_name" "$SCHED_TOMBSTONE" 2>/dev/null; then
+        SCHED_SKIP=$((SCHED_SKIP + 1)); continue
+      fi
       forced=0
       if [ -d "$target" ]; then
         if [ "$RESEED_FLEET" = "1" ]; then


### PR DESCRIPTION
Closes #796.

## The bug (measured)
`ensureDefaultScheduledTasks()` runs on every dashboard start (`src/web.ts:593`) and re-seeds any shipped default whose directory is missing. The install/update shell seed loops (`update.sh`, `install-linux.sh`) are skip-if-missing as well. Nothing recorded a deletion, so a default the operator deleted came back on the next restart or update. That is exactly the reporter's repro: delete a scheduled task, refresh the app, it reappears.

## The fix
A tombstone file `~/.claude/scheduled-tasks/.removed-defaults` (newline-separated task names) that all three seed points consult:
- the DELETE route records the removal (`markDefaultTaskRemoved`);
- `ensureDefaultScheduledTasks()` and both shell seed loops skip a tombstoned name;
- creating or updating a task with that name clears the entry (`clearDefaultTaskRemoved` in `writeScheduledTask`), so bringing a default back stays a deliberate UI action.

The tombstone is a plain dotfile in the tasks dir, so `listScheduledTasks` (which filters to directories) never treats it as a task, and the shell seeders read it with `grep -qxF`.

## Verification
- New vitest regression (`scheduled-task-deletion-tombstone.test.ts`): delete a default, re-run the seeder, assert it is not resurrected; re-create clears the tombstone and it then survives re-seed. 4/4 pass.
- Manual round trip against a temp HOME with the compiled `dist`: seed 4 defaults, delete `memoria-heartbeat`, re-seed does not recreate it, re-create lifts the tombstone.
- `bash -n` clean on `update.sh` and `install-linux.sh`.

Base is `develop`. No dependency or schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)