### PR TITLE
fix(scheduler): rescue the main agent's parked line to disk, then clear it (GH #890)

### DIFF
--- a/src/__tests__/parked-input-rescue.test.ts
+++ b/src/__tests__/parked-input-rescue.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { existsSync, readFileSync, rmSync, mkdirSync, chmodSync } from 'node:fs'
+import { join, dirname, basename, resolve } from 'node:path'
+import {
+  rescueParkedInput,
+  decideMainParkedEscalation,
+  PARKED_RESCUE_DIR,
+  MAIN_PARKED_HEARTBEAT_AFTER,
+  MAIN_PARKED_OWNER_AFTER,
+  MAIN_PARKED_RESCUE_AFTER,
+} from '../web/agent-process.js'
+import { logger } from '../logger.js'
+
+// GH #890: a prompt parked in the main agent's input box makes the session read
+// as busy, so every later scheduled task is deferred. The reporter saw the whole
+// scheduler stall silently until the line was cleared by hand; measured again on
+// 2026-09-09 as 22 skipped tasks in one hour.
+//
+// Clearing that box is only acceptable because the text is rescued first AND the
+// save is read back. A save nobody verified is a delete with extra steps, and
+// the box may hold work nothing will re-deliver.
+
+const cleanup: string[] = []
+afterEach(() => {
+  for (const p of cleanup.splice(0)) rmSync(p, { force: true })
+})
+
+describe('rescueParkedInput', () => {
+  it('writes the text and returns a path that actually holds it', () => {
+    const text = 'Igen, ird meg Baloghnak a valaszt'
+    const path = rescueParkedInput('marveen-channels', text)
+    expect(path).not.toBeNull()
+    cleanup.push(path!)
+    expect(existsSync(path!)).toBe(true)
+    expect(readFileSync(path!, 'utf-8')).toContain(text)
+  })
+
+  it('labels the saved text as a scrape of the visible box, so a tail is not read as the whole message', () => {
+    const path = rescueParkedInput('marveen-channels', 'valami')
+    cleanup.push(path!)
+    const body = readFileSync(path!, 'utf-8')
+    expect(body).toContain('scrape of the VISIBLE input box')
+    expect(body).toContain('session: marveen-channels')
+  })
+
+  it('keeps multi-line text intact', () => {
+    const text = 'elso sor\nmasodik sor\nharmadik sor'
+    const path = rescueParkedInput('marveen-channels', text)
+    cleanup.push(path!)
+    expect(readFileSync(path!, 'utf-8')).toContain(text)
+  })
+
+  it('does not collide when two rescues happen for the same session', () => {
+    const a = rescueParkedInput('marveen-channels', 'egyik', 1_700_000_000_000)
+    const b = rescueParkedInput('marveen-channels', 'masik', 1_700_000_001_000)
+    cleanup.push(a!, b!)
+    expect(a).not.toBe(b)
+    expect(readFileSync(a!, 'utf-8')).toContain('egyik')
+    expect(readFileSync(b!, 'utf-8')).toContain('masik')
+  })
+
+  it('cannot be walked out of the rescue directory by a hostile session name', () => {
+    // The property that matters is containment, not the absence of a dot: the
+    // separators are what a traversal needs, and they are gone. A literal '..'
+    // left INSIDE one filename segment cannot climb anywhere.
+    const path = rescueParkedInput('weird/../name with spaces', 'x')
+    cleanup.push(path!)
+    expect(dirname(resolve(path!))).toBe(resolve(PARKED_RESCUE_DIR))
+    expect(basename(path!)).not.toContain('/')
+    expect(basename(path!)).not.toContain(' ')
+  })
+
+  it('returns null when the save cannot be made, so the caller must not clear', () => {
+    const err = vi.spyOn(logger, 'error').mockImplementation(() => logger)
+    // A directory where the file should be makes writeFileSync throw: the point
+    // is that ANY failure lands here rather than in a clear.
+    const stamp = 1_700_000_002_000
+    const blocked = join(
+      PARKED_RESCUE_DIR,
+      `marveen-channels-${new Date(stamp).toISOString().replace(/[:.]/g, '-')}.txt`,
+    )
+    mkdirSync(blocked, { recursive: true })
+    try {
+      expect(rescueParkedInput('marveen-channels', 'nem menthet', stamp)).toBeNull()
+      expect(err).toHaveBeenCalled()
+    } finally {
+      rmSync(blocked, { recursive: true, force: true })
+      err.mockRestore()
+    }
+  })
+})
+
+describe('decideMainParkedEscalation: the rescue stage', () => {
+  it('does not rescue before the owner has been told and given a stage to act', () => {
+    expect(decideMainParkedEscalation(MAIN_PARKED_HEARTBEAT_AFTER, false)).toBe('heartbeat')
+    expect(decideMainParkedEscalation(MAIN_PARKED_OWNER_AFTER, false)).toBe('owner')
+    expect(decideMainParkedEscalation(MAIN_PARKED_RESCUE_AFTER - 1, true)).toBe('heartbeat')
+  })
+
+  it('rescues and clears once the same text has outlasted the owner stage', () => {
+    expect(decideMainParkedEscalation(MAIN_PARKED_RESCUE_AFTER, true)).toBe('rescue-and-clear')
+    expect(decideMainParkedEscalation(MAIN_PARKED_RESCUE_AFTER + 10, true)).toBe('rescue-and-clear')
+  })
+
+  it('rescues even if the owner notification never went out, because the stall is the harm', () => {
+    expect(decideMainParkedEscalation(MAIN_PARKED_RESCUE_AFTER, false)).toBe('rescue-and-clear')
+  })
+
+  it('keeps the ladder ordered: heartbeat < owner < rescue', () => {
+    expect(MAIN_PARKED_HEARTBEAT_AFTER).toBeLessThan(MAIN_PARKED_OWNER_AFTER)
+    expect(MAIN_PARKED_OWNER_AFTER).toBeLessThan(MAIN_PARKED_RESCUE_AFTER)
+  })
+})

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -2696,6 +2696,61 @@ const SUBAGENT_PARKED_ESCALATE_AFTER = 6  // ~3min for a sub-agent whose auto-cl
 // the first threshold, per the spec).
 export const MAIN_PARKED_HEARTBEAT_AFTER = 6
 export const MAIN_PARKED_OWNER_AFTER = 12
