### PR TITLE
feat(channels): log every exit of channels.sh -- exit 0 included (CHEXIT910)

### DIFF
--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -271,6 +271,46 @@ if [ "${1:-}" = "--classify-unlock-residue" ]; then
   exit 0
 fi
 
+# CHEXIT910: EVERY exit of the real run leaves a row -- exit 0 included.
+#
+# Why: this script has SEVEN `exit 0` paths and channels-failures.log, true to
+# its name, records only failures -- so a clean self-exit leaves NO trace
+# anywhere (measured on hermes 2026-09-09 20:25:03: the service's main process
+# exited 0, systemd's Restart=on-failure did not restart it, and the box lost
+# its supervisor with nothing to read afterwards; journald had no line either,
+# because leftover cgroup processes suppressed the usual "Deactivated" record).
+# Marveen's ordering decision (msg 23453): exit LOGGING lands first; only then
+# is a Restart-policy change even discussable, because until the exit is
+# measured, `on-failure` is the last remaining signal.
+#
+# Scope, stated: an EXIT trap covers every code-path exit (explicit `exit N`,
+# end-of-script, `set -e`-style aborts) but NOT an untrapped fatal signal --
+# systemd/launchd already record "code=killed, signal=..." in that case, so
+# the invisible class was precisely the clean self-exit this closes.
+#
+# Placed AFTER the test seams above (their contract is "no tmux / store /
+# session" -- a trap before them would make every seam invocation write into
+# the repo's store/). Growth is bounded by service lifecycle frequency (the
+# chronic hermes churn is ~36 exits/day, a few KB); no rotation needed.
+# The log target is env-overridable so the positive-control test can point it
+# at a fixture file instead of a live store/.
+CHANNELS_EXITS_LOG="${CHANNELS_EXITS_LOG:-$INSTALL_DIR/store/channels-exits.log}"
+record_channels_exit() {
+  _rc="$1"
+  _line="$2"
+  echo "$(date '+%Y-%m-%d %H:%M:%S') channels.sh exit code=${_rc} line=${_line} pid=$$" >> "$CHANNELS_EXITS_LOG" 2>/dev/null \
+    || echo "channels.sh: exit-log write FAILED (code=${_rc} line=${_line} target=$CHANNELS_EXITS_LOG)" >&2
+}
+trap 'record_channels_exit "$?" "$LINENO"' EXIT
+
+# Positive-control seam for the trap itself (Marveen's stipulation, msg 23453):
+# a deliberate exit through the test path MUST write a row, otherwise a silent
+# log is indistinguishable from "no exit happened". Sits AFTER the trap so the
+# exit exercises the real handler; touches nothing else.
+if [ "${1:-}" = "--exit-probe" ]; then
+  exit "${2:-0}"
+fi
+
 # Self-healing guard: ensure PLUGIN_ID is enabled in the PROJECT settings.json
 # before launch. A PR review-reset or branch-switch that reverts
 # .claude/settings.json can silently drop the entry and disable the channel

