### PR TITLE
fix(dashboard): read the main agent's live model from where it actually runs (GH #816)

### DIFF
--- a/src/__tests__/main-agent-active-model-location.test.ts
+++ b/src/__tests__/main-agent-active-model-location.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { mkdtempSync, mkdirSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { resolveTranscriptLocation } from '../web/routes/agents.js'
+import { MAIN_AGENT_ID, PROJECT_ROOT } from '../config.js'
+import { projectsDirFor } from '../web/active-model.js'
+
+// GH #816: the dashboard showed the main agent's model as the DEFAULT_MODEL
+// fallback rather than the model the process was on, and the display read as a
+// statement rather than as "I do not know". The reporter saw the owner take it
+// for a silent downgrade of their assistant.
+//
+// The reason activeModel could never fill that gap: the row resolved the
+// transcript location through agentDir(name), i.e. <root>/agents/<main>. The
+// main agent runs in PROJECT_ROOT, under the channels session, so the reader
+// was pointed at a different working directory than the one being written.
+// Measured on the live install at the same moment: the old path resolved to a
+// directory that EXISTS and yields null, the new one yields claude-opus-5,
+// which is what the process was running. The old directory not being missing is
+// why this never surfaced as an error.
+
+describe('resolveTranscriptLocation', () => {
+  it('points the MAIN agent at PROJECT_ROOT, where it actually runs', () => {
+    expect(resolveTranscriptLocation(MAIN_AGENT_ID).workingDir).toBe(PROJECT_ROOT)
+  })
+
+  it('does NOT point the main agent at agents/<name>, the path that made activeModel null', () => {
+    expect(resolveTranscriptLocation(MAIN_AGENT_ID).workingDir).not.toContain(join('agents', MAIN_AGENT_ID))
+  })
+
+  it('keeps sub-agents on their own working directory', () => {
+    const loc = resolveTranscriptLocation('some-sub-agent')
+    expect(loc.workingDir).toContain(join('agents', 'some-sub-agent'))
+    expect(loc.workingDir).not.toBe(PROJECT_ROOT)
+  })
+
+  it('encodes to the project dir the session actually writes', () => {
+    // The encoding is what ties the two halves together: PROJECT_ROOT
+    // /Users/x/ClaudeClaw becomes -Users-x-ClaudeClaw, which is the directory
+    // name observed on a live install.
+    const loc = resolveTranscriptLocation(MAIN_AGENT_ID)
+    const dir = projectsDirFor(loc.workingDir, loc.configDir)
+    expect(dir).toContain(PROJECT_ROOT.replace(/[/.]/g, '-'))
+  })
+})
+
+describe('resolveTranscriptLocation: isolated config root', () => {
+  // With main-agent isolation the session writes under <root>/.channels-config.
+  // The probe is filesystem-based rather than a re-derivation of the launcher's
+  // isolation decision, so these two cases are about the directory existing.
+  let tmp: string
+
+  beforeAll(() => { tmp = mkdtempSync(join(tmpdir(), 'gh816-')) })
+  afterAll(() => { rmSync(tmp, { recursive: true, force: true }) })
+
+  it('returns a configDir only when the isolated projects dir exists', () => {
+    // On this checkout the real PROJECT_ROOT decides the answer; assert the
+    // contract rather than a machine-specific value.
+    const loc = resolveTranscriptLocation(MAIN_AGENT_ID)
+    if (loc.configDir !== undefined) {
+      expect(loc.configDir).toBe(join(PROJECT_ROOT, '.channels-config'))
+    } else {
+      expect(loc.configDir).toBeUndefined()
+    }
+  })
+
+  it('projectsDirFor falls back to the shared root when no configDir is given', () => {
+    const withIsolation = projectsDirFor('/w', '/iso')
+    const without = projectsDirFor('/w', undefined, '/home/u')
+    expect(withIsolation).toBe(join('/iso', 'projects', '-w'))
+    expect(without).toBe(join('/home/u', '.claude', 'projects', '-w'))
+    mkdirSync(join(tmp, 'unused'), { recursive: true })
+  })
+})

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -447,6 +447,43 @@ interface AgentDetail extends AgentSummary {
   hasApiKey: boolean
 }
 
+// Where a READER finds the transcript of a given agent.
+//
+// GH #816: the main agent's row resolved this the same way as a sub-agent's,
+// through agentDir(name) -> <root>/agents/<main>. The main agent does not run
+// there; it runs in PROJECT_ROOT, under the channels session, so the reader was
+// pointed at a different working directory than the one being written.
+//
+// Measured on the live install, 2026-09-09, same moment, same process:
+//   agents/<main>  -> projects/-Users-marvin-ClaudeClaw-agents-marveen  (exists) -> null
+//   PROJECT_ROOT   -> projects/-Users-marvin-ClaudeClaw                 (exists) -> claude-opus-5
+// The old directory is not missing, which is why this never surfaced as an
+// error: it is a real directory holding another session's history, and it
+// simply has no current model to report.
+//
+// The consequence is the trust problem in the report: activeModel stayed null,
+// the row fell back to the configured value with modelSource "default", and a
+// fallback shown as a plain value reads as a statement. The reporter's owner
+// took it for a silent downgrade of their assistant.
+//
+// The config root matters too. With main-agent isolation the session writes
+// under <root>/.channels-config; on this install that path is a symlink to
+// ~/.claude/projects, but an install without the symlink would read an empty
+// shared root and go back to reporting null. Probing for the directory (rather
+// than re-deriving the launcher's isolation decision) is the same approach
+// resolveAgentConfigDirForRead uses, and for the same reason: duplicating the
+// launcher's logic is how the two paths drift.
+export function resolveTranscriptLocation(name: string): { workingDir: string; configDir: string | undefined } {
+  if (!isMainChannelsAgent(name)) {
+    return { workingDir: agentDir(name), configDir: resolveAgentConfigDir(name).configDir ?? undefined }
+  }
+  const isolated = join(PROJECT_ROOT, '.channels-config')
+  return {
+    workingDir: PROJECT_ROOT,
+    configDir: existsSync(join(isolated, 'projects')) ? isolated : undefined,
+  }
+}
+
 function getAgentSummary(name: string): AgentSummary {
   const dir = agentDir(name)
   const configRoot = agentConfigRoot(name)
@@ -490,6 +527,10 @@ function getAgentSummary(name: string): AgentSummary {
   // no pane to inspect). One capture-pane per running agent on the list poll.
   const reauth = running ? detectReauthNeeded(capturePane(mainSessionName)) : { needsReauth: false }
 
+  // The main agent runs in PROJECT_ROOT, not in agents/<name>; see
+  // resolveTranscriptLocation.
+  const transcript = resolveTranscriptLocation(name)
+
   return {
     name,
     displayName: readAgentDisplayName(name),
@@ -498,7 +539,7 @@ function getAgentSummary(name: string): AgentSummary {
     modelProfile: typeof agentModelConfig.modelProfile === 'string' ? agentModelConfig.modelProfile : null,
     modelSource: modelResolution.source,
     modelProfileError: modelResolution.error ?? null,
-    activeModel: running ? readActiveModelFromProjectDir(dir, runningSince ?? undefined, resolveAgentConfigDir(name).configDir ?? undefined) : null,
+    activeModel: running ? readActiveModelFromProjectDir(transcript.workingDir, runningSince ?? undefined, transcript.configDir) : null,
     runningSince,
     authMode: readAgentAuthMode(name),
     securityProfile: readAgentSecurityProfile(name),


### PR DESCRIPTION
Refs #816. Deliberately **not** `Fixes`, so the merge does not close the issue while the reporter's install is still on the old code.

## Measured, at the same moment, on the same process

The row resolved its transcript location through `agentDir(name)` -> `<root>/agents/<main>`. The main agent runs in PROJECT_ROOT, under the channels session.

```
agents/<main> -> projects/-Users-...-ClaudeClaw-agents-marveen   exists -> null
PROJECT_ROOT  -> projects/-Users-...-ClaudeClaw                  exists -> claude-opus-5
```

and the process itself: `claude --dangerously-skip-permissions --model claude-opus-5[1m] --channels ...`

The old directory is **not missing**, which is why this never surfaced as an error. It is a real directory holding another session's history; it simply has no current model to report. So `activeModel` stayed null and the row fell back to the configured value with `modelSource: "default"`.

That is the trust problem in the report: a fallback shown as a plain value reads as a statement, and the reporter's owner took it for a silent downgrade of their assistant.

## What changed

`resolveTranscriptLocation(name)` answers where a **reader** finds an agent's transcript:

- main agent: PROJECT_ROOT, plus `<root>/.channels-config` as the config root when its `projects` dir exists.
- sub-agents: unchanged.

The isolated root matters beyond this install. Here `.channels-config/projects` is a symlink to `~/.claude/projects`, so either root reads the same file; on an install without that symlink the shared root would be empty and the value would go back to null. The directory is probed on the filesystem rather than re-derived from the launcher's isolation decision, the same approach and the same reason as `resolveAgentConfigDirForRead`: duplicating the launcher's logic is how two paths drift.

## What this does not do

It does not change what `model` shows or how `modelSource` is computed. The reporter offered two fixes; this is the one that makes the measured value available. Whether the UI should prefer `activeModel` over the configured value, or show the fallback differently, is a display decision and is left alone.

## Verification

- 6 new tests in `src/__tests__/main-agent-active-model-location.test.ts`.
- `npx vitest run`: 402 files, 5134 passed, 1 skipped, 0 failed.
- `npx tsc --noEmit`: clean.
- The before/after above was run against the real production root, because inside a worktree PROJECT_ROOT is the worktree and neither path exists there. Worth stating: the unit tests alone could not have proved this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
