### PR TITLE
fix(search): retry the FTS branch with OR when AND finds nothing (GH #1025)

### DIFF
--- a/src/__tests__/fts-or-fallback.test.ts
+++ b/src/__tests__/fts-or-fallback.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeAll } from 'vitest'
+import { buildFtsMatchExpression, initDatabase, saveAgentMemory, searchAgentMemories, getDb } from '../db.js'
+
+// GH #1025: joining tokens with a space is an implicit AND in FTS5, so every
+// word of a question had to appear in a memory. The reporter measured
+// "meddig tart a felmondasi ido" returning 0 rows while "felmondasi ido"
+// returned the correct memory at rank 1, because no memory contains "meddig".
+describe('buildFtsMatchExpression', () => {
+  it('still ANDs by default, so today working queries keep their precision', () => {
+    expect(buildFtsMatchExpression('felmondasi ido')).toBe('felmondasi* ido*')
+  })
+
+  it('produces an explicit OR expression when asked for the relaxed pass', () => {
+    expect(buildFtsMatchExpression('felmondasi ido', 'OR')).toBe('felmondasi* OR ido*')
+  })
+
+  it('relaxes every token of a naturally phrased question', () => {
+    expect(buildFtsMatchExpression('meddig tart a felmondasi ido', 'OR'))
+      .toBe('meddig* OR tart* OR a* OR felmondasi* OR ido*')
+  })
+
+  it('gives a single token query the same expression either way, so no second pass runs', () => {
+    expect(buildFtsMatchExpression('felmondas', 'OR')).toBe(buildFtsMatchExpression('felmondas'))
+  })
+
+  it('returns an empty expression for a query with no usable tokens', () => {
+    expect(buildFtsMatchExpression('   ')).toBe('')
+    expect(buildFtsMatchExpression('!!! ???', 'OR')).toBe('')
+  })
+
+  it('keeps punctuation splitting identical in both modes', () => {
+    expect(buildFtsMatchExpression('rank-check serper.dev', 'OR'))
+      .toBe('rank* OR check* OR serper* OR dev*')
+  })
+})
+
+describe('searchAgentMemories AND-then-OR fallback (integration, in-memory FTS5)', () => {
+  beforeAll(() => {
+    process.env.NODE_ENV = 'test'
+    initDatabase(':memory:')
+    saveAgentMemory('tester', 'Antal felmondasi ideje harom honap, a szerzodes 12. pontja szerint.', 'warm', 'felmondas, szerzodes')
+    saveAgentMemory('tester', 'A parkolobérlet havi dija 18000 forint.', 'warm', 'parkolas')
+  })
+
+  it('the strict AND pass finds nothing for the naturally phrased question', () => {
+    // The exact shape reported: no memory contains the word "meddig".
+    const strict = buildFtsMatchExpression('meddig tart a felmondasi ido')
+    const rows = getDb().prepare(
+      `SELECT m.id FROM memories m JOIN memories_fts f ON m.id = f.rowid
+       WHERE f.memories_fts MATCH ? AND m.agent_id = ?`
+    ).all(strict, 'tester')
+    expect(rows).toHaveLength(0)
+  })
+
+  it('the search answers the same question, because it retries with OR', () => {
+    const results = searchAgentMemories('tester', 'meddig tart a felmondasi ido', 5)
+    expect(results.length).toBeGreaterThan(0)
+    expect(results[0].content).toContain('felmondasi ideje')
+  })
+
+  it('reports that it had to relax, so a caller can tell a strict hit from a rescued one', () => {
+    const relaxedTrace = { relaxed: false }
+    searchAgentMemories('tester', 'meddig tart a felmondasi ido', 5, relaxedTrace)
+    expect(relaxedTrace.relaxed).toBe(true)
+
+    const strictTrace = { relaxed: false }
+    const strictHits = searchAgentMemories('tester', 'felmondasi ideje', 5, strictTrace)
+    expect(strictHits.length).toBeGreaterThan(0)
+    expect(strictTrace.relaxed).toBe(false)
+  })
+
+  it('does not relax when AND already has an answer, so precision is unchanged', () => {
+    const results = searchAgentMemories('tester', 'parkolobérlet havi dija', 5)
+    expect(results).toHaveLength(1)
+    expect(results[0].content).toContain('parkolobérlet')
+  })
+})

