### PR TITLE
fix(scaffold): the generated curl examples stop handing agents a shell-expanding payload (CURLQUOTE910)

### DIFF
--- a/src/__tests__/generated-curl-payload-quoting.test.ts
+++ b/src/__tests__/generated-curl-payload-quoting.test.ts
@@ -100,6 +100,22 @@ describe('generated autonomy block: no shell-expanding curl payload', () => {
     const level1 = block.slice(block.indexOf('Level 1'), block.indexOf('Level 2'))
     expect(level1).toContain(`--data-binary @- <<'JSON'`)
   })
+
+  // Carried over from the earlier CURLQUOTE909 branch, which fixed the same two
+  // lines and never shipped. Its level 1 assertion pinned a single-quoted payload,
+  // which the heredoc supersedes -- but the two protections underneath it are
+  // real and were not otherwise covered here.
+  it('the level 1 payload names the agent itself, not a placeholder', () => {
+    const block = writtenAutonomyBlock('named-agent')
+    const level1 = block.slice(block.indexOf('Level 1'), block.indexOf('Level 2'))
+    expect(level1).toContain('"from":"named-agent"')
+    expect(level1).not.toContain('AGENT_NAME')
+  })
+
+  it('the token read in the header still interpolates -- do not quote that away', () => {
+    const block = writtenAutonomyBlock('token-agent')
+    expect(block).toContain('$(cat ')
+  })
 })
 
 describe('generateClaudeMd source: no shell-expanding curl payload', () => {
@@ -120,5 +136,24 @@ describe('generateClaudeMd source: no shell-expanding curl payload', () => {
     const body = src.slice(fnStart, fnEnd)
     const offenders = body.split('\n').filter((l) => SHELL_EXPANDING_PAYLOAD.test(l))
     expect(offenders, `shell-expanding payload in generateClaudeMd:\n${offenders.join('\n')}`).toEqual([])
+  })
+
+  it('the stranger-sender block ships the quoted heredoc, whatever the sender wrote', () => {
+    const body = src.slice(fnStart, fnEnd)
+    const blockStart = body.indexOf('## Új ismeretlen sender első üzenete')
+    expect(blockStart, 'stranger-sender block not found').toBeGreaterThan(0)
+    const rest = body.slice(blockStart + 5)
+    const nextHeader = rest.indexOf('\n## ')
+    const block = body.slice(blockStart, blockStart + 5 + (nextHeader > 0 ? nextHeader : rest.length))
+    expect(block).toContain(`--data-binary @- <<'JSON'`)
+  })
+
+  // Widest of the source assertions, and the reason it is here: a third curl
+  // example added anywhere else in this file would escape the two scoped checks
+  // above. The earlier branch had this one; the scoped checks alone would not
+  // have caught a new offender outside both blocks.
+  it('no curl example anywhere in the scaffold uses a double-quoted payload', () => {
+    const offenders = src.split('\n').filter((l) => l.includes('curl ') && SHELL_EXPANDING_PAYLOAD.test(l))
+    expect(offenders, `shell-expanding payload in agent-scaffold.ts:\n${offenders.join('\n')}`).toEqual([])
   })
 })