--- a/src/__tests__/channels-exit-log.test.ts
+++ b/src/__tests__/channels-exit-log.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { readFileSync, mkdtempSync, rmSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+// CHEXIT910: channels.sh has SEVEN exit-0 paths and zero exit logging --
+// channels-failures.log records only failures, so a clean self-exit left no
+// trace anywhere (hermes, 2026-09-09 20:25:03: main process exited 0,
+// Restart=on-failure did not restart, supervisor lost, nothing to read).
+// The EXIT trap closes that: every code-path exit writes a row.
+//
+// The positive control here is Marveen's explicit stipulation (msg 23453): a
+// deliberate exit through the test seam MUST produce a row -- a silent log is
+// indistinguishable from "no exit happened", so the proof is a written line,
+// never the trap's presence in the source alone. The source assertions below
+// are secondary pins on placement, not the proof.
+
+const ROOT = join(__dirname, '..', '..')
+const SCRIPT = join(ROOT, 'scripts', 'channels.sh')
+const CHANNELS = readFileSync(SCRIPT, 'utf-8')
+
+function runExitProbe(code: string, logPath: string): number {
+  try {
+    execFileSync('bash', [SCRIPT, '--exit-probe', code], {
+      encoding: 'utf-8',
+      env: { ...process.env, CHANNELS_EXITS_LOG: logPath },
+    })
+    return 0
+  } catch (e) {
+    return (e as { status?: number }).status ?? -1
+  }
+}
+
+describe('channels.sh exit logging (CHEXIT910)', () => {
+  it('POSITIVE CONTROL: a deliberate exit 0 writes a row -- the invisible class', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'chexit-'))
+    try {
+      const log = join(dir, 'exits.log')
+      expect(runExitProbe('0', log)).toBe(0)
+      expect(existsSync(log)).toBe(true)
+      const rows = readFileSync(log, 'utf-8').trim().split('\n')
+      expect(rows).toHaveLength(1)
+      expect(rows[0]).toMatch(/channels\.sh exit code=0 line=\d+ pid=\d+/)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('a non-zero exit is recorded with ITS code, and the trap does not clobber the exit status', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'chexit-'))
+    try {
+      const log = join(dir, 'exits.log')
+      expect(runExitProbe('7', log)).toBe(7)
+      expect(readFileSync(log, 'utf-8')).toMatch(/exit code=7 line=\d+/)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('the trap sits AFTER the store-free test seams and BEFORE the exit-probe seam', () => {
+    const lastSeam = CHANNELS.indexOf('--classify-unlock-residue')
+    const trapAt = CHANNELS.indexOf("trap 'record_channels_exit")
+    const probeAt = CHANNELS.indexOf('--exit-probe')
+    expect(lastSeam).toBeGreaterThan(-1)
+    expect(trapAt).toBeGreaterThan(lastSeam)
+    expect(probeAt).toBeGreaterThan(trapAt)
+  })
+
+  it('seams before the trap stay store-free: a seam invocation writes NO exit row', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'chexit-'))
+    try {
+      const log = join(dir, 'exits.log')
+      execFileSync('bash', [SCRIPT, '--classify-unlock-residue'], {
+        encoding: 'utf-8',
+        input: '/mcp',
+        env: { ...process.env, CHANNELS_EXITS_LOG: log },
+      })
+      expect(existsSync(log)).toBe(false)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('exit rows go to their own log, never into channels-failures.log', () => {
+    // A clean exit 0 rendered as a "failure" row would misclassify for the
+    // next reader (Marveen msg 23453) -- the handler must reference only the
+    // dedicated target.
+    const fnStart = CHANNELS.indexOf('record_channels_exit() {')
+    const fnEnd = CHANNELS.indexOf('\n}', fnStart)
+    const fn = CHANNELS.slice(fnStart, fnEnd)
+    expect(fn).toContain('CHANNELS_EXITS_LOG')
+    expect(fn).not.toContain('channels-failures.log')
+    expect(CHANNELS).toContain('CHANNELS_EXITS_LOG="${CHANNELS_EXITS_LOG:-$INSTALL_DIR/store/channels-exits.log}"')
+  })
+})


### PR DESCRIPTION
## Mi ez

Marveen döntése (msg 23453) a hermes supervisor-vesztés triázsából: ELŐSZÖR a kilépés-naplózás, és csak utána dönthető el a soak-box Restart-policy váltása.

A channels.sh-ban HÉT `exit 0` út van és nulla `trap ... EXIT` -- a channels-failures.log a nevéhez hűen csak hibákat naplóz, tehát egy szabályos exit 0 nyomtalanul távozik. Mért következmény (hermes, 2026-09-09 20:25:03): a service main process exit 0-val zárt, a Restart=on-failure nem indította újra, a soak-box supervisor nélkül maradt, és utólag SEMMI nem volt olvasható -- a journald-ból is hiányzott a sor (a leftover cgroup-processzek elnyomták a Deactivated rekordot).

## A változás

- EXIT-trap, ami MINDEN kilépésnél (exit 0-t beleértve) kódot + sort + pid-et ír a `store/channels-exits.log`-ba -- KÜLÖN fájl, nem a failures-log, mert ott egy exit 0 hibának látszana és a következő olvasó rosszul sorolná be.
- A trap a store-mentes teszt-seamek UTÁN települ (azok kontraktusa marad), és a célfájl env-vel (`CHANNELS_EXITS_LOG`) felülírható a tesztekhez.
- `--exit-probe` seam a trap MÖGÖTT: a pozitív kontroll Marveen kikötése -- egy szándékos exitnek sort KELL írnia, mert a néma napló megkülönböztethetetlen a "nem volt kilépés"-től.
- Hatókör kimondva: az untrapped fatális szignál nem ezen az úton látszik -- azt a systemd/launchd `code=killed`-ként amúgy is rögzíti; a láthatatlan osztály pont a tiszta self-exit volt.
- A trap NEM nyúl a kilépési kódhoz (a teszt ezt is pinning-eli: `--exit-probe 7` → status 7 ÉS `code=7` sor).

## Verify

- Viselkedési tesztek (bash-futtatással, fixture loggal): exit 0 ír sort; exit 7 a saját kódjával ír ÉS a status marad 7; a trap ELŐTTI seam nem ír sort; a handler csak a dedikált logra hivatkozik.
- Kézi smoke macOS bash 3.2-n: mindkét próba sort írt, kilépési kód érintetlen (a linux/mac kettősség miatt külön futtatva -- a suite CI-je linuxon megy).
- `bash -n` + `npx tsc --noEmit`: tiszta. Teljes suite: **409 fájl, 5239 passed, 1 skipped** (a skip meglévő).

Kártya: SOAKSUPERV910 / SUPERVISORPOLICY910 kontextus, döntés: Marveen msg 23453. A merge után a hermes soak-körben élesben is visszamérem (a következő churn-exit sort kell hagyjon).

🤖 Generated with [Claude Code](https://claude.com/claude-code)