+// One more stage past the owner notification (~6 min at UNWEDGE_COOLDOWN_MS),
+// so the operator has had a full stage with the manual fix in hand before the
+// box is rescued and cleared for them. GH #890.
+export const MAIN_PARKED_RESCUE_AFTER = 24
+
+// Where a rescued parked line is written before the box is cleared.
+export const PARKED_RESCUE_DIR = join(STORE_DIR, 'parked-input')
+
+/**
+ * Write the parked text to disk and READ IT BACK before reporting success.
+ *
+ * The read-back is the whole point, not diligence theatre. Clearing an input box
+ * destroys the only copy of whatever was in it; a save whose success nobody
+ * checked is indistinguishable from no save at all, and it would turn this
+ * function into a delete with extra steps. Returns the path only when the file
+ * exists and its content matches what we meant to store; on any failure the
+ * caller must leave the box alone.
+ *
+ * The saved text is a SCRAPE of the VISIBLE box, and that limit is written into
+ * the file itself: an overfull box drops its head rows in the TUI, so the rescue
+ * can be a tail fragment. Better a labelled fragment on disk than a silent
+ * total loss, but the label has to travel with it or the next reader will treat
+ * a fragment as the whole message.
+ */
+export function rescueParkedInput(
+  session: string,
+  text: string,
+  nowMs: number = Date.now(),
+): string | null {
+  try {
+    mkdirSync(PARKED_RESCUE_DIR, { recursive: true })
+    const stamp = new Date(nowMs).toISOString().replace(/[:.]/g, '-')
+    const safeSession = session.replace(/[^A-Za-z0-9._-]/g, '_')
+    const path = join(PARKED_RESCUE_DIR, `${safeSession}-${stamp}.txt`)
+    const body =
+      `# Parked input rescued before the box was cleared\n` +
+      `# session: ${session}\n` +
+      `# saved:   ${new Date(nowMs).toISOString()}\n` +
+      `# NOTE: this is a scrape of the VISIBLE input box. An overfull box drops\n` +
+      `#       its head rows in the TUI, so this may be the tail of a longer line.\n` +
+      `\n${text}\n`
+    writeFileSync(path, body, 'utf-8')
+    // Read back: the file has to exist AND hold what we wrote. A partial write,
+    // a full disk or a read-only store all land here rather than in a clear.
+    const readBack = readFileSync(path, 'utf-8')
+    if (!readBack.includes(text)) {
+      logger.error({ session, path }, 'parked-input rescue: read-back did not match, refusing to clear the box')
+      return null
+    }
+    return path
+  } catch (err) {
+    logger.error({ session, err }, 'parked-input rescue: save failed, refusing to clear the box')
+    return null
+  }
+}
 
 // Pure decision, exported for tests: which escalation stage applies. 'owner'
 // fires once per episode (ownerNotified latches via the record's escalated
