### PR TITLE
fix(pane-writers): bring the identity /rename under the send lane (IDENTLANE910)

### DIFF
--- a/src/__tests__/session-send-lock.test.ts
+++ b/src/__tests__/session-send-lock.test.ts
@@ -132,4 +132,42 @@ describe('sendPromptToSession delivery-lock wiring', () => {
     expect(CHANNEL_MONITOR).toMatch(/withSessionSendLock\(session, null, 'recover'/)
     expect(CHANNEL_MONITOR).toMatch(/lockMode: 'held'/)
   })
+
+  // IDENTLANE910. scheduleIdentitySetup was the writer #885 and #895 both
+  // missed: it typed `/rename <name>` with a bare send-keys on a
+  // fire-and-forget timer. Measured 2026-09-10 09:40:01 -- a restart fired it
+  // while the scheduler was chunk-pasting a task prompt into the same pane, and
+  // `/rename Marveen_is` landed in the MIDDLE of that prompt, between two words
+  // of a python expression. The reading agent saw an unprovenanced self-rename
+  // command inside its own instructions.
+  //
+  // This test is a source contract for the same reason the two above are: the
+  // race needs a restart and a concurrent delivery to collide within the same
+  // second, so it is not reproducible on demand in CI. What IS checkable is
+  // that the send site sits inside a lane acquisition.
+  it('the identity /rename send is inside a send-lane acquisition, not a bare send-keys', () => {
+    const fn = AGENT_PROCESS.slice(AGENT_PROCESS.indexOf('export async function scheduleIdentitySetup'))
+    const body = fn.slice(0, fn.indexOf('\n}\n') + 3)
+    expect(body).toMatch(/tryAcquireSessionSendLane\(session, host\)/)
+    // The send-keys that types the slash command must be guarded: the acquire
+    // has to appear BEFORE it in the function body.
+    const acquireAt = body.indexOf('releaseIdentityLane = tryAcquireSessionSendLane')
+    const sendAt = body.indexOf("runTmux(host, ['send-keys', '-t', session, cmd, 'Enter']")
+    expect(acquireAt).toBeGreaterThanOrEqual(0)
+    expect(sendAt).toBeGreaterThan(acquireAt)
+    // And it must be released, or the pane's lane wedges for every later writer.
+    expect(body).toMatch(/releaseIdentityLane\(\)/)
+  })
+
+  it('a busy lane defers the identity /rename instead of dropping it silently', () => {
+    const fn = AGENT_PROCESS.slice(AGENT_PROCESS.indexOf('export async function scheduleIdentitySetup'))
+    const body = fn.slice(0, fn.indexOf('\n}\n') + 3)
+    // Retry loop, not a one-shot skip: a skipped /rename would leave the
+    // session unnamed for its whole life.
+    expect(body).toMatch(/IDENTITY_LANE_MAX_ATTEMPTS/)
+    // Both the deferral and the give-up are logged -- a skip nobody logs is
+    // not a skip.
+    expect(body).toMatch(/Identity \/rename deferred/)
+    expect(body).toMatch(/Identity \/rename abandoned/)
+  })
 })

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -2146,34 +2146,90 @@ export function identitySlashCommands(displayName: string): string[] {
 const MODAL_DISMISS_DELAY_MS = 8000
 const IDENTITY_SEND_DELAY_MS = 5000
 
+// How many times the identity send retries when the pane's send lane is held
+// by a live delivery, and how long it waits between tries. Unlike the modal
+// dismissals (skip-on-busy is harmless -- a modal that is really up keeps the
+// pane non-idle and the next writer's own gate handles it), a SKIPPED /rename
+// leaves the session unnamed for its whole life, so this one waits its turn.
+// 5 x 3s spans a typical chunked delivery without holding the lane itself.
+const IDENTITY_LANE_RETRY_MS = 3000
+const IDENTITY_LANE_MAX_ATTEMPTS = 5
+
 // Schedule the identity setup for a freshly (re)spawned session: once it has
 // had time to render, dismiss any first-run/resume modals, then send `/rename`.
 // Shared by startAgentProcess and the channel-monitor recovery respawns
 // (resumeMarveenSession / respawnMarveenSessionFresh), which previously left the
 // main session without its identity after auto-recovery. Fire-and-forget; all
 // errors are swallowed/logged so a missed setup never tears down the caller.
+//
+// IDENTLANE910: both pane-touching spans run INSIDE the per-pane send lane.
+// This writer was the one DELIVLOCK805 (#885) and PANEWRITERS805 (#895) missed:
+// it typed `/rename <name>` with a bare `runTmux(['send-keys', ...])` on a
+// fire-and-forget timer, outside the lane. Measured 2026-09-10 09:40:01: an
+// update.sh restart fired identity setup while the scheduler was chunk-pasting
+// a task prompt into the SAME pane, and `/rename Marveen_is` spliced into the
+// MIDDLE of that prompt -- between two words of a python expression on line 100
+// of the task's SKILL.md. The prompt file on disk was clean, so the splice
+// happened in transit. Reading agent saw an unprovenanced self-rename command
+// embedded in its own instructions; it did not execute it, but a writer that
+// can inject arbitrary text into another writer's framed message is exactly the
+// defect class #885 closed for deliveries.
 export async function scheduleIdentitySetup(session: string, displayName: string, host: string | null = null): Promise<void> {
   setTimeout(() => {
     void (async () => {
-      try {
-        await dismissSurveyModalIfPresent(session, host)
-        await dismissResumeSummaryModalIfPresent(session, host)
-        await dismissModelConsentDialogIfPresent(session, host)
-        await dismissFeedbackDraftModalIfPresent(session, host)
-      } catch (err) {
-        logger.warn({ err, session }, 'Post-restart modal dismiss failed')
+      // Modal dismissals: fail-closed acquire, same as sendPromptToSession's
+      // pre-emit dismissals. Skipping on a busy lane is safe here -- a delivery
+      // holding the lane runs its OWN dismissals before emitting.
+      const releaseDismissLane = tryAcquireSessionSendLane(session, host)
+      if (releaseDismissLane) {
+        try {
+          await dismissSurveyModalIfPresent(session, host)
+          await dismissResumeSummaryModalIfPresent(session, host)
+          await dismissModelConsentDialogIfPresent(session, host)
+          await dismissFeedbackDraftModalIfPresent(session, host)
+        } catch (err) {
+          logger.warn({ err, session }, 'Post-restart modal dismiss failed')
+        } finally {
+          releaseDismissLane()
+        }
+      } else {
+        logger.info({ session }, 'Identity setup: modal dismissals skipped -- a delivery holds this pane send lane')
       }
       setTimeout(() => {
         void (async () => {
-          try {
-            for (const cmd of identitySlashCommands(displayName)) {
-              runTmux(host, ['send-keys', '-t', session, cmd, 'Enter'], { timeout: 5000 })
-              await delay(1000)
+          // The /rename itself: retry-until-free rather than skip. The lane is
+          // re-acquired here (not held across the 5s render wait) so we never
+          // block a delivery while merely waiting.
+          for (let attempt = 1; attempt <= IDENTITY_LANE_MAX_ATTEMPTS; attempt++) {
+            const releaseIdentityLane = tryAcquireSessionSendLane(session, host)
+            if (!releaseIdentityLane) {
+              logger.info(
+                { session, displayName, attempt, max: IDENTITY_LANE_MAX_ATTEMPTS },
+                'Identity /rename deferred -- a delivery holds this pane send lane; retrying',
+              )
+              await delay(IDENTITY_LANE_RETRY_MS)
+              continue
             }
-            logger.info({ session, displayName }, 'Set session /rename')
-          } catch (err) {
-            logger.warn({ err, session, displayName }, 'Failed to set session /rename')
+            try {
+              for (const cmd of identitySlashCommands(displayName)) {
+                runTmux(host, ['send-keys', '-t', session, cmd, 'Enter'], { timeout: 5000 })
+                await delay(1000)
+              }
+              logger.info({ session, displayName, attempt }, 'Set session /rename')
+            } catch (err) {
+              logger.warn({ err, session, displayName }, 'Failed to set session /rename')
+            } finally {
+              releaseIdentityLane()
+            }
+            return
           }
+          // Gave up: the display name stays default. Cosmetic, and strictly
+          // better than splicing `/rename` into someone else's message. Logged
+          // loudly because a skip nobody logs is not a skip.
+          logger.warn(
+            { session, displayName, max: IDENTITY_LANE_MAX_ATTEMPTS },
+            'Identity /rename abandoned -- pane send lane stayed busy; session keeps its default name',
+          )
         })()
       }, IDENTITY_SEND_DELAY_MS)
     })()


### PR DESCRIPTION
## What

`scheduleIdentitySetup` typed `/rename <displayName>` with a bare
`runTmux(['send-keys', ...])` on a fire-and-forget timer, **outside** the per-pane
send lane. This PR brings both of its pane-touching spans under the lane.

DELIVLOCK805 (#885) added the mutex and PANEWRITERS805 (#895) brought six
in-process writers under it. This was the seventh, and it was missed.

## Why -- measured, not hypothetical

2026-09-10 09:40:01. An `update.sh` restart fired identity setup while the
scheduler was chunk-pasting a task prompt into the **same** pane. What the
reading agent received:

```
print('$pr', len(d), ... (d[-1]['user']['login'] if/rename Marveen_is d else '-'))
```

`/rename Marveen_is` landed in the **middle** of the prompt, between two words of
a python expression on line 100 of the task's own SKILL.md.

The prompt file on disk was byte-clean (md5 unchanged since 09-05), so the splice
happened **in transit**. The agent saw an unprovenanced self-rename command
embedded in its own instructions. It did not execute it -- but a writer that can
inject arbitrary text into another writer's framed message is exactly the defect
class #885 closed for deliveries, and here it reached an agent's instruction
stream rather than a chat message.

Evidence trail: `dashboard.log` logs `Set session /rename` for the identity
writer, and its timestamp falls in the same second as the scheduler's paste.

## How

| span | lane mode | on busy |
|---|---|---|
| modal dismissals | fail-closed acquire | skip + log (the delivery holding the lane runs its own dismissals) |
| the `/rename` send | acquire per attempt | **retry** 5 x 3s, then give up + log |

The `/rename` retries rather than skips because a skipped rename leaves the
session unnamed for its whole life. The lane is re-acquired for the send rather
than held across the 5s render wait, so a delivery is never blocked while we are
merely waiting.

Both the deferral and the give-up are logged -- a skip nobody logs is not a skip.
On give-up the session keeps its default name: cosmetic, and strictly better than
splicing `/rename` into someone else's message.

## Tests

Two source contracts added to `session-send-lock.test.ts`, alongside the existing
ones for `sendPromptToSession` and the recovery re-inject:

- the acquire precedes the `send-keys`, and the lane is released;
- a busy lane defers rather than silently drops (retry loop + both log lines).

The race needs a restart and a delivery to collide within the same second, so it
is not reproducible on demand -- hence source contracts rather than a behavioural
test. **Both new tests were verified to fail against the unfixed function** and
pass with it.

`tsc --noEmit`: clean. Targeted suites: 12 passed.

### Pre-existing failures, unrelated to this change

The full suite reports `2 failed | 5188 passed` on my machine, in
`script-tests-runner.test.ts` (`migrate-agent-id-linux.test.sh`,
`intel-db.test.sh`). Root cause is `sqlite3: command not found` -- the CLI is not
installed here. **Control: the same two tests fail with this change stashed**, on
the same worktree. Not introduced by this PR.
