### PR TITLE
test(context-guard): pin the tone difference between the three handoff requests

### DIFF
--- a/src/__tests__/context-guard-handoff-prompt-tone.test.ts
+++ b/src/__tests__/context-guard-handoff-prompt-tone.test.ts
@@ -1,0 +1,164 @@
+// The three handoff requests the guard can send are worded differently ON
+// PURPOSE, and nothing pinned that until now: the act tier tells an agent its
+// context is critical and to drop what it is doing; the idle tier fires on a
+// session that has been quiet, where there is nothing in flight to drop, so
+// the same alarm would push a routine housekeeping restart into being handled
+// as an emergency; the stale-refresh asks for an update to an artifact that
+// already exists, where "write a handoff" would read as a bug.
+//
+// The risk is not that a sentence is missing. It is that two of them CONVERGE
+// -- by a copy-paste, or by the selecting ternary flipping -- and the agent on
+// the receiving end cannot tell. These assertions are therefore written as
+// mutual exclusions between the tiers, not as spell-checks of one string.
+//
+// The selection itself is a nested ternary inside an async side-effecting
+// function, so it is pinned at source level: the alarming prompt must stay the
+// FALLBACK, reached only when neither the stale nor the idle prefix matched.
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import {
+  handoffPrompt,
+  idleFlushHandoffPrompt,
+  staleRefreshHandoffPrompt,
+} from '../web/context-guard-runner.js'
+
+const PATH = '/tmp/agents/x/HANDOFF.md'
+
+// Vocabulary that means "drop everything, this is an emergency".
+const ALARM = ['kritikus', 'NE folytasd']
+// Vocabulary that means "nothing is on fire, this is housekeeping".
+const ROUTINE = ['Rutin karbantartás', 'nem vészhelyzet']
+
+const act = () => handoffPrompt(93, PATH)
+const idle = () => idleFlushHandoffPrompt(501_234, 45, PATH)
+const stale = () => staleRefreshHandoffPrompt(37, PATH)
+
+describe('every handoff request keeps the properties all three share', () => {
+  it('carries the authenticated-directive envelope', () => {
+    for (const p of [act(), idle(), stale()]) expect(p.startsWith('[CONTEXT-GUARD]')).toBe(true)
+  })
+
+  it('names the exact handoff path it was given', () => {
+    for (const p of [act(), idle(), stale()]) expect(p).toContain(PATH)
+  })
+
+  it('ends the turn -- the agent must stop, not continue working', () => {
+    for (const p of [act(), idle(), stale()]) expect(p).toContain('ÁLLJ MEG')
+  })
+})
+
+describe('act tier: the alarm is intended here', () => {
+  it('states the measured percentage it was given', () => {
+    expect(act()).toContain('~93%')
+  })
+
+  it('uses the alarm vocabulary', () => {
+    for (const word of ALARM) expect(act()).toContain(word)
+  })
+
+  it('does NOT reassure -- the routine wording would understate a full window', () => {
+    for (const word of ROUTINE) expect(act()).not.toContain(word)
+  })
+})
+
+describe('idle tier: the alarm would be false here', () => {
+  it('opens by saying it is routine, before any number', () => {
+    for (const word of ROUTINE) expect(idle()).toContain(word)
+  })
+
+  // The single assertion this whole file exists for: an idle agent that reads
+  // "kritikus" abandons work it was never asked to abandon.
+  it('carries NO alarm vocabulary', () => {
+    for (const word of ALARM) expect(idle()).not.toContain(word)
+  })
+
+  it('reports the token count it measured, in thousands', () => {
+    expect(idle()).toContain('~501k token')
+  })
+
+  it('rounds the token count rather than truncating it', () => {
+    expect(idleFlushHandoffPrompt(1_500, 30, PATH)).toContain('~2k token')
+    expect(idleFlushHandoffPrompt(1_499, 30, PATH)).toContain('~1k token')
+  })
+
+  it('states the idle period it acted on', () => {
+    expect(idle()).toContain('45 perce')
+  })
+
+  // Without this, an idle agent with nothing in flight can read the request as
+  // unanswerable and stall instead of stopping.
+  it('says that "nothing in flight" is a complete answer', () => {
+    expect(idle()).toContain('nincs félbehagyott feladatod')
+  })
+
+  it('does NOT quote a percentage -- the idle tier runs with pct unmeasured', () => {
+    expect(idle()).not.toContain('%')
+  })
+})
+
+describe('stale-refresh: an update, not a first write', () => {
+  it('asks for a refresh of the existing file', () => {
+    expect(stale()).toContain('frissítsd')
+  })
+
+  it('does NOT ask for a first write, which would read as a bug to the agent', () => {
+    expect(stale()).not.toContain('írj HANDOFF.md-t')
+  })
+
+  it('states how much work the artifact no longer covers', () => {
+    expect(stale()).toContain('~37 perc')
+  })
+})
+
+describe('the three tiers cannot collapse into each other', () => {
+  it('no two requests produce the same text for the same handoff path', () => {
+    const texts = [act(), idle(), stale()]
+    expect(new Set(texts).size).toBe(3)
+  })
+
+  it('the alarm and the reassurance never appear in the same request', () => {
+    for (const p of [act(), idle(), stale()]) {
+      const alarming = ALARM.some((w) => p.includes(w))
+      const reassuring = ROUTINE.some((w) => p.includes(w))
+      expect(alarming && reassuring).toBe(false)
+    }
+  })
+})
+
+describe('the selecting ternary keeps the alarming prompt as the fallback', () => {
+  const src = readFileSync(join(process.cwd(), 'src/web/context-guard-runner.ts'), 'utf-8')
+  const caseStart = src.indexOf("case 'request-handoff':")
+  const caseEnd = src.indexOf("case 'restart':", caseStart)
+  const block = src.slice(caseStart, caseEnd)
+
+  it('the measure is not vacuous -- the selecting block is found and calls all three', () => {
+    expect(caseStart, "request-handoff case not found").toBeGreaterThan(0)
+    expect(caseEnd, 'restart case not found after it').toBeGreaterThan(caseStart)
+    for (const fn of ['staleRefreshHandoffPrompt(', 'idleFlushHandoffPrompt(', 'handoffPrompt(']) {
+      expect(block).toContain(fn)
+    }
+  })
+
+  it('the stale prefix selects the refresh wording', () => {
+    expect(block.indexOf('STALE_REFRESH_REASON_PREFIX')).toBeLessThan(block.indexOf('staleRefreshHandoffPrompt('))
+  })
+
+  it('the idle prefix selects the routine wording', () => {
+    expect(block.indexOf('IDLE_FLUSH_REASON_PREFIX')).toBeLessThan(block.indexOf('idleFlushHandoffPrompt('))
+  })
+
+  // Order is the assertion: the bare handoffPrompt call must come LAST, after
+  // both guarded branches. If it moves ahead of the idle branch, every idle
+  // flush starts shouting.
+  it('the alarming wording is reached only after both guarded branches', () => {
+    const idleCall = block.indexOf('idleFlushHandoffPrompt(')
+    const bare = block.lastIndexOf(': handoffPrompt(')
+    // Both must be PRESENT before their order means anything: with either call
+    // missing, indexOf returns -1 and the comparison passes for the wrong
+    // reason. Measured -- a ternary swap leaves this assertion green without it.
+    expect(idleCall).toBeGreaterThan(0)
+    expect(bare).toBeGreaterThan(0)
+    expect(bare).toBeGreaterThan(idleCall)
+  })
+})


