### PR TITLE
fix(config): say so when an unknown channel provider falls back to telegram (GH #846)

### DIFF
--- a/src/__tests__/channel-provider-unknown-value.test.ts
+++ b/src/__tests__/channel-provider-unknown-value.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import { resolveProviderType, getProviderType, resetProviderTypeAnnouncements } from '../channel-provider.js'
+import { logger } from '../logger.js'
+
+// GH #846: the reporter set CHANNEL_PROVIDER=none believing it meant "no
+// channel", and filed a crash against the respawn path. There is no `none`
+// provider: the value resolved to telegram, so their main session came up on a
+// plugin they had deliberately not configured. The crash they reported is no
+// longer reachable; the silent substitution behind it is, and it is the quieter
+// of the two failures.
+//
+// The fallback itself stays -- refusing to start on a typo would turn it into an
+// outage. What these tests pin is that it is never silent.
+
+describe('resolveProviderType (pure)', () => {
+  it('accepts every provider this build knows', () => {
+    for (const t of ['telegram', 'slack', 'discord', 'googlechat', 'teams'] as const) {
+      expect(resolveProviderType(t)).toEqual({ type: t, raw: t, unrecognised: false })
+    }
+  })
+
+  it('treats an unset value as a default, not as a mistake', () => {
+    expect(resolveProviderType(undefined)).toEqual({ type: 'telegram', raw: '', unrecognised: false })
+    expect(resolveProviderType('')).toEqual({ type: 'telegram', raw: '', unrecognised: false })
+    expect(resolveProviderType('   ')).toEqual({ type: 'telegram', raw: '', unrecognised: false })
+  })
+
+  it('flags the reported value: "none" is not a provider, it is telegram in disguise', () => {
+    expect(resolveProviderType('none')).toEqual({ type: 'telegram', raw: 'none', unrecognised: true })
+  })
+
+  it('flags a typo the same way, which is the wider case', () => {
+    expect(resolveProviderType('telegran').unrecognised).toBe(true)
+    expect(resolveProviderType('Slack').unrecognised).toBe(true)
+    expect(resolveProviderType('slack ').unrecognised).toBe(false) // trimmed, still valid
+  })
+
+  it('never returns a type outside the known set, whatever it is handed', () => {
+    for (const v of ['none', 'telegran', 'MATRIX', '../etc/passwd', '{}']) {
+      expect(['telegram', 'slack', 'discord', 'googlechat', 'teams']).toContain(resolveProviderType(v).type)
+    }
+  })
+})
+
+describe('getProviderType announces an unrecognised value', () => {
+  let warn: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    resetProviderTypeAnnouncements()
+    warn = vi.spyOn(logger, 'warn').mockImplementation(() => logger)
+  })
+  afterEach(() => { warn.mockRestore() })
+
+  it('warns for "none", and names both what was configured and what is used', () => {
+    expect(getProviderType('none')).toBe('telegram')
+    expect(warn).toHaveBeenCalledTimes(1)
+    const [fields, message] = warn.mock.calls[0] as [Record<string, unknown>, string]
+    expect(fields.configured).toBe('none')
+    expect(fields.using).toBe('telegram')
+    expect(message).toContain('none')
+    expect(message).toContain('telegram')
+  })
+
+  it('says it once per distinct value, not once per call', () => {
+    getProviderType('none')
+    getProviderType('none')
+    getProviderType('none')
+    expect(warn).toHaveBeenCalledTimes(1)
+
+    getProviderType('telegran')
+    expect(warn).toHaveBeenCalledTimes(2)
+  })
+
+  it('stays silent for a value this build understands, and for an unset one', () => {
+    getProviderType('slack')
+    getProviderType(undefined)
+    getProviderType('')
+    expect(warn).not.toHaveBeenCalled()
+  })
+})

--- a/src/channel-provider.ts
+++ b/src/channel-provider.ts
@@ -588,12 +588,63 @@ export function getProvider(type: ChannelProviderType): ChannelProvider {
   return markedProviders[type]
 }
 