--- a/src/__tests__/generated-curl-payload-quoting.test.ts
+++ b/src/__tests__/generated-curl-payload-quoting.test.ts
@@ -1,0 +1,124 @@
+// CURLQUOTE910: the generator must not hand agents a curl form whose payload the
+// shell expands. In a double-quoted `-d "{...}"` the shell runs backticks and
+// $(...) INSIDE the payload and substitutes the output, so a report that quotes a
+// filename, a hash, or -- worse -- a stranger's message text executes it, and the
+// POST still returns 200. Nothing marks the loss on either end, which is why the
+// shape is pinned by tests instead of by care: a reader copying the block cannot
+// tell a working example from a hazardous one by looking at it.
+//
+// Two generated surfaces carry a curl example into every agent's CLAUDE.md:
+//   1. buildAutonomyBody()  -- rewritten on EVERY agent start (ensureAutonomySection)
+//   2. generateClaudeMd()   -- written once, at agent creation (stranger-sender rule)
+// Both are asserted here: (1) functionally, on the file the generator writes, and
+// (2) at source level, the established idiom for the LLM-calling generator.
+import { describe, it, expect, vi } from 'vitest'
+import { mkdtempSync, writeFileSync, readFileSync, mkdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+const tmpRoot = mkdtempSync(join(tmpdir(), 'marveen-curlquote-test-'))
+
+vi.mock('../config.js', () => ({
+  PROJECT_ROOT: tmpRoot,
+  OWNER_NAME: 'TestOwner',
+  MAIN_AGENT_ID: 'agent-a',
+  BOT_NAME: 'agent-a',
+  CHANNEL_PROVIDER: 'telegram',
+  WEB_PORT: 3420,
+  OWNER_DRIVE_FOLDER: '',
+  DASHBOARD_PUBLIC_URL: '',
+  AGENT_API_ORIGIN: '',
+  APP_TZ: 'Europe/Budapest',
+}))
+
+vi.mock('../web/agent-config.js', () => ({
+  agentDir: (name: string) => join(tmpRoot, 'agents', name),
+  agentConfigRoot: () => join(tmpRoot, 'agents'),
+  listAgentNames: () => ['agent-a', 'agent-b'],
+  readAgentCapabilities: () => [],
+}))
+
+vi.mock('../web/atomic-write.js', () => ({
+  atomicWriteFileSync: (path: string, content: string) => writeFileSync(path, content, 'utf-8'),
+}))
+
+const { ensureAutonomySection } = await import('../web/agent-scaffold.js')
+
+const MARKER_BEGIN = '<!-- BEGIN GENERATED: autonomy-wiring (auto-generated, do not edit by hand) -->'
+const MARKER_END = '<!-- END GENERATED: autonomy-wiring -->'
+
+// A payload the shell expands: -d / --data followed by a double quote.
+const SHELL_EXPANDING_PAYLOAD = /(?:^|\s)(?:-d|--data|--data-raw)\s+"/
+
+function writtenAutonomyBlock(agentName: string): string {
+  const dir = join(tmpRoot, 'agents', agentName)
+  mkdirSync(dir, { recursive: true })
+  writeFileSync(join(dir, 'CLAUDE.md'), `# ${agentName}\n`, 'utf-8')
+  ensureAutonomySection(agentName)
+  const file = readFileSync(join(dir, 'CLAUDE.md'), 'utf-8')
+  const from = file.indexOf(MARKER_BEGIN)
+  const to = file.indexOf(MARKER_END)
+  expect(from, 'autonomy block not written').toBeGreaterThanOrEqual(0)
+  expect(to, 'autonomy end marker not written').toBeGreaterThan(from)
+  return file.slice(from, to)
+}
+
+describe('generated autonomy block: no shell-expanding curl payload', () => {
+  it('the measure is not vacuous -- the written block really carries curl examples', () => {
+    const block = writtenAutonomyBlock('meter-check-agent')
+    const curlLines = block.split('\n').filter((l) => l.trimStart().startsWith('curl '))
+    expect(curlLines.length).toBeGreaterThanOrEqual(2)
+  })
+
+  // Positive control: the level 2 approvals example has ALWAYS used a single-quoted
+  // payload. It must pass the same measure today, before any fix -- a meter that
+  // cannot see the correct form is blind to the broken one.
+  it('positive control: the level 2 approvals example passes the measure', () => {
+    const block = writtenAutonomyBlock('control-agent')
+    const level2 = block.slice(block.indexOf('Level 2'))
+    const approvals = level2.split('\n').find((l) => l.includes('/api/approvals') && l.includes('POST'))
+    expect(approvals, '/api/approvals POST example not found').toBeTruthy()
+    expect(approvals!).not.toMatch(SHELL_EXPANDING_PAYLOAD)
+    expect(approvals!).toContain(`-d '`)
+  })
+
+  it('the level 1 inter-agent example does not use a double-quoted payload', () => {
+    const block = writtenAutonomyBlock('level1-agent')
+    const level1 = block.slice(block.indexOf('Level 1'), block.indexOf('Level 2'))
+    expect(level1).toContain('/api/messages')
+    expect(level1).not.toMatch(SHELL_EXPANDING_PAYLOAD)
+  })
+
+  it('no line of the whole generated block uses a double-quoted payload', () => {
+    const block = writtenAutonomyBlock('whole-block-agent')
+    const offenders = block.split('\n').filter((l) => SHELL_EXPANDING_PAYLOAD.test(l))
+    expect(offenders, `shell-expanding payload in generated block:\n${offenders.join('\n')}`).toEqual([])
+  })
+
+  it('the level 1 example ships the quoted-heredoc form, so free text stays inert', () => {
+    const block = writtenAutonomyBlock('heredoc-agent')
+    const level1 = block.slice(block.indexOf('Level 1'), block.indexOf('Level 2'))
+    expect(level1).toContain(`--data-binary @- <<'JSON'`)
+  })
+})
+
+describe('generateClaudeMd source: no shell-expanding curl payload', () => {
+  const src = readFileSync(join(process.cwd(), 'src/web/agent-scaffold.ts'), 'utf-8')
+  const fnStart = src.indexOf('export async function generateClaudeMd')
+  const fnEnd = src.indexOf('export async function generateSoulMd')
+
+  it('the measure is not vacuous -- the generator body is found and carries curl examples', () => {
+    expect(fnStart, 'generateClaudeMd not found').toBeGreaterThan(0)
+    expect(fnEnd, 'generateSoulMd terminator not found').toBeGreaterThan(fnStart)
+    expect(src.slice(fnStart, fnEnd)).toContain('curl -s -X POST')
+  })
+
+  // The stranger-sender ARANYSZABÁLY example interpolates a stranger's own words
+  // into the payload. That is the one place a double-quoted payload is not a style
+  // question: the stranger writes the command that runs.
+  it('the stranger-sender example does not use a double-quoted payload', () => {
+    const body = src.slice(fnStart, fnEnd)
+    const offenders = body.split('\n').filter((l) => SHELL_EXPANDING_PAYLOAD.test(l))
+    expect(offenders, `shell-expanding payload in generateClaudeMd:\n${offenders.join('\n')}`).toEqual([])
+  })
+})

--- a/src/__tests__/generated-curl-payload-quoting.test.ts
+++ b/src/__tests__/generated-curl-payload-quoting.test.ts
@@ -116,6 +116,22 @@ describe('generated autonomy block: no shell-expanding curl payload', () => {
     const block = writtenAutonomyBlock('token-agent')
     expect(block).toContain('$(cat ')
   })
+
+  // The warning that ships with the fix recommends a heredoc. A heredoc whose
+  // delimiter is NOT quoted expands exactly like a double-quoted string, so a
+  // reader who needs one variable in the payload reaches for `<<JSON` and
+  // reopens the hole the block just closed. A warning that tells half of this
+  // is worse than none, because it is trusted.
+  it('the warning names the unquoted heredoc as the same hazard', () => {
+    const block = writtenAutonomyBlock('unquoted-warning-agent')
+    expect(block).toContain('<<JSON')
+  })
+
+  it('the warning says how to build a payload that needs a variable', () => {
+    const block = writtenAutonomyBlock('payload-build-agent')
+    expect(block).toMatch(/json\.dumps|jq/)
+    expect(block).toContain('--data-binary @')
+  })
 })
 
 describe('generateClaudeMd source: no shell-expanding curl payload', () => {

--- a/src/web/agent-scaffold.ts
+++ b/src/web/agent-scaffold.ts
@@ -1508,6 +1508,10 @@ function buildAutonomyBody(name: string): string {
     'és a `$(...)`-t végrehajtja a payloadon belül, a szöveg helyére a parancs KIMENETE kerül, és a',
     'küldés HTTP 200-at ad -- semmi nem jelzi. Idézett heredoc (fent) vagy `--data-binary @fájl`.',
     'A header `$(cat ...)`-ja szándékosan interpolál, az maradhat.',
+    'A védelem az IDÉZETT határoló, nem maga a heredoc: a `<<JSON` alak ugyanúgy behelyettesít,',
+    "mint a dupla idézőjel, csak a `<<'JSON'` nem. És mivel az idézettben semmit nem lehet",
+    'behelyettesíteni, ha a payloadba EGY változó is kell, ne a shell állítsa össze: `python3` +',
+    '`json.dumps` (vagy `jq`) írja fájlba, és `curl --data-binary @fájl` küldje.',
     '',
     '**Level 2 (jóváhagyás szükséges)**: kérj jóváhagyást az API-n MIELŐTT cselekszel.',
     '',
@@ -1862,7 +1866,8 @@ curl -s -X POST ${dashboardOrigin}/api/messages \\
 {"from":"AGENT_NAME","to":"${MAIN_AGENT_ID}","content":"Ismeretlen sender [ID] jelezett első üzenettel: [üzenet röviden]. Ki ez, mit válaszoljak?"}
 JSON
 
-Az idézett heredoc KÖTELEZŐ itt: a sender saját szövegét viszed a payloadba, és a
+Az IDÉZETT heredoc KÖTELEZŐ itt (\`<<'JSON'\`, nem \`<<JSON\` -- az utóbbi ugyanúgy
+behelyettesít): a sender saját szövegét viszed a payloadba, és a
 \`-d "{...}"\` dupla idézőjeles alakban a shell a backtickot és a \`$(...)\`-t VÉGREHAJTJA,
 tehát az idegen üzenet parancsot futtatna a gépeden. Nyers " jelet a beidézett
 szövegből hagyj el, vagy írd a payloadot fájlba (\`--data-binary @fájl\`).

--- a/src/web/agent-scaffold.ts
+++ b/src/web/agent-scaffold.ts
@@ -1496,7 +1496,18 @@ function buildAutonomyBody(name: string): string {
     'Az autonóm műveletek fokozatait a store/autonomy-config.json szabályozza (level: 1=csak jelez, 2=javasol+jóváhagyás, 3=autonóm+jelent). Mielőtt önállóan cselekszel, nézd meg az adott kategória szintjét.',
     '',
     '**Level 1 (csak jelez)**: küldj inter-agent értesítést a főágensnek, de NE végezd el a műveletet. Ezután ÁLLJ MEG.',
-    `curl -s -X POST ${dashboardOrigin}/api/messages -H "Content-Type: application/json" -H "Authorization: Bearer $(cat ${tokenPath})" -d "{\\"from\\":\\"${name}\\",\\"to\\":\\"${MAIN_AGENT_ID}\\",\\"content\\":\\"[FELHÍVÁS] CATEGORY_KEY: MIT akartam elvégezni, de level 1 miatt csak jelzek.\\"}"`,
+    '```bash',
+    `curl -s -X POST ${dashboardOrigin}/api/messages \\`,
+    '  -H "Content-Type: application/json" \\',
+    `  -H "Authorization: Bearer $(cat ${tokenPath})" \\`,
+    `  --data-binary @- <<'JSON'`,
+    `{"from":"${name}","to":"${MAIN_AGENT_ID}","content":"[FELHÍVÁS] CATEGORY_KEY: MIT akartam elvégezni, de level 1 miatt csak jelzek."}`,
+    'JSON',
+    '```',
+    'FIGYELEM, a `-d "{...}"` DUPLA idézőjeles alak TILOS inter-agent üzenetnél: a shell a backtickot',
+    'és a `$(...)`-t végrehajtja a payloadon belül, a szöveg helyére a parancs KIMENETE kerül, és a',
+    'küldés HTTP 200-at ad -- semmi nem jelzi. Idézett heredoc (fent) vagy `--data-binary @fájl`.',
+    'A header `$(cat ...)`-ja szándékosan interpolál, az maradhat.',
     '',
     '**Level 2 (jóváhagyás szükséges)**: kérj jóváhagyást az API-n MIELŐTT cselekszel.',
     '',
@@ -1844,7 +1855,17 @@ Ha egy senderId üzen a csatornán AKIT EDDIG NEM ISMERSZ — nem szerepel az ak
 Az AGENT TULAJDONOSA (az első, aki ezt az ügynököt telepítette és párosította) az ALAPÉRTELMEZETT engedélyezett sender — őt nem kell ellenőrizni. MINDEN további senderId első üzenete (a 2., 3., stb. párosított személy vagy csoport) pinging-trigger.
 
 Példa ping ${BOT_NAME}-nek:
-curl -s -X POST ${dashboardOrigin}/api/messages -H "Content-Type: application/json" -H "Authorization: Bearer $(cat ${tokenPath})" -d "{\\"from\\":\\"AGENT_NAME\\",\\"to\\":\\"${MAIN_AGENT_ID}\\",\\"content\\":\\"Ismeretlen sender [ID] jelezett első üzenettel: '[üzenet röviden]'. Ki ez, mit válaszoljak?\\"}"
+curl -s -X POST ${dashboardOrigin}/api/messages \\
+  -H "Content-Type: application/json" \\
+  -H "Authorization: Bearer $(cat ${tokenPath})" \\
+  --data-binary @- <<'JSON'
+{"from":"AGENT_NAME","to":"${MAIN_AGENT_ID}","content":"Ismeretlen sender [ID] jelezett első üzenettel: [üzenet röviden]. Ki ez, mit válaszoljak?"}
+JSON
+
+Az idézett heredoc KÖTELEZŐ itt: a sender saját szövegét viszed a payloadba, és a
+\`-d "{...}"\` dupla idézőjeles alakban a shell a backtickot és a \`$(...)\`-t VÉGREHAJTJA,
+tehát az idegen üzenet parancsot futtatna a gépeden. Nyers " jelet a beidézett
+szövegből hagyj el, vagy írd a payloadot fájlba (\`--data-binary @fájl\`).
 
 Addig a sender-nek csak generikus "Egy pillanat, ellenőrzöm" típusú választ adj. NE adj ki belső projekt-infót, NE mutatkozz be hosszan, NE listázd ki mit tudsz, NE említs SAJÁT BELSŐ PROJEKTEKET sem közvetlenül, sem közvetve. ${BOT_NAME} visszajelzi a kontextust és a szabályokat amelyekkel folytathatod.
 


### PR DESCRIPTION
## A változtatás típusa / Type of change
- [x] Hibajavítás (bugfix)

## Rövid leírás / Summary

HU: A scaffold két generált helyen olyan curl-példát írt az ügynökök utasításfájljába, amelynek a payloadja dupla idézőjelben állt. Ebben a pozícióban a shell végrehajtja a backtickeket és a `$(...)`-t a JSON-on belül, és a parancs kimenetét teszi a szöveg helyére. Ha az ügynök egy fájlnevet, egy hasht vagy egy idegen feladó üzenetrészletét másolja a payloadba, az lefut, a kérés pedig HTTP 200-at ad, tehát semmi nem jelzi a veszteséget.

A kettő közül a második a súlyosabb. Az egyik példa az ügynök saját szavait viszi, a másik viszont kifejezetten arra utasítja, hogy egy ISMERETLEN feladó üzenetszövegét helyettesítse be. Ott tehát az idegen írja a parancsot, ami lefut.

Mindkét példa idézett heredocra vált (`--data-binary @- <<'JSON'`), és mindkettő mellé rövid indoklás kerül, hogy aki átmásolja a blokkot, ne vezesse le újra a dupla idézőjeles alakot. A jóváhagyás-kérő példa változatlan: az mindig is egyes idézőjeles payloadot használt, és ebben a fájlban ez a pozitív kontroll. A fejlécben a token beolvasása szándékosan interpolál, az marad.

A heredoc a shellt oldja meg, a JSON-t nem, ezért az idegen feladós példa már nem teszi aposztrófok közé az idézett töredéket, és kimondja, mit kell tenni egy nyers idézőjellel.

A két generált felület viselkedése eltér: az egyik minden ügynök-indításkor újraíródik, tehát a meglévő fájlok maguktól konvergálnak, a másik csak létrehozáskor íródik, tehát a meglévő fájlok külön migrációig megtartják a régi alakot. Az a migráció nem része ennek a PR-nek.

A figyelmeztetés maga is kiegészült, mert a felére hiányos volt. Heredocot ajánlott, és nem mondta ki, hogy a védelem az IDÉZETT határoló: a `<<JSON` alak ugyanúgy behelyettesít, mint a dupla idézőjel. Mivel az idézett határolóval semmit nem lehet behelyettesíteni, aki egyetlen változót akar a payloadba, visszanyúl az idézetlen alakhoz, és újranyitja a lyukat. Ezért a szöveg most azt is kimondja, hogy egy változót tartalmazó payloadot ne a shell állítson össze, hanem `json.dumps` vagy `jq` írja fájlba, és a curl a `--data-binary @fájl` alakkal küldje.

EN: The scaffold wrote a curl example into agent instruction files in two generated places, with the payload inside a double-quoted shell string. In that position the shell runs backticks and `$(...)` inside the JSON and substitutes the command output for the text. When an agent pastes a filename, a hash, or an excerpt of a stranger's message into the payload, that content is executed, and the request still returns HTTP 200, so nothing surfaces the loss.

The second of the two is the worse one. One example carries the agent's own words; the other explicitly instructs the agent to substitute an UNKNOWN sender's message text. There the stranger writes the command that runs.

Both examples move to a quoted heredoc (`--data-binary @- <<'JSON'`), each with a short reason so that a reader copying the block does not re-derive the double-quoted shape. The approval-request example is untouched: it has always used a single-quoted payload and serves as the in-file positive control. The token read in the header interpolates on purpose and stays.

The heredoc solves the shell, not the JSON, so the stranger-sender example no longer wraps the quoted fragment in apostrophes and says what to do with a raw quote.

The two generated surfaces behave differently: one is rewritten on every agent start, so existing files converge on their own, while the other is written once at creation, so existing files keep the old form until a separate migration. That migration is out of scope here.

The warning itself was extended, because it closed only half the hole. It recommended a heredoc without saying that the protection is the QUOTED delimiter: `<<JSON` expands exactly like a double-quoted string. Since a quoted delimiter interpolates nothing, anyone who needs a single variable in the payload reaches for the unquoted form and reopens what the block just closed. The text now also says that a payload needing a variable should not be assembled by the shell at all: `json.dumps` or `jq` writes it to a file and curl sends it with `--data-binary @file`.

## Kapcsolódó issue / Related issue
Nincs nyitott GitHub issue. / No open GitHub issue.

## Hogyan teszteltem / How it was tested

HU: A teszt előbb készült, mint a javítás, és a helyes okból volt piros: a hét állításból négy bukott a javítás előtti fán (az első példa sora, a teljes generált blokk, a heredoc-alak, és a generátor forrása), miközben a két üresség-ellenőrzés és a pozitív kontroll már akkor is zöld volt. Egy mérő, amelyik a helyes alakot nem látja, a hibásra is vak.

A viselkedés determinisztikusan mérve, nem érveléssel: azonos payloaddal a régi alak a kézbesített törzsbe az `echo VEGREHAJTVA` kimenetét teszi, az idézett heredoc a backtickot és a `$(...)`-t is betűhíven adja át.

Egy korábbi, ki nem szállított ág ugyanezt a két helyet javította. Állításonként összevetettem a két tesztet, és négy védelmet átemeltem: a payload az ügynök saját nevét vigye, ne helyőrzőt; a fejlécben a token olvasása maradjon interpoláló, mert egy hanyag idézés-javítás a veszéllyel együtt azt is eltüntetné; az idegen feladós blokk tartalmazza a heredocot, a blokkra állítva; és a legszélesebb, hogy az egész fájlban egyetlen curl-példa se használjon dupla idézőjeles payloadot. Az utolsó mérve, nem feltételezve: a javítás előtti forráson két találatot ad, a mostanin nullát.

Kapuk: typecheck, syntax-check és a teljes tesztcsomag, mind nulla kilépési kóddal.

EN: The test was written before the fix and was red for the right reason: four of its seven assertions failed on the pre-fix tree (the first example line, the whole generated block, the heredoc shape, and the generator source), while the two non-vacuity checks and the positive control passed already. A meter that cannot see the correct form is blind to the broken one.

Behaviour measured deterministically rather than argued: with the same payload, the old form places the output of `echo VEGREHAJTVA` into the delivered body, while the quoted heredoc passes both the backtick and the `$(...)` verbatim.

An earlier, unshipped branch fixed the same two places. The two tests were compared assertion by assertion and four protections were carried over: the payload must name the agent itself, never a placeholder; the token read in the header must keep interpolating, since a careless quoting fix would remove it along with the hazard; the stranger-sender block must carry the heredoc, asserted on the block; and the widest one, that no curl example anywhere in the file may use a double-quoted payload. The last is measured, not assumed: it finds two offenders on the pre-fix source and none on the current one.

Gates: typecheck, syntax-check and the full test suite, all with exit code zero.

## Kockázatok / Risks

HU: A változás egy generált szöveg alakját érinti, futó logikát nem. A generált blokkot újraíró felület a következő indításkor a javított alakot írja ki, ami szándékos. A második felület csak létrehozáskor fut, tehát a már meglévő fájlokat nem gyógyítja; ez tudott korlát, és külön munka.

EN: The change affects the shape of generated text, not running logic. The surface that rewrites its block will emit the corrected form on the next start, which is intended. The second surface only runs at creation, so it does not heal files that already exist; that is a known limit and separate work.

## Ellenőrzőlista / Checklist
- [x] A javítás mindkét generált helyet lefedi, nem csak azt, amelyik a hibát kiváltotta.
- [x] A jóváhagyás-kérő példa érintetlen, és fájlon belüli pozitív kontrollként szolgál.
- [x] A fejléc token-interpolációja külön állítással védve.
- [x] Regressziós teszt, a javítás előtt pirosra mérve, üresség-ellenőrzéssel és pozitív kontrollal.
- [x] Négy védelem átemelve egy korábbi, ki nem szállított ágról, két állítás szándékos kihagyása a commit-üzenetben indokolva.
- [x] docs/ frissítés nem szükséges: a magyarázat a generált szövegbe és a tesztbe került.
- [x] A figyelmeztetés az idézetlen heredocot is megnevezi, külön piros próbával mérve.
- [x] Nincs beégetett szenzitív adat.
- [x] Saját, beszédes nevű branch: fix/autonomy-example-curl-quoting