### PR DESCRIPTION
## A változtatás típusa / Type of change
- [x] Teszt-lefedés (tests only)

## Rövid leírás / Summary

HU: A context-guard négy különböző szöveggel kérhet handoffot, és a hangvételük szándékosan tér el. A telítettségi szint azt mondja, hogy a kontextus kritikus, és a folyamatban lévő munkát félbe kell hagyni. A tétlenségi szint olyan sessionre fut, ami régóta csendes, tehát nincs mit félbehagyni, és ugyanaz a riasztó szöveg egy rutin karbantartást vészhelyzetté tenne annak, aki olvassa. A frissítés-kérés egy már meglévő fájl kiegészítését kéri, ahol az "írj handoffot" hibának olvasódna. A negyedik, az újraindítás utáni szöveg, már fedve volt.

Ebből a négyből háromra egyetlen teszt sem hivatkozott. Nem regresszió, eddig sem volt, de azt jelenti, hogy a szándékos különbség mögött semmi nem állt.

Az állítások ezért kölcsönös kizárásként vannak megírva, nem helyesírás-ellenőrzésként. Ami elromolhat, az nem egy elgépelés, hanem két szint EGYBEMOSÓDÁSA: egy másolás, vagy a választó feltétel elcsúszása. A riasztó szókészlet ezért kötelező a telítettségi szövegben és tilos a tétlenségiben, a megnyugtató fordítva, és a három szöveg ugyanarra az útvonalra nem adhatja ugyanazt. A tétlenségi szövegben külön tiltott a százalék, mert az a szint mérés nélküli százalékkal fut, és a "~0%, kritikus" pontosan az a hamis riasztás, ami miatt a külön szöveg létezik.

A választás maga beágyazott feltétel egy mellékhatásos async függvényben, ezért forrás-szinten van rögzítve: minden őrzött ág a saját szövege előtt áll, és a riasztó hívás marad a fallback, amit csak mindkét őrzött ág után lehet elérni.

