### PR TITLE
fix(channels): install-scope the main agent's channel state so other sessions cannot hijack the bot (#915)

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -112,12 +112,21 @@ if [[ -d "${HOME}/.claude/projects" ]]; then
   ( cd "${HOME}" && find .claude/projects -maxdepth 2 -type d -name memory -print ) >> "${HOMELIST}"
 fi
 # MAIN orchestrator channel tokens + pairing state, per provider. bot.pid and
-# inbox/ are runtime/transient and intentionally excluded.
+# inbox/ are runtime/transient and intentionally excluded. Since #915 the
+# main state dir is install-scoped (<repo>/.claude/channels/<provider>); the
+# HOME base only still holds it on an unmigrated install -- take both, each
+# from its own list so restore puts them back where they came from.
 if [[ -d "${HOME}/.claude/channels" ]]; then
   ( cd "${HOME}" && find .claude/channels -maxdepth 2 \
       \( -name '.env' -o -name 'access.json' -o -name 'invites.json' \) \
       -print ) >> "${HOMELIST}"
   ( cd "${HOME}" && find .claude/channels -maxdepth 2 -type d -name 'approved' -print ) >> "${HOMELIST}"
+fi
+if [[ -d "${REPO_ROOT}/.claude/channels" ]]; then
+  ( cd "${REPO_ROOT}" && find .claude/channels -maxdepth 2 \
+      \( -name '.env' -o -name 'access.json' -o -name 'invites.json' \) \
+      -print ) >> "${REPOLIST}"
+  ( cd "${REPO_ROOT}" && find .claude/channels -maxdepth 2 -type d -name 'approved' -print ) >> "${REPOLIST}"
 fi
 # launchd jobs for this fleet. The job labels are com.<MAIN_AGENT_ID>.<service>
 # (see src/web/main-agent.ts), so resolve MAIN_AGENT_ID the way the app does

--- a/scripts/channel-watchdog.sh
+++ b/scripts/channel-watchdog.sh
@@ -202,7 +202,22 @@ fi
 
 # Full PATH with .bun/bin -- without it the respawned bun telegram bridge does
 # not come up and the session is channel-less.
-RESPAWN_CMD="export PATH=\"/opt/homebrew/bin:\$HOME/.bun/bin:/home/linuxbrew/.linuxbrew/bin:\$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin\" && export CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false && ${CFG_ENV}$CLAUDE --dangerously-skip-permissions ${MODEL_FLAG}--channels plugin:${CHANNEL_PROVIDER}@claude-plugins-official${EXTRA_CHANNELS}"
+#
+# #915: the respawned session must carry the same install-scoped *_STATE_DIR
+# channels.sh exports at spawn, or the plugin falls back to the shared
+# ~/.claude/channels/<provider>/ and the hijack window reopens on the first
+# watchdog respawn. Mirror channels.sh's STATE_ENV_VAR mapping.
+case "$CHANNEL_PROVIDER" in
+  slack)    STATE_ENV_VAR="SLACK_STATE_DIR" ;;
+  whatsapp) STATE_ENV_VAR="WHATSAPP_STATE_DIR" ;;
+  teams)    STATE_ENV_VAR="TEAMS_STATE_DIR" ;;
+  discord)  STATE_ENV_VAR="DISCORD_STATE_DIR" ;;
+  *)        STATE_ENV_VAR="TELEGRAM_STATE_DIR" ;;
+esac
+MAIN_CHAN_DIR="$INSTALL_DIR/.claude/channels/$CHANNEL_PROVIDER"
+STATE_DIR_ENV=""
+[ -f "$MAIN_CHAN_DIR/.env" ] && STATE_DIR_ENV="export ${STATE_ENV_VAR}='${MAIN_CHAN_DIR}' && "
+RESPAWN_CMD="export PATH=\"/opt/homebrew/bin:\$HOME/.bun/bin:/home/linuxbrew/.linuxbrew/bin:\$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin\" && export CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false && ${STATE_DIR_ENV}${CFG_ENV}$CLAUDE --dangerously-skip-permissions ${MODEL_FLAG}--channels plugin:${CHANNEL_PROVIDER}@claude-plugins-official${EXTRA_CHANNELS}"
 
 reason="keepalive stale ${age}s"
 [ "$STALE" != true ] && reason=""

--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -366,8 +366,10 @@ unset _p
 
 # Extra safety net for existing installs whose tmux server already has a
 # polluted global env -- scrub channel tokens so new child sessions don't
-# inherit them. The main agent's plugin will still load its token from
-# ~/.claude/channels/<provider>/.env via the plugin's own bootstrap.
+# inherit them. The main agent's plugin will still load its token from the
+# install-scoped state dir (see the #915 migration below) via the exported
+# *_STATE_DIR, falling back to ~/.claude/channels/<provider>/.env only on an
+# unmigrated install.
 command -v tmux >/dev/null 2>&1 && tmux set-environment -g -u TELEGRAM_BOT_TOKEN 2>/dev/null || true
 command -v tmux >/dev/null 2>&1 && tmux set-environment -g -u SLACK_BOT_TOKEN 2>/dev/null || true
 command -v tmux >/dev/null 2>&1 && tmux set-environment -g -u DISCORD_BOT_TOKEN 2>/dev/null || true
@@ -712,6 +714,51 @@ if [ -n "$ORPHAN_PIDS2" ]; then
   /bin/kill -KILL $ORPHAN_PIDS2 2>/dev/null || true
 fi
 