@@ -2703,7 +2758,22 @@ export const MAIN_PARKED_OWNER_AFTER = 12
 export function decideMainParkedEscalation(
   fails: number,
   ownerNotified: boolean,
-): 'none' | 'heartbeat' | 'owner' {
+): 'none' | 'heartbeat' | 'owner' | 'rescue-and-clear' {
+  // GH #890: past the owner-notify stage the box has held the SAME text for
+  // roughly MAIN_PARKED_RESCUE_AFTER cooldown rounds, and every scheduled task
+  // in the meantime has been deferred -- the reporter's symptom, and measured
+  // again on 2026-09-09 as 22 skipped tasks in one hour. Leaving it parked is
+  // not neutral: it is a silent, open-ended stall of the whole scheduler.
+  //
+  // Clearing it is only acceptable because the text is rescued to disk and the
+  // save is read back FIRST (rescueParkedInput). That is what separates this
+  // from the move rejected in GH #717: submitting an operator's half-typed line
+  // is irreversible, clearing a line whose verified copy sits in store/ is not.
+  //
+  // The threshold sits AFTER the owner notification on purpose. The operator has
+  // already been told, with the manual fix, and has had a full stage to act. A
+  // human composing a message for two minutes is never in this branch.
+  if (fails >= MAIN_PARKED_RESCUE_AFTER) return 'rescue-and-clear'
   if (fails >= MAIN_PARKED_OWNER_AFTER && !ownerNotified) return 'owner'
   if (fails >= MAIN_PARKED_HEARTBEAT_AFTER) return 'heartbeat'
   return 'none'
@@ -2805,11 +2875,38 @@ export async function clearStaleParkedInput(session: string, host: string | null
       logger.warn({ session, parked: parked.slice(0, 60), fails }, 'message-router: main-agent parked input -- owner notified with manual fix (box untouched)')
     } else if (stage === 'heartbeat') {
       logger.warn({ session, parked: parked.slice(0, 60), fails }, 'message-router: main-agent parked input -- persisting; visible to the heartbeat round (box untouched)')
-    } else {
+    } else if (stage !== 'rescue-and-clear') {
       logger.debug({ session, parked: parked.slice(0, 60), fails }, 'message-router: main-agent parked input -- left untouched')
     }
-    unwedgeAttempts.set(key, { last: nowMs, sig: parked, fails, escalated })
-    return false
+
+    // GH #890: the box has held the same text past the owner-notify stage and
+    // is stalling every scheduled task behind it. Rescue the line to disk, and
+    // clear ONLY if that save read back intact. If the save fails we keep the
+    // old behaviour exactly -- untouched box, escalation record, no keystroke.
+    if (stage === 'rescue-and-clear') {
+      const rescuedPath = rescueParkedInput(session, parked, nowMs)
+      if (rescuedPath == null) {
+        logger.warn(
+          { session, parked: parked.slice(0, 60), fails },
+          'message-router: main-agent parked input -- rescue save failed, box left untouched (a clear without a verified copy is a delete)',
+        )
+        unwedgeAttempts.set(key, { last: nowMs, sig: parked, fails, escalated })
+        return false
+      }
+      notifyChannel(
+        `🧹 A fo agens (${session}) input-mezojeben ~${Math.round((fails * UNWEDGE_COOLDOWN_MS) / 60000)} perce allt egy parkolt sor, ` +
+        `es emiatt minden utemezett feladat varakozott. A sort KIMENTETTUK es a mezot kitisztitottuk, ` +
+        `hogy a csatorna ujra dolgozzon. A szoveg itt van: ${rescuedPath}`,
+      ).catch(() => { /* notify is best-effort */ })
+      logger.warn(
+        { session, parked: parked.slice(0, 60), fails, rescuedPath },
+        'message-router: main-agent parked input rescued to disk, clearing the box',
+      )
+      // Fall through to the shared clear sequence below.
+    } else {
+      unwedgeAttempts.set(key, { last: nowMs, sig: parked, fails, escalated })
+      return false
+    }
   }
 
   // Forward deletion, budgeted by the visible row count -- see the rationale and


