### PR TITLE
fix(memories): honour offset so a >200-memory install stops serving a truncated list as complete (#947)

### DIFF
--- a/src/__tests__/memory-offset-paging.test.ts
+++ b/src/__tests__/memory-offset-paging.test.ts
@@ -1,0 +1,116 @@
+// #947: GET /api/memories ignored `offset`, so an install with >200 memories
+// served the same first page on every request -- silently truncated, no total,
+// no hasMore, no error. A paging loop over it never terminated and over-counted
+// (measured: 2200 counted for 353 real). These tests pin the fix:
+//   1. paging with offset is exhaustive and non-repeating;
+//   2. the memory cache key includes offset (page 2 is not page 1's cache);
+//   3. paging stays exhaustive when every row shares one accessed_at second
+//      (the id DESC tie-break), the shape a bulk import produces;
+//   4. category listings paginate too;
+//   5. offset combined with a search query (q) is rejected, not dropped.
+import { describe, it, expect, beforeEach } from 'vitest'
+import { Readable } from 'node:stream'
+import {
+  initDatabase, saveAgentMemory, getAgentMemories, getDb, clearMemoryCache,
+} from '../db.js'
+import { tryHandleMemories } from '../web/routes/memories.js'
+import type { RouteContext } from '../web/routes/types.js'
+
+const AGENT = 'pager'
+
+function seed(n: number, opts: { sameSecond?: boolean; category?: string } = {}): void {
+  const db = getDb()
+  const base = 1_700_000_000
+  for (let i = 0; i < n; i++) {
+    const { id } = saveAgentMemory(AGENT, `memory ${i}`, opts.category ?? 'warm', `kw${i}`)
+    // control accessed_at precisely: distinct-descending by default, or one
+    // shared second to exercise the tie-break.
+    const accessed = opts.sameSecond ? base : base + i
+    db.prepare('UPDATE memories SET accessed_at = ? WHERE id = ?').run(accessed, id)
+  }
+  clearMemoryCache()
+}
+
+function getCtx(qs: string): { ctx: RouteContext; out: { status: number; body: any } } {
+  const out: { status: number; body: any } = { status: 200, body: null }
+  const res: any = {
+    writeHead(status: number) { out.status = status; return res },
+    setHeader() { return res },
+    end(chunk?: string) { if (chunk) out.body = JSON.parse(chunk) },
+  }
+  const url = new URL(`http://localhost:3420/api/memories?${qs}`)
+  const req: any = Readable.from([])
+  req.headers = {}
+  return { ctx: { req, res, path: url.pathname, method: 'GET', url } as RouteContext, out }
+}
+
+describe('#947: GET /api/memories offset paging', () => {
+  beforeEach(() => { initDatabase(':memory:'); clearMemoryCache() })
+
+  it('pages exhaustively and never repeats a row (distinct accessed_at)', () => {
+    seed(250)
+    const seen = new Set<number>()
+    let offset = 0
+    let pages = 0
+    for (;;) {
+      const page = getAgentMemories(AGENT, 100, undefined, offset)
+      if (page.length === 0) break
+      for (const m of page) {
+        expect(seen.has(m.id), `row ${m.id} returned twice`).toBe(false)
+        seen.add(m.id)
+      }
+      offset += 100
+      if (++pages > 10) throw new Error('paging did not terminate')
+    }
+    expect(seen.size).toBe(250)
+  })
+
+  it('the cache key includes offset -- page 2 is not served page 1 rows', () => {
+    seed(250)
+    const p1 = getAgentMemories(AGENT, 100, undefined, 0)   // populates cache
+    const p2 = getAgentMemories(AGENT, 100, undefined, 100) // must NOT hit p1's cache
+    expect(p1[0].id).not.toBe(p2[0].id)
+    expect(new Set([...p1, ...p2].map(m => m.id)).size).toBe(200)
+  })
+
+  it('stays exhaustive when every row shares one accessed_at second', () => {
+    seed(250, { sameSecond: true })
+    const seen = new Set<number>()
+    for (let offset = 0; offset < 250; offset += 50) {
+      for (const m of getAgentMemories(AGENT, 50, undefined, offset)) {
+        expect(seen.has(m.id), `row ${m.id} repeated across a tied page`).toBe(false)
+        seen.add(m.id)
+      }
+    }
+    expect(seen.size).toBe(250)
+  })
+
+  it('category listings paginate too', () => {
+    seed(120, { category: 'cold' })
+    const p1 = getAgentMemories(AGENT, 50, 'cold', 0)
+    const p2 = getAgentMemories(AGENT, 50, 'cold', 50)
+    const p3 = getAgentMemories(AGENT, 50, 'cold', 100)
+    const ids = new Set([...p1, ...p2, ...p3].map(m => m.id))
+    expect(p1.length).toBe(50)
+    expect(p3.length).toBe(20)
+    expect(ids.size).toBe(120)
+  })
+
+  it('rejects offset combined with q (400), rather than dropping it', async () => {
+    seed(10)
+    const { ctx, out } = getCtx('agent=pager&q=memory&offset=5')
+    expect(await tryHandleMemories(ctx)).toBe(true)
+    expect(out.status).toBe(400)
+    expect(String(out.body.error)).toContain('offset')
+  })
+
+  it('the HTTP listing honours offset end to end', async () => {
+    seed(250)
+    const p1 = getCtx('agent=pager&limit=100&offset=0')
+    const p2 = getCtx('agent=pager&limit=100&offset=100')
+    await tryHandleMemories(p1.ctx)
+    await tryHandleMemories(p2.ctx)
+    expect(Array.isArray(p1.out.body)).toBe(true)
+    expect(p1.out.body[0].id).not.toBe(p2.out.body[0].id)
+  })
+})

--- a/src/db.ts
+++ b/src/db.ts
@@ -1570,10 +1570,15 @@ export function decayMemories(): void {
   db.prepare('UPDATE memories SET salience = MAX(salience * 0.995, 0.01) WHERE created_at < ?').run(oneWeekAgo)
 }
 
-export function getMemoriesForChat(chatId: string, limit = 10): Memory[] {
+export function getMemoriesForChat(chatId: string, limit = 10, offset = 0): Memory[] {
+  // id DESC tie-break (#947): accessed_at has 1-second granularity, so a bulk
+  // import leaves hundreds of rows sharing one value; without a stable
+  // secondary sort SQLite may order the ties differently between queries, and
+  // LIMIT/OFFSET over them can repeat a row on one page and never return
+  // another. id is the unique insertion order, so it makes paging total.
   return db
-    .prepare('SELECT * FROM memories WHERE chat_id = ? ORDER BY accessed_at DESC LIMIT ?')
-    .all(chatId, limit) as Memory[]
+    .prepare('SELECT * FROM memories WHERE chat_id = ? ORDER BY accessed_at DESC, id DESC LIMIT ? OFFSET ?')
+    .all(chatId, limit, offset) as Memory[]
 }
 
 // --- In-process memory cache (TTL-based) ---
@@ -1660,17 +1665,21 @@ export function saveAgentMemory(
 // accessed memories" instead of "the N most recent <category> memories", so an
 // older-but-still-active memory would drop out of the list with no truncation
 // signal -- invisible to the caller, and worst right after a restart.
-export function getAgentMemories(agentId: string, limit: number = 20, category?: string): Memory[] {
-  const key = `${agentId}:${limit}:${category ?? ''}`
+export function getAgentMemories(agentId: string, limit: number = 20, category?: string, offset: number = 0): Memory[] {
+  // offset is part of the cache key (#947): without it page 2 would be served
+  // page 1's cached rows for up to MEMORY_CACHE_TTL_MS. id DESC tie-break for
+  // the same reason getMemoriesForChat has one -- accessed_at ties are common
+  // after a bulk import and make LIMIT/OFFSET non-total without it.
+  const key = `${agentId}:${limit}:${category ?? ''}:${offset}`
   const cached = memoryCacheGet(key)
   if (cached) return cached
   const result = (category
     ? db.prepare(
-        "SELECT * FROM memories WHERE (agent_id = ? OR category = 'shared') AND category = ? ORDER BY accessed_at DESC LIMIT ?"
-      ).all(agentId, category, limit)
+        "SELECT * FROM memories WHERE (agent_id = ? OR category = 'shared') AND category = ? ORDER BY accessed_at DESC, id DESC LIMIT ? OFFSET ?"
+      ).all(agentId, category, limit, offset)
     : db.prepare(
-        "SELECT * FROM memories WHERE (agent_id = ? OR category = 'shared') ORDER BY accessed_at DESC LIMIT ?"
-      ).all(agentId, limit)) as Memory[]
+        "SELECT * FROM memories WHERE (agent_id = ? OR category = 'shared') ORDER BY accessed_at DESC, id DESC LIMIT ? OFFSET ?"
+      ).all(agentId, limit, offset)) as Memory[]
   memoryCacheSet(key, result)
   return result
 }

--- a/src/web/routes/memories.ts
+++ b/src/web/routes/memories.ts
@@ -83,6 +83,21 @@ export async function tryHandleMemories(ctx: RouteContext): Promise<boolean> {
     const tier = url.searchParams.get('tier') || url.searchParams.get('category') || ''
     const limit = Math.min(parseInt(url.searchParams.get('limit') || '50', 10), 200)
     const mode = url.searchParams.get('mode') || 'fts'
+    // #947: offset is honoured on the LISTING branches only. A negative or
+    // non-numeric value is clamped to 0 (no page skip) rather than erroring --
+    // the failure this fixes was a SILENT one, and a hard 400 on a stray value
+    // would trade it for a different surprise.
+    const offsetRaw = parseInt(url.searchParams.get('offset') || '0', 10)
+    const offset = Number.isFinite(offsetRaw) && offsetRaw > 0 ? offsetRaw : 0
+    // offset makes no sense on a relevance-ranked search: hybridSearch fuses two
+    // rankings and searchAgentMemories oversamples FTS then re-ranks in JS, so a
+    // SQL OFFSET would page over a DIFFERENT ranking than page 1 returned.
+    // Reject the combination loudly instead of dropping offset silently --
+    // silently dropping the parameter is the class of bug #947 is about.
+    if (offset > 0 && q) {
+      json(res, { error: 'offset is not supported together with q (search results are relevance-ranked, not a stable page order)' }, 400)
+      return true
+    }
 
     let results: Memory[]
     // GH #1025: a hybrid answer built entirely by the vector branch looks the
@@ -106,9 +121,9 @@ export async function tryHandleMemories(ctx: RouteContext): Promise<boolean> {
       }
     } else if (agentId) {
       // Category goes into the query, not a post-filter: see getAgentMemories.
-      results = getAgentMemories(agentId, limit, tier || undefined)
+      results = getAgentMemories(agentId, limit, tier || undefined, offset)
     } else {
-      results = getMemoriesForChat(ALLOWED_CHAT_ID, limit)
+      results = getMemoriesForChat(ALLOWED_CHAT_ID, limit, offset)
     }
 
     // Still needed for the search branches above, which rank by relevance and


### PR DESCRIPTION
Refs #947 -- kept OPEN until release; this PR targets develop, not the default branch. Marveen closes it at promote time.

## The bug

`/api/memories` capped `limit` at 200 and never read `offset`. On an install with more than 200 memories, every page returned the same first 200 rows, with nothing in the response saying the list was partial -- no `total`, no `hasMore`, no error. A paging loop did not terminate on its own and over-counted (the reporter measured 2200 memories counted for 353 real). Anything that counts, audits or exports through the endpoint worked from silently truncated data that looked right.

## The fix (the reporter's plan)

- `getAgentMemories` and `getMemoriesForChat` take an `offset` and thread it into the two **listing** branches.
- `offset` is part of the `getAgentMemories` cache key -- otherwise page 2 is served page 1's cached rows for up to `MEMORY_CACHE_TTL_MS`.
- `ORDER BY accessed_at DESC` gains an `id DESC` tie-break. `accessed_at` has 1-second granularity, so a bulk import leaves hundreds of rows tied and SQLite may order those ties differently from query to query; `LIMIT`/`OFFSET` over them could repeat a row on a page and never return another.
- `offset` is **not** added to the search branches: `hybridSearch` fuses two rankings and `searchAgentMemories` oversamples FTS and re-ranks in JS, so a SQL `OFFSET` would page over a different ranking than page 1 returned. `offset` together with `q` is rejected with a 400 that explains why -- silently dropping the parameter is the class of bug being fixed. A stray/negative `offset` on a listing is clamped to 0 rather than 400'd, since the original failure was silent and a hard error on a typo would just trade one surprise for another.

The response shape stays a bare array, so existing dashboard callers are unaffected.

## Verification

New `memory-offset-paging.test.ts`: exhaustive non-repeating paging (distinct `accessed_at`); the cache key includes `offset` (page 2 is not page 1); paging stays exhaustive when every row shares one `accessed_at` second (the tie-break); category listings paginate; `offset`+`q` is rejected; and the HTTP listing honours `offset` end to end.

`tsc --noEmit` clean; the 35 memory tests pass; no new failures versus a clean `develop` worktree (the same 33 hook/gate-wiring tests fail identically on stock `develop` in a worktree and are green on CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)