+const KNOWN_PROVIDER_TYPES: readonly ChannelProviderType[] = ['telegram', 'slack', 'discord', 'googlechat', 'teams']
+
+export interface ProviderTypeResolution {
+  /** The provider that will actually be used. */
+  type: ChannelProviderType
+  /** The configured value, trimmed. Empty string when nothing was configured. */
+  raw: string
+  /**
+   * A value WAS configured, and it is not one this build knows. The caller gets
+   * `telegram` regardless, which is why this flag has to travel with it.
+   */
+  unrecognised: boolean
+}
+
+/**
+ * Resolve a configured channel-provider name, and say whether it was understood.
+ *
+ * Pure, so the substitution can be tested without touching a log. The falling
+ * back itself is deliberate and stays: a build that refuses to start on an
+ * unknown provider name would turn a typo into an outage. What is not
+ * acceptable is doing it in silence, which is what GH #846 walked into.
+ *
+ * The reporter set `CHANNEL_PROVIDER=none` believing it meant "no channel", and
+ * filed a crash against the respawn path. There is no `none` provider: the value
+ * resolved to `telegram`, so their main session came up on a channel plugin they
+ * had deliberately not configured. A typo (`telegran`, `Slack`) lands in exactly
+ * the same place. The original report is the loud version of this; the silent
+ * substitution is the one that is harder to notice and therefore worse.
+ */
+export function resolveProviderType(envValue: string | undefined): ProviderTypeResolution {
+  const raw = (envValue ?? '').trim()
+  const known = KNOWN_PROVIDER_TYPES.find((t) => t === raw)
+  if (known) return { type: known, raw, unrecognised: false }
+  return { type: 'telegram', raw, unrecognised: raw.length > 0 }
+}
+
+// Say it once per distinct bad value, not once per call: getProviderType is
+// called on every isolated-config provision, and a warning that repeats becomes
+// a warning nobody reads.
+const announcedProviderValues = new Set<string>()
+
 export function getProviderType(envValue: string | undefined): ChannelProviderType {
-  if (envValue === 'slack') return 'slack'
-  if (envValue === 'discord') return 'discord'
-  if (envValue === 'googlechat') return 'googlechat'
-  if (envValue === 'teams') return 'teams'
-  return 'telegram'
+  const resolved = resolveProviderType(envValue)
+  if (resolved.unrecognised && !announcedProviderValues.has(resolved.raw)) {
+    announcedProviderValues.add(resolved.raw)
+    logger.warn(
+      { configured: resolved.raw, using: resolved.type, known: KNOWN_PROVIDER_TYPES },
+      `Unknown channel provider "${resolved.raw}" -- falling back to "${resolved.type}". This is NOT what was configured: ` +
+        `the session will come up on the ${resolved.type} plugin. There is no "none" provider; a channel-less agent is not a supported configuration today.`,
+    )
+  }
+  return resolved.type
+}
+
+/** Test seam: the announce-once memory is process-wide by design. */
+export function resetProviderTypeAnnouncements(): void {
+  announcedProviderValues.clear()
 }
 
 // Compiled location is dist/channel-provider.js, so '..' is the install root --


### PR DESCRIPTION
Addresses the silent half of #846. The feature half (a genuinely channel-less main agent) is a separate decision and is not in this PR.

## Measured first

On `develop` at c8806b82:

- `buildMainSessionRespawnCmd` does append `--channels plugin:${pluginId}` unconditionally, as the report says.
- But `ChannelProviderType` is `'telegram' | 'slack' | 'discord' | 'googlechat' | 'teams'`, and `getProviderType()` maps **everything else, including `none`, to `telegram`**. So `provider.pluginId` is never empty and the malformed `--channels plugin:` cannot be produced. `readExtraChannelPluginIds()` filters empties, so it cannot come from there either.

The reported crash is therefore unreachable. What produced it is not: setting `CHANNEL_PROVIDER=none` does not give you a channel-less agent, it silently gives you Telegram, and after a hard restart the session comes up on a plugin the operator deliberately did not configure. A typo (`telegran`, `Slack`) lands in the same place.

I did not add a guard for the empty-id case on its own. Unreachable code that looks like a fix is how an issue gets closed without being fixed.

## What changed

- `resolveProviderType()` is the pure resolver and reports `unrecognised` alongside the type, so the substitution is testable without touching a log.
- `getProviderType()` warns **once per distinct unrecognised value**, naming what was configured, what is used instead, the known set, and that a channel-less agent is not supported today. Once per value rather than once per call, because it runs on every isolated-config provision.
- An unset or empty value is a default, not a mistake, and stays silent.

The fallback behaviour itself is unchanged on purpose: refusing to start on an unknown name would turn a typo into an outage.

Both call sites are covered, including `web/agent-process.ts`, where a sub-agent's mistyped provider was equally silent.

## Verification

- New suite `src/__tests__/channel-provider-unknown-value.test.ts`, 8 tests: every known value, unset and whitespace treated as a default, `none` and typos flagged, the return type never escaping the known set, the warning content, and the once-per-distinct-value behaviour.
- `npx vitest run`: 399 files, 5112 passed, 1 skipped, 0 failed.
- `npx tsc --noEmit`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