### PR DESCRIPTION
Refs #890. The third way rather than either of the two obvious ones: the line is **rescued and verified** before the box is cleared.

## The problem, restated from the code

A prompt parked in the main agent's input box makes the pane read `typing`, so `isSessionReadyForPrompt()` stays false and every later scheduled task is deferred. The janitor already un-wedges sub-agent boxes; the main agent's box was deliberately never touched, because a parked line there could be a real reply (the 2026-06-30 "Balogh" near-miss) and clearing it destroys the only copy of work nothing will re-deliver.

That framed the choice as: submit it, delete it, or leave the scheduler stalled. All three are bad, and the third one was the status quo. Measured again on 2026-09-09: **22 skipped scheduled tasks in one hour**.

## What changed

`rescueParkedInput()` writes the text to `store/parked-input/`, **reads the file back**, and returns the path only when the content is actually there. On any failure it returns null and the caller leaves the box exactly as it behaves today: untouched, escalation recorded, no keystroke.

The read-back is the point of the whole change, not diligence theatre. Clearing an input box destroys the only copy of what was in it, so a save nobody verified is a delete with extra steps. That is why this is a named function with its own tests rather than an inline `writeFileSync` next to the clear.

Two things that travel with the rescue:

- **The saved file states its own limitation.** The text is a scrape of the VISIBLE box; an overfull box drops its head rows in the TUI, so the rescue can be a tail fragment. Better a labelled fragment on disk than a silent total loss, but the label has to be there or the next reader treats a fragment as the whole message.
- **The owner is told where the file is**, so the line can actually be recovered rather than theoretically preserved.

The new stage sits **after** the owner notification (`MAIN_PARKED_RESCUE_AFTER = 24`, twice the owner threshold). The operator has already been told, with the manual fix, and has had a full stage to act. A human composing a message for two minutes is never in this branch.

## Why this does not contradict #1260

In GH #717 the same box is deliberately not touched. The move there was a bare Enter, which **submits** a half-typed line under the owner's name and cannot be undone. Here the line is preserved, verified, and its location handed to the owner. The distinction is not how destructive the operation looks, it is whether the work survives it.

## Verification

- New suite `src/__tests__/parked-input-rescue.test.ts`, 10 tests: content round-trip, multi-line text, the scrape label, no filename collision between two rescues, containment against a hostile session name, and the failure path returning null so the caller cannot clear.
- The existing `main-parked-escalation.test.ts` still passes unchanged: the new stage is above the thresholds it asserts.
- `npx vitest run`: 403 files, 5144 passed, 1 skipped, 0 failed. `npx tsc --noEmit`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
