### PR TITLE
fix(voice): stop the Hungarian transcription looping on a silent/noisy tail (VOICEWHISPER910)

### DIFF
--- a/scripts/voice/_vtools.py
+++ b/scripts/voice/_vtools.py
@@ -76,7 +76,7 @@ def _token(state_dir):
 def _whisper(path):
     from faster_whisper import WhisperModel
     m = WhisperModel("small", device="cpu", compute_type="int8")
-    segs, _ = m.transcribe(path, language="hu", beam_size=5)
+    segs, _ = m.transcribe(path, language="hu", beam_size=5, condition_on_previous_text=False)
     print(" ".join(s.text.strip() for s in segs).strip())
 
 
@@ -157,7 +157,7 @@ def canary(voice_onnx, expected_text):
                        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         from faster_whisper import WhisperModel
         m = WhisperModel("small", device="cpu", compute_type="int8")
-        segs, _ = m.transcribe(wav, language="hu", beam_size=5)
+        segs, _ = m.transcribe(wav, language="hu", beam_size=5, condition_on_previous_text=False)
         transcript = " ".join(s.text.strip() for s in segs).strip()
         exp_words = _normalize(expected_text).split()
         got_words = set(_normalize(transcript).split())

--- a/scripts/voice/test_vtools_repetition.py
+++ b/scripts/voice/test_vtools_repetition.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Behaviour test for VOICEWHISPER910: the Hungarian voice transcription must
+not loop on a repetition-prone clip.
+
+This measures the REPETITION in the output, not the presence of the
+`condition_on_previous_text` argument. faster-whisper defaults that flag to
+True, and with a noisy or silent tail the decoder echoes its own previous
+output, so a voice message can come back with a phrase repeated two or three
+times. `_vtools` now passes `condition_on_previous_text=False` at both call
+sites; this test proves the effect on the transcript.
+
+It builds one deterministic clip: a short Hungarian sentence (piper is
+deterministic for a fixed voice and text) followed by a seeded low-amplitude
+noise tail (Python's `random`, fixed seed), so the same bytes are produced on
+every run and faster-whisper's beam search is deterministic on them. Then:
+
+  1. Positive control: transcribing that clip WITH condition_on_previous_text
+     =True reproduces the echo (a phrase repeats). Without this the guard below
+     would be vacuous -- a clip that never loops proves nothing.
+  2. Guard: the shipped `_vtools._whisper` output (which now sets the flag to
+     False) contains no repeated phrase.
+
+Needs the voice venv (faster-whisper, piper), a Hungarian voice, and ffmpeg.
+Skips cleanly when any is absent, so it never fails for lack of the model.
+
+Run: ~/.local/share/marveen-voice/venv/bin/python scripts/voice/test_vtools_repetition.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import os
+import random
+import re
+import struct
+import subprocess
+import sys
+import tempfile
+import wave
+from contextlib import redirect_stdout
+from pathlib import Path
+from shutil import which
+
+VOICE = os.path.expanduser("~/.local/share/marveen-voice/voices/hu_HU-imre-medium.onnx")
+SENTENCE = "Ez egy rovid teszt mondat a hangatiras ellenorzesehez."
+FFMPEG = which("ffmpeg") or "/opt/homebrew/bin/ffmpeg"
+
+
+def _skip(msg: str) -> None:
+    print(f"SKIP: {msg}")
+    sys.exit(0)
+
+
+def _have_deps() -> bool:
+    try:
+        import faster_whisper  # noqa: F401
+        import piper  # noqa: F401
+    except Exception:
+        return False
+    return os.path.exists(VOICE) and os.path.exists(FFMPEG)
+
+
+def _build_clip(dirpath: str) -> str:
+    """A short sentence plus a deterministic seeded noise tail."""
+    speech = os.path.join(dirpath, "s.wav")
+    noise = os.path.join(dirpath, "n.wav")
+    clip = os.path.join(dirpath, "c.wav")
+    subprocess.run(
+        [sys.executable, "-m", "piper", "-m", VOICE, "-f", speech],
+        input=SENTENCE.encode(), check=True,
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+    random.seed(42)
+    sr, dur = 22050, 40
+    with wave.open(noise, "w") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(sr)
+        frames = bytearray()
+        for _ in range(sr * dur):
+            v = max(-32767, min(32767, int(random.gauss(0, 1) * 350)))
+            frames += struct.pack("<h", v)
+        w.writeframes(bytes(frames))
+    lst = os.path.join(dirpath, "l.txt")
+    Path(lst).write_text(f"file '{speech}'\nfile '{noise}'\n")
+    subprocess.run(
+        [FFMPEG, "-y", "-f", "concat", "-safe", "0", "-i", lst, "-ar", "22050", "-ac", "1", clip],
+        check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+    return clip
+
+
+def _max_repeated_trigram(text: str) -> int:
+    """How many times the most-repeated 3-word phrase occurs. 1 means no
+    phrase repeats; a loop pushes this above 1."""
+    words = re.sub(r"[^a-z0-9 ]", " ", text.lower()).split()
+    if len(words) < 3:
+        return 1
+    counts: dict[tuple[str, str, str], int] = {}
+    best = 1
+    for i in range(len(words) - 2):
+        tri = (words[i], words[i + 1], words[i + 2])
+        counts[tri] = counts.get(tri, 0) + 1
+        best = max(best, counts[tri])
+    return best
+
+
+FAILURES: list[str] = []
+
+
+def main() -> None:
+    if not _have_deps():
+        _skip("voice venv / piper / hu voice / ffmpeg not available; run with the marveen-voice venv")
+
+    from faster_whisper import WhisperModel
+
+    spec = importlib.util.spec_from_file_location("_vtools", Path(__file__).resolve().parent / "_vtools.py")
+    vtools = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(vtools)
+
+    with tempfile.TemporaryDirectory() as d:
+        clip = _build_clip(d)
+
+        # 1. Positive control: the flag's OLD default really does loop on this clip.
+        model = WhisperModel("small", device="cpu", compute_type="int8")
+        segs, _ = model.transcribe(clip, language="hu", beam_size=5, condition_on_previous_text=True)
+        looped = " ".join(s.text.strip() for s in segs).strip()
+        control = _max_repeated_trigram(looped)
+        if control <= 1:
+            FAILURES.append(
+                "positive control failed: condition_on_previous_text=True did not loop on the "
+                f"fixture (max repeated 3-gram {control}); the fixture no longer triggers the bug, "
+                "so the guard below would be vacuous. Rebuild the reproducer before trusting this test."
+            )
+
+        # 2. Guard: the shipped path (_vtools._whisper -> flag False) does not loop.
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            vtools._whisper(clip)
+        shipped = buf.getvalue().strip()
+        repeats = _max_repeated_trigram(shipped)
+        if repeats > 1:
+            FAILURES.append(
+                f"_vtools._whisper looped: a 3-word phrase repeats {repeats} times in the transcript "
+                f"-> {shipped!r}. condition_on_previous_text is not False on the live path."
+            )
+
+        print(f"positive control (True) max-repeat={control}; shipped (_whisper) max-repeat={repeats}")
+
+    if FAILURES:
+        for f in FAILURES:
+            print("FAIL:", f)
+        sys.exit(1)
+    print("OK: repetition-prone clip loops under True, clean under the shipped False path.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## The bug (silent)
faster-whisper defaults `condition_on_previous_text=True`. On a silent or noisy tail the decoder conditions on its own previous output and echoes a phrase two or three times, so a voice message comes back with a wrong transcript. Nobody re-checks a transcript, so the owner reads words he did not say. Not an error, a wrong answer.

Reported from an external fork user's post, re-measured on our own tree: `scripts/voice/_vtools.py:79` and `:160` both called `m.transcribe(..., beam_size=5)` with no `condition_on_previous_text`; the string appears nowhere in the tree; the installed package (`~/.local/share/marveen-voice/venv`) has the default `True`.

## The fix
`condition_on_previous_text=False` at both call sites (`_whisper` and `canary`). Both, so the loop cannot survive on the site that was missed.

## The test measures the repetition, not the flag
`scripts/voice/test_vtools_repetition.py` builds a deterministic clip (fixed piper sentence + seeded noise tail, so the same bytes every run and beam search is deterministic), then:
1. **Positive control:** with `condition_on_previous_text=True` the clip loops (a 3-word phrase repeats). Without this the guard would be vacuous, a clip that never loops proves nothing.
2. **Guard:** the shipped `_vtools._whisper` output has no repeated phrase.

Measured (small, cpu, int8):
- `True`: `... a hangatiras ellenorzesehez. Feliratd a hangatiras ellenorzesehez.` (max repeated 3-gram = 2)
- `False` (shipped): the clean sentence (max repeated 3-gram = 1)

Reverting the fix on `_whisper` turns the guard red (verified). The test skips cleanly when the voice venv, piper, the hu voice or ffmpeg are absent, and follows the repo's standalone Python test convention:

    ~/.local/share/marveen-voice/venv/bin/python scripts/voice/test_vtools_repetition.py

## Left unchanged, on purpose
`beam_size=5` and the `small` model were not touched. The flag alone resolved the loop, and I did not find beam size or model size to be a factor; changing either is a separate decision with a different cost.

Base is `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)