### PR TITLE
fix(keepalive): detect a poller launched from a full path (GH #1147)

### DIFF
--- a/scripts/channel-keepalive-probe.sh
+++ b/scripts/channel-keepalive-probe.sh
@@ -91,14 +91,31 @@ descends_from_pane() {
 
 alive=0
 # Candidate pollers: bun/node processes whose argv references a /telegram/
-# plugin dir. Anchored on path separators to avoid matching an unrelated argv.
+# plugin dir.
+#
+# RUNTIME_TOKEN_RX below is the portable ERE spelling of the TS side's
+# /\b(bun|node)\b/ (src/channel-coordinator/provider-poller-match.ts). It must
+# stay equivalent to it: two detectors that disagree about the same process is
+# the defect GH #1147 reported, not a detail. The previous pattern here was
+# '(^| )(bun|node)( |$|.*/)', which required a SPACE or line start before the
+# runtime token, so a poller launched from a full path -- the shape the official
+# bun installer produces, /home/USER/.bun/bin/bun -- never matched, the probe
+# reported "no live telegram poller", and the keepalive was never advanced. With
+# the 45 minute liveness ceiling that turns a quiet-but-healthy session into a
+# fresh respawn every 15 minutes: the reporter measured 41 of them in one night,
+# each losing the main agent's conversation.
+#
+# \b is NOT used here on purpose: BSD grep (macOS) does not support it reliably,
+# and this probe runs on both. The character-class form is the portable
+# equivalent.
+RUNTIME_TOKEN_RX='(^|[^A-Za-z0-9_])(bun|node)([^A-Za-z0-9_]|$)'
 while read -r cand; do
   [ -z "$cand" ] && continue
   if descends_from_pane "$cand"; then
     alive=1
     break
   fi
-done < <(ps -axo pid,command 2>/dev/null | grep -E '(^| )(bun|node)( |$|.*/)' | grep -E '/telegram/' | grep -v grep | awk '{print $1}')
+done < <(ps -axo pid,command 2>/dev/null | grep -E "$RUNTIME_TOKEN_RX" | grep -E '/telegram/' | grep -v grep | awk '{print $1}')
 
 if [ "$alive" -ne 1 ]; then
   # Do NOT advance the keepalive: a dead pipe must stay visibly stale so a real

--- a/src/__tests__/keepalive-probe-poller-regex.test.ts
+++ b/src/__tests__/keepalive-probe-poller-regex.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { execFileSync } from 'node:child_process'
+import { matchesProviderPollerCmd } from '../channel-coordinator/provider-poller-match.js'
+
+// GH #1147: scripts/channel-keepalive-probe.sh and the TypeScript detector both
+// answer "is this argv a telegram poller?", and they disagreed. The shell side
+// required a space or line start before the runtime token, so a poller launched
+// from a full path -- what the official bun installer produces -- never matched.
+// The probe then reported "no live telegram poller" and never advanced the
+// keepalive; with the 45 minute liveness ceiling the reporter measured 41 fresh
+// respawns in one night, each losing the main agent's conversation.
+//
+// These tests pin the two implementations against ONE corpus, so the next
+// divergence fails here instead of on a stranger's host at 3am.
+
+const PROBE = join(process.cwd(), 'scripts', 'channel-keepalive-probe.sh')
+
+// The pattern the probe actually runs, read from the script rather than
+// duplicated here -- a copy would drift exactly the way this test exists to stop.
+function probeRuntimeRegex(): string {
+  const src = readFileSync(PROBE, 'utf-8')
+  const m = src.match(/^RUNTIME_TOKEN_RX='([^']+)'$/m)
+  expect(m, 'RUNTIME_TOKEN_RX not found in the probe script').not.toBeNull()
+  return m![1]
+}
+
+// Run the real grep the probe runs. Testing the ERE through a JS RegExp would
+// prove nothing about how BSD/GNU grep reads it, which is where this bug lived.
+function shellAccepts(cmd: string): boolean {
+  const runtime = probeRuntimeRegex()
+  try {
+    const out = execFileSync('/bin/sh', ['-c', `printf '%s\\n' "$1" | grep -E "$2" | grep -E '/telegram/' | grep -v grep`, 'sh', cmd, runtime], { encoding: 'utf-8' })
+    return out.trim().length > 0
+  } catch {
+    return false // grep exits non-zero when nothing matches
+  }
+}
+
+const TELEGRAM_POLLERS = [
+  // The exact argv from the report: bun from the official installer's path.
+  '3319876 /home/telep/.bun/bin/bun run --cwd /home/telep/.claude/plugins/cache/claude-plugins-official/telegram/0.0.6 --shell=bun --silent start',
+  // bun on PATH, the shape the old pattern did match.
+  '123 bun run --cwd /home/u/.claude/plugins/cache/claude-plugins-official/telegram/0.0.6 start',
+  // node from a full path, and from an nvm path.
+  '456 /usr/local/bin/node /home/u/.claude/plugins/cache/claude-plugins-official/telegram/server.js',
+  '789 /home/u/.nvm/versions/node/v22.3.0/bin/node /home/u/.claude/plugins/.../telegram/server.js',
+]
+
+const NOT_POLLERS = [
+  // node_modules must not read as the node runtime: the token is followed by _.
+  '999 /usr/lib/node_modules/some-tool/cli.js --plugin /telegram/x',
+  // right plugin dir, wrong runtime.
+  '111 python3 /home/u/.claude/plugins/cache/claude-plugins-official/telegram/bot.py',
+  // right runtime, no telegram plugin dir.
+  '222 /home/u/.bun/bin/bun run --cwd /home/u/.claude/plugins/cache/x/discord/0.1.0 start',
+]
+
+describe('channel-keepalive-probe.sh poller detection', () => {
+  it('accepts a full-path bun poller, which is the case the report was filed for', () => {
+    expect(shellAccepts(TELEGRAM_POLLERS[0])).toBe(true)
+  })
+
+  it('accepts every known telegram poller shape', () => {
+    for (const cmd of TELEGRAM_POLLERS) {
+      expect(shellAccepts(cmd), cmd).toBe(true)
+    }
+  })
+
+  it('rejects argv that is not a telegram poller', () => {
+    for (const cmd of NOT_POLLERS) {
+      expect(shellAccepts(cmd), cmd).toBe(false)
+    }
+  })
+
+  it('does not use \\b, which BSD grep on macOS does not support reliably', () => {
+    expect(probeRuntimeRegex()).not.toContain('\\b')
+  })
+})
+
+describe('the shell probe and the TypeScript detector agree', () => {
+  // This is the defect the reporter named: two detectors, one question, two
+  // answers. The verdicts must match on every sample, in both directions.
+  it('agrees on every telegram poller sample', () => {
+    for (const cmd of TELEGRAM_POLLERS) {
+      expect(matchesProviderPollerCmd(cmd, 'telegram'), `TS: ${cmd}`).toBe(true)
+      expect(shellAccepts(cmd), `shell: ${cmd}`).toBe(true)
+    }
+  })
+
+  it('agrees on every non-poller sample', () => {
+    for (const cmd of NOT_POLLERS) {
+      expect(matchesProviderPollerCmd(cmd, 'telegram'), `TS: ${cmd}`).toBe(false)
+      expect(shellAccepts(cmd), `shell: ${cmd}`).toBe(false)
+    }
+  })
+})


### PR DESCRIPTION
Fixes #1147.

## Measured first

Live on `develop` at 8d61e782, `scripts/channel-keepalive-probe.sh:101`, pattern unchanged from the report. Ran the reporter's exact argv through both patterns:

```
$ printf '%s\n' '3319876 /home/telep/.bun/bin/bun run --cwd .../telegram/0.0.6 --shell=bun --silent start' \
  | grep -cE '(^| )(bun|node)( |$|.*/)'    # old
0
  | grep -cE '(^|[^A-Za-z0-9_])(bun|node)([^A-Za-z0-9_]|$)'   # new
1
```

## What changed

The probe now uses the portable ERE spelling of the TypeScript side's `/\b(bun|node)\b/` (`src/channel-coordinator/provider-poller-match.ts`), pulled into a named `RUNTIME_TOKEN_RX` variable with the reasoning above it.

This takes the reporter's **second** suggestion rather than the minimal one. Their point that two detectors answering the same question and disagreeing is the actual defect is right, and a second ad-hoc narrowing would have left that intact. Rewriting the probe to call the TS detector was rejected for a different reason: it is a standalone systemd/launchd probe, and making it depend on a built bundle trades one fragility for another.

`\b` is deliberately not used: BSD grep on macOS does not support it reliably and this probe runs on both platforms.

## Regression test

`src/__tests__/keepalive-probe-poller-regex.test.ts`, 6 tests, and two things about how it is built are the point:

- It **reads the pattern out of the script** rather than restating it. A copy would drift exactly the way this test exists to prevent.
- It **runs the real `grep -E`** rather than translating the ERE to a JS RegExp. The bug lived in how grep reads the pattern, so a JS approximation would prove nothing.

Four samples that must match (including the reporter's exact argv, bun on PATH, node from a full path, node from an nvm path) and three that must not (`node_modules` where the token is followed by `_`, python with the right plugin dir, bun with the wrong plugin dir). Each is asserted against the shell probe **and** `matchesProviderPollerCmd`, in both directions, so the two cannot silently diverge again.

Verified both ways: **3 of 6 fail** on the old pattern, all 6 pass on the new one.

## Verification

- `npx vitest run` in a clean worktree: 397 files, 5093 passed, 1 skipped, 0 failed.
- `npx tsc --noEmit`: clean. `bash -n` on the probe: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
