### PR TITLE
fix(pane-writers): bring the two not-ready-path janitors under the send lane (PANEWRITERS910)

### DIFF
--- a/src/__tests__/janitor-under-send-lane.test.ts
+++ b/src/__tests__/janitor-under-send-lane.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// PANEWRITERS910: behavioural pin for the two not-ready-path janitors under
+// the per-pane send lane. Both fire raw send-keys and are driven by timers
+// independent of the delivery path (message-router tick, schedule-runner tick,
+// inbox-nudge-watcher, telegram-inbox-wake), so a delivery pausing past
+// clearStaleParkedInput's 2s stability window looks exactly like a stale
+// parked line -- the IDENTLANE910 splice class. The contract pinned here:
+//   - lane HELD by a delivery -> both janitors return false and send NOTHING;
+//   - lane free               -> both act (positive control, so a broken
+//                                acquire cannot pass as "safely skipped");
+//   - lockMode 'held'         -> clearStaleParkedInput still acts (the
+//                                schedule-runner reinject site owns the lane;
+//                                a re-acquire there would self-deadlock into
+//                                a permanent false skip).
+//
+// Same harness as parked-input-escalation.test.ts: capturePane/runTmux are
+// LOCAL to agent-process and go through node:child_process execFileSync, so we
+// mock execFileSync with arg-inspection. session-send-lock is deliberately NOT
+// mocked -- the test holds the real lane the way a real delivery does.
+
+const h = vi.hoisted(() => {
+  const SEP = '─'.repeat(80)
+  const FOOTER = '  ⏵⏵ bypass permissions on (shift+tab to cycle)'
+  // Real, normal-intensity parked line (survives the dim strip).
+  const PARKED = ['', SEP, '❯ Csendes heartbeat.', SEP, FOOTER].join('\n')
+  // The self-drafted feedback modal: bordered option line ABOVE the prompt
+  // marker, idle footer, no busy indicators -- detectsFeedbackDraftModal fires.
+  const MODAL = [
+    '╭──────────────────────────────────────────────╮',
+    '│ ✻ Bug report drafted: sample summary…        │',
+    '│ 1 to review · 2 to send · 0 to dismiss       │',
+    '╰──────────────────────────────────────────────╯',
+    '', SEP, '❯ ', SEP, FOOTER,
+  ].join('\n')
+  return { PARKED, MODAL, pane: PARKED, calls: [] as string[][] }
+})
+
+vi.mock('node:child_process', async (orig) => ({
+  ...(await orig() as object),
+  execFileSync: vi.fn((_file: string, args?: string[]) => {
+    if (Array.isArray(args)) {
+      h.calls.push(args)
+      if (args.includes('capture-pane')) return h.pane
+    }
+    return ''
+  }),
+}))
+vi.mock('../notify.js', () => ({ notifyChannel: vi.fn(async () => {}), notifyTelegram: vi.fn(async () => {}) }))
+
+import { clearStaleParkedInput, clearFeedbackModalAndRecheck } from '../web/agent-process.js'
+import { tryAcquireSessionSendLane, __resetSessionSendLocks } from '../web/session-send-lock.js'
+
+function sentKeys(): string[][] {
+  return h.calls.filter(a => a.includes('send-keys'))
+}
+
+beforeEach(() => {
+  h.calls.length = 0
+  __resetSessionSendLocks()
+})
+
+describe('clearStaleParkedInput under the send lane', () => {
+  // Distinct session per case: the module-level cooldown map keys on session,
+  // so reusing one would turn a later case into a cooldown skip.
+  it('skips fail-closed while a delivery holds the lane: false, zero keystrokes', async () => {
+    h.pane = h.PARKED
+    const release = tryAcquireSessionSendLane('subagent-lane-busy', null)!
+    try {
+      expect(await clearStaleParkedInput('subagent-lane-busy')).toBe(false)
+    } finally {
+      release()
+    }
+    expect(sentKeys().length).toBe(0)
+  })
+
+  it('positive control: with the lane free the clear sequence fires', async () => {
+    h.pane = h.PARKED
+    await clearStaleParkedInput('subagent-lane-free')
+    expect(sentKeys().length).toBeGreaterThan(0)
+  }, 15_000) // real 2s stable-confirm + clear-settle delays
+
+  it("lockMode 'held': acts even though the caller owns the lane (no self-deadlock skip)", async () => {
+    h.pane = h.PARKED
+    const release = tryAcquireSessionSendLane('subagent-lane-held', null)!
+    try {
+      await clearStaleParkedInput('subagent-lane-held', null, { lockMode: 'held' })
+    } finally {
+      release()
+    }
+    expect(sentKeys().length).toBeGreaterThan(0)
+  }, 15_000)
+})
+
+describe('clearFeedbackModalAndRecheck under the send lane', () => {
+  it('skips fail-closed while a delivery holds the lane: false, zero keystrokes', async () => {
+    h.pane = h.MODAL
+    const release = tryAcquireSessionSendLane('subagent-modal-busy', null)!
+    try {
+      expect(await clearFeedbackModalAndRecheck('subagent-modal-busy')).toBe(false)
+    } finally {
+      release()
+    }
+    expect(sentKeys().length).toBe(0)
+  })
+
+  it("positive control: with the lane free the dismissal '0' fires", async () => {
+    h.pane = h.MODAL
+    await clearFeedbackModalAndRecheck('subagent-modal-free')
+    expect(sentKeys().some(a => a[a.length - 1] === '0')).toBe(true)
+  }, 15_000)
+})

