### PR TITLE
fix(recovery): no keystroke on a parked input we cannot attribute to us (GH #717)

### DIFF
--- a/src/__tests__/stuck-input-action.test.ts
+++ b/src/__tests__/stuck-input-action.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest'
+import { applyStuckRestartBusyGuard } from '../web/channel-monitor.js'
 import {
   decideStuckInputAction,
   submitLanded,
@@ -108,16 +109,20 @@ describe('decideStuckInputAction (recovery-decision unit)', () => {
     expect(a).toBe('hold')
   })
 
-  it('STUCKINPUT805: box so short even the tail marker is cut -> no machine evidence -> default path', () => {
-    // scheduledTaskBlock and machineOrigin both read false when every marker
-    // is outside the visible box. Multi-row holds; single-row keeps the
-    // harmless legacy Enter. Neither destroys anything.
+  it('STUCKINPUT805: box so short even the tail marker is cut -> no machine evidence -> hold', () => {
+    // scheduledTaskBlock and machineOrigin both read false when every marker is
+    // outside the visible box.
+    //
+    // CONTRACT CHANGED (GH #717): the single-row case asserted 'enter' here and
+    // called it "the harmless legacy Enter". It is not harmless. With no machine
+    // evidence the park may be an operator's own draft, and Enter submits it
+    // half-typed. Both row counts now hold.
     expect(decideStuckInputAction(facts({
       rowCount: 3, allowPlainReinject: true, hasPlainText: true, escalate: true,
     }))).toBe('hold')
     expect(decideStuckInputAction(facts({
       rowCount: 1, allowPlainReinject: true, hasPlainText: true, escalate: true,
-    }))).toBe('enter')
+    }))).toBe('hold')
   })
 
   it('multi-row with nothing safely re-injectable -> hold (never corrupt via Enter)', () => {
@@ -141,8 +146,29 @@ describe('decideStuckInputAction (recovery-decision unit)', () => {
     expect(decideStuckInputAction(facts({ rowCount: 1, blockTruncated: true, escalate: true }))).toBe('enter')
   })
 
-  it('single-row default (swallowed Enter) -> bare Enter', () => {
-    expect(decideStuckInputAction(facts({ rowCount: 1, escalate: true }))).toBe('enter')
+  // CONTRACT CHANGED (GH #717). The default used to bare-Enter any single-row
+  // box on the theory that it was a swallowed Enter. The reporter measured what
+  // else it hits: attach to the main session, type a line, pause past the
+  // confirm window, and the unfinished sentence submits itself.
+  it('single-row default with NO machine origin -> hold, never submit an unidentified park', () => {
+    expect(decideStuckInputAction(facts({ rowCount: 1, escalate: true }))).toBe('hold')
+  })
+
+  it('single-row default WITH machine origin -> bare Enter, the swallowed-Enter remedy survives', () => {
+    expect(decideStuckInputAction(facts({ rowCount: 1, escalate: true, machineOrigin: true }))).toBe('enter')
+    expect(decideStuckInputAction(facts({ rowCount: 1, escalate: false, machineOrigin: true }))).toBe('enter')
+  })
+
+  it('machine origin does not license an Enter on a multi-row box', () => {
+    // The older invariant still holds: a bare Enter in a multi-row box inserts a
+    // newline and corrupts the message, whoever put the text there.
+    expect(decideStuckInputAction(facts({ rowCount: 2, escalate: true, machineOrigin: true }))).toBe('hold')
+  })
+
+  it('a truncated <channel> block still Enters single-row: the block itself is the evidence', () => {
+    // Distinct from the default path: parkedChannelInput found OUR block, so the
+    // origin question is already answered even though the capture is incomplete.
+    expect(decideStuckInputAction(facts({ rowCount: 1, blockTruncated: true, machineOrigin: false }))).toBe('enter')
   })
 
   // 2026-07-25 hermes incident: a multi-row scheduled-task tick parked on the
@@ -208,5 +234,26 @@ describe('parkedInputRowCount', () => {
 
   it('idle / empty box -> 0', () => {
     expect(parkedInputRowCount(IDLE)).toBe(0)
+  })
+})
+
+// GH #717 end to end: the same machineOrigin signal must gate BOTH the watcher's
+// keystroke and the hard-restart busy-guard, or the fix on one path becomes a
+// new destructive path on the other. These pin that they agree.
+describe('GH #717: an unidentified park is neither submitted nor restarted away', () => {
+  it('the watcher holds on a suspected human draft', () => {
+    expect(decideStuckInputAction(facts({ rowCount: 1, escalate: true, machineOrigin: false }))).toBe('hold')
+  })
+
+  it('and the busy-guard skips the hard restart for the same pane', () => {
+    // applyStuckRestartBusyGuard only lets a restart through on a 'typing' pane
+    // when machineOrigin is true. So the pane the watcher now refuses to Enter
+    // is also the pane the restart path refuses to act on: holding does not
+    // hand the draft to a restart instead.
+    expect(applyStuckRestartBusyGuard('typing', 'restart', { machineOrigin: false, softRemedy: false })).toBe('skip')
+  })
+
+  it('a machine-origin park with no soft remedy is still restartable, so a real wedge is not immortal', () => {
+    expect(applyStuckRestartBusyGuard('typing', 'restart', { machineOrigin: true, softRemedy: false })).toBe('restart')
   })
 })

--- a/src/pane-state.ts
+++ b/src/pane-state.ts
@@ -1884,7 +1884,9 @@ export interface StuckInputActionFacts {
  *   - A TRUNCATED <channel> block (chat_id unrecoverable) must not be
  *     re-injected; multi-row truncated holds (awaiting the keystroke fix),
  *     single-row keeps the harmless legacy Enter.
- *   - Otherwise a bare Enter is the swallowed-Enter remedy, but only single-row.
+ *   - A bare Enter is the swallowed-Enter remedy, but only single-row AND only
+ *     with positive machine origin: an unidentified park may be the operator's
+ *     own draft, and Enter would submit it half-typed (GH #717).
  */
 export function decideStuckInputAction(f: StuckInputActionFacts): StuckInputAction {
   const multiRow = f.rowCount > 1
@@ -1932,10 +1934,36 @@ export function decideStuckInputAction(f: StuckInputActionFacts): StuckInputActi
   // Truncated safety preamble: clear only (never re-inject a stale preamble).
   if (f.truncatedPreamble && f.escalate) return 'clear-preamble'
   // Truncated <channel> block: hold a multi-row (Enter would corrupt; re-inject
-  // would answer the wrong chat_id), keep the harmless legacy Enter single-row.
+  // would answer the wrong chat_id), keep the Enter single-row. The Enter is
+  // safe here for the same reason the branches above are: a <channel> block,
+  // even a truncated one, IS positive evidence that we put the text there.
   if (f.blockTruncated) return multiRow ? 'hold' : 'enter'
-  // Default swallowed-Enter remedy -- never on multi-row.
-  return multiRow ? 'hold' : 'enter'
+  // Nothing above identified the park. GH #717: this default used to bare-Enter
+  // any single-row box, which submits an operator's half-typed draft the moment
+  // they pause past the confirm window. The reporter measured it repeatedly from
+  // a `tmux attach` on the main session; the remaining text is lost from the
+  // prompt and the agent answers a fragment.
+  //
+  // Every branch above establishes origin before it acts -- a channel block, a
+  // scheduled-task tick, a registry match, or an explicit machine-origin marker
+  // -- and the plain re-inject path already refuses to touch an uncertain park
+  // for exactly this reason ("a human's text has no re-delivery"). That rule was
+  // applied to the branches that clear or re-type and not to the one that
+  // presses Enter, even though submitting a half-typed draft destroys the same
+  // work. This closes that gap: no positive origin, no keystroke.
+  //
+  // What this costs, stated plainly: a genuine swallowed-Enter delivery whose
+  // parked text carries no recognisable marker is no longer rescued by the
+  // watcher. That failure is a DELAY and it has a safety net -- the ledger
+  // live-drain returns unanswered inbound to the running session on its own
+  // cycle. Submitting an operator's unfinished sentence is irreversible and
+  // goes out under the owner's name. The two are not the same weight.
+  //
+  // The hard-restart busy-guard is unaffected: applyStuckRestartBusyGuard only
+  // allows a restart on a 'typing' pane when machineOrigin is true, so an
+  // unidentified park (a suspected human draft) still yields 'skip' there --
+  // the same signal now gates both paths, which is the point.
+  return !multiRow && f.machineOrigin ? 'enter' : 'hold'
 }
 
 // Would the soft stuck-input recovery have ANY submitting/clearing move for

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -378,9 +378,10 @@ export function applyStuckRestartBusyGuard(
 
 // Session-agnostic stuck-input recovery: capture the pane, and if a channel
 // notification is parked at the ❯ prompt, get it SUBMITTED (Enter-first, then
-// clear + verbatim re-inject of the COMPLETE block). The gate fires ONLY for a
-// parked <channel> block, so a human's own draft is never touched. Returns the
-// next StuckInputState. Used for the main session AND every sub-agent session.
+// clear + verbatim re-inject of the COMPLETE block). The gate tracks ANY parked
+// text; the ORIGIN check lives in decideStuckInputAction, which refuses every
+// move -- keystroke included -- on a park it cannot attribute to us (GH #717).
+// Returns the next StuckInputState. Used for the main session AND every sub-agent session.
 // Recover a channel/inter-agent message stranded at the ❯ prompt by getting it
 // SUBMITTED. Tracks ANY parked input (stuckInputSignature), Enter-first, then
 // escalates after MAIN_STUCK_ENTER_ATTEMPTS. Escalation has three safe paths:
@@ -1981,9 +1982,12 @@ export function startChannelPluginMonitor(): NodeJS.Timeout | null {
     }
 
     // Stuck channel-input recovery (main + sub-agents). Recover a channel
-    // notification stranded at the ❯ prompt by getting it SUBMITTED. The gate
-    // (parkedChannelInput != null) fires ONLY for a parked <channel> block, so
-    // a human's own hand-typed draft is never touched. Enter-first (faithful);
+    // notification stranded at the ❯ prompt by getting it SUBMITTED. The entry
+    // gate is ANY parked text (stuckInputSignature); what protects a human's
+    // hand-typed draft is decideStuckInputAction, which since GH #717 makes no
+    // move at all without positive machine origin. The older wording here
+    // claimed the gate itself was origin-scoped, which it never was, and that
+    // claim is how the Enter branch kept submitting operator drafts. Enter-first (faithful);
     // escalate to clear+re-inject only after MAIN_STUCK_ENTER_ATTEMPTS, and
     // only when the captured block looks COMPLETE -- a truncated capture stays
     // on Enter rather than risk a partial re-inject to the wrong chat_id.


### PR DESCRIPTION
Fixes #717.

## The change

`decideStuckInputAction`'s final default was `return multiRow ? 'hold' : 'enter'`, so a single-row parked box with no channel block, no scheduled-task block, no registry match and no machine-origin marker got a bare Enter. It is now `!multiRow && f.machineOrigin ? 'enter' : 'hold'`.

The principle was already in this file, applied to the other branches. `reinject-plain` requires positive machine origin, with the reason written out: *"agent-terminal reaches sub-agent panes too, and clearing or re-injecting a human's text destroys work nothing will re-deliver."* That rule was applied to the branches that clear or re-type and not to the one that presses Enter, even though submitting a half-typed draft destroys the same work in the same way.

The truncated `<channel>` branch keeps its single-row Enter: a channel block, even an incomplete one, is positive evidence that we put the text there.

## The trade, stated rather than buried

A genuine swallowed-Enter delivery whose parked text carries no recognisable marker is no longer rescued by the watcher. That failure is a **delay**, and it has a safety net: the ledger live-drain returns unanswered inbound to the running session on its own cycle. Submitting an operator's unfinished sentence is **irreversible** and goes out under the owner's name. The two failures are not the same weight, which is what decided the direction.

## The knock-on, measured rather than assumed

Making the watcher hold more often could have handed the same panes to the hard restart instead. It does not, and the tests now pin it: `applyStuckRestartBusyGuard` only lets a restart through on a `typing` pane when `machineOrigin` is true. So the pane the watcher now refuses to Enter is also the pane the restart path refuses to act on. The same signal gates both, which is the point. A machine-origin park with no soft remedy stays restartable, so a real wedge does not become immortal (the 2026-07-25 hermes case).

## Contract changes, deliberate

Two existing assertions encoded the old behaviour and are changed, not silenced:

- `single-row default (swallowed Enter) -> bare Enter` now holds, with a companion test that a machine-origin park still Enters, so the swallowed-Enter remedy is not lost.
- the marker-less short box case called its Enter "the harmless legacy Enter". It is not harmless, and the test now says so.

## Comments corrected

Two comments claimed the gate *"fires ONLY for a parked `<channel>` block, so a human's own hand-typed draft is never touched"*. The code never did that. The reporter found the mismatch, and an inaccurate comment sitting above the call site is part of why the gap survived review for this long.

## Verification

- `npx vitest run`: 398 files, 5110 passed, 1 skipped, 0 failed.
- `npx tsc --noEmit`: clean.
- `src/__tests__/stuck-input-action.test.ts`: 28 tests, including three new ones that assert the watcher and the busy-guard agree in both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
