### PR TITLE
feat(logs): copytruncate rotation for the launcher-redirected logs (LOGROTATE910)

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -144,7 +144,12 @@ elif [ "$OS" = "Linux" ]; then
     if _service_live "$INSTALL_DIR/store/dashboard.pid" "dist/index.js"; then
       echo "Dashboard mar fut, ujrainditas kihagyva."
     else
-      nohup "$NODE_BIN" "$INSTALL_DIR/dist/index.js" > "$INSTALL_DIR/store/dashboard.log" 2>&1 9>&- &
+      # >> (append), deliberately: the in-app log rotation (LOGROTATE910) is
+      # copy-then-truncate, which is only safe for O_APPEND writers -- a plain
+      # > redirect keeps its offset after the truncate and turns the log into
+      # a sparse file. launchd StandardOutPath and systemd append: already
+      # open in append mode; this redirect must match them.
+      nohup "$NODE_BIN" "$INSTALL_DIR/dist/index.js" >> "$INSTALL_DIR/store/dashboard.log" 2>&1 9>&- &
       echo $! > "$INSTALL_DIR/store/dashboard.pid"
     fi
     if _service_live "$INSTALL_DIR/store/channels.pid" "channels.sh"; then

--- a/src/__tests__/log-rotation.test.ts
+++ b/src/__tests__/log-rotation.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync, openSync, writeSync, closeSync, statSync } from 'node:fs'
+import { gunzipSync } from 'node:zlib'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { rotateLogFile, runLogRotationSweep, ROTATED_LOG_NAMES } from '../web/log-rotation.js'
+
+// Copytruncate rotation (LOGROTATE910). The load-bearing property is the last
+// test: a writer holding the file open in APPEND mode keeps landing lines in
+// the truncated live file -- the exact shape mv-based rotation breaks.
+
+let dir: string
+beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'logrot-')) })
+afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
+
+const fill = (path: string, bytes: number, ch = 'x') => writeFileSync(path, ch.repeat(bytes))
+
+describe('rotateLogFile', () => {
+  it('leaves a file at or under the cap untouched', () => {
+    const p = join(dir, 'a.log')
+    fill(p, 100)
+    const res = rotateLogFile(p, { maxBytes: 100 })
+    expect(res.rotated).toBe(false)
+    expect(statSync(p).size).toBe(100)
+    expect(existsSync(`${p}.1.gz`)).toBe(false)
+  })
+
+  it('is a no-op on a missing file (never throws at boot on a fresh install)', () => {
+    expect(rotateLogFile(join(dir, 'missing.log')).rotated).toBe(false)
+  })
+
+  it('rotates an over-cap file: content lands gzipped in .1.gz, live file truncates to 0', () => {
+    const p = join(dir, 'a.log')
+    writeFileSync(p, 'line-one\nline-two\n' + 'x'.repeat(200))
+    const res = rotateLogFile(p, { maxBytes: 50 })
+    expect(res.rotated).toBe(true)
+    expect(statSync(p).size).toBe(0)
+    const archived = gunzipSync(readFileSync(`${p}.1.gz`)).toString()
+    expect(archived).toContain('line-one')
+    expect(archived).toContain('line-two')
+    expect(existsSync(`${p}.1.gz.tmp`)).toBe(false)
+  })
+
+  it('shifts generations and drops the oldest at the keep cap', () => {
+    const p = join(dir, 'a.log')
+    for (const n of [1, 2, 3]) writeFileSync(`${p}.${n}.gz`, `gen-${n}`)
+    fill(p, 60)
+    rotateLogFile(p, { maxBytes: 50, keep: 3 })
+    // old gen-3 dropped, gen-2 -> 3, gen-1 -> 2, fresh archive at 1
+    expect(readFileSync(`${p}.3.gz`).toString()).toBe('gen-2')
+    expect(readFileSync(`${p}.2.gz`).toString()).toBe('gen-1')
+    expect(gunzipSync(readFileSync(`${p}.1.gz`)).toString()).toBe('x'.repeat(60))
+    expect(existsSync(`${p}.4.gz`)).toBe(false)
+  })
+
+  // The reason this whole module exists: the writer's fd survives the
+  // rotation. An APPEND-mode writer (launchd StandardOutPath, systemd
+  // append:, start.sh >>) writes its next line at the NEW EOF of the
+  // truncated file. With mv-rotation the same write would vanish into the
+  // moved inode.
+  it('an O_APPEND writer keeps landing lines in the truncated live file', () => {
+    const p = join(dir, 'a.log')
+    const fd = openSync(p, 'a')
+    writeSync(fd, 'before-rotation\n'.repeat(10))
+    const res = rotateLogFile(p, { maxBytes: 10 })
+    expect(res.rotated).toBe(true)
+    writeSync(fd, 'after-rotation\n')
+    closeSync(fd)
+    const live = readFileSync(p).toString()
+    expect(live).toBe('after-rotation\n')
+    expect(gunzipSync(readFileSync(`${p}.1.gz`)).toString()).toContain('before-rotation')
+  })
+})
+
+describe('runLogRotationSweep', () => {
+  it('rotates only the covered, over-cap files and reports them by name', () => {
+    fill(join(dir, 'dashboard.log'), 100)
+    fill(join(dir, 'channels.log'), 10)
+    fill(join(dir, 'provenance-flagged.log'), 100) // ledger: NOT covered
+    const rotated = runLogRotationSweep(dir, { maxBytes: 50 })
+    expect(rotated).toEqual(['dashboard.log'])
+    expect(statSync(join(dir, 'provenance-flagged.log')).size).toBe(100)
+    expect(statSync(join(dir, 'channels.log')).size).toBe(10)
+  })
+
+  it('covers exactly the launcher-redirected stdout/stderr family', () => {
+    // Pin the list: adding a log here is a deliberate decision (ledgers must
+    // never slip in), and removing one must break a test, not go quietly.
+    expect([...ROTATED_LOG_NAMES].sort()).toEqual([
+      'channel-coordinator.error.log',
+      'channel-coordinator.log',
+      'channels.error.log',
+      'channels.log',
+      'dashboard.error.log',
+      'dashboard.log',
+    ])
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import { runDecaySweep, runDailyDigest } from './memory.js'
 import { initHeartbeat, stopHeartbeat, ensureHeartbeatWorkerHidden } from './heartbeat.js'
 import { ensureHeartbeatAgent, shouldBootHeartbeatAgent, HEARTBEAT_AGENT_NAME } from './web/heartbeat-agent-scaffold.js'
 import { startAgentProcess } from './web/agent-process.js'
+import { runLogRotationSweep, LOG_ROTATION_SWEEP_MS } from './web/log-rotation.js'
 import { renameSharedCredentialsIfSafe, fleetTokenBootPass } from './web/claude-credentials-guard.js'
 import { startWebServer } from './web.js'
 import { logger } from './logger.js'
@@ -399,6 +400,7 @@ function releaseLock(): void {
 let decayInterval: NodeJS.Timeout | null = null
 let digestTimer: NodeJS.Timeout | null = null
 let digestInterval: NodeJS.Timeout | null = null
+let logRotationInterval: NodeJS.Timeout | null = null
 let heartbeatStarted = false
 let webServer: HttpServer | null = null
 let shuttingDown = false
@@ -418,6 +420,7 @@ const shutdown = (): void => {
     if (decayInterval) clearInterval(decayInterval)
     if (digestTimer) clearTimeout(digestTimer)
     if (digestInterval) clearInterval(digestInterval)
+    if (logRotationInterval) clearInterval(logRotationInterval)
 
     const hardKill = setTimeout(() => {
       logger.warn({ timeoutMs: SHUTDOWN_HARD_KILL_MS }, 'Graceful shutdown timeout, hard exit')
@@ -481,6 +484,12 @@ async function main(): Promise<void> {
   runDecaySweep()
   decayInterval = setInterval(runDecaySweep, 24 * 60 * 60 * 1000)
   logger.info('Memoria leepulesi ciklus beallitva (24 oras)')
+
+  // Log rotation (LOGROTATE910): copytruncate on the launcher-redirected
+  // logs, size-capped, hourly check. Runs inside the dashboard so every
+  // platform gets it without launchd/systemd/cron wiring.
+  runLogRotationSweep()
+  logRotationInterval = setInterval(runLogRotationSweep, LOG_ROTATION_SWEEP_MS)
 
   // Daily digest at 23:00. Timer handles kept so shutdown can drop them.
   function scheduleDailyDigest() {

--- a/src/web/log-rotation.ts
+++ b/src/web/log-rotation.ts
@@ -1,0 +1,112 @@
+import { existsSync, statSync, readFileSync, writeFileSync, renameSync, truncateSync, unlinkSync } from 'node:fs'
+import { gzipSync } from 'node:zlib'
+import { join } from 'node:path'
+import { STORE_DIR } from '../config.js'
+import { logger } from '../logger.js'
+
+// Log rotation for the launcher-redirected logs (LOGROTATE910, 2026-09-10).
+//
+// Why copytruncate and not mv: every writer of these files holds them as its
+// own STDOUT/STDERR, opened ONCE at process start by the launcher (launchd
+// StandardOutPath on macOS, systemd StandardOutput=append: on Linux, start.sh
+// >> redirect). An mv-based rotation silently breaks that shape: the process
+// keeps writing into the moved inode, the "rotated" file receives nothing and
+// the old one keeps growing invisibly. Copy-then-truncate leaves the fd alone.
+//
+// Why truncate is safe here (measured on the live host, lsof FILE-FLAG): the
+// writers hold the fd with O_APPEND ("AP"), so after the truncate every write
+// lands at the new EOF. A non-append writer would instead keep its old offset
+// and turn the file sparse -- which is why start.sh's redirect is >> (append),
+// and why that redirect must never regress to >.
+//
+// STATED LOSS: lines written between the copy and the truncate are lost from
+// both files. Measured write rate on the busiest log (dashboard.log,
+// 2026-09-10): ~21 bytes/s peak, ~0.4-1.8 MB/day -- the copy-to-truncate
+// window is well under a second, so the expected loss is 0-1 line per
+// rotation, a few rotations per month. If a future writer becomes high-volume
+// and buffered, this trade-off must be re-measured, not assumed.
+//
+// COVERED FILES ARE AN EXPLICIT LIST, deliberately: store/ also holds
+// append-only ledgers (provenance-flagged.log, egress-blocked.log, ...) whose
+// full history is the point -- a generic *.log sweep would rotate evidence.
+// If a new launcher-redirected log appears, EXTEND THIS LIST, otherwise its
+// growth is silent (the same discipline as the installer drift sentinel's
+// covered-files list).
+export const ROTATED_LOG_NAMES = [
+  'dashboard.log',
+  'dashboard.error.log',
+  'channel-coordinator.log',
+  'channel-coordinator.error.log',
+  'channels.log',
+  'channels.error.log',
+] as const
+
+// Retention, named in numbers (owner-readable, not "eleg lesz"): rotate a file
+// once it exceeds 20 MB, keep 5 gzipped generations. At the measured rates
+// that is roughly 2-7 weeks per generation on the busiest log, i.e. months of
+// history, in at most ~6 files per log (live + 5 archives).
+export const MAX_LOG_BYTES = 20 * 1024 * 1024
+export const KEEP_GENERATIONS = 5
+
+export const LOG_ROTATION_SWEEP_MS = 60 * 60 * 1000 // hourly size check
+
+export interface RotationResult {
+  rotated: boolean
+  sizeBytes: number
+}
+
+/**
+ * Rotate one log file if it exceeds maxBytes: shift the .N.gz generations up
+ * (dropping the oldest), gzip the current content to .1.gz, then truncate the
+ * live file to zero. The live fd of the writing process is never touched.
+ */
+export function rotateLogFile(
+  path: string,
+  opts: { maxBytes?: number; keep?: number } = {},
+): RotationResult {
+  const maxBytes = opts.maxBytes ?? MAX_LOG_BYTES
+  const keep = opts.keep ?? KEEP_GENERATIONS
+  if (!existsSync(path)) return { rotated: false, sizeBytes: 0 }
+  const sizeBytes = statSync(path).size
+  if (sizeBytes <= maxBytes) return { rotated: false, sizeBytes }
+
+  // Shift generations from the oldest down, so .1.gz is free for the new one.
+  const gen = (n: number) => `${path}.${n}.gz`
+  const oldest = gen(keep)
+  if (existsSync(oldest)) unlinkSync(oldest)
+  for (let n = keep - 1; n >= 1; n--) {
+    if (existsSync(gen(n))) renameSync(gen(n), gen(n + 1))
+  }
+
+  // Copy (compressed), then truncate. Write the archive via a temp name +
+  // rename so a crash mid-write never leaves a half .1.gz masquerading as a
+  // complete generation.
+  const tmp = `${gen(1)}.tmp`
+  writeFileSync(tmp, gzipSync(readFileSync(path)))
+  renameSync(tmp, gen(1))
+  truncateSync(path, 0)
+  return { rotated: true, sizeBytes }
+}
+
+/** Run one sweep over the covered logs. Returns the rotated file names. */
+export function runLogRotationSweep(
+  storeDir: string = STORE_DIR,
+  opts: { maxBytes?: number; keep?: number } = {},
+): string[] {
+  const rotated: string[] = []
+  for (const name of ROTATED_LOG_NAMES) {
+    const path = join(storeDir, name)
+    try {
+      const res = rotateLogFile(path, opts)
+      if (res.rotated) {
+        rotated.push(name)
+        logger.info({ file: name, sizeBytes: res.sizeBytes }, 'Log rotated (copytruncate)')
+      }
+    } catch (err) {
+      // A rotation failure must never take the service down; the file simply
+      // keeps growing until the next sweep and the error says why.
+      logger.error({ err, file: name }, 'Log rotation failed')
+    }
+  }
+  return rotated
+}


### PR DESCRIPTION
## Measured before designed (the order was the request)

- store/dashboard.log 58 MB (born Apr 14), channel-coordinator.log 17 MB (born Jun 2); no rotation and zero copytruncate hits in the tree.
- Both files are the writing process's own STDOUT, opened once by the launcher: lsof on the live host shows FD 1, FILE-FLAG "R,W,AP" (O_APPEND) for both node processes. launchd StandardOutPath and the systemd units (StandardOutput=append:) open in append mode; scripts/start.sh was the one writer shape using a plain > redirect.
- Write rate on the busiest log: ~21 B/s at a busy moment, ~0.4-1.8 MB/day overall.

## Consequences the design follows

- mv-rotation is out: the writer keeps the moved inode, the fresh file receives nothing (the external fork user's warning holds here, measured shape).
- copytruncate is safe for these writers BECAUSE they are O_APPEND: after the truncate, the next write lands at the new EOF. A non-append writer would keep its old offset and turn the file sparse, so start.sh's redirect goes > to >> in this same PR.
- Stated loss, in numbers: lines written between the copy and the truncate are lost; at the measured rate that is 0-1 line per rotation, and a rotation fires every few weeks per log. If a future writer becomes high-volume and buffered, this trade-off must be re-measured.

## What ships

- src/web/log-rotation.ts: rotateLogFile (generation shift, gzip to .1.gz via tmp+rename, truncate) + runLogRotationSweep over an EXPLICIT covered list (the six launcher-redirected stdout/stderr logs). The list is deliberate: store/ also holds append-only ledgers (provenance-flagged.log, egress-blocked.log) whose full history is the point -- a generic *.log sweep would rotate evidence. A test pins the exact list.
- Retention named in numbers: 20 MB cap, 5 gzipped generations, hourly check -- roughly 2-7 weeks per generation on the busiest log, months of history, at most 6 files per log.
- Boot wiring in src/index.ts next to the decay sweep (run at start + hourly), interval dropped at shutdown like the other timers.
- Tests (7): over/under cap, missing file, generation shift with oldest dropped, sweep skips uncovered ledgers, and the load-bearing one: an O_APPEND writer's next line lands in the truncated live file while the archive holds the old content.

Full suite 5188 passed / 1 skipped, tsc clean.

Refs LOGROTATE910.

🤖 Generated with [Claude Code](https://claude.com/claude-code)