--- a/src/__tests__/pane-writers-under-send-lock.test.ts
+++ b/src/__tests__/pane-writers-under-send-lock.test.ts
@@ -116,4 +116,27 @@ describe('every unguarded pane writer routes through the send lane', () => {
     const heldIdx = src.indexOf("if (lockMode === 'held') {\n    await dismissSurveyModalIfPresent")
     expect(heldIdx).toBeGreaterThan(-1)
   })
+
+  // PANEWRITERS910: the two not-ready-path janitors. Their behaviour under a
+  // held lane is pinned in janitor-under-send-lane.test.ts; these pin the
+  // source shape so a refactor cannot silently drop the acquire.
+  it('clearStaleParkedInput acquires fail-closed, releases in finally, and honours lockMode held', () => {
+    const src = read('../web/agent-process.ts')
+    expect(src).toMatch(/stale-parked-input janitor skipped/)
+    // The held branch delegates WITHOUT acquiring; the acquire branch wraps the
+    // same lane-holding tail in try/finally.
+    expect(src).toMatch(/return clearStaleParkedInputInLane\(session, host, a, parked, key, nowMs, prev\)/)
+    expect(src).toMatch(/return await clearStaleParkedInputInLane\(session, host, a, parked, key, nowMs, prev\)\s*\} finally \{\s*releaseLane\(\)/)
+  })
+
+  it('clearFeedbackModalAndRecheck acquires fail-closed around the dismissal keystrokes', () => {
+    const src = read('../web/agent-process.ts')
+    expect(src).toMatch(/feedback-draft modal dismissal skipped/)
+    expect(src).toMatch(/await dismissFeedbackDraftModalIfPresent\(session, host\)\s*\} finally \{\s*releaseLane\(\)/)
+  })
+
+  it("schedule-runner's reinject site declares the lane it already holds", () => {
+    const src = read('../web/schedule-runner.ts')
+    expect(src).toMatch(/clearStaleParkedInput\(session, host, \{ lockMode: 'held' \}\)/)
+  })
 })

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -1976,12 +1976,28 @@ export async function dismissResumeSummaryModalIfPresent(session: string, host: 
 // Returns true only if the modal was actually there AND the pane became ready
 // after clearing it -- a false keeps the caller on its existing skip path, so
 // nothing about the busy case changes.
+//
+// PANEWRITERS910: the dismissal keystrokes run under the per-pane send lane,
+// fail-closed (same contract as sendPromptToSession's pre-emit dismissals and
+// scheduleIdentitySetup's modal span). All four refusal-branch callers run on
+// their own timers, so without the lane this could press '0'/Escape into a
+// pane mid-delivery. A busy lane returns false: the holder is a delivery,
+// which runs its own pre-emit dismissals, so skipping loses nothing.
 export async function clearFeedbackModalAndRecheck(session: string, host: string | null = null): Promise<boolean> {
   try {
     const pane = capturePane(session, host)
     if (pane == null || !detectsFeedbackDraftModal(pane)) return false
-    logger.warn({ session }, 'pane held by a Claude Code feedback-draft modal on the not-ready path, dismissing')
-    await dismissFeedbackDraftModalIfPresent(session, host)
+    const releaseLane = tryAcquireSessionSendLane(session, host)
+    if (!releaseLane) {
+      logger.info({ session }, 'feedback-draft modal dismissal skipped -- a delivery holds this pane send lane (fail-closed)')
+      return false
+    }
+    try {
+      logger.warn({ session }, 'pane held by a Claude Code feedback-draft modal on the not-ready path, dismissing')
+      await dismissFeedbackDraftModalIfPresent(session, host)
+    } finally {
+      releaseLane()
+    }
     return await isSessionReadyForPrompt(session, host)
   } catch (err) {
     logger.warn({ err, session }, 'Failed to clear the feedback-draft modal on the not-ready path')
@@ -2913,7 +2929,23 @@ const unwedgeAttempts = new Map<string, { last: number; sig: string; fails: numb
 // parked text -- never 'busy'/processing) AND the text is unchanged across a
 // short settle, so input a human or agent is actively typing is never clobbered.
 // Returns true if it cleared something (caller should retry delivery next tick).
-export async function clearStaleParkedInput(session: string, host: string | null = null): Promise<boolean> {
+//
+// PANEWRITERS910: the settle-confirm and the clearing keystrokes run under the
+// per-pane send lane, fail-closed. The callers (message-router janitor and the
+// schedule-runner's two janitor sites) tick on independent timers, so without
+// the lane the Ctrl-U/C-k sequence could fire into a pane holding a delivery's
+// half-typed message -- a chunked send pausing past the 2s stability window
+// reads exactly like a stale parked line (same defect class as IDENTLANE910).
+// A busy lane returns false: if a delivery owns the pane, the "parked" text is
+// in-transit, not stale. lockMode 'held' is for the ONE caller already inside
+// the lane (schedule-runner's reinject path, which runs in its delivery's
+// withSessionSendLock span) -- acquiring again there would self-deadlock into
+// a false skip.
+export async function clearStaleParkedInput(
+  session: string,
+  host: string | null = null,
+  opts: { lockMode?: 'acquire' | 'held' } = {},
+): Promise<boolean> {
   const a = capturePane(session, host)
   if (a == null || detectPaneState(a) !== 'typing') return false
   // DIM-GUARD (2026-06-30, Szabi insight): extract the parked TEXT from the
@@ -2937,6 +2969,33 @@ export async function clearStaleParkedInput(session: string, host: string | null
   const prev = unwedgeAttempts.get(key)
   if (prev && prev.sig === parked && nowMs - prev.last < UNWEDGE_COOLDOWN_MS) return false
 
+  if ((opts.lockMode ?? 'acquire') === 'held') {
+    return clearStaleParkedInputInLane(session, host, a, parked, key, nowMs, prev)
+  }
+  const releaseLane = tryAcquireSessionSendLane(session, host)
+  if (!releaseLane) {
+    logger.info({ session }, 'stale-parked-input janitor skipped -- a delivery holds this pane send lane (the box likely holds in-transit text, not a wedge)')
+    return false
+  }
+  try {
+    return await clearStaleParkedInputInLane(session, host, a, parked, key, nowMs, prev)
+  } finally {
+    releaseLane()
+  }
+}
+
+// The lane-holding tail of clearStaleParkedInput: stability confirm, main-agent
+// escalation bookkeeping, and the clearing keystrokes. Split out so the lane
+// release lives in ONE finally regardless of which of the many exits runs.
+async function clearStaleParkedInputInLane(
+  session: string,
+  host: string | null,
+  a: string,
+  parked: string,
+  key: string,
+  nowMs: number,
+  prev: { last: number; sig: string; fails: number; escalated: boolean } | undefined,
+): Promise<boolean> {
   await delay(PARKED_STABLE_CONFIRM_MS)
   const b = capturePane(session, host)
   // Changed (someone is typing) or already cleared -> leave it alone, and do not

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -1016,8 +1016,10 @@ async function attemptFireTask(
             // is off because the box is 'typing', not idle -- the pre-flight gate
             // would otherwise burn its whole budget and time out every attempt.
             // lockMode 'held': we are already inside this pane's lane; taking
-            // the lock again would deadlock the promise-chain mutex.
-            if (await clearStaleParkedInput(session, host)) {
+            // the lock again would deadlock the promise-chain mutex. That goes
+            // for the clear too (PANEWRITERS910): its own acquire would see
+            // OUR lane busy and skip, so this call site must say it holds it.
+            if (await clearStaleParkedInput(session, host, { lockMode: 'held' })) {
               await sendPromptToSession(session, fullPrompt, host, { waitForIdle: false, lockMode: 'held' })
               logger.info({ task: task.name, session, attempt }, 'Scheduled prompt re-injected after swallowed Enter')
             } else {

--- a/src/web/session-send-lock.ts
+++ b/src/web/session-send-lock.ts
@@ -29,6 +29,15 @@
 // sendPromptToSession, so no in-process lock can reach it (a cross-process file
 // lock would be a separate change). A reader must not assume the pane is fully
 // serialized: it is serialized for the two acquirers above, no more.
+//
+// Since then, brought under the lane one by one (each with a fail-closed
+// acquire -- see pane-writers-under-send-lock.test.ts for the per-writer
+// contract): channel-mcp-reconnect, channel-plugin-unlock, reauth-healer,
+// agent-worker's /clear, the pre-emit modal dismissals (#895), the identity
+// /rename (IDENTLANE910, #1272), and the two not-ready-path janitors --
+// clearStaleParkedInput and clearFeedbackModalAndRecheck (PANEWRITERS910).
+// Still uncovered: routes/agent-terminal.ts (operator-driven keystrokes) and
+// the cross-process channel-plugin delivery above.
 
 const delay = (ms: number): Promise<void> => new Promise(res => setTimeout(res, ms))
 


### PR DESCRIPTION
## Mi ez

A PANEWRITERS910 kártya (#1272 teljesség-lelet) lezárása. A `clearStaleParkedInput` és a `clearFeedbackModalAndRecheck` lane nélküli pane-írók voltak: nyers `send-keys`-t küldtek a delivery-útvonaltól független timerekről (message-router tick, schedule-runner tick, inbox-nudge-watcher, telegram-inbox-wake).

## A mérés (a kártya első lépése)

**Futhatnak-e delivery-vel párhuzamosan egy pane-be? IGEN.**
- Mind a négy driver saját timeren fut ugyanabban a processzben; a chunked delivery await-pontjain interleave-elnek.
- Egyik függvény sem konzultálta a lane-t; mindkettő közvetlen `runTmux(['send-keys',...])`-t hív.
- A `clearStaleParkedInput` belső őrei ('typing' state + 2s stabilitás + cooldown) szűkítik, de nem zárják az ablakot: egy 2s-nél hosszabb szünetet tartó delivery félig begépelt üzenete pontosan úgy néz ki, mint egy stale parkolt sor. Ugyanaz a defekt-osztály, mint az IDENTLANE910 (2026-09-10 09:40, élőben mért /rename-splice).

A kártya döntési szabálya szerint tehát: **lane**, nem exemption.

## A fix

- `clearFeedbackModalAndRecheck`: fail-closed `tryAcquireSessionSendLane` a dismissal-keystroke köré (a sendPromptToSession pre-emit dismissal-jainak és a scheduleIdentitySetup-nak a mintája). Foglalt lane → `false`, a hívó marad a meglévő skip-útján.
- `clearStaleParkedInput`: a stabilitás-megerősítés + escalation + törlő szekvencia egy `clearStaleParkedInputInLane` tail-be került, amit az acquire-ág try/finally-ben, a `lockMode: 'held'` ág acquire nélkül hív. Az EGYETLEN lane-en belüli hívóhely (schedule-runner reinject, a delivery saját `withSessionSendLock` span-jében) 'held'-et ad át — az újra-acquire ott önmagával deadlockolna permanens hamis skipbe.
- `session-send-lock.ts` fejléc-komment frissítve: mi került azóta lane alá, és mi maradt fedetlen (routes/agent-terminal.ts + cross-process channel-plugin delivery — kimondva, nem javítva).

## Verify

- Új viselkedési pin: `janitor-under-send-lane.test.ts` (tartott lane → 0 keystroke; szabad lane pozitív kontroll; 'held' mód cselekszik).
- Forrás-szerződések a `pane-writers-under-send-lock.test.ts`-ben.
- `npx tsc --noEmit`: tiszta. Teljes suite: **408 fájl, 5233 passed, 1 skipped** (a skip meglévő).

Kártya: PANEWRITERS910. Base: develop (db4e4723-ról ágazva).

🤖 Generated with [Claude Code](https://claude.com/claude-code)