+# #915: install-scoped main-agent channel state. The shared
+# ~/.claude/channels/<provider>/ default meant any OTHER Claude Code session on
+# this host (CLI, desktop app) loaded the same bot token, SIGTERMed the pid in
+# bot.pid and took the bot over -- silently: no reply, empty transcript, no log
+# line anywhere. Sub-agents were never affected because their launcher exports
+# *_STATE_DIR; the main agent gets the same treatment now.
+#
+# One-time migration: MOVE (never copy) the legacy state into $MAIN_CHAN_DIR.
+# A token left behind in the shared path keeps the hijack window open, so the
+# legacy dir must end up with no live .env. The whole directory moves --
+# access.json (pairing allowlist), inbox/, progress/, invites.json -- because
+# a fresh-born state dir would silently drop the allowlist and delivery state.
+# Runs AFTER the session kill + orphan reaps above, so nothing is polling out
+# of the legacy dir while it moves. Idempotent: a migrated install skips both
+# branches.
+LEGACY_CHAN_DIR="$HOME/.claude/channels/$CHANNEL_PROVIDER"
+if [ "$LEGACY_CHAN_DIR" != "$MAIN_CHAN_DIR" ] && [ -f "$LEGACY_CHAN_DIR/.env" ]; then
+  if [ ! -f "$MAIN_CHAN_DIR/.env" ]; then
+    mkdir -p "$(dirname "$MAIN_CHAN_DIR")"
+    if [ ! -e "$MAIN_CHAN_DIR" ] && mv "$LEGACY_CHAN_DIR" "$MAIN_CHAN_DIR" 2>/dev/null; then
+      echo "[channels] #915: migrated $LEGACY_CHAN_DIR -> $MAIN_CHAN_DIR"
+    else
+      # Target already exists (partial earlier run): move entry by entry.
+      mkdir -p "$MAIN_CHAN_DIR"
+      for _entry in "$LEGACY_CHAN_DIR"/.[!.]* "$LEGACY_CHAN_DIR"/*; do
+        [ -e "$_entry" ] || continue
+        mv "$_entry" "$MAIN_CHAN_DIR/" 2>/dev/null || true
+      done
+      echo "[channels] #915: merged $LEGACY_CHAN_DIR into $MAIN_CHAN_DIR"
+    fi
+  else
+    # Both hold a .env (e.g. a fresh onboarding already wrote install-scoped):
+    # the shared-path token must not stay live -- park it next to the new one,
+    # keeping the file instead of deleting history.
+    mv "$LEGACY_CHAN_DIR/.env" "$MAIN_CHAN_DIR/.env.legacy-$(date +%s)" 2>/dev/null || true
+    echo "[channels] #915: parked stale legacy .env from $LEGACY_CHAN_DIR"
+  fi
+fi
+# Export for this script AND build the launch-command prefix for the spawned
+# session: the plugin honours *_STATE_DIR, and with it exported the main
+# session's poller does carry it (measured in #915) -- the old comment claiming
+# otherwise described the unexported state.
+export "$STATE_ENV_VAR"="$MAIN_CHAN_DIR"
+STATE_DIR_ENV="export ${STATE_ENV_VAR}='${MAIN_CHAN_DIR}' && "
+
 # P1 FIX: put the Claude auth token into the tmux SERVER global env BEFORE
 # new-session. A new session inherits the tmux SERVER's global environment, not
 # this shell's. The tmux server is SHARED across every agent, so if a sub-agent
@@ -769,7 +816,7 @@ $TMUX set-environment -g DISABLE_AUTOUPDATER 1 2>/dev/null || true
 # otherwise new-session below fails with "duplicate session".
 $TMUX kill-session -t "$SESSION" 2>/dev/null || true
 $TMUX new-session -d -s "$SESSION" -c "$INSTALL_DIR" \
-  "${MCP_BATCH_ENV}${CFG_ENV}$CLAUDE --dangerously-skip-permissions ${MODEL_FLAG}--channels plugin:${PLUGIN_ID}${EXTRA_CHANNELS}"
+  "${STATE_DIR_ENV}${MCP_BATCH_ENV}${CFG_ENV}$CLAUDE --dangerously-skip-permissions ${MODEL_FLAG}--channels plugin:${PLUGIN_ID}${EXTRA_CHANNELS}"
 
 # Session startup guard: a Claude Code first-run dialogusait auto-accept-eljuk
 # kulonben a headless session orokre parkolna a prompton es a Telegram plugin
@@ -843,7 +890,7 @@ for i in 1 2 3 4 5 6 7 8 9 10 11 12; do
         # entry); see the PR description / card 7EB18437.
         [ -e "$INSTALL_DIR/CLAUDE.md" ] && ln -sf "$INSTALL_DIR/CLAUDE.md" "$_CHANNELS_STARTDIR/CLAUDE.md" 2>/dev/null || true
         $TMUX new-session -d -s "$SESSION" -c "$_CHANNELS_STARTDIR" \
-          "${MCP_BATCH_ENV}${CFG_ENV}$CLAUDE --dangerously-skip-permissions ${MODEL_FLAG}--channels plugin:${PLUGIN_ID}${EXTRA_CHANNELS}"
+          "${STATE_DIR_ENV}${MCP_BATCH_ENV}${CFG_ENV}$CLAUDE --dangerously-skip-permissions ${MODEL_FLAG}--channels plugin:${PLUGIN_ID}${EXTRA_CHANNELS}"
         unset _CHANNELS_STARTDIR
       fi
       continue
@@ -1085,10 +1132,11 @@ START_TS=$(date +%s)
 #
 # Thresholds are deliberately COARSER than the dashboard monitor's (~60-120s)
 # so in normal operation the dashboard acts FIRST and this only fires when the
-# dashboard couldn't -- avoids double-restart races. bot.pid lives at the
-# main-agent channelStateDir(): ~/.claude/channels/<provider>/bot.pid (HOME-,
-# not INSTALL_DIR-relative; see src/channel-provider.ts channelStateDir()).
-MAIN_BOT_PID_FILE="$HOME/.claude/channels/$CHANNEL_PROVIDER/bot.pid"
+# dashboard couldn't -- avoids double-restart races. bot.pid lives in the
+# main-agent state dir -- install-scoped since the #915 migration above, which
+# has already run by the time this executes (see src/channel-provider.ts
+# channelStateDir() for the matching server-side resolution).
+MAIN_BOT_PID_FILE="$MAIN_CHAN_DIR/bot.pid"
 # Never-started budget: generous so a slow cold-start (WSL first-run, MCP
 # handshake + /mcp unlock retries) is never killed prematurely. The plugin
 # normally writes bot.pid within ~1-2 min; 10 min is a safe ceiling.

--- a/scripts/disk-space-guard.sh
+++ b/scripts/disk-space-guard.sh
@@ -52,7 +52,14 @@ INSTALL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 SCRATCH_DIR="${DISK_GUARD_SCRATCH_DIR:-/tmp}"
 STATE_DIR="${DISK_GUARD_STATE_DIR:-$INSTALL_DIR/store}"
 ALERT_STAMP="$STATE_DIR/.disk-guard-alerted"
-TG_ENV="$HOME/.claude/channels/telegram/.env"
+# #915: main channel state is install-scoped once migrated; the legacy shared
+# path only serves unmigrated installs.
+TG_CHAN_DIR="${TELEGRAM_STATE_DIR:-}"
+if [ -z "$TG_CHAN_DIR" ]; then
+  TG_CHAN_DIR="$INSTALL_DIR/.claude/channels/telegram"
+  [ -f "$TG_CHAN_DIR/.env" ] || TG_CHAN_DIR="$HOME/.claude/channels/telegram"
+fi
+TG_ENV="$TG_CHAN_DIR/.env"
 LOG_TAG="disk-space-guard"
 
 log() { echo "$(date '+%Y-%m-%d %H:%M:%S') [$LOG_TAG] $*" || true; }

--- a/scripts/fleet-memory-gate.sh
+++ b/scripts/fleet-memory-gate.sh
@@ -74,12 +74,19 @@ OBSERVE_FLAG="$STATE_DIR/.fleet-memgate-observe"  # if present -> observe-only
 # file flag (touch/rm store/.fleet-memgate-observe) or MARVEEN_MEM_GATE_OBSERVE=1.
 OBSERVE=0
 if [[ "${MARVEEN_MEM_GATE_OBSERVE:-0}" == "1" || -f "$OBSERVE_FLAG" ]]; then OBSERVE=1; fi
-ENV_FILE="${TELEGRAM_ENV:-$HOME/.claude/channels/telegram/.env}"
+# #915: main channel state is install-scoped once migrated; the legacy shared
+# path only serves unmigrated installs.
+TG_CHAN_DIR="${TELEGRAM_STATE_DIR:-}"
+if [ -z "$TG_CHAN_DIR" ]; then
+  TG_CHAN_DIR="$INSTALL_DIR/.claude/channels/telegram"
+  [ -f "$TG_CHAN_DIR/.env" ] || TG_CHAN_DIR="$HOME/.claude/channels/telegram"
+fi
+ENV_FILE="${TELEGRAM_ENV:-$TG_CHAN_DIR/.env}"
 # Alert target: the owner's chat id. Resolve from the channel access.json (the
 # first allow-listed sender) so no chat-id is ever hardcoded; override with
 # MARVEEN_ALERT_CHAT_ID. Empty -> the Telegram alert is skipped (log only), never
 # sent to a stranger.
-ACCESS_JSON="${TELEGRAM_ACCESS:-$HOME/.claude/channels/telegram/access.json}"
+ACCESS_JSON="${TELEGRAM_ACCESS:-$TG_CHAN_DIR/access.json}"
 CHAT_ID="${MARVEEN_ALERT_CHAT_ID:-}"
 if [[ -z "$CHAT_ID" && -f "$ACCESS_JSON" ]] && command -v python3 >/dev/null 2>&1; then
   CHAT_ID="$(python3 -c 'import json,sys

--- a/scripts/hooks/claude-usage.py
+++ b/scripts/hooks/claude-usage.py
@@ -73,9 +73,15 @@ MISSING_SCRIPT_REPLY = "Nem sikerult lekerdezni a keret-allapotot: a lekerdezo s
 
 
 def state_dir():
+    # #915: env override, then the install-scoped dir once it holds the .env,
+    # then the legacy shared path (unmigrated installs only).
     d = os.environ.get("TELEGRAM_STATE_DIR")
     if d:
         return d
+    _root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    _inst = os.path.join(_root, ".claude", "channels", "telegram")
+    if os.path.isfile(os.path.join(_inst, ".env")):
+        return _inst
     return os.path.expanduser("~/.claude/channels/telegram")
 
 

--- a/scripts/hooks/telegram-ack.py
+++ b/scripts/hooks/telegram-ack.py
@@ -27,7 +27,16 @@ CHANNEL_RX = re.compile(r'<channel\s+([^>]*)>', re.DOTALL)
 ATTR_RX = re.compile(r'(\w+)="([^"]*)"')
 STATE_FILE = os.path.expanduser("~/.claude/.telegram-ack-state")
 MAX_STATE = 500  # keep the last N acked keys, bounded
-TOKEN_ENV = os.path.expanduser("~/.claude/channels/telegram/.env")
+def _token_env_path():
+    # #915: env override, then install-scoped once migrated, then legacy shared.
+    d = os.environ.get("TELEGRAM_STATE_DIR")
+    if not d:
+        _root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        _inst = os.path.join(_root, ".claude", "channels", "telegram")
+        d = _inst if os.path.isfile(os.path.join(_inst, ".env")) else os.path.expanduser("~/.claude/channels/telegram")
+    return os.path.join(d, ".env")
+
+TOKEN_ENV = _token_env_path()
 TOKEN_RX = re.compile(r'[0-9]+:[A-Za-z0-9_-]+')
 
 

--- a/scripts/hooks/telegram_fallback_send.py
+++ b/scripts/hooks/telegram_fallback_send.py
@@ -44,8 +44,16 @@ def api_base():
 
 
 def state_dir(cli_dir=None):
-    return (cli_dir or os.environ.get("TELEGRAM_STATE_DIR")
-            or os.path.expanduser("~/.claude/channels/telegram"))
+    # #915: cli arg, then env override, then install-scoped once migrated,
+    # then the legacy shared path.
+    d = cli_dir or os.environ.get("TELEGRAM_STATE_DIR")
+    if d:
+        return d
+    _root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    _inst = os.path.join(_root, ".claude", "channels", "telegram")
+    if os.path.isfile(os.path.join(_inst, ".env")):
+        return _inst
+    return os.path.expanduser("~/.claude/channels/telegram")
 
 
 def session_id(cli_sid=None):

--- a/scripts/hooks/telegram_progress.py
+++ b/scripts/hooks/telegram_progress.py
@@ -23,9 +23,15 @@ REACTION = "✍️"                            # ✍️
 
 
 def state_dir():
+    # #915: env override, then the install-scoped dir once it holds the .env,
+    # then the legacy shared path (unmigrated installs only).
     d = os.environ.get("TELEGRAM_STATE_DIR")
     if d:
         return d
+    _root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    _inst = os.path.join(_root, ".claude", "channels", "telegram")
+    if os.path.isfile(os.path.join(_inst, ".env")):
+        return _inst
     return os.path.expanduser("~/.claude/channels/telegram")
 
 

--- a/scripts/hooks/telegram_progress_clear.py
+++ b/scripts/hooks/telegram_progress_clear.py
@@ -38,9 +38,15 @@ INSTRUCTION = (
 
 
 def state_dir():
+    # #915: env override, then the install-scoped dir once it holds the .env,
+    # then the legacy shared path (unmigrated installs only).
     d = os.environ.get("TELEGRAM_STATE_DIR")
     if d:
         return d
+    _root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    _inst = os.path.join(_root, ".claude", "channels", "telegram")
+    if os.path.isfile(os.path.join(_inst, ".env")):
+        return _inst
     return os.path.expanduser("~/.claude/channels/telegram")
 
 

--- a/scripts/hooks/telegram_progress_reply_clear.py
+++ b/scripts/hooks/telegram_progress_reply_clear.py
@@ -19,7 +19,15 @@ import sys, os, json, urllib.request
 
 
 def state_dir():
-    return os.environ.get("TELEGRAM_STATE_DIR") or os.path.expanduser("~/.claude/channels/telegram")
+    # #915: env override, then install-scoped once migrated, then legacy shared.
+    d = os.environ.get("TELEGRAM_STATE_DIR")
+    if d:
+        return d
+    _root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    _inst = os.path.join(_root, ".claude", "channels", "telegram")
+    if os.path.isfile(os.path.join(_inst, ".env")):
+        return _inst
+    return os.path.expanduser("~/.claude/channels/telegram")
 
 
 def token(sd):

--- a/scripts/hooks/telegram_progress_watchdog.py
+++ b/scripts/hooks/telegram_progress_watchdog.py
@@ -51,6 +51,9 @@ import datetime, os, glob, json, time, subprocess, urllib.request
 FLEET_ROOT = os.environ.get("MARVEEN_ROOT") or os.path.expanduser("~/marveen")
 SCAN_GLOBS = [
     os.path.join(FLEET_ROOT, "agents", "*", ".claude", "channels", "telegram", "progress"),
+    # #915: the main agent's state dir is install-scoped once migrated; scan
+    # both bases -- at most one holds live progress markers.
+    os.path.join(FLEET_ROOT, ".claude", "channels", "telegram", "progress"),
     os.path.expanduser("~/.claude/channels/telegram/progress"),
 ]
 DOWN_GRACE_SEC = 120        # agent down + placeholder older than this -> fire

--- a/scripts/host-restart-watchdog.sh
+++ b/scripts/host-restart-watchdog.sh
@@ -22,7 +22,15 @@ set -uo pipefail
 
 STATE_DIR="${MARVEEN_STORE:-$HOME/marveen/store}"
 STATE_FILE="$STATE_DIR/.last-btime"
-ENV_FILE="${TELEGRAM_ENV:-$HOME/.claude/channels/telegram/.env}"
+INSTALL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+# #915: main channel state is install-scoped once migrated; the legacy shared
+# path only serves unmigrated installs.
+TG_CHAN_DIR="${TELEGRAM_STATE_DIR:-}"
+if [ -z "$TG_CHAN_DIR" ]; then
+  TG_CHAN_DIR="$INSTALL_DIR/.claude/channels/telegram"
+  [ -f "$TG_CHAN_DIR/.env" ] || TG_CHAN_DIR="$HOME/.claude/channels/telegram"
+fi
+ENV_FILE="${TELEGRAM_ENV:-$TG_CHAN_DIR/.env}"
 # Alert target chat-id -- MUST come from the install's own config; there is
 # deliberately NO hardcoded fallback (a hardcoded id would make every downstream
 # install send its host-stability alerts to that one private chat).

--- a/scripts/limit-monitor.sh
+++ b/scripts/limit-monitor.sh
@@ -65,7 +65,13 @@ fi
 
 send_alert() {
   local msg="$1" tag="$2" token
-  token="$(grep -oE '[0-9]+:[A-Za-z0-9_-]+' "$HOME/.claude/channels/telegram/.env" 2>/dev/null | head -1)"
+  # #915: install-scoped state dir once migrated, legacy shared otherwise.
+  local chan_dir="${TELEGRAM_STATE_DIR:-}"
+  if [ -z "$chan_dir" ]; then
+    chan_dir="$INSTALL_DIR/.claude/channels/telegram"
+    [ -f "$chan_dir/.env" ] || chan_dir="$HOME/.claude/channels/telegram"
+  fi
+  token="$(grep -oE '[0-9]+:[A-Za-z0-9_-]+' "$chan_dir/.env" 2>/dev/null | head -1)"
   if [ -z "$token" ]; then
     log "ALERT wanted but no bot token found: $tag"
     return 1

--- a/scripts/set-bot-menu.sh
+++ b/scripts/set-bot-menu.sh
@@ -19,8 +19,15 @@ if [ "$CHANNEL_PROVIDER" != "telegram" ]; then
 fi
 
 # Load bot token
-if [ -f "$HOME/.claude/channels/telegram/.env" ]; then
-  BOT_TOKEN=$(grep TELEGRAM_BOT_TOKEN "$HOME/.claude/channels/telegram/.env" | cut -d= -f2)
+# #915: main channel state is install-scoped once migrated; the legacy shared
+# path only serves unmigrated installs.
+TG_CHAN_DIR="${TELEGRAM_STATE_DIR:-}"
+if [ -z "$TG_CHAN_DIR" ]; then
+  TG_CHAN_DIR="$INSTALL_DIR/.claude/channels/telegram"
+  [ -f "$TG_CHAN_DIR/.env" ] || TG_CHAN_DIR="$HOME/.claude/channels/telegram"
+fi
+if [ -f "$TG_CHAN_DIR/.env" ]; then
+  BOT_TOKEN=$(grep TELEGRAM_BOT_TOKEN "$TG_CHAN_DIR/.env" | cut -d= -f2)
 elif [ -f "$INSTALL_DIR/.env" ]; then
   BOT_TOKEN=$(grep TELEGRAM_BOT_TOKEN "$INSTALL_DIR/.env" | cut -d= -f2)
 fi

--- a/scripts/stuck-modal-guard.sh
+++ b/scripts/stuck-modal-guard.sh
@@ -43,7 +43,14 @@ FIRSTSEEN_STAMP="$STORE/.stuck-modal-firstseen"
 RESPAWN_STAMP="$STORE/.channel-last-respawn"           # SHARED with channel-watchdog.sh
 RESPAWN_COUNT_FILE="$STORE/.stuck-modal-respawns"
 BACKOFF_STAMP="$STORE/.stuck-modal-backoff-alerted"
-TG_ENV="$HOME/.claude/channels/telegram/.env"
+# #915: main channel state is install-scoped once migrated; the legacy shared
+# path only serves unmigrated installs.
+TG_CHAN_DIR="${TELEGRAM_STATE_DIR:-}"
+if [ -z "$TG_CHAN_DIR" ]; then
+  TG_CHAN_DIR="$INSTALL_DIR/.claude/channels/telegram"
+  [ -f "$TG_CHAN_DIR/.env" ] || TG_CHAN_DIR="$HOME/.claude/channels/telegram"
+fi
+TG_ENV="$TG_CHAN_DIR/.env"
 LOG_TAG="stuck-modal-guard"
 
 STUCK_SECONDS="${STUCK_MODAL_SECONDS:-120}"   # must stay stuck this long before acting

--- a/scripts/telegram-live-progress.py
+++ b/scripts/telegram-live-progress.py
@@ -145,6 +145,13 @@ def config(state=None):
 
 def channel_dir(agent):
     if agent == MAIN_AGENT:
+        # #915: env override, then install-scoped once migrated, then legacy shared.
+        d = os.environ.get("TELEGRAM_STATE_DIR")
+        if d:
+            return d
+        inst = os.path.join(ROOT, ".claude", "channels", "telegram")
+        if os.path.isfile(os.path.join(inst, ".env")):
+            return inst
         return os.path.expanduser("~/.claude/channels/telegram")
     return os.path.join(ROOT, "agents", agent, ".claude", "channels", "telegram")
 

--- a/scripts/unit-fail-notify.sh
+++ b/scripts/unit-fail-notify.sh
@@ -12,7 +12,15 @@
 set -uo pipefail
 
 UNIT="${1:-unknown.unit}"
-ENV_FILE="${TELEGRAM_ENV:-$HOME/.claude/channels/telegram/.env}"
+INSTALL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+# #915: main channel state is install-scoped once migrated; the legacy shared
+# path only serves unmigrated installs.
+TG_CHAN_DIR="${TELEGRAM_STATE_DIR:-}"
+if [ -z "$TG_CHAN_DIR" ]; then
+  TG_CHAN_DIR="$INSTALL_DIR/.claude/channels/telegram"
+  [ -f "$TG_CHAN_DIR/.env" ] || TG_CHAN_DIR="$HOME/.claude/channels/telegram"
+fi
+ENV_FILE="${TELEGRAM_ENV:-$TG_CHAN_DIR/.env}"
 # Alert target chat-id -- MUST be provided by the install's own config; there is
 # deliberately NO hardcoded fallback (a hardcoded id would make every downstream
 # install send its alerts to that one private chat via its own bot token).

--- a/scripts/verify-channels-health.sh
+++ b/scripts/verify-channels-health.sh
@@ -15,7 +15,14 @@ MAIN_AGENT_ID="${MAIN_AGENT_ID:-marveen}"
 # N2: sanitize — strip any character that is not alphanumeric, underscore, or hyphen.
 MAIN_AGENT_ID="${MAIN_AGENT_ID//[^a-zA-Z0-9_-]/}"
 SESSION="${MAIN_AGENT_ID}-channels"
-BOT_PID_FILE="$HOME/.claude/channels/telegram/bot.pid"
+# #915: main channel state is install-scoped once migrated; the legacy shared
+# path only serves unmigrated installs.
+TG_CHAN_DIR="${TELEGRAM_STATE_DIR:-}"
+if [ -z "$TG_CHAN_DIR" ]; then
+  TG_CHAN_DIR="$INSTALL_DIR/.claude/channels/telegram"
+  [ -f "$TG_CHAN_DIR/.env" ] || TG_CHAN_DIR="$HOME/.claude/channels/telegram"
+fi
+BOT_PID_FILE="$TG_CHAN_DIR/bot.pid"
 
 fail=0
 note() { echo "  $1"; }

--- a/scripts/voice/stt.sh
+++ b/scripts/voice/stt.sh
@@ -11,5 +11,10 @@ if [[ -f "$SCRIPT_DIR/_vtools.py" ]]; then
   DEST="$SCRIPT_DIR"
 fi
 FID="${1:?usage: stt.sh <file_id> [state_dir]}"
-STATE_DIR="${2:-$HOME/.claude/channels/telegram}"
+# #915: arg, then env override, then install-scoped once migrated, then legacy.
+STATE_DIR="${2:-${TELEGRAM_STATE_DIR:-}}"
+if [ -z "$STATE_DIR" ]; then
+  STATE_DIR="$(cd "$(dirname "$0")/../.." && pwd)/.claude/channels/telegram"
+  [ -f "$STATE_DIR/.env" ] || STATE_DIR="$HOME/.claude/channels/telegram"
+fi
 exec "$DEST/venv/bin/python" "$DEST/_vtools.py" transcribe "$FID" "$STATE_DIR"

--- a/scripts/voice/tts.sh
+++ b/scripts/voice/tts.sh
@@ -13,7 +13,12 @@ fi
 VOICE_ARG="${1:?usage: tts.sh <voice> <chat_id> <text...>}"; shift
 CHAT_ID="${1:?missing chat_id}"; shift
 TEXT="$*"
-STATE_DIR="${VOICE_STATE_DIR:-$HOME/.claude/channels/telegram}"
+# #915: env overrides, then install-scoped once migrated, then legacy shared.
+STATE_DIR="${VOICE_STATE_DIR:-${TELEGRAM_STATE_DIR:-}}"
+if [ -z "$STATE_DIR" ]; then
+  STATE_DIR="$(cd "$(dirname "$0")/../.." && pwd)/.claude/channels/telegram"
+  [ -f "$STATE_DIR/.env" ] || STATE_DIR="$HOME/.claude/channels/telegram"
+fi
 case "$VOICE_ARG" in
   imre)  ONNX="$DEST/voices/hu_HU-imre-medium.onnx" ;;
   anna)  ONNX="$DEST/voices/hu_HU-anna-medium.onnx" ;;

--- a/src/__tests__/channel-state-dir-915.test.ts
+++ b/src/__tests__/channel-state-dir-915.test.ts
@@ -1,0 +1,143 @@
+// #915: the main agent's channel state dir resolution. The shared
+// ~/.claude/channels/<provider>/ default let any other Claude Code session on
+// the host read the bot token and take the bot over. The contract under test:
+//
+//   1. an explicit <PROVIDER>_STATE_DIR env override wins unconditionally --
+//      it is what the running plugin itself was launched with;
+//   2. the legacy shared dir is served ONLY while it still holds the .env and
+//      the install-scoped dir does not (an unmigrated install, whose poller is
+//      still running out of the legacy dir);
+//   3. everything else -- fresh install (no .env anywhere) and migrated
+//      install -- resolves install-scoped, so a first onboarding writes the
+//      token there and no shared-path copy is ever born.
+//
+// The ordering is tested through the pure resolver, not the filesystem-backed
+// wrapper, so no test ever creates files under the real home directory.
+import { describe, it, expect } from 'vitest'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { resolveMainChannelStateDir, channelStateDir, channelStateDirEnvVar } from '../channel-provider.js'
+
+function hasEnvIn(dirsWithEnv: Set<string>) {
+  return (dir: string) => dirsWithEnv.has(dir)
+}
+
+describe('resolveMainChannelStateDir (#915 ordering)', () => {
+  const installScoped = '/install/.claude/channels/telegram'
+  const legacy = '/home/user/.claude/channels/telegram'
+
+  it('env override wins over everything, even a live legacy .env', () => {
+    const got = resolveMainChannelStateDir({
+      envOverride: '/custom/state',
+      installScoped,
+      legacy,
+      hasEnvFile: hasEnvIn(new Set([legacy])),
+    })
+    expect(got).toBe('/custom/state')
+  })
+
+  it('unmigrated install (legacy .env only) keeps resolving legacy', () => {
+    const got = resolveMainChannelStateDir({
+      envOverride: undefined,
+      installScoped,
+      legacy,
+      hasEnvFile: hasEnvIn(new Set([legacy])),
+    })
+    expect(got).toBe(legacy)
+  })
+
+  it('migrated install (install-scoped .env) resolves install-scoped', () => {
+    const got = resolveMainChannelStateDir({
+      envOverride: undefined,
+      installScoped,
+      legacy,
+      hasEnvFile: hasEnvIn(new Set([installScoped])),
+    })
+    expect(got).toBe(installScoped)
+  })
+
+  it('both hold a .env: install-scoped wins (the migrated copy is live)', () => {
+    const got = resolveMainChannelStateDir({
+      envOverride: undefined,
+      installScoped,
+      legacy,
+      hasEnvFile: hasEnvIn(new Set([installScoped, legacy])),
+    })
+    expect(got).toBe(installScoped)
+  })
+
+  it('fresh install (no .env anywhere) is born install-scoped, never legacy', () => {
+    const got = resolveMainChannelStateDir({
+      envOverride: undefined,
+      installScoped,
+      legacy,
+      hasEnvFile: hasEnvIn(new Set()),
+    })
+    expect(got).toBe(installScoped)
+  })
+})
+
+describe('channelStateDir wrapper', () => {
+  it('honours the per-provider env override end to end', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'chanstate-'))
+    try {
+      const key = channelStateDirEnvVar('telegram')
+      const prev = process.env[key]
+      process.env[key] = tmp
+      try {
+        expect(channelStateDir('telegram')).toBe(tmp)
+      } finally {
+        if (prev === undefined) delete process.env[key]
+        else process.env[key] = prev
+      }
+    } finally {
+      rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+
+  it('an agentDir keeps its agent-scoped path untouched by the env override', () => {
+    const key = channelStateDirEnvVar('telegram')
+    const prev = process.env[key]
+    process.env[key] = '/should/not/leak'
+    try {
+      expect(channelStateDir('telegram', '/agents/samu')).toBe(join('/agents/samu', '.claude', 'channels', 'telegram'))
+    } finally {
+      if (prev === undefined) delete process.env[key]
+      else process.env[key] = prev
+    }
+  })
+
+  it('maps every provider to its own env var name', () => {
+    expect(channelStateDirEnvVar('telegram')).toBe('TELEGRAM_STATE_DIR')
+    expect(channelStateDirEnvVar('slack')).toBe('SLACK_STATE_DIR')
+    expect(channelStateDirEnvVar('discord')).toBe('DISCORD_STATE_DIR')
+    expect(channelStateDirEnvVar('googlechat')).toBe('GOOGLECHAT_STATE_DIR')
+    expect(channelStateDirEnvVar('teams')).toBe('TEAMS_STATE_DIR')
+  })
+})
+
+describe('the migration ordering the pure resolver implies', () => {
+  it('a real tmp fixture: legacy-only -> legacy; after a move -> install-scoped', () => {
+    // Sanity-check the hasEnvFile shape against a real filesystem, still in
+    // tmp: the same predicate channelStateDir wires in.
+    const base = mkdtempSync(join(tmpdir(), 'chanstate-fs-'))
+    try {
+      const inst = join(base, 'install', '.claude', 'channels', 'telegram')
+      const legacy = join(base, 'home', '.claude', 'channels', 'telegram')
+      mkdirSync(legacy, { recursive: true })
+      writeFileSync(join(legacy, '.env'), 'TELEGRAM_BOT_TOKEN=x\n')
+      const hasEnvFile = (dir: string) => existsSync(join(dir, '.env'))
+      const opts = { envOverride: undefined, installScoped: inst, legacy, hasEnvFile }
+      expect(resolveMainChannelStateDir(opts)).toBe(legacy)
+      // migrate: move the .env (the channels.sh migration moves the whole dir)
+      mkdirSync(inst, { recursive: true })
+      writeFileSync(join(inst, '.env'), 'TELEGRAM_BOT_TOKEN=x\n')
+      rmSync(join(legacy, '.env'))
+      expect(resolveMainChannelStateDir(opts)).toBe(inst)
+    } finally {
+      rmSync(base, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/__tests__/owner-chat-fresh-install.test.ts
+++ b/src/__tests__/owner-chat-fresh-install.test.ts
@@ -33,21 +33,33 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const REAL = '1268077055'
 
 let home: string
+let stateDir: string
 let sent: Array<{ url: string; chatId: unknown }>
 let originalHome: string | undefined
 let originalChat: string | undefined
+let originalStateDir: string | undefined
 
 beforeEach(() => {
   home = mkdtempSync(join(tmpdir(), 'freshinstall-'))
-  mkdirSync(join(home, '.claude', 'channels', 'telegram'), { recursive: true })
+  stateDir = join(home, '.claude', 'channels', 'telegram')
+  mkdirSync(stateDir, { recursive: true })
   // The wizard DID pair successfully: this is the file the plugin enforces.
   writeFileSync(
-    join(home, '.claude', 'channels', 'telegram', 'access.json'),
+    join(stateDir, 'access.json'),
     JSON.stringify({ dmPolicy: 'allowlist', allowFrom: [REAL], groups: {}, pending: {} }),
   )
   originalHome = process.env['HOME']
   originalChat = process.env['ALLOWED_CHAT_ID']
+  originalStateDir = process.env['TELEGRAM_STATE_DIR']
   process.env['HOME'] = home
+  // #915: the main agent's channel state dir is resolved by channelStateDir,
+  // which honours TELEGRAM_STATE_DIR (the value channels.sh exports at spawn)
+  // and otherwise prefers the install-scoped dir over the legacy ~/.claude one.
+  // Point it at this fixture explicitly so the test measures its OWN access.json
+  // deterministically -- rather than depending on the resolver's HOME fallback
+  // (which no longer wins unconditionally) or on an ambient TELEGRAM_STATE_DIR
+  // leaking in from the process that runs the suite.
+  process.env['TELEGRAM_STATE_DIR'] = stateDir
 
   sent = []
   vi.stubGlobal('fetch', async (url: string, init?: { body?: string }) => {
@@ -68,6 +80,8 @@ afterEach(() => {
   else process.env['HOME'] = originalHome
   if (originalChat === undefined) delete process.env['ALLOWED_CHAT_ID']
   else process.env['ALLOWED_CHAT_ID'] = originalChat
+  if (originalStateDir === undefined) delete process.env['TELEGRAM_STATE_DIR']
+  else process.env['TELEGRAM_STATE_DIR'] = originalStateDir
   rmSync(home, { recursive: true, force: true })
 })
 
@@ -95,7 +109,7 @@ describe('fresh wizard install (no usable ALLOWED_CHAT_ID, channel paired)', () 
     // still called the API with "0" and collected a 400 nobody read. The fix
     // has to be silence, not a different bad request.
     writeFileSync(
-      join(home, '.claude', 'channels', 'telegram', 'access.json'),
+      join(stateDir, 'access.json'),
       JSON.stringify({ dmPolicy: 'allowlist', allowFrom: [], groups: {}, pending: {} }),
     )
     vi.resetModules()

--- a/src/channel-provider.ts
+++ b/src/channel-provider.ts
@@ -1,7 +1,8 @@
 import https from 'node:https'
 import { readFileSync, existsSync } from 'node:fs'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { homedir } from 'node:os'
+import { fileURLToPath } from 'node:url'
 import { logger } from './logger.js'
 import { formatForTelegram, splitMessage } from './format.js'
 import { markIfTestRun } from './test-run-marker.js'
@@ -595,17 +596,59 @@ export function getProviderType(envValue: string | undefined): ChannelProviderTy
   return 'telegram'
 }
 
+// Compiled location is dist/channel-provider.js, so '..' is the install root --
+// the same convention config.ts uses for PROJECT_ROOT. Computed locally because
+// config.ts imports this module (importing it back would be circular).
+const INSTALL_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+
+/** TELEGRAM_STATE_DIR / SLACK_STATE_DIR / ... -- the env var the channel plugin
+ *  itself honours. channels.sh exports it into the main session so the plugin,
+ *  its hooks and this server all agree on one directory. */
+export function channelStateDirEnvVar(provider: ChannelProviderType): string {
+  return `${provider.toUpperCase()}_STATE_DIR`
+}
+
+// Main-agent channel state resolution (#915). The shared ~/.claude/channels/
+// default meant ANY other Claude Code session on the host loaded the same bot
+// token and silently took the bot over. The main agent's state is therefore
+// install-scoped (<install>/.claude/channels/<provider>), the way sub-agents'
+// always was. Order:
+//   1. <PROVIDER>_STATE_DIR env override -- the value the plugin itself runs
+//      with, so when set it is authoritative for every reader in this process.
+//   2. legacy ~/.claude/channels/<provider>, but ONLY while it still holds the
+//      .env and the install-scoped dir does not -- i.e. an install whose
+//      channels.sh has not migrated yet. Readers must keep working against the
+//      still-running legacy poller during that window.
+//   3. install-scoped -- the default for migrated AND fresh installs, so a
+//      first onboarding writes the token here and no shared-path copy is ever
+//      born.
+/** The ordering logic alone, pure so the contract is unit-testable without
+ *  touching the real home directory. */
+export function resolveMainChannelStateDir(opts: {
+  envOverride: string | undefined
+  installScoped: string
+  legacy: string
+  hasEnvFile: (dir: string) => boolean
+}): string {
+  if (opts.envOverride) return opts.envOverride
+  if (opts.hasEnvFile(opts.legacy) && !opts.hasEnvFile(opts.installScoped)) return opts.legacy
+  return opts.installScoped
+}
+
 export function channelStateDir(provider: ChannelProviderType, agentDir?: string): string {
-  const base = agentDir
-    ? join(agentDir, '.claude', 'channels')
-    : join(homedir(), '.claude', 'channels')
   const subdir =
     provider === 'slack' ? 'slack'
     : provider === 'discord' ? 'discord'
     : provider === 'googlechat' ? 'googlechat'
     : provider === 'teams' ? 'teams'
     : 'telegram'
-  return join(base, subdir)
+  if (agentDir) return join(agentDir, '.claude', 'channels', subdir)
+  return resolveMainChannelStateDir({
+    envOverride: process.env[channelStateDirEnvVar(provider)],
+    installScoped: join(INSTALL_ROOT, '.claude', 'channels', subdir),
+    legacy: join(homedir(), '.claude', 'channels', subdir),
+    hasEnvFile: (dir) => existsSync(join(dir, '.env')),
+  })
 }
 
 export function readChannelToken(provider: ChannelProviderType, envFilePath: string): string | null {

--- a/src/web/fleet-transfer.ts
+++ b/src/web/fleet-transfer.ts
@@ -16,6 +16,7 @@ import {
   randomBytes, createCipheriv, createDecipheriv, scryptSync,
 } from 'node:crypto'
 import { PROJECT_ROOT, STORE_DIR, MAIN_AGENT_ID, BOT_NAME, BRAND_NAME, OWNER_NAME, CHANNEL_PROVIDER } from '../config.js'
+import { channelStateDir, type ChannelProviderType } from '../channel-provider.js'
 import { atomicWriteFileSync } from './atomic-write.js'
 import { updateEnvFile } from '../env.js'
 import { AGENTS_BASE_DIR, listAgentNames } from './agent-config.js'
@@ -477,6 +478,19 @@ function exportChannelsAccess(channelsDir: string): Record<string, unknown> {
   return channelsAccess
 }
 
+// Per-provider main-agent access.json via the #915 resolver. Only providers
+// whose resolved dir actually holds an access.json appear, mirroring
+// exportChannelsAccess's behaviour.
+function exportMainChannelAccessResolved(): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  const providers: ChannelProviderType[] = ['telegram', 'slack', 'discord', 'googlechat', 'teams']
+  for (const provider of providers) {
+    const accessPath = join(channelStateDir(provider), 'access.json')
+    if (existsSync(accessPath)) out[provider] = safeReadJson(accessPath)
+  }
+  return out
+}
+
 // Main agent lives at PROJECT_ROOT -- exported separately since it's not under agents/.
 function exportMainAgent(
   bindingLookup: Map<string, Map<string, Map<string, string>>>,
@@ -505,8 +519,14 @@ function exportMainAgent(
     }
   }
 
