### PR TITLE
fix(scaffold): name the token by its absolute path in the prose too (GH #944)

### DIFF
--- a/src/__tests__/agent-scaffold-dashboard-origin.test.ts
+++ b/src/__tests__/agent-scaffold-dashboard-origin.test.ts
@@ -134,6 +134,26 @@ describe('generateClaudeMd prompt: no hardcoded localhost:3420', () => {
     expect(fnBody).toContain('${dashboardOrigin}/api/daily-log')
   })
 
+  // GH #944: the curl examples always used the absolute ${tokenPath}, but the
+  // prose line above them named the token by its project-relative path. Agents
+  // copy prose as readily as code, and a sub-agent's working directory is
+  // agents/<name>/, where store/.dashboard-token does not exist. `cat` on a
+  // missing file yields an empty string, so curl sends "Authorization: Bearer "
+  // and the call 401s with nothing logged on the agent side. Two agents hit it
+  // independently on 2026-08-09.
+  it('never names the token by a project-relative path in the prompt body', () => {
+    expect(fnBody).not.toContain('store/.dashboard-token')
+  })
+
+  it('names the token by the absolute tokenPath in the prose, not only in the curl examples', () => {
+    expect(fnBody).toContain('a token a ${tokenPath} fájlban')
+  })
+
+  it('states the working-directory rule that makes the absolute path necessary', () => {
+    expect(fnBody).toContain('A munkakönyvtárad NEM a projekt gyökere')
+    expect(fnBody).toContain('MINDIG abszolút úttal hivatkozz')
+  })
+
   it('references dashboardOrigin in the schedules API curl example', () => {
     expect(fnBody).toContain('${dashboardOrigin}/api/schedules')
   })

--- a/src/web/agent-scaffold.ts
+++ b/src/web/agent-scaffold.ts
@@ -1698,7 +1698,8 @@ A memoria 3 retegbol all (hot/warm/cold) + napi naplo.
 
 ### NINCS MENTAL NOTE! Ha meg kell jegyezni -> AZONNAL mentsd:
 
-Minden /api/* végpont Bearer tokenes: a token a store/.dashboard-token fájlban.
+Minden /api/* végpont Bearer tokenes: a token a ${tokenPath} fájlban.
+A munkakönyvtárad NEM a projekt gyökere, hanem ${join(PROJECT_ROOT, 'agents')}/AGENT_NAME, ezért a projekt fájljaira (token, scripts/) MINDIG abszolút úttal hivatkozz. Relatív úttal a fájl nem létezik: a cat üres sztringet ad, a curl üres Bearert küld, és a hívás némán 401-gyel elhal.
 
 Memória mentés:
 curl -s -X POST ${dashboardOrigin}/api/memories -H "Content-Type: application/json" -H "Authorization: Bearer $(cat ${tokenPath})" -d '{"agent_id":"AGENT_NAME","content":"MIT","category":"CATEGORY","keywords":"kulcsszo1, kulcsszo2"}'


### PR DESCRIPTION
Fixes #944.

## Measured first

Live on `develop` at 8f96248d, `src/web/agent-scaffold.ts:1701`:

```
Minden /api/* végpont Bearer tokenes: a token a store/.dashboard-token fájlban.
```

The curl examples immediately below it already use the absolute `${tokenPath}`, and `src/web/agent-scaffold.ts:42` carries a comment about the 2026-07-25 incident where relative paths silently killed sub-agent memory saves. Only the prose line was missed, which is the part an agent is most likely to copy.

## What changed

The prose names `${tokenPath}`, and states the rule that makes it necessary, since that is the thing the agent does not otherwise know: its working directory is `agents/<name>/`, not the project root, so project files need absolute paths, and the failure mode when they do not have one is a silent 401 rather than an error.

## Regression test

Three assertions in `src/__tests__/agent-scaffold-dashboard-origin.test.ts`, the file that already guards this prompt body against a hardcoded `localhost:3420`:

- the prompt body never contains `store/.dashboard-token`
- the prose names the token by `${tokenPath}`
- the working-directory rule is present

Verified both ways: **3 failed** on the unfixed source, **31 passed** on the fixed one.

## Verification

- `npx vitest run` in a clean worktree: 391 files, 5044 passed, 1 skipped, 0 failed.
- `npx tsc --noEmit`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
