### PR TITLE
docs(governance): version-stamp the gate rationale, the skip-permissions bypass claim measured false (SKIPDENY910)

### DIFF
--- a/scripts/email-send-gate.mjs
+++ b/scripts/email-send-gate.mjs
@@ -15,10 +15,17 @@
 // string) and claims no more. Our sub-agents are not adversaries; if that
 // assumption ever changes, this gate is the wrong tool.
 //
-// Why a hook and not a permissions deny-list: permissive security profiles
-// launch Claude Code with --dangerously-skip-permissions, which BYPASSES the
-// settings.json allow/deny list. A PreToolUse hook runs regardless of
-// permission mode, so it is the only reliable mode-independent gate.
+// Why a hook and not a permissions deny-list: the hook is version- and
+// mode-independent, and it can analyze command CONTENT (the Bash send-shape
+// heuristics below), which a name/prefix deny rule cannot express.
+// CORRECTION (SKIPDENY910, measured 2026-09-10): this comment used to claim
+// that --dangerously-skip-permissions BYPASSES the settings.json deny list.
+// That is false on every CLI version we measured (2.1.63, 2.1.110, 2.1.267;
+// marker-file ground truth, deny arm vs no-deny control, -p AND interactive
+// TUI): the deny list IS enforced under the flag, and a tool-name deny is
+// enforced by removing the tool from the session entirely. The hook remains
+// the primary gate anyway -- future CLI behavior is not a contract, and the
+// deny list stays a second, independent layer, not the load-bearing one.
 //
 // This file is wired into every sub-agent's .claude/settings.json by
 // writeAgentSettingsFromProfile() (agent-scaffold.ts), guarded by

--- a/src/web/agent-scaffold.ts
+++ b/src/web/agent-scaffold.ts
@@ -656,9 +656,12 @@ export function emailGateCommandStale(preToolUse: unknown, expected: string): bo
 }
 
 // Idempotently wire the email-send-gate PreToolUse hook into a settings.json
-// object. A deny-list rule alone would NOT enforce this: permissive profiles
-// launch with --dangerously-skip-permissions, which bypasses allow/deny --
-// hooks run regardless of permission mode. Name-agnostic so a customer install
+// object. The hook (not a deny rule) is the primary gate because it inspects
+// command CONTENT and is version/mode-independent. (An earlier version of this
+// comment claimed --dangerously-skip-permissions bypasses the deny list; that
+// is false on every measured CLI version -- 2.1.63/2.1.110/2.1.267, SKIPDENY910
+// 2026-09-10 -- but the hook stays primary: future CLI behavior is not a
+// contract.) Name-agnostic so a customer install
 // gates its own sub-agents (the caller's MAIN_AGENT_ID guard exempts the owner).
 export function injectEmailSendGate(existing: Record<string, unknown>, threadReply = false): void {
   const hooks = (existing.hooks && typeof existing.hooks === 'object'


### PR DESCRIPTION
Comment-only. Two places in the tree justified the PreToolUse hard-gates with the claim that permissive profiles (--dangerously-skip-permissions) bypass the settings.json allow/deny list: the email-send-gate.mjs header and the injectEmailSendGate docstring. Meanwhile the SELF_PACE_TOOL_DENY comment claimed the opposite. The repo was self-contradictory, and the bypass claim is the false half.

Measured 2026-09-10 (SKIPDENY910 card carries the full protocol): deny arm vs no-deny control, marker-file ground truth, both -p and interactive TUI, on CLI 2.1.63 (2026-02), 2.1.110 (the hermes soak box) and 2.1.267 (prod). The deny list is enforced under the flag on all of them; a tool-name deny removes the tool from the session entirely. No transition version exists in our band, so the claim was likely never measured true in 2.1.x.

Why this matters as a doc fix and nothing more: the next reader of the old comment could conclude the deny lists our scaffold writes are inert on permissive profiles (they are not), or conversely build a new protection on deny alone (future CLI behavior is not a contract). Both comments now state the measured versions and keep the hook as the primary gate.

No behavior change; tsc clean, gate suites green (48 tests).

Refs SKIPDENY910.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
