### PR TITLE
fix(kanban): reject unknown PUT fields and stop no-op writes faking freshness (#1023)

### DIFF
--- a/src/__tests__/kanban-put-unknown-field.test.ts
+++ b/src/__tests__/kanban-put-unknown-field.test.ts
@@ -1,0 +1,87 @@
+// #1023: PUT /api/kanban/:id used to accept any JSON body, drop the fields it
+// did not recognise, bump updated_at anyway, and answer 200 {ok:true}. Twice a
+// real closing note was lost this way (a `description_append` that never
+// existed as a column), and because updated_at was fresh the card never looked
+// stale. Two guarantees under test:
+//   1. an unknown field is rejected with 400 -- and the card is NOT touched;
+//   2. a no-op PUT (a known field echoed back unchanged) does not bump
+//      updated_at, so the "go look, this is stale" signal survives.
+// Plus the load-bearing compatibility claim: the dashboard's whole-`{...card}`
+// PUT (assignee/parent edits, carrying id/seq/created_at/labels/blockers) still
+// succeeds.
+import { describe, it, expect, beforeEach } from 'vitest'
+import { Readable } from 'node:stream'
+import { initDatabase, createKanbanCard, getKanbanCard } from '../db.js'
+import { tryHandleKanban } from '../web/routes/kanban.js'
+import type { RouteContext } from '../web/routes/types.js'
+
+function putCtx(id: string, payload: unknown): { ctx: RouteContext; out: { status: number; body: any } } {
+  const out: { status: number; body: any } = { status: 200, body: null }
+  const res: any = {
+    writeHead(status: number) { out.status = status; return res },
+    setHeader() { return res },
+    end(chunk?: string) { if (chunk) out.body = JSON.parse(chunk) },
+  }
+  const req: any = Readable.from([Buffer.from(JSON.stringify(payload))])
+  const url = new URL(`http://localhost:3420/api/kanban/${encodeURIComponent(id)}`)
+  return { ctx: { req, res, path: url.pathname, method: 'PUT', url } as RouteContext, out }
+}
+
+describe('PUT /api/kanban/:id -- unknown fields are rejected, no-ops do not refresh', () => {
+  beforeEach(() => { initDatabase(':memory:') })
+
+  it('rejects an unknown field with 400 and does NOT touch the card', async () => {
+    createKanbanCard({ id: 'c1', title: 'Card one', status: 'planned' })
+    const before = getKanbanCard('c1')!
+    // simulate a later real write happening at a later second
+    await new Promise((r) => setTimeout(r, 1100))
+    const { ctx, out } = putCtx('c1', { status: 'done', description_append: 'result text' })
+    expect(await tryHandleKanban(ctx)).toBe(true)
+    expect(out.status).toBe(400)
+    expect(out.body.error).toContain('description_append')
+    // the whole write is refused: status did NOT change, updated_at did NOT move
+    const after = getKanbanCard('c1')!
+    expect(after.status).toBe('planned')
+    expect(after.updated_at).toBe(before.updated_at)
+  })
+
+  it('a no-op PUT (unchanged known fields) does not bump updated_at', async () => {
+    createKanbanCard({ id: 'c2', title: 'Card two', status: 'planned' })
+    const before = getKanbanCard('c2')!
+    await new Promise((r) => setTimeout(r, 1100))
+    const { ctx, out } = putCtx('c2', { status: 'planned', title: 'Card two' })
+    expect(await tryHandleKanban(ctx)).toBe(true)
+    expect(out.status).toBe(200)
+    expect(getKanbanCard('c2')!.updated_at).toBe(before.updated_at)
+  })
+
+  it('a real change still writes and bumps updated_at', async () => {
+    createKanbanCard({ id: 'c3', title: 'Card three', status: 'planned' })
+    const before = getKanbanCard('c3')!
+    await new Promise((r) => setTimeout(r, 1100))
+    const { ctx, out } = putCtx('c3', { status: 'in_progress' })
+    expect(await tryHandleKanban(ctx)).toBe(true)
+    expect(out.status).toBe(200)
+    const after = getKanbanCard('c3')!
+    expect(after.status).toBe('in_progress')
+    expect(after.updated_at).toBeGreaterThan(before.updated_at)
+  })
+
+  it('accepts the dashboard whole-card PUT (read-only fields + embedded arrays)', async () => {
+    createKanbanCard({ id: 'c4', title: 'Card four', status: 'planned', assignee: 'samu' })
+    const card = getKanbanCard('c4')!
+    // shape of web/app.js's { ...card, assignee } send: base columns + seq +
+    // last_status_at + the GET-embedded labels/blockers arrays.
+    const { ctx, out } = putCtx('c4', {
+      ...card,
+      seq: 4,
+      last_status_at: card.created_at,
+      labels: [{ id: 'l1', name: 'x', color: '#fff' }],
+      blockers: [],
+      assignee: 'zara',
+    })
+    expect(await tryHandleKanban(ctx)).toBe(true)
+    expect(out.status).toBe(200)
+    expect(getKanbanCard('c4')!.assignee).toBe('zara')
+  })
+})

--- a/src/db.ts
+++ b/src/db.ts
@@ -2144,6 +2144,16 @@ export function createKanbanCard(card: {
 // agent and every script uses -- wrote none. Measured 2026-08-29: 8 events in
 // the whole table, the newest 6 weeks old, so "when did this card become
 // in_progress" was unanswerable for essentially every card on the board.
+// The columns updateKanbanCard actually writes. Exported so the HTTP boundary
+// (PUT /api/kanban/:id) can validate a body against exactly this set instead of
+// duplicating the list -- a field that is not here is silently dropped by the
+// spread below, which is the #1023 data-loss bug when the caller believed it
+// was writing one (e.g. `description_append`).
+export const KANBAN_WRITABLE_FIELDS = [
+  'title', 'description', 'status', 'assignee', 'priority', 'project',
+  'parent_id', 'due_date', 'sort_order', 'archived_at',
+] as const
+
 export function updateKanbanCard(
   id: string,
   fields: Partial<Omit<KanbanCard, 'id' | 'created_at'>>,
@@ -2153,6 +2163,14 @@ export function updateKanbanCard(
   if (!card) return false
   const now = Math.floor(Date.now() / 1000)
   const f = { ...card, ...fields, updated_at: now }
+  // #1023: bump updated_at ONLY when a writable column actually changes. The
+  // UPDATE below always matches the row, so a no-op PUT (an unknown field, or a
+  // known field echoed back unchanged) used to stamp updated_at=now and report
+  // success -- destroying the exact "this card is stale, go look" signal the
+  // failed write should have preserved. A no-op is not a failure: return true
+  // (the card exists) but touch nothing.
+  const realChange = KANBAN_WRITABLE_FIELDS.some((k) => f[k] !== card[k])
+  if (!realChange) return true
   const changed = db.prepare(
     `UPDATE kanban_cards SET title=?, description=?, status=?, assignee=?, priority=?, project=?, parent_id=?, due_date=?, sort_order=?, updated_at=?, archived_at=?
      WHERE id=?`

--- a/src/web/routes/kanban.ts
+++ b/src/web/routes/kanban.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto'
 import { join } from 'node:path'
 import {
-  listKanbanCards, createKanbanCard, updateKanbanCard,
+  listKanbanCards, createKanbanCard, updateKanbanCard, KANBAN_WRITABLE_FIELDS,
   deleteKanbanCard, moveKanbanCard, archiveKanbanCard, unarchiveKanbanCard,
   getKanbanComments, addKanbanComment, getKanbanCardEvents, listKanbanProjects,
   getKanbanCard, getChildCards, getDb,
@@ -28,6 +28,19 @@ import { logger } from '../../logger.js'
 import { readBody, json, jsonMaybeGzip } from '../http-helpers.js'
 import { getEffectiveSettingValue } from '../../settings-store.js'
 import type { RouteContext } from './types.js'
+
+// #1023: keys a PUT /api/kanban/:id body may carry WITHOUT being a writable
+// column -- the read-only card fields and the GET-embedded arrays the dashboard
+// sends back when it PUTs a whole `{...card}` object (web/app.js assignee/parent
+// edits). Accepted and ignored; anything neither here nor in
+// KANBAN_WRITABLE_FIELDS is a caller mistake and gets a 400.
+const KANBAN_READONLY_FIELDS = new Set<string>([
+  'id', 'seq', 'created_at', 'updated_at', 'last_status_at', 'labels', 'blockers',
+  // dispatched_at is a real column set by the dispatch path (markKanbanCardDispatched),
+  // never by a PUT, but getKanbanCard's SELECT * returns it so the dashboard's
+  // whole-card send carries it back. Accept-and-ignore, do not 400.
+  'dispatched_at',
+])
 
 // A headless agent cannot "drag" a card to done, so the dispatch hands it the
 // exact curl commands to (1) post a short, human-readable result summary as a
@@ -464,6 +477,27 @@ export async function tryHandleKanban(ctx: RouteContext): Promise<boolean> {
     // of the field set so it can never be mistaken for one. Same name the /move
     // route already accepts, so callers do not have to learn a second spelling.
     const { actor, ...data } = JSON.parse(body.toString()) as Record<string, unknown> & { actor?: string }
+    // #1023: reject unknown fields loudly instead of dropping them silently.
+    // updateKanbanCard writes only KANBAN_WRITABLE_FIELDS, so anything outside
+    // the accepted set below was silently discarded while the write still
+    // reported success and bumped updated_at -- twice a real closing note was
+    // lost this way (#1023). A body that carries a key the writer cannot honour
+    // is a caller bug, and a 400 that names the accepted fields is strictly
+    // better than a 200 that did not do what the caller asked.
+    //
+    // KANBAN_READONLY_FIELDS are the columns and GET-embedded arrays the
+    // dashboard round-trips: the UI sends the whole `{...card}` object on an
+    // assignee or parent edit (web/app.js), so these must be accepted-and-
+    // ignored rather than rejected, or every UI edit would 400.
+    const unknown = Object.keys(data).filter(
+      (k) => !(KANBAN_WRITABLE_FIELDS as readonly string[]).includes(k) && !KANBAN_READONLY_FIELDS.has(k),
+    )
+    if (unknown.length > 0) {
+      json(res, {
+        error: `Unknown field(s): ${unknown.join(', ')}. Accepted: ${KANBAN_WRITABLE_FIELDS.join(', ')}`,
+      }, 400)
+      return true
+    }
     if (updateKanbanCard(id, data, actor)) { json(res, { ok: true }); return true }
     json(res, { error: 'Kártya nem található' }, 404)
     return true


### PR DESCRIPTION
Closes #1023.

## The bug

`PUT /api/kanban/:id` accepted any JSON body without validation. A field the server did not know was dropped, the response was `{"ok":true}`, and `updated_at` was bumped anyway -- so the card looked freshly updated while its content did not change. Two real losses on the same fleet, five days apart, both a closing note sent as `description_append` (not a column): the note vanished, the card kept showing the sub-task open, and because `updated_at` was recent nothing looked stale.

## The fix

- **Reject unknown fields at the HTTP boundary.** The route validates the body against `KANBAN_WRITABLE_FIELDS` (the columns `updateKanbanCard` actually writes, now exported from `db.ts` so the list is not duplicated) plus a read-only ignore-set. An unknown key returns 400 naming the accepted set. This is the field whitelist the `db.ts` comment (card `531c6500`) already anticipated.
- **The read-only ignore-set** is what makes it safe: `web/app.js` PUTs the whole `{...card}` object on assignee and parent edits, so the body carries `id, seq, created_at, updated_at, last_status_at, dispatched_at` and the GET-embedded `labels`/`blockers` arrays. Those are accepted-and-ignored, not rejected, or every dashboard edit would 400.
- **No-op writes no longer fake freshness.** `updateKanbanCard` bumps `updated_at` only when a writable column actually changes. A no-op PUT still returns true (the card exists) but touches nothing -- no `updated_at`, no ancestor stamp, no event -- so a failed or empty write cannot disguise a stale card. This is point 2 of the issue, which it framed as independent.

## Verification

New `kanban-put-unknown-field.test.ts`:
- an unknown field is rejected with 400 and the card is NOT touched (status unchanged, `updated_at` unmoved);
- a no-op PUT (known fields echoed back unchanged) does not bump `updated_at`;
- a real change still writes and bumps `updated_at`;
- the dashboard whole-card PUT (read-only fields + embedded arrays) still succeeds -- the compatibility claim that gates the whole approach.

`tsc --noEmit` clean; no new failures versus a clean `develop` worktree (the same 33 hook/gate-wiring tests fail identically on stock `develop` in a worktree and are green on CI -- a known worktree artifact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