--- a/src/db.ts
+++ b/src/db.ts
@@ -1403,7 +1403,7 @@ export function saveMemory(
 // search terms. We also cap the number and length of tokens to bound query
 // cost (the sanitizer previously allowed an arbitrary-length prefix expansion
 // that could make a single request scan the entire index).
-export function buildFtsMatchExpression(query: string): string {
+export function buildFtsMatchExpression(query: string, join: 'AND' | 'OR' = 'AND'): string {
   const MAX_TOKENS = 20
   const MAX_TOKEN_LEN = 64
   const sanitized = query
@@ -1419,7 +1419,35 @@ export function buildFtsMatchExpression(query: string): string {
     .filter((t) => t.length > 0)
     .slice(0, MAX_TOKENS)
     .map((t) => t.slice(0, MAX_TOKEN_LEN) + '*')
-  return tokens.join(' ')
+  // A space between FTS5 terms is an implicit AND, so the default keeps the
+  // strict behaviour. 'OR' is the relaxed pass used by ftsWithOrFallback.
+  return join === 'OR' ? tokens.join(' OR ') : tokens.join(' ')
+}
+
+/**
+ * Run an FTS query strictly first, and only if that finds nothing, run it again
+ * with the tokens ORed together.
+ *
+ * Why a fallback and not a plain OR: joining with a space makes every word of
+ * the question mandatory, so a naturally phrased question returns zero rows
+ * while its keywords return the right memory at rank 1 (GH #1025 measured
+ * "meddig tart a felmondasi ido" -> 0 results, "felmondasi ido" -> the correct
+ * memory, first place; the store contained the answer, and the word "meddig"
+ * simply appears in no memory). Switching to OR outright would relax every
+ * query that works today, including the ones AND already answers well. This
+ * keeps AND's precision where AND has an answer and only relaxes where the
+ * alternative is nothing at all, which is what the caller was getting.
+ *
+ * A single-token query has nothing to relax, so it runs once.
+ */
+function ftsWithOrFallback<T>(query: string, run: (terms: string) => T[]): { rows: T[]; relaxed: boolean } {
+  const strict = buildFtsMatchExpression(query)
+  if (!strict) return { rows: [], relaxed: false }
+  const rows = run(strict)
+  if (rows.length > 0) return { rows, relaxed: false }
+  const relaxedTerms = buildFtsMatchExpression(query, 'OR')
+  if (relaxedTerms === strict) return { rows, relaxed: false }
+  return { rows: run(relaxedTerms), relaxed: true }
 }
 
 // -- Recency-weighted retrieval (Roitman 17.4.2) --
@@ -1476,19 +1504,19 @@ function withoutRank<T extends { rank: number }>(rows: T[]): Omit<T, 'rank'>[] {
 }
 
 export function searchMemories(query: string, chatId: string, limit = 3): Memory[] {
-  const terms = buildFtsMatchExpression(query)
-  if (!terms) return []
   try {
-    const candidates = db
-      .prepare(
-        `SELECT m.*, f.rank AS rank FROM memories m
-         JOIN memories_fts f ON m.id = f.rowid
-         WHERE f.content MATCH ? AND m.chat_id = ?
-         ORDER BY rank
-         LIMIT ?`
-      )
-      .all(terms, chatId, limit * RECENCY_OVERSAMPLE) as (Memory & { rank: number })[]
-    return withoutRank(reRankByRecency(candidates, limit)) as Memory[]
+    const { rows } = ftsWithOrFallback(query, (terms) =>
+      db
+        .prepare(
+          `SELECT m.*, f.rank AS rank FROM memories m
+           JOIN memories_fts f ON m.id = f.rowid
+           WHERE f.content MATCH ? AND m.chat_id = ?
+           ORDER BY rank
+           LIMIT ?`
+        )
+        .all(terms, chatId, limit * RECENCY_OVERSAMPLE) as (Memory & { rank: number })[]
+    )
+    return withoutRank(reRankByRecency(rows, limit)) as Memory[]
   } catch {
     return []
   }
@@ -1632,17 +1660,18 @@ export function getAgentMemories(agentId: string, limit: number = 20, category?:
   return result
 }
 
-export function searchAgentMemories(agentId: string, query: string, limit: number = 10): Memory[] {
-  const terms = buildFtsMatchExpression(query)
-  if (!terms) return []
+export function searchAgentMemories(agentId: string, query: string, limit: number = 10, trace?: { relaxed: boolean }): Memory[] {
   try {
-    const candidates = db.prepare(
-      `SELECT m.*, f.rank AS rank FROM memories m
-       JOIN memories_fts f ON m.id = f.rowid
-       WHERE f.memories_fts MATCH ? AND (m.agent_id = ? OR m.category = 'shared')
-       ORDER BY rank LIMIT ?`
-    ).all(terms, agentId, limit * RECENCY_OVERSAMPLE) as (Memory & { rank: number })[]
-    return withoutRank(reRankByRecency(candidates, limit)) as Memory[]
+    const { rows, relaxed } = ftsWithOrFallback(query, (terms) =>
+      db.prepare(
+        `SELECT m.*, f.rank AS rank FROM memories m
+         JOIN memories_fts f ON m.id = f.rowid
+         WHERE f.memories_fts MATCH ? AND (m.agent_id = ? OR m.category = 'shared')
+         ORDER BY rank LIMIT ?`
+      ).all(terms, agentId, limit * RECENCY_OVERSAMPLE) as (Memory & { rank: number })[]
+    )
+    if (trace) trace.relaxed = relaxed
+    return withoutRank(reRankByRecency(rows, limit)) as Memory[]
   } catch {
     return db.prepare(
       "SELECT * FROM memories WHERE (agent_id = ? OR category = 'shared') AND (content LIKE ? OR keywords LIKE ?) ORDER BY accessed_at DESC LIMIT ?"
@@ -1756,10 +1785,9 @@ export function recallByDateRange(from: string, to: string, agentId?: string): R
 }
 
 export function recallSearch(query: string, agentId?: string, limit = 50): RecallResult {
-  const terms = buildFtsMatchExpression(query)
   let memories: Memory[] = []
   const escaped = escapeLike(query)
-  if (terms) {
+  if (buildFtsMatchExpression(query)) {
     try {
       // Was ORDER BY created_at DESC (pure recency, relevance ignored); now the
       // same λ-blend as the other search paths, so a strongly matching older
@@ -1767,10 +1795,12 @@ export function recallSearch(query: string, agentId?: string, limit = 50): Recal
       const sql = agentId
         ? `SELECT m.*, f.rank AS rank FROM memories m JOIN memories_fts f ON m.id = f.rowid WHERE f.memories_fts MATCH ? AND (m.agent_id = ? OR m.category = 'shared') ORDER BY rank LIMIT ?`
         : `SELECT m.*, f.rank AS rank FROM memories m JOIN memories_fts f ON m.id = f.rowid WHERE f.memories_fts MATCH ? ORDER BY rank LIMIT ?`
-      const candidates = agentId
-        ? db.prepare(sql).all(terms, agentId, limit * RECENCY_OVERSAMPLE) as (Memory & { rank: number })[]
-        : db.prepare(sql).all(terms, limit * RECENCY_OVERSAMPLE) as (Memory & { rank: number })[]
-      memories = withoutRank(reRankByRecency(candidates, limit)) as Memory[]
+      const { rows } = ftsWithOrFallback(query, (terms) =>
+        agentId
+          ? db.prepare(sql).all(terms, agentId, limit * RECENCY_OVERSAMPLE) as (Memory & { rank: number })[]
+          : db.prepare(sql).all(terms, limit * RECENCY_OVERSAMPLE) as (Memory & { rank: number })[]
+      )
+      memories = withoutRank(reRankByRecency(rows, limit)) as Memory[]
     } catch {
       const sql = agentId
         ? "SELECT * FROM memories WHERE (agent_id = ? OR category = 'shared') AND (content LIKE ? ESCAPE '\\' OR keywords LIKE ? ESCAPE '\\') ORDER BY created_at DESC LIMIT ?"
@@ -3236,15 +3266,50 @@ function vectorSearch(agentId: string, queryEmbedding: number[], limit: number =
   return scored.slice(0, limit).map(s => s.memory)
 }
 
-export async function hybridSearch(agentId: string, query: string, limit: number = 10): Promise<Memory[]> {
+/**
+ * What a hybrid search actually did. GH #1025: when the FTS branch returns
+ * nothing, RRF does not return nothing -- the vector branch fills the whole
+ * result list on its own, and the caller gets confident-looking rows with no
+ * lexical support and no sign that half the search failed. The trace makes that
+ * case observable instead of leaving the caller to infer it.
+ */
+export interface HybridSearchTrace {
+  ftsHits: number
+  vectorHits: number
+  /** The FTS branch found nothing with AND and was retried with OR. */
+  ftsRelaxed: boolean
+  /** Every returned row came from the vector branch alone. */
+  vectorOnly: boolean
+}
+
+export async function hybridSearch(
+  agentId: string,
+  query: string,
+  limit: number = 10,
+  trace?: HybridSearchTrace,
+): Promise<Memory[]> {
   const k = 60 // RRF constant
 
   // FTS5 results
-  const ftsResults = searchAgentMemories(agentId, query, limit * 2)
+  const ftsTrace = { relaxed: false }
+  const ftsResults = searchAgentMemories(agentId, query, limit * 2, ftsTrace)
 
   // Vector results
   const queryEmbedding = await generateEmbedding(query)
   const vecResults = queryEmbedding ? vectorSearch(agentId, queryEmbedding, limit * 2) : []
+
+  if (trace) {
+    trace.ftsHits = ftsResults.length
+    trace.vectorHits = vecResults.length
+    trace.ftsRelaxed = ftsTrace.relaxed
+    trace.vectorOnly = ftsResults.length === 0 && vecResults.length > 0
+  }
+  if (ftsResults.length === 0 && vecResults.length > 0) {
+    logger.warn(
+      { agentId, query, vectorHits: vecResults.length },
+      'hybrid search: the keyword branch found nothing, the answer comes from the vector branch alone',
+    )
+  }
 
   // Reciprocal Rank Fusion
   const scores: Map<number, number> = new Map()

--- a/src/web/routes/memories.ts
+++ b/src/web/routes/memories.ts
@@ -8,6 +8,7 @@ import { MAIN_AGENT_ID, ALLOWED_CHAT_ID, OLLAMA_URL, APP_TZ } from '../../config
 import { logger } from '../../logger.js'
 import { readBody, json, jsonMaybeGzip } from '../http-helpers.js'
 import { detectHomoglyphs, formatHomoglyphWarning } from '../../homoglyph.js'
+import type { HybridSearchTrace } from '../../db.js'
 import type { RouteContext } from './types.js'
 
 // Canonical memory categories. Kept in sync with the DB CHECK constraint in
@@ -84,8 +85,12 @@ export async function tryHandleMemories(ctx: RouteContext): Promise<boolean> {
     const mode = url.searchParams.get('mode') || 'fts'
 
     let results: Memory[]
+    // GH #1025: a hybrid answer built entirely by the vector branch looks the
+    // same as one with lexical support. The trace rides the response so the
+    // caller can tell them apart.
+    const hybridTrace: HybridSearchTrace = { ftsHits: 0, vectorHits: 0, ftsRelaxed: false, vectorOnly: false }
     if (q && mode === 'hybrid') {
-      results = await hybridSearch(agentId || MAIN_AGENT_ID, q, limit)
+      results = await hybridSearch(agentId || MAIN_AGENT_ID, q, limit, hybridTrace)
     } else if (q && agentId) {
       results = searchAgentMemories(agentId, q, limit)
       if (results.length === 0) {
@@ -124,6 +129,15 @@ export async function tryHandleMemories(ctx: RouteContext): Promise<boolean> {
       created_label: new Date(m.created_at * 1000).toLocaleString('hu-HU', { timeZone: APP_TZ }),
       accessed_label: new Date(m.accessed_at * 1000).toLocaleString('hu-HU', { timeZone: APP_TZ }),
     }))
+    // The body of this endpoint is a bare array and several callers index into
+    // it, so the trace rides a header rather than changing the shape.
+    if (q && mode === 'hybrid') {
+      res.setHeader(
+        'X-Memory-Search',
+        `fts=${hybridTrace.ftsHits}; vector=${hybridTrace.vectorHits};` +
+          ` relaxed=${hybridTrace.ftsRelaxed}; vector-only=${hybridTrace.vectorOnly}`,
+      )
+    }
     jsonMaybeGzip(req, res, formatted)
     return true
   }


### PR DESCRIPTION
Fixes #1025 (items 1 and the visibility half; items 2 and 3 deliberately left out, see below).

## Measured first

The bug is live on `develop` at 8f96248d, at `src/db.ts` as reported: `tokens.join(' ')` is an implicit AND in FTS5.

The integration test in this PR reproduces the reported shape end to end, and its first assertion is the negative control: with the strict expression, the naturally phrased question matches **zero** rows against a store that holds the answer. The second assertion shows the same question answered after the retry.

## What changed

- `buildFtsMatchExpression(query, join)` can build the relaxed expression. **The default is unchanged**, so every query that works today keeps AND's precision.
- `ftsWithOrFallback()` runs the strict pass first and retries with OR only when the strict pass returns nothing. A plain switch to OR would relax every query including the ones AND answers well; this relaxes only where the alternative is an empty result. A single-token query has nothing to relax and runs once.
- All three FTS call sites go through it: `searchMemories`, `searchAgentMemories`, `recallSearch`.
- `hybridSearch` takes an optional trace (fts hits, vector hits, whether it relaxed, whether the answer came from the vector branch alone) and logs a warning in the vector-only case. That is the second half of the report: an empty FTS branch does not produce an empty answer, it produces an unmarked one. `GET /api/memories` returns a bare array that callers index into, so the trace rides an `X-Memory-Search` header instead of changing the response shape.

## What is not in this PR, and why

The reporter's items 2 (a minimum-similarity floor on `vectorSearch`) and 3 (weighting the RRF branches) are tuning decisions, not defects, and their own measurement is the reason to leave them: similarity spans 0.431 to 0.626 across all 948 embedded rows with the correct answer at rank 65, so there is no separation to threshold on. Picking a number without a corpus to calibrate against would be guesswork dressed as a fix. Raised separately for a product decision.

## Verification

- `npx vitest run` in a clean worktree: 392 files, 5051 passed, 1 skipped, 0 failed.
- `npx tsc --noEmit`: clean.
- New suite `src/__tests__/fts-or-fallback.test.ts`, 10 tests: expression building in both modes, the single-token no-op, and four integration tests on an in-memory FTS5 database including the negative control and a check that a query AND already answers is not relaxed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
