### PR TITLE
docs(readme): name Marveen an agent harness for discoverability (#1152)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
 
 Marveen egy AI asszisztens keretrendszer, ami Claude Code-ra épül. Saját AI csapatot építhetsz, akik Telegramon vagy Slacken kommunikálnak veled, önállóan dolgoznak, és egymással is együttműködnek.
 
+Marveen is a self-hostable **agent harness** for Claude Code: it runs a team of AI agents, each with its own chat channel (Telegram or Slack), persistent memory, scheduled tasks, and MCP tools, lets them delegate work to one another, and gives you a web dashboard to watch and steer them.
+
 ## Funkciók
 
 - **AI Csapat**: Több ágens, mindegyik saját csatornával (Telegram vagy Slack), személyiséggel és memóriával


### PR DESCRIPTION
Closes #1152 (README part).

@szepeviktor asked for the term "agent harness" in the README so people searching for it find the project. This adds one accurate English sentence to the intro that describes what Marveen already is (a self-hostable harness running a team of Claude Code agents with channels, memory, scheduled tasks and MCP tools, plus a dashboard), rather than padding keywords.

The second half of the request (relevant topics in the GitHub About box) is repo metadata, set separately on the repo.

Base is `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)