EN: The context guard can ask for a handoff with four different texts, and their tone differs on purpose. The saturation tier says the context is critical and that work in flight must be dropped. The idle tier fires on a session that has been quiet, where there is nothing in flight to drop, and the same alarming text would turn routine housekeeping into an emergency for whoever reads it. The refresh request asks for an update to a file that already exists, where "write a handoff" would read as a bug. The fourth, the post-restart text, was already covered.

Three of those four had no test referencing them at all. Not a regression, it was never covered, but it means nothing stood behind a difference that is deliberate.

The assertions are therefore written as mutual exclusions rather than spell-checks. What can break is not a typo but two tiers CONVERGING, through a copy-paste or through the selecting condition drifting. The alarm vocabulary is required in the saturation text and forbidden in the idle one, the reassurance the other way round, and no two of the three may produce the same text for the same path. The idle text additionally may not quote a percentage, since that tier runs with the percentage unmeasured and "~0%, critical" is exactly the false alarm the separate wording exists to prevent.

The selection itself is a nested conditional inside a side-effecting async function, so it is pinned at source level: each guarded branch precedes its own text, and the alarming call remains the fallback, reachable only after both guarded branches.

## Kapcsolódó issue / Related issue
Nincs nyitott GitHub issue. / No open GitHub issue.

## Hogyan teszteltem / How it was tested

HU: Minden állítás mutációval van ellenőrizve, nem feltételezve. Hat rontást vittem be az éles szövegbe és vontam vissza, mindegyik a várt állítást döntötte: a két szöveg felcserélése a választó feltételben, a riasztó szöveg a tétlenségi ágra, kerekítés helyett csonkítás a token-számnál, a megállítás elhagyása, százalék beengedése a tétlenségi szövegbe, és a frissítés-kérés első írássá alakítása. A forrás utána bizonyíthatóan érintetlen.

Az egyik mutáció nem a kódban, hanem MAGÁBAN A TESZTBEN talált gyengeséget, és ezt érdemes kimondani: a sorrendet állító, forrás-szintű ellenőrzés zölden maradt a két hívás felcserélésekor, mert hiányzó elemre a keresés mínusz egyet ad, és bármely valós pozíció nagyobb nála. Az állítás most előbb a jelenlétet mondja ki, aztán a sorrendet, és ugyanaz a mutáció pirosra viszi. A fájl a hibát egyébként is fogta két másik állítással, de a sorrend-mérő magától soha nem kapta volna el.

Kapuk: typecheck, syntax-check és a teljes tesztcsomag, mind nulla kilépési kóddal. Éles kódot a PR nem módosít.

EN: Every assertion is mutation-checked rather than assumed. Six mutations of the production text were applied and reverted, each turning the expected assertions red: swapping the two texts in the selecting condition, giving the idle branch the alarming wording, truncating instead of rounding the token count, dropping the stop instruction, letting a percentage into the idle text, and turning the refresh request into a first write. The source is verifiably untouched afterwards.

One mutation found a weakness in the TEST rather than in the code, which is worth stating: the source-level ordering assertion stayed green when the two calls were swapped, because a missing element makes the lookup return minus one and any real position beats it. The assertion now states presence before order, and the same mutation turns it red. The file caught the mutation anyway through two other assertions, but the ordering meter alone never would have.

Gates: typecheck, syntax-check and the full test suite, all with exit code zero. No production file is modified by this PR.

## Kockázatok / Risks

HU: Teszt-only változás, futó kód nem mozdul. A kockázat inkább az ellenkezője: az állítások a szövegek MOSTANI hangvételét rögzítik, tehát egy szándékos újrafogalmazás pirosra viszi őket. Ez a cél, de aki a szöveget írja, számítson rá, hogy az állítást is frissítenie kell.

EN: Tests only, no running code moves. The risk is the opposite one: the assertions pin the CURRENT tone of these texts, so a deliberate rewording will turn them red. That is the point, but whoever rewrites the text should expect to update the assertion with it.

## Ellenőrzőlista / Checklist
- [x] A negyedik, korábban fedetlen prompt is bekerült, mert ugyanaz a hibaosztály.
- [x] Az állítások a szintek összekeveredését fogják, nem egyetlen szöveg meglétét.
- [x] Minden állítás mutációval ellenőrizve, a forrás visszaállítva.
- [x] A mutáció által talált teszt-gyengeség javítva és a commit-üzenetben kimondva.
- [x] Éles kód nem módosul: a diff egyetlen új tesztfájl.
- [x] docs/ frissítés nem szükséges.
- [x] Nincs beégetett szenzitív adat.
- [x] Saját, beszédes nevű branch: test/handoff-prompt-tier-tone
