### PR TITLE
fix(agents): read contextTokens from the real transcript location (GATECTX910)

### DIFF
--- a/src/__tests__/model-suggest.test.ts
+++ b/src/__tests__/model-suggest.test.ts
@@ -249,3 +249,24 @@ describe('MODELSUGGEST807 -- top tier is the shipped distribution default', () =
     expect(humanModelLabel('claude-sonnet-5')).toBe('Sonnet 5')
   })
 })
+
+// GATECTX910: the contextTokens the suggestion runs on must be read from the
+// place the session actually writes its transcript. A bare agentDir() read is
+// blind to an isolated config root (false 0 in the signals) AND to the main
+// agent, which runs in PROJECT_ROOT (its listing row measured null live,
+// 2026-09-10). Source contract: every contextTokens read in routes/agents.ts
+// goes through resolveTranscriptLocation, never through a bare `dir`.
+describe('GATECTX910 -- contextTokens reads resolve the real transcript location', () => {
+  it('routes/agents.ts has no readContextTokensFromProjectDir call on a bare dir', async () => {
+    const { readFileSync } = await import('node:fs')
+    const { join, dirname } = await import('node:path')
+    const { fileURLToPath } = await import('node:url')
+    const src = readFileSync(
+      join(dirname(fileURLToPath(import.meta.url)), '../web/routes/agents.ts'), 'utf-8')
+    const calls = src.match(/readContextTokensFromProjectDir\([^)]*\)/g) ?? []
+    expect(calls.length).toBeGreaterThan(0)
+    for (const call of calls) {
+      expect(call).toContain('transcript.workingDir, transcript.configDir')
+    }
+  })
+})

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -560,7 +560,11 @@ function getAgentSummary(name: string): AgentSummary {
     hasAvatar: findAvatarForAgent(name) !== null,
     autoRestart: readAutoRestartConfig(name),
     contextGuard: readContextGuardConfig(name),
-    contextTokens: running ? readContextTokensFromProjectDir(dir, resolveAgentConfigDir(name).configDir ?? undefined) : null,
+    // GATECTX910: same location the activeModel read above uses. The previous
+    // `dir` + configured-config-dir pair was blind to the MAIN agent (which
+    // runs in PROJECT_ROOT with the .channels-config probe): its listing row
+    // showed contextTokens null while a live transcript sat right there.
+    contextTokens: running ? readContextTokensFromProjectDir(transcript.workingDir, transcript.configDir) : null,
     needsReauth: reauth.needsReauth,
     reauthReason: reauth.reason,
   }
@@ -940,7 +944,15 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
       const personaMd = existsSync(personaPath) ? readFileSync(personaPath, 'utf-8') : ''
       const personaText = [claudeMd, personaMd].filter(Boolean).join('\n')
       const currentModel = readAgentModel(name)
-      const contextTokens = readContextTokensFromProjectDir(dir) ?? 0
+      // GATECTX910: read the transcript where the session actually writes it.
+      // The bare `dir` read had two blind spots: an agent with an isolated
+      // config root (CLAUDE_CONFIG_DIR) read as a false 0, and the MAIN agent
+      // -- which runs in PROJECT_ROOT, not agents/<name> -- always read as 0
+      // (measured live 2026-09-10: contextTokens null on the listing's own
+      // main row for the same reason). resolveTranscriptLocation answers both,
+      // and is what the activeModel read above already uses.
+      const transcript = resolveTranscriptLocation(name)
+      const contextTokens = readContextTokensFromProjectDir(transcript.workingDir, transcript.configDir) ?? 0
 
       const kanban = kanbanMap.get(name)
       const signals: AgentSignals = {


### PR DESCRIPTION
## Mi ez

A GATECTX910 kártya: a model-suggest signals map (routes/agents.ts, korábban :943) a `contextTokens`-t csupasz `agentDir()`-ból, config-gyökér nélkül olvasta — izolált `CLAUDE_CONFIG_DIR`-ös agensnél hamis 0 ment a javaslatba (#1233 mellék-lelet).

## Amit a mérés még kihozott (ugyanaz a hiba-alak, nem lábjegyzet)

A fix mérése közben élőben mértem a listázást is: a FŐ-AGENS sora `contextTokens: null`-t ad, miközben az `activeModel` ugyanott helyesen oldódik fel. Ok: a lista (:563) is `dir` + configured-config-dir párost használt, a fő-agens viszont PROJECT_ROOT-ban fut (.channels-config probe-bal), nem `agents/<name>`-ben.

## A fix

Mindkét olvasás a meglévő, dokumentált reader-helperen megy át: `resolveTranscriptLocation(name)` — ugyanazon, amit a szomszédos `activeModel`-olvasás már használ. Sub-agensekre az argumentumok bájtra azonosak a korábbi lista-olvasáséval (nulla viselkedés-változás); a fő-agensre mindkét végpont a ténylegesen írt transcriptet kezdi olvasni.

## Verify

- Élő mérés a fix előtt: `marveen contextTokens=None` a /api/agents-en, miközben `samu=202669` (a hiba reprodukált).
- Forrás-szerződés teszt: minden `readContextTokensFromProjectDir` hívás a routes/agents.ts-ben `transcript.workingDir, transcript.configDir`-en át megy.
- `npx tsc --noEmit`: tiszta. Teljes suite: **407 fájl, 5226 passed, 1 skipped** (a skip meglévő).
- A fő-agens élő null→érték átfordulása csak deploy után mérhető vissza (a futó dashboard a prod fából szolgál) — a merge utáni host-update körben visszamérem.

Kártya: GATECTX910. Base: develop (db4e4723).

🤖 Generated with [Claude Code](https://claude.com/claude-code)