-  // Main agent channel access lives at ~/.claude/channels/<provider>/access.json
-  const channelsAccess = exportChannelsAccess(join(homedir(), '.claude', 'channels'))
+  // Main agent channel access lives at <state dir>/access.json per provider.
+  // channelStateDir (#915) resolves env override, then the legacy shared
+  // ~/.claude path while unmigrated, then the install-scoped dir -- merge the
+  // legacy base first so a migrated provider's install-scoped copy wins.
+  const channelsAccess = {
+    ...exportChannelsAccess(join(homedir(), '.claude', 'channels')),
+    ...exportMainChannelAccessResolved(),
+  }
 
   return {
     agentId: MAIN_AGENT_ID,
@@ -921,11 +941,15 @@ function writeMainAgentFiles(ma: MainAgentExport, tracker: WriteTracker): void {
   trackedWrite(join(PROJECT_ROOT, '.mcp.json'), JSON.stringify(deplaceholderMcp(ma.mcp), null, 2), tracker)
   trackedWrite(join(claudeDir, 'settings.json'), JSON.stringify(ma.settings, null, 2), tracker)
 
-  // Main agent channel access: ~/.claude/channels/<provider>/access.json
-  // B1: provider names validated by validateNames() before this is called
+  // Main agent channel access: written into the #915-resolved state dir for
+  // known providers (install-scoped on a fresh target), legacy shared base for
+  // anything else. B1: provider names validated by validateNames() first.
   const channelsBase = join(homedir(), '.claude', 'channels')
+  const knownProviders = new Set(['telegram', 'slack', 'discord', 'googlechat', 'teams'])
   for (const [provider, access] of Object.entries(ma.channelsAccess ?? {})) {
-    const provDir = safeJoin(channelsBase, provider)
+    const provDir = knownProviders.has(provider)
+      ? channelStateDir(provider as ChannelProviderType)
+      : safeJoin(channelsBase, provider)
     trackedMkdir(provDir, tracker)
     trackedWrite(join(provDir, 'access.json'), JSON.stringify(access, null, 2), tracker)
   }

--- a/src/web/routes/voice.ts
+++ b/src/web/routes/voice.ts
@@ -36,14 +36,18 @@ const SAFE_FILE_ID_RE = /^[A-Za-z0-9_\-]{10,200}$/
 // Known agent channel dirs -- only these are accepted as state_dir.
 // The channel plugin stores its .env (bot token) here.
 const CHANNELS_BASE = join(homedir(), '.claude', 'channels')
+// Install-scoped main-agent base (#915): <install>/.claude/channels/<provider>.
+const INSTALL_CHANNELS_BASE = join(PROJECT_ROOT, '.claude', 'channels')
 
-// Safe paths: ~/.claude/channels/<provider>/  OR  <AGENTS_BASE_DIR>/<name>/.claude/channels/<provider>/
-// Both must contain a .env file. '..' traversal always rejected.
+// Safe paths: ~/.claude/channels/<provider>/, <install>/.claude/channels/<provider>/
+// OR <AGENTS_BASE_DIR>/<name>/.claude/channels/<provider>/
+// All must contain a .env file. '..' traversal always rejected.
 function isSafeStateDir(dir: string): boolean {
   const resolved = dir.replace(/\/$/, '')
   if (resolved.includes('..')) return false
   if (!existsSync(join(resolved, '.env'))) return false
   if (resolved.startsWith(CHANNELS_BASE + '/') || resolved === CHANNELS_BASE) return true
+  if (resolved.startsWith(INSTALL_CHANNELS_BASE + '/') || resolved === INSTALL_CHANNELS_BASE) return true
   if (resolved.startsWith(AGENTS_BASE_DIR + '/')) {
     // Must match: <AGENTS_BASE_DIR>/<agentName>/.claude/channels/<provider>
     const rel = resolved.slice(AGENTS_BASE_DIR.length + 1)

--- a/src/web/telegram.ts
+++ b/src/web/telegram.ts
@@ -1,7 +1,7 @@
 import { readFileSync, existsSync } from 'node:fs'
 import { join } from 'node:path'
-import { homedir } from 'node:os'
 import { PROJECT_ROOT } from '../config.js'
+import { channelStateDir } from '../channel-provider.js'
 import { resolveOwnerChatId } from '../owner-chat.js'
 import { logger } from '../logger.js'
 import { agentDir, readFileOr, findAvatarForAgent } from './agent-config.js'
@@ -54,11 +54,11 @@ export function readAgentTeamsConfig(name: string): { hasTeams: boolean } {
   return { hasTeams: !!m?.[1]?.trim() }
 }
 
-// Marveen's Telegram channel lives under the global ~/.claude path, not
-// under agents/marveen, because the main agent reuses the system Claude
-// Code channel install. Read it the same way the plugin does.
+// Marveen's channel state is resolved by channelStateDir (#915): env
+// override, then the legacy shared ~/.claude path while unmigrated, then the
+// install-scoped dir. Read it the same way the plugin does.
 export function readMarveenTelegramConfig(): { hasTelegram: boolean; botUsername?: string } {
-  const envPath = join(homedir(), '.claude', 'channels', 'telegram', '.env')
+  const envPath = join(channelStateDir('telegram'), '.env')
   if (!existsSync(envPath)) return { hasTelegram: false }
   const content = readFileOr(envPath, '')
   const tokenMatch = content.match(/TELEGRAM_BOT_TOKEN=(.+)/)
@@ -67,34 +67,33 @@ export function readMarveenTelegramConfig(): { hasTelegram: boolean; botUsername
   return { hasTelegram: true, botUsername: marveenBotUsernameCache.value }
 }
 
-// Discord / Slack mirror of the above: same global ~/.claude/channels path
-// since Marveen's channel session reuses the system install. Lets the
-// dashboard answer "is Marveen connected?" per provider without per-agent
-// state lookup. botUsername omitted -- the Discord/Slack flows don't
+// Discord / Slack mirror of the above: same channelStateDir resolution as
+// the Telegram reader. Lets the dashboard answer "is Marveen connected?"
+// per provider without per-agent state lookup. botUsername omitted -- the Discord/Slack flows don't
 // surface a @username the same way Telegram does.
 export function readMarveenDiscordConfig(): { hasDiscord: boolean } {
-  const envPath = join(homedir(), '.claude', 'channels', 'discord', '.env')
+  const envPath = join(channelStateDir('discord'), '.env')
   if (!existsSync(envPath)) return { hasDiscord: false }
   const tokenMatch = readFileOr(envPath, '').match(/DISCORD_BOT_TOKEN=(.+)/)
   return { hasDiscord: !!tokenMatch?.[1]?.trim() }
 }
 
 export function readMarveenGooglechatConfig(): { hasGooglechat: boolean } {
-  const envPath = join(homedir(), '.claude', 'channels', 'googlechat', '.env')
+  const envPath = join(channelStateDir('googlechat'), '.env')
   if (!existsSync(envPath)) return { hasGooglechat: false }
   const m = readFileOr(envPath, '').match(/GOOGLECHAT_PROJECT_ID=(.+)/)
   return { hasGooglechat: !!m?.[1]?.trim() }
 }
 
 export function readMarveenTeamsConfig(): { hasTeams: boolean } {
-  const envPath = join(homedir(), '.claude', 'channels', 'teams', '.env')
+  const envPath = join(channelStateDir('teams'), '.env')
   if (!existsSync(envPath)) return { hasTeams: false }
   const m = readFileOr(envPath, '').match(/TEAMS_BOT_APP_ID=(.+)/)
   return { hasTeams: !!m?.[1]?.trim() }
 }
 
 export function readMarveenSlackConfig(): { hasSlack: boolean } {
-  const envPath = join(homedir(), '.claude', 'channels', 'slack', '.env')
+  const envPath = join(channelStateDir('slack'), '.env')
   if (!existsSync(envPath)) return { hasSlack: false }
   const tokenMatch = readFileOr(envPath, '').match(/SLACK_BOT_TOKEN=(.+)/)
   return { hasSlack: !!tokenMatch?.[1]?.trim() }
@@ -104,7 +103,7 @@ export function readMarveenSlackConfig(): { hasSlack: boolean } {
 export const marveenBotUsernameCache: { value?: string; fetchedAt: number } = { fetchedAt: 0 }
 
 export async function refreshMarveenBotUsername(): Promise<void> {
-  const envPath = join(homedir(), '.claude', 'channels', 'telegram', '.env')
+  const envPath = join(channelStateDir('telegram'), '.env')
   if (!existsSync(envPath)) return
   const tokenMatch = readFileOr(envPath, '').match(/TELEGRAM_BOT_TOKEN=(.+)/)
   const token = tokenMatch?.[1]?.trim()

--- a/src/web/voice-directive.ts
+++ b/src/web/voice-directive.ts
@@ -3,17 +3,24 @@ import { join } from 'node:path'
 import { homedir } from 'node:os'
 import { STORE_DIR, WEB_PORT } from '../config.js'
 import { AGENTS_BASE_DIR } from './agent-config.js'
+import { channelStateDir, type ChannelProviderType } from '../channel-provider.js'
+
+const KNOWN_PROVIDERS = new Set<string>(['telegram', 'slack', 'discord', 'googlechat', 'teams'])
 
 // Resolve the directory where an agent's channel plugin stores its bot .env.
 // Search order:
 //   1. <AGENTS_BASE_DIR>/<agentId>/.claude/channels/<provider>   (sub-agent own channel)
 //   2. ~/.claude/channels/<provider>-<agentId>                   (alternative naming)
-//   3. ~/.claude/channels/<provider>                             (global fallback / main agent)
+//   3. channelStateDir(provider)                                 (main agent -- env override,
+//      then legacy shared path while unmigrated, then install-scoped; #915)
 export function resolveAgentChannelStateDir(agentId: string, provider: string): string {
+  const mainDir = KNOWN_PROVIDERS.has(provider)
+    ? channelStateDir(provider as ChannelProviderType)
+    : join(homedir(), '.claude', 'channels', provider)
   const candidates = [
     join(AGENTS_BASE_DIR, agentId, '.claude', 'channels', provider),
     join(homedir(), '.claude', 'channels', `${provider}-${agentId}`),
-    join(homedir(), '.claude', 'channels', provider),
+    mainDir,
   ]
   return candidates.find((d) => existsSync(join(d, '.env'))) ?? candidates[candidates.length - 1]
 }


### PR DESCRIPTION
Closes #915.

## The bug

The main agent's channel state (and therefore its bot token) lived in the shared `~/.claude/channels/<provider>/`. Any other Claude Code session started on the same host loaded the plugin, read that same token, SIGTERMed the pid in `bot.pid` and took the bot over. Inbound messages then went to that session instead of `<main>-channels`, completely silently: no reply, empty channels transcript, empty dashboard conversation, no error in any log. Sub-agents were never affected because their launcher exports `<PROVIDER>_STATE_DIR` and uses their own dir.

## The fix

Give the main agent install-scoped channel state, the way sub-agents already have it.

- **`channelStateDir()`** resolves in order: `<PROVIDER>_STATE_DIR` env override, then the legacy shared `~/.claude` path while it still holds the `.env` and the install-scoped dir does not (an unmigrated install, whose poller is still live), then install-scoped (`<install>/.claude/channels/<provider>`) for migrated and fresh installs. The ordering is extracted as the pure `resolveMainChannelStateDir` so it is unit-testable without touching the real home dir.
- **`channels.sh`**: one-time MOVE (never copy -- a copy left behind keeps the hijack window open) of the whole legacy dir into the install-scoped dir, after the session kill + orphan reaps so nothing is polling out of it mid-move; exports `*_STATE_DIR` into both spawn sites; reads `bot.pid` from the new dir.
- **`channel-watchdog.sh`**: the respawn command carries the same `*_STATE_DIR`, or the hijack window reopens on the first watchdog respawn.
- **Server-side readers** routed through the resolver: `telegram.ts` (the five `readMarveen*Config` helpers), `voice-directive.ts`, `routes/voice.ts` `isSafeStateDir` allowlist, `fleet-transfer.ts` export/import.
- **Notifier scripts + telegram hooks** (progress / ack / fallback / usage / live-progress / watchdog, and the alert scripts) resolve env > install-scoped > legacy the same way.
- **`backup.sh`** archives the install-scoped channel dir alongside the legacy one.

After migration, another session still loads the plugin but finds no token in the default location and exits, leaving the running poller alone.

## Verification

- New `channel-state-dir-915.test.ts`: the resolver ordering (env override wins; unmigrated legacy stays legacy; migrated + fresh both resolve install-scoped; both-present favours install-scoped), plus the env-var mapping and the agentDir path.
- `owner-chat-fresh-install.test.ts` updated to point at its fixture via `TELEGRAM_STATE_DIR` so it measures its own `access.json` deterministically instead of the HOME fallback that no longer wins unconditionally.
- `tsc --noEmit` clean; full local vitest shows no new failures versus a clean `develop` worktree (the 33 hook/gate-wiring failures reproduce identically on stock `develop` in a worktree and are green on CI -- a known worktree-isolation artifact, not from this change).

## Note on scope

This is a fleet install where `homedir()` is one machine. The migration is idempotent and reversible (the legacy dir's contents are moved, not deleted; a parked `.env.legacy-<ts>` is kept when both dirs already hold one). The reporter of #915 implemented essentially this locally and ran it for a couple of hours before reverting; this PR follows their outline, with the resolver made testable and the readers audited exhaustively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
