### PR TITLE
feat(governance): thread-scoped outbound email right as a per-agent capability (BONIMAIL910)

### DIFF
--- a/scripts/email-send-gate.mjs
+++ b/scripts/email-send-gate.mjs
@@ -27,6 +27,7 @@
 import { readFileSync, realpathSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
+import { homedir } from 'node:os'
 
 // Bash command patterns that send mail. SUBGATEPOZ822 (2026-08-22): these are
 // no longer the primary trigger -- they matched CONTENT anywhere in the
@@ -192,13 +193,14 @@ const MANAGE_EMAIL_SEND_OPS = new Set(['send', 'reply', 'replyall', 'forward'])
 // Pure decision: does this tool call send (or attempt to send) email?
 // Returns { deny, kind? }. `kind` selects the deny wording at the hook
 // entrypoint: 'draft-required' is the manage_email case (drafting is fine,
-// only the actual send is refused), everything else is the sub-agent
-// governance block.
+// only the actual send is refused), 'send_email' is the direct MCP send tool
+// (the only path the thread-reply capability below can narrow), everything
+// else is the sub-agent governance block.
 export function gateDecision(toolName, toolInput) {
   const name = String(toolName ?? '')
   // Any MCP send_email tool, name-agnostic (gmail or a differently-named
   // server in a customer install -> the matcher + this both key on send_email).
-  if (/send_email/i.test(name)) return { deny: true }
+  if (/send_email/i.test(name)) return { deny: true, kind: 'send_email' }
   // @aaronsb/google-workspace-mcp multiplexes read, draft and send behind one
   // manage_email tool, so the tool NAME cannot decide this one -- the operation
   // plus the draft flag can. This is what replaces the server's own
@@ -270,6 +272,143 @@ export function readBrandEnv(readFile = (p) => readFileSync(p, 'utf-8')) {
   }
 }
 
+// --- thread-scoped reply (BONIMAIL910) --------------------------------------
+// Owner decision 2026-09-10: ONE named agent may send outbound email, but ONLY
+// into an EXISTING Gmail thread and ONLY to addresses that already appear in
+// that thread's headers. The capability is granted per agent in code
+// (agent-scaffold.ts appends --allow-thread-reply to this hook's command when
+// the agent's capability list contains EMAIL_THREAD_REPLY_CAPABILITY); every
+// other agent keeps the unconditional deny above.
+//
+// Why THREAD-MEMBERSHIP and not a topic rule: the 2026-06-25 incident that
+// created this gate was a sub-agent mailing a FABRICATED address in the
+// owner's name. Membership in an existing thread is checkable in code; "is
+// this financial" is not. The narrowing closes exactly the failure shape that
+// created the rule: a new address can never be introduced.
+//
+// Every branch below fails CLOSED: missing threadId, unparseable recipient,
+// empty participant list, credential/fetch/HTTP error, timeout -> deny.
+
+// One address token. Deliberately simple: it must match what appears both in
+// the tool input and in Gmail's From/To/Cc header values.
+const ADDR_TOKEN = /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi
+
+// Parse one recipient entry ("addr" or "Name <addr>") to a bare lowercase
+// address. Returns '' when the entry is not a single clean address -- the
+// caller treats that as deny (an unparseable recipient must never slip past
+// the membership check).
+export function extractAddress(raw) {
+  const s = String(raw ?? '').trim()
+  const angle = s.match(/<([^<>]+)>$/)
+  const cand = (angle ? angle[1] : s).trim()
+  return /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i.test(cand) ? cand.toLowerCase() : ''
+}
+
+// Validate the send_email tool input as a thread-reply request. Pure.
+// Returns { ok: true, threadId, recipients } or { ok: false, reason }.
+export function threadReplyRequest(toolInput) {
+  const threadId = toolInput?.threadId
+  if (typeof threadId !== 'string' || !threadId.trim()) {
+    return { ok: false, reason: 'threadId hianyzik (uj szal nyitasa tiltott)' }
+  }
+  const raw = [toolInput?.to, toolInput?.cc, toolInput?.bcc]
+    .flatMap((v) => (Array.isArray(v) ? v : v == null ? [] : [v]))
+  if (!raw.length) return { ok: false, reason: 'nincs cimzett' }
+  const recipients = []
+  for (const r of raw) {
+    const addr = extractAddress(r)
+    if (!addr) return { ok: false, reason: `ertelmezhetetlen cimzett: ${String(r)}` }
+    recipients.push(addr)
+  }
+  return { ok: true, threadId: threadId.trim(), recipients }
+}
+
+// The membership decision itself. Pure. Empty participant list denies: a
+// thread we could not read participants from authorizes nothing.
+export function threadMembershipDecision(recipients, participants) {
+  const set = new Set((participants ?? []).map((p) => String(p).toLowerCase()).filter(Boolean))
+  if (!set.size) return { allow: false, reason: 'a szal resztvevo-listaja ures (fail-closed)' }
+  for (const r of recipients) {
+    if (!set.has(r)) return { allow: false, reason: `cimzett nincs a szalban: ${r}` }
+  }
+  return { allow: true }
+}
+
+// Collect every address that appears in the thread's From/To/Cc/Reply-To
+// headers. Pure over the Gmail API thread payload (format=metadata).
+export function extractParticipants(threadData) {
+  const out = new Set()
+  for (const msg of threadData?.messages ?? []) {
+    for (const h of msg?.payload?.headers ?? []) {
+      const n = String(h?.name ?? '').toLowerCase()
+      if (n === 'from' || n === 'to' || n === 'cc' || n === 'reply-to') {
+        for (const m of String(h?.value ?? '').matchAll(ADDR_TOKEN)) out.add(m[0].toLowerCase())
+      }
+    }
+  }
+  return [...out]
+}
+
+// Fetch the thread's participant addresses with the same credentials the Gmail
+// MCP server uses (same mailbox the send would go through, so the gate and the
+// send see the same thread). Path resolution mirrors the MCP server's own:
+// GMAIL_CREDENTIALS_PATH / GMAIL_OAUTH_PATH env overrides, else ~/.gmail-mcp.
+// Throws on ANY failure; per-request timeouts keep the whole check well under
+// the hook's 10s budget (a hook timeout would be a NON-blocking error, i.e.
+// fail-open -- the script must always decide first).
+export async function fetchThreadParticipants(threadId, opts = {}) {
+  const fetchImpl = opts.fetchImpl ?? fetch
+  const readFile = opts.readFile ?? ((p) => readFileSync(p, 'utf-8'))
+  const now = opts.now ?? (() => Date.now())
+  const home = process.env.HOME || homedir()
+  const credPath = process.env.GMAIL_CREDENTIALS_PATH || join(home, '.gmail-mcp', 'credentials.json')
+  const keysPath = process.env.GMAIL_OAUTH_PATH || join(home, '.gmail-mcp', 'gcp-oauth.keys.json')
+  const creds = JSON.parse(readFile(credPath))
+  let accessToken = creds.access_token
+  const fresh = typeof creds.expiry_date === 'number' && creds.expiry_date > now() + 60_000
+  if (!fresh) {
+    const keys = JSON.parse(readFile(keysPath))
+    const k = keys.installed ?? keys.web
+    if (!k?.client_id || !k?.client_secret || !creds.refresh_token) {
+      throw new Error('gmail credentials incomplete')
+    }
+    const res = await fetchImpl(k.token_uri || 'https://oauth2.googleapis.com/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        client_id: k.client_id,
+        client_secret: k.client_secret,
+        refresh_token: creds.refresh_token,
+        grant_type: 'refresh_token',
+      }).toString(),
+      signal: AbortSignal.timeout(3500),
+    })
+    if (!res.ok) throw new Error(`token refresh failed: ${res.status}`)
+    accessToken = (await res.json())?.access_token
+  }
+  if (!accessToken) throw new Error('no gmail access token')
+  const url = 'https://gmail.googleapis.com/gmail/v1/users/me/threads/'
+    + encodeURIComponent(threadId)
+    + '?format=metadata&metadataHeaders=From&metadataHeaders=To&metadataHeaders=Cc&metadataHeaders=Reply-To'
+  const res = await fetchImpl(url, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+    signal: AbortSignal.timeout(3500),
+  })
+  if (!res.ok) throw new Error(`thread fetch failed: ${res.status}`)
+  return extractParticipants(await res.json())
+}
+
+// Deny wording for the thread-reply case: the agent HAS a send right, the
+// specific call fell outside it. Says what the right covers and the way out.
+export function buildThreadDenyMsg(botName, detail) {
+  return (
+    'Kimeno email ezzel a jogosultsaggal CSAK meglevo szalba mehet, es csak a ' +
+    `szalban mar szereplo cimzettnek (szal-kapu). Elutasitva: ${detail}. ` +
+    `Uj cimzetthez vagy uj szalhoz kuldd a tervezett emailt ${botName}nek ` +
+    'inter-agent uzenetben jovahagyasra.'
+  )
+}
+
 function allow() { process.exit(0) }
 
 function deny(reason) {
@@ -308,7 +447,25 @@ if (isInvokedDirectly()) {
   const { deny: shouldDeny, kind } = gateDecision(payload?.tool_name, payload?.tool_input)
   if (shouldDeny) {
     const { botName, ownerName } = readBrandEnv()
-    deny(kind === 'draft-required' ? buildDraftOnlyMsg(ownerName) : buildGateMsg(botName, ownerName))
+    if (kind === 'draft-required') deny(buildDraftOnlyMsg(ownerName))
+    // Thread-scoped narrowing: only when the scaffold wired this agent's hook
+    // command with the flag (capability-driven, regenerated on every spawn),
+    // and only for the direct send_email tool. Bash send routes and
+    // manage_email stay fully gated even for the capable agent.
+    if (kind === 'send_email' && process.argv.includes('--allow-thread-reply')) {
+      const req = threadReplyRequest(payload?.tool_input)
+      if (!req.ok) deny(buildThreadDenyMsg(botName, req.reason))
+      let verdict
+      try {
+        const participants = await fetchThreadParticipants(req.threadId)
+        verdict = threadMembershipDecision(req.recipients, participants)
+      } catch {
+        verdict = { allow: false, reason: 'a szal resztvevoi nem olvashatok (fail-closed)' }
+      }
+      if (verdict.allow) allow()
+      deny(buildThreadDenyMsg(botName, verdict.reason))
+    }
+    deny(buildGateMsg(botName, ownerName))
   }
   allow()
 }

--- a/src/__tests__/email-thread-reply-gate.test.ts
+++ b/src/__tests__/email-thread-reply-gate.test.ts
@@ -1,0 +1,332 @@
+import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { join } from 'node:path'
+import {
+  gateDecision,
+  extractAddress,
+  threadReplyRequest,
+  threadMembershipDecision,
+  extractParticipants,
+  fetchThreadParticipants,
+  buildThreadDenyMsg,
+  // @ts-expect-error -- plain .mjs hook script, no types
+} from '../../scripts/email-send-gate.mjs'
+import {
+  injectEmailSendGate,
+  hasThreadReplyCapability,
+  emailGateCommandStale,
+  EMAIL_THREAD_REPLY_CAPABILITY,
+  EMAIL_THREAD_REPLY_FLAG,
+} from '../web/agent-scaffold.js'
+import { MAIN_AGENT_ID } from '../config.js'
+
+const ROOT = join(__dirname, '..', '..')
+const GATE = join(ROOT, 'scripts', 'email-send-gate.mjs')
+
+// Thread-scoped reply narrowing (BONIMAIL910, owner decision 2026-09-10):
+// ONE capability-holding agent may send, but only into an existing thread and
+// only to addresses already in it. Everything here proves BOTH arms -- the
+// in-thread allow AND the out-of-thread deny -- plus the fail-closed edges.
+
+describe('extractAddress', () => {
+  it('parses bare addresses and Name <addr> forms, lowercased', () => {
+    expect(extractAddress('Sara@Example.COM')).toBe('sara@example.com')
+    expect(extractAddress('Kiss Sara <sara@example.com>')).toBe('sara@example.com')
+    expect(extractAddress('  x@y.hu  ')).toBe('x@y.hu')
+  })
+
+  it('returns empty on anything that is not a single clean address', () => {
+    expect(extractAddress('not-an-address')).toBe('')
+    expect(extractAddress('a@b.hu, c@d.hu')).toBe('')
+    expect(extractAddress('')).toBe('')
+    expect(extractAddress(null)).toBe('')
+    expect(extractAddress({})).toBe('')
+  })
+})
+
+describe('threadReplyRequest', () => {
+  it('accepts a well-formed reply into an existing thread', () => {
+    const r = threadReplyRequest({
+      threadId: '198f2b4c7d3e1a09',
+      to: ['partner@ceg.hu'],
+      cc: ['Masik Fel <masik@ceg.hu>'],
+    })
+    expect(r.ok).toBe(true)
+    expect(r.threadId).toBe('198f2b4c7d3e1a09')
+    expect(r.recipients).toEqual(['partner@ceg.hu', 'masik@ceg.hu'])
+  })
+
+  it('denies without a threadId (a new thread can never be opened)', () => {
+    expect(threadReplyRequest({ to: ['partner@ceg.hu'] }).ok).toBe(false)
+    expect(threadReplyRequest({ threadId: '', to: ['x@y.hu'] }).ok).toBe(false)
+    expect(threadReplyRequest({ threadId: '   ', to: ['x@y.hu'] }).ok).toBe(false)
+    expect(threadReplyRequest({ threadId: 42, to: ['x@y.hu'] }).ok).toBe(false)
+  })
+
+  it('denies with no recipients or an unparseable recipient (fail-closed)', () => {
+    expect(threadReplyRequest({ threadId: 't1' }).ok).toBe(false)
+    expect(threadReplyRequest({ threadId: 't1', to: [] }).ok).toBe(false)
+    expect(threadReplyRequest({ threadId: 't1', to: ['jo@cim.hu', 'nem cim'] }).ok).toBe(false)
+  })
+
+  it('counts bcc as recipients too (no hidden new address)', () => {
+    const r = threadReplyRequest({ threadId: 't1', to: ['a@b.hu'], bcc: ['rejtett@uj.hu'] })
+    expect(r.ok).toBe(true)
+    expect(r.recipients).toContain('rejtett@uj.hu')
+  })
+})
+
+describe('threadMembershipDecision (the two control arms)', () => {
+  const participants = ['szota.szabolcs.ai@gmail.com', 'partner@ceg.hu']
+
+  it('ALLOWS a recipient already in the thread (control 1: the open arm)', () => {
+    expect(threadMembershipDecision(['partner@ceg.hu'], participants).allow).toBe(true)
+  })
+
+  it('DENIES a recipient outside the thread (control 2: the closed arm)', () => {
+    const v = threadMembershipDecision(['idegen@masik.hu'], participants)
+    expect(v.allow).toBe(false)
+    expect(v.reason).toContain('idegen@masik.hu')
+  })
+
+  it('denies when ANY recipient is outside, even if others are inside', () => {
+    expect(threadMembershipDecision(['partner@ceg.hu', 'idegen@masik.hu'], participants).allow).toBe(false)
+  })
+
+  it('is case-insensitive on the participant side', () => {
+    expect(threadMembershipDecision(['partner@ceg.hu'], ['Partner@Ceg.HU']).allow).toBe(true)
+  })
+
+  it('denies on an empty participant list (fail-closed)', () => {
+    expect(threadMembershipDecision(['partner@ceg.hu'], []).allow).toBe(false)
+    expect(threadMembershipDecision(['partner@ceg.hu'], undefined).allow).toBe(false)
+  })
+})
+
+describe('extractParticipants', () => {
+  it('collects From/To/Cc/Reply-To addresses across the thread, deduped', () => {
+    const thread = {
+      messages: [
+        { payload: { headers: [
+          { name: 'From', value: 'Kiss Sara <sara@ceg.hu>' },
+          { name: 'To', value: 'szota.szabolcs.ai@gmail.com, Masik <masik@ceg.hu>' },
+          { name: 'Subject', value: 'nem cim, nem szamit' },
+        ] } },
+        { payload: { headers: [
+          { name: 'from', value: 'szota.szabolcs.ai@gmail.com' },
+          { name: 'Cc', value: 'SARA@CEG.HU' },
+        ] } },
+      ],
+    }
+    const got = extractParticipants(thread)
+    expect(got.sort()).toEqual(['masik@ceg.hu', 'sara@ceg.hu', 'szota.szabolcs.ai@gmail.com'].sort())
+  })
+
+  it('returns [] on an empty or malformed payload', () => {
+    expect(extractParticipants({})).toEqual([])
+    expect(extractParticipants(null)).toEqual([])
+    expect(extractParticipants({ messages: [{}] })).toEqual([])
+  })
+})
+
+describe('fetchThreadParticipants (injected I/O, no network)', () => {
+  const keys = JSON.stringify({ installed: {
+    client_id: 'cid', client_secret: 'cs', token_uri: 'https://oauth2.googleapis.com/token',
+  } })
+  const thread = {
+    messages: [{ payload: { headers: [{ name: 'From', value: 'partner@ceg.hu' }] } }],
+  }
+
+  it('uses the stored access token while it is fresh', async () => {
+    const creds = JSON.stringify({ access_token: 'AT', refresh_token: 'RT', expiry_date: Date.now() + 3_600_000 })
+    const calls: string[] = []
+    const fetchImpl = async (url: string, init?: { headers?: Record<string, string> }) => {
+      calls.push(url)
+      expect(init?.headers?.Authorization).toBe('Bearer AT')
+      return { ok: true, json: async () => thread }
+    }
+    const got = await fetchThreadParticipants('t1', {
+      fetchImpl,
+      readFile: (p: string) => (p.endsWith('credentials.json') ? creds : keys),
+    })
+    expect(got).toEqual(['partner@ceg.hu'])
+    expect(calls).toHaveLength(1)
+    expect(calls[0]).toContain('/threads/t1?format=metadata')
+  })
+
+  it('refreshes an expired token first', async () => {
+    const creds = JSON.stringify({ access_token: 'OLD', refresh_token: 'RT', expiry_date: Date.now() - 1000 })
+    const calls: string[] = []
+    const fetchImpl = async (url: string, init?: { headers?: Record<string, string> }) => {
+      calls.push(url)
+      if (url.includes('oauth2.googleapis.com')) return { ok: true, json: async () => ({ access_token: 'NEW' }) }
+      expect(init?.headers?.Authorization).toBe('Bearer NEW')
+      return { ok: true, json: async () => thread }
+    }
+    const got = await fetchThreadParticipants('t1', {
+      fetchImpl,
+      readFile: (p: string) => (p.endsWith('credentials.json') ? creds : keys),
+    })
+    expect(got).toEqual(['partner@ceg.hu'])
+    expect(calls).toHaveLength(2)
+  })
+
+  it('throws on refresh failure, thread-fetch failure, or unreadable creds', async () => {
+    const creds = JSON.stringify({ access_token: 'AT', refresh_token: 'RT', expiry_date: 0 })
+    await expect(fetchThreadParticipants('t1', {
+      fetchImpl: async () => ({ ok: false, status: 401, json: async () => ({}) }),
+      readFile: (p: string) => (p.endsWith('credentials.json') ? creds : keys),
+    })).rejects.toThrow()
+    await expect(fetchThreadParticipants('t1', {
+      fetchImpl: async () => ({ ok: true, json: async () => ({}) }),
+      readFile: () => { throw new Error('ENOENT') },
+    })).rejects.toThrow()
+  })
+
+  it('URL-encodes the threadId (no path escape into another API route)', async () => {
+    const creds = JSON.stringify({ access_token: 'AT', expiry_date: Date.now() + 3_600_000 })
+    let seen = ''
+    await fetchThreadParticipants('a/../b?x=1', {
+      fetchImpl: async (url: string) => { seen = url; return { ok: true, json: async () => thread } },
+      readFile: (p: string) => (p.endsWith('credentials.json') ? creds : keys),
+    })
+    expect(seen).toContain('/threads/a%2F..%2Fb%3Fx%3D1?')
+  })
+})
+
+// gateDecision itself must be unchanged in effect: send_email still denies for
+// everyone; only the entrypoint's flagged path can narrow it.
+describe('gateDecision regression (kind tag added, behavior unchanged)', () => {
+  it('still denies every send_email, now tagged for the entrypoint', () => {
+    const d = gateDecision('mcp__server-gmail-autoauth-mcp__send_email', { threadId: 't1', to: ['a@b.hu'] })
+    expect(d.deny).toBe(true)
+    expect(d.kind).toBe('send_email')
+  })
+})
+
+describe('hasThreadReplyCapability', () => {
+  it('grants only a sub-agent that carries the capability', () => {
+    expect(hasThreadReplyCapability('boni', [EMAIL_THREAD_REPLY_CAPABILITY])).toBe(true)
+    expect(hasThreadReplyCapability('boni', [])).toBe(false)
+    expect(hasThreadReplyCapability('samu', ['other:cap'])).toBe(false)
+  })
+
+  it('never applies to the main agent (it is not gated at all)', () => {
+    expect(hasThreadReplyCapability(MAIN_AGENT_ID, [EMAIL_THREAD_REPLY_CAPABILITY])).toBe(false)
+  })
+})
+
+describe('injectEmailSendGate with the thread-reply flag', () => {
+  const innerCommand = (s: Record<string, unknown>): string => {
+    const pre = (s.hooks as Record<string, unknown>).PreToolUse as Array<Record<string, unknown>>
+    expect(pre).toHaveLength(1)
+    return (pre[0].hooks as Array<{ command: string }>)[0].command
+  }
+
+  it('default stays byte-identical shape: no flag', () => {
+    const s: Record<string, unknown> = {}
+    injectEmailSendGate(s)
+    expect(innerCommand(s)).not.toContain(EMAIL_THREAD_REPLY_FLAG)
+  })
+
+  it('threadReply=true appends the flag to the hook command', () => {
+    const s: Record<string, unknown> = {}
+    injectEmailSendGate(s, true)
+    const cmd = innerCommand(s)
+    expect(cmd).toContain('email-send-gate.mjs')
+    expect(cmd.endsWith(` ${EMAIL_THREAD_REPLY_FLAG}`)).toBe(true)
+  })
+
+  it('re-apply toggles cleanly in both directions (respawn regenerates)', () => {
+    const s: Record<string, unknown> = {}
+    injectEmailSendGate(s, true)
+    injectEmailSendGate(s, false)
+    expect(innerCommand(s)).not.toContain(EMAIL_THREAD_REPLY_FLAG)
+    injectEmailSendGate(s, true)
+    expect(innerCommand(s)).toContain(EMAIL_THREAD_REPLY_FLAG)
+  })
+})
+
+describe('emailGateCommandStale (migration sees a grant AND a revocation)', () => {
+  const entry = (command: string) => [{
+    matcher: 'Bash|.*send_email.*|.*manage_email.*',
+    hooks: [{ type: 'command', command }],
+  }]
+  const base = '"/usr/bin/node" "/x/scripts/email-send-gate.mjs"'
+
+  it('flags a wired-but-unflagged entry when the capability expects the flag', () => {
+    expect(emailGateCommandStale(entry(base), `${base} ${EMAIL_THREAD_REPLY_FLAG}`)).toBe(true)
+  })
+
+  it('flags a still-flagged entry after the capability was revoked', () => {
+    expect(emailGateCommandStale(entry(`${base} ${EMAIL_THREAD_REPLY_FLAG}`), base)).toBe(true)
+  })
+
+  it('is quiet when the entry matches the expectation', () => {
+    expect(emailGateCommandStale(entry(base), base)).toBe(false)
+    const flagged = `${base} ${EMAIL_THREAD_REPLY_FLAG}`
+    expect(emailGateCommandStale(entry(flagged), flagged)).toBe(false)
+  })
+
+  it('ignores unrelated entries and tolerates a missing array', () => {
+    expect(emailGateCommandStale([{ matcher: 'WebFetch', hooks: [{ command: 'x' }] }], base)).toBe(false)
+    expect(emailGateCommandStale(undefined, base)).toBe(false)
+  })
+})
+
+// Entrypoint integration: run the real script the way the hook runner does.
+// The allow arm of the LIVE thread check needs the real mailbox and is proved
+// in the two-control live probe (PR body); here every hermetic arm is pinned.
+describe('gate script entrypoint (spawned, no network)', () => {
+  const run = (args: string[], payload: unknown, env: Record<string, string> = {}) => {
+    const out = execFileSync(process.execPath, [GATE, ...args], {
+      input: JSON.stringify(payload),
+      timeout: 15_000,
+      env: { ...process.env, ...env },
+    }).toString()
+    return out ? JSON.parse(out) : null
+  }
+  const sendPayload = (tool_input: Record<string, unknown>) => ({
+    tool_name: 'mcp__server-gmail-autoauth-mcp__send_email',
+    tool_input,
+  })
+
+  it('WITHOUT the flag a send_email still gets the unconditional governance deny', () => {
+    const res = run([], sendPayload({ threadId: 't1', to: ['barki@ceg.hu'] }))
+    expect(res.hookSpecificOutput.permissionDecision).toBe('deny')
+    expect(res.hookSpecificOutput.permissionDecisionReason).toContain('governance hard-gate')
+  })
+
+  it('with the flag but NO threadId: thread-gate deny, no network touched', () => {
+    const res = run([EMAIL_THREAD_REPLY_FLAG], sendPayload({ to: ['partner@ceg.hu'] }))
+    expect(res.hookSpecificOutput.permissionDecision).toBe('deny')
+    expect(res.hookSpecificOutput.permissionDecisionReason).toContain('szal-kapu')
+    expect(res.hookSpecificOutput.permissionDecisionReason).toContain('threadId hianyzik')
+  })
+
+  it('with the flag but unreadable credentials: fail-closed deny', () => {
+    const res = run(
+      [EMAIL_THREAD_REPLY_FLAG],
+      sendPayload({ threadId: 't1', to: ['partner@ceg.hu'] }),
+      {
+        GMAIL_CREDENTIALS_PATH: '/nonexistent/credentials.json',
+        GMAIL_OAUTH_PATH: '/nonexistent/keys.json',
+      },
+    )
+    expect(res.hookSpecificOutput.permissionDecision).toBe('deny')
+    expect(res.hookSpecificOutput.permissionDecisionReason).toContain('fail-closed')
+  })
+
+  it('with the flag, non-mail tools still pass (flag widens nothing else)', () => {
+    expect(run([EMAIL_THREAD_REPLY_FLAG], { tool_name: 'Bash', tool_input: { command: 'git status' } })).toBeNull()
+    // and a Bash SEND route stays denied even for the capable agent
+    const res = run([EMAIL_THREAD_REPLY_FLAG], { tool_name: 'Bash', tool_input: { command: 'echo hi | sendmail x@y.hu' } })
+    expect(res.hookSpecificOutput.permissionDecision).toBe('deny')
+    expect(res.hookSpecificOutput.permissionDecisionReason).toContain('governance hard-gate')
+  })
+
+  it('deny message names the way out with the configured bot name', () => {
+    expect(buildThreadDenyMsg('Marveen', 'proba')).toContain('Marveen')
+    expect(buildThreadDenyMsg('Marveen', 'proba')).toContain('proba')
+  })
+})

--- a/src/web/agent-scaffold.ts
+++ b/src/web/agent-scaffold.ts
@@ -575,7 +575,9 @@ export function writeAgentSettingsFromProfile(name: string, profile: ProfileTemp
   // authorizes those autonomously (so test/deploy runs are never blocked); the
   // actual incident vector -- an agent answering its OWN posed question -- is
   // covered by the self-pace block + the #0 CLAUDE.md doctrine.
-  if (agentGetsEmailGate(name)) injectEmailSendGate(existing)
+  if (agentGetsEmailGate(name)) {
+    injectEmailSendGate(existing, hasThreadReplyCapability(name, readAgentCapabilities(name)))
+  }
   if (agentGetsGovernanceGates(name)) injectSelfPaceGate(existing)
   if (agentGetsKanbanWriteGate(name)) {
     injectKanbanWriteGate(existing)
@@ -593,6 +595,26 @@ export function writeAgentSettingsFromProfile(name: string, profile: ProfileTemp
 // rule). Pure + exported so the main-exempt guarantee is unit-testable.
 export function agentGetsEmailGate(name: string): boolean {
   return name !== MAIN_AGENT_ID
+}
+
+// Owner decision 2026-09-10 (BONIMAIL910): a single named agent may send
+// outbound email, narrowed to THREAD-SCOPED REPLIES ONLY -- into an existing
+// Gmail thread, to addresses already present in that thread. The grant is a
+// per-agent CAPABILITY (agent-config.json "capabilities" / persona
+// frontmatter), not a hardcoded agent name (distribution-hardcode rule) and
+// not a hand-edit of settings.json (which writeAgentSettingsFromProfile
+// silently reverts on the next spawn). The scaffold turns the capability into
+// a --allow-thread-reply flag on the gate hook command; the gate script
+// enforces thread membership fail-closed. The main agent never needs it, and
+// for every agent without the capability the gate is byte-identical to before.
+export const EMAIL_THREAD_REPLY_CAPABILITY = 'email:thread-reply'
+export const EMAIL_THREAD_REPLY_FLAG = '--allow-thread-reply'
+
+// Pure predicate (capabilities passed in, so the rule is unit-testable without
+// touching the filesystem): the main agent is exempt from the gate entirely,
+// so the capability is meaningless there and never emits a flag.
+export function hasThreadReplyCapability(name: string, capabilities: string[]): boolean {
+  return name !== MAIN_AGENT_ID && capabilities.includes(EMAIL_THREAD_REPLY_CAPABILITY)
 }
 
 // The matcher is a FULL-match regex against the tool name, and an MCP tool's
@@ -617,18 +639,39 @@ export function emailGateMatcherStale(preToolUse: unknown): boolean {
   })
 }
 
+// Does an existing email-gate entry carry a command OTHER than the expected
+// one? Needed because hookCommandWired() is a substring check: the flagged
+// thread-reply command CONTAINS the unflagged one, so after a capability
+// revocation the wiring check alone would report the stale flagged entry as
+// healthy forever. Exact comparison of the inner command settles both
+// directions (grant not yet applied, grant since revoked).
+export function emailGateCommandStale(preToolUse: unknown, expected: string): boolean {
+  if (!Array.isArray(preToolUse)) return false
+  return preToolUse.some((e) => {
+    if (!JSON.stringify(e).includes('email-send-gate.mjs')) return false
+    const inner = (e as { hooks?: unknown }).hooks
+    if (!Array.isArray(inner)) return true
+    return inner.some((h) => (h as { command?: unknown })?.command !== expected)
+  })
+}
+
 // Idempotently wire the email-send-gate PreToolUse hook into a settings.json
 // object. A deny-list rule alone would NOT enforce this: permissive profiles
 // launch with --dangerously-skip-permissions, which bypasses allow/deny --
 // hooks run regardless of permission mode. Name-agnostic so a customer install
 // gates its own sub-agents (the caller's MAIN_AGENT_ID guard exempts the owner).
-export function injectEmailSendGate(existing: Record<string, unknown>): void {
+export function injectEmailSendGate(existing: Record<string, unknown>, threadReply = false): void {
   const hooks = (existing.hooks && typeof existing.hooks === 'object'
     ? existing.hooks
     : (existing.hooks = {})) as Record<string, unknown>
-  const command = hookCommand(join(PROJECT_ROOT, 'scripts', 'email-send-gate.mjs'))
+  const base = hookCommand(join(PROJECT_ROOT, 'scripts', 'email-send-gate.mjs'))
   // Registration guard: a /tmp or missing path must never enter shared settings.
-  if (isUnsafeHookCommand(command)) return
+  if (isUnsafeHookCommand(base)) return
+  // The thread-reply capability rides on the hook COMMAND, so the grant lives
+  // in the same regenerated-on-every-spawn settings.json as the gate itself:
+  // revoking the capability removes the flag at the next spawn, and a manual
+  // settings edit can neither grant nor keep it.
+  const command = threadReply ? `${base} ${EMAIL_THREAD_REPLY_FLAG}` : base
   const entry = {
     matcher: EMAIL_GATE_MATCHER,
     hooks: [{ type: 'command', command, timeout: 10 }],
@@ -1126,13 +1169,17 @@ export function ensureGovernanceGateCommands(name: string): boolean {
   // wired at all, or it IS wired but under a pre-2026-08-10 matcher that cannot
   // match a qualified MCP tool name. The second one is why the wiring check
   // alone is not enough -- it would report the gate healthy forever.
+  const threadReply = hasThreadReplyCapability(name, readAgentCapabilities(name))
+  const emailCmdExpected = threadReply ? `${emailCmd} ${EMAIL_THREAD_REPLY_FLAG}` : emailCmd
   const needEmail = agentGetsEmailGate(name)
-    && (!hookCommandWired(ptuJson, emailCmd) || emailGateMatcherStale(ptu))
+    && (!hookCommandWired(ptuJson, emailCmdExpected)
+      || emailGateMatcherStale(ptu)
+      || emailGateCommandStale(ptu, emailCmdExpected))
   const needPace = agentGetsGovernanceGates(name) && !hookCommandWired(ptuJson, paceCmd)
   if (!needEmail && !needPace) return false
   // The injectors dedupe by script basename, so a stale bare-`node` entry is
   // replaced in place rather than accumulated.
-  if (needEmail) injectEmailSendGate(settings)
+  if (needEmail) injectEmailSendGate(settings, threadReply)
   if (needPace) injectSelfPaceGate(settings)
   atomicWriteFileSync(settingsPath, JSON.stringify(settings, null, 2))
   return true


### PR DESCRIPTION
## What

Owner decision 2026-09-10 (BONIMAIL910): **one named agent may send outbound email, but ONLY into an existing Gmail thread and ONLY to addresses already present in that thread** (From/To/Cc/Reply-To headers). A new address can never be introduced -- exactly the failure shape of the 2026-06-25 incident that created the gate (a sub-agent mailed a fabricated address in the owner's name).

## Mechanism

- **Grant = capability, not a name, not a settings edit.** `EMAIL_THREAD_REPLY_CAPABILITY` (`email:thread-reply`) in the agent's capability list (`agent-config.json` / persona frontmatter). The scaffold turns it into an `--allow-thread-reply` flag on the email-send-gate hook command, so the grant lives in the same regenerated-on-every-spawn settings.json as the gate itself: a manual settings edit can neither grant nor keep it, and revoking the capability removes the flag at the next spawn. `ensureGovernanceGateCommands` repairs BOTH directions (grant not yet applied / grant since revoked) via the new exact-command `emailGateCommandStale` check -- the substring `hookCommandWired` check alone would have reported a revoked-but-still-flagged entry healthy forever.
- **The gate fetches the thread's participants with the same credentials the Gmail MCP send would use** (same mailbox, same thread view), and fails CLOSED on every edge: missing threadId, unparseable recipient, empty participant list, credential/fetch/HTTP error. Per-request 3.5s timeouts keep the script's decision well under the 10s hook budget (a hook timeout would be a NON-blocking error, i.e. fail-open -- the script must always decide first).
- **Nothing else widens.** Bash send routes and manage_email stay fully gated even for the capable agent; without the flag the gate is byte-identical to before; the main agent is exempt as before; no agent is granted the capability in this PR (that is a runtime config step after merge).

## Probe results (requirement 1: both control arms)

Live, against a real thread (`1a089fc722084dc2`), script invoked exactly as the hook runner does, stdin PreToolUse payload -- no email was sent (the gate only decides):

| control | call | result |
|---|---|---|
| 1 open arm | `--allow-thread-reply`, To = address in the thread's To header | **ALLOW** (exit 0, no output) |
| 2 closed arm | `--allow-thread-reply`, To = fabricated address | **DENY**: `cimzett nincs a szalban: idegen@nemletezik.hu` |
| 3 Reply-To | `--allow-thread-reply`, To = address present only in Reply-To | **ALLOW** -- measured the header, the address IS a header participant; Reply-To is included by design (it is the canonical reply target) |
| 4 no flag | same in-thread call WITHOUT the flag | **DENY**: unchanged unconditional governance message |

Hermetic tests pin the same two arms on the pure functions plus the fail-closed edges (missing threadId, unparseable recipient, empty participants, unreadable credentials, URL-encoding of threadId), the scaffold flag toggle in both directions, and the migration staleness in both directions. Full suite: **404 files / 5181 tests green**, tsc clean.

## Requirement 2 (restart-survival) -- post-merge step

The live read-back (grant the capability, respawn the agent, read the flagged command back from `agents/<name>/.claude/settings.json`) needs the merged code running on the host, so it is the explicit next step after merge + host update; the toggle semantics are unit-pinned here. I will report the read-back on the card.

Refs BONIMAIL910.

🤖 Generated with [Claude Code](https://claude.com/claude-code)