### PR TITLE
fix(update): rollback message names the running Node version (#950 follow-up)

### DIFF
--- a/src/__tests__/update-native-module-loadcheck.test.ts
+++ b/src/__tests__/update-native-module-loadcheck.test.ts
@@ -44,4 +44,18 @@ describe('update.sh native-module handling (#950)', () => {
     // EBADENGINE (#735) and hit the ABI trap (#950).
     expect(PKG.engines.node).not.toContain('<24')
   })
+
+  it('keeps the lower bound at Node 22 (better-sqlite3 13.x requires >=22)', () => {
+    expect(PKG.engines.node).toMatch(/>=\s*22/)
+  })
+
+  it('the rollback path names the running Node version so a Node 20 host learns why', () => {
+    // Anchor on the restart gate (not the earlier prebuild rebuild that shares
+    // the native_module_loads guard).
+    const gate = UPDATE.indexOf('verify the native module actually loads before we restart')
+    expect(gate).toBeGreaterThan(-1)
+    const tail = UPDATE.slice(gate, gate + 1400)
+    expect(tail).toContain('node -v')
+    expect(tail).toContain('Node 22')
+  })
 })

--- a/update.sh
+++ b/update.sh
@@ -738,6 +738,10 @@ if [ "${SKIP_BUILD:-0}" != "1" ]; then
   # that cannot open its database.
   if ! native_module_loads; then
     echo -e "${RED}HIBA:${NC} a better-sqlite3 modul nem toltheto be a frissites utan. Visszaallitas (${OLD_VERSION})..."
+    # #950 follow-up: name the Node version and the requirement, so a host still
+    # on Node 20 learns WHY every update rolls back (better-sqlite3 13.x needs
+    # Node >=22) instead of only seeing "the module cannot load".
+    echo -e "  ${DIM}Futo Node: $(node -v 2>/dev/null || echo '?'). A better-sqlite3 13.x Node 22 vagy ujabbat igenyel; ha ez alatt futsz, frissitsd a Node-ot es futtasd ujra a frissitest.${NC}"
     if [ -n "$OLD_VERSION_FULL" ]; then
       git reset --hard "$OLD_VERSION_FULL" >/dev/null 2>&1 || true
       npm ci --silent --include=dev 2>/dev/null || true
@@ -746,7 +750,7 @@ if [ "${SKIP_BUILD:-0}" != "1" ]; then
       [ -d "$INSTALL_DIR/dist" ] && echo "$OLD_VERSION_FULL" > "$BUILT_COMMIT_FILE"
     fi
     RESULT_STATUS="rolled-back"
-    RESULT_MSG="A frissites utan a natv adatbazis-modul nem toltodott be; a rendszer visszaallt a korabbi mukodo verziora (${OLD_VERSION}). A frissites nem ment ki."
+    RESULT_MSG="A frissites utan a natv adatbazis-modul nem toltodott be (futo Node: $(node -v 2>/dev/null || echo ?); a better-sqlite3 13.x Node 22 vagy ujabbat igenyel). A rendszer visszaallt a korabbi mukodo verziora (${OLD_VERSION}). A frissites nem ment ki."
     restore_stash_before_exit
     exit 6
   fi


### PR DESCRIPTION
Follow-up to #1251 (merged), requested in review.

#1251 raised `engines.node` to `>=22` because better-sqlite3 13.x requires it. A host still on Node 20 now hits the load-check rollback on every update, but the message only said the module cannot load, without telling the operator a Node upgrade is the fix. They would see the same failure on every update and not know why.

This adds the running Node version and the `>=22` requirement to both the console line and the stored result message on the load-check rollback path, and extends the regression test to pin the lower bound and assert the message.

`bash -n` clean; the `update-native-module-loadcheck` suite is 6/6.

Base is `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)