### PR TITLE
fix(channels): exit-log line attribution on bash 5 -- DEBUG-trap tracker (CHEXITLINE910)

### DIFF
--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -297,11 +297,36 @@ fi
 CHANNELS_EXITS_LOG="${CHANNELS_EXITS_LOG:-$INSTALL_DIR/store/channels-exits.log}"
 record_channels_exit() {
   _rc="$1"
-  _line="$2"
-  echo "$(date '+%Y-%m-%d %H:%M:%S') channels.sh exit code=${_rc} line=${_line} pid=$$" >> "$CHANNELS_EXITS_LOG" 2>/dev/null \
-    || echo "channels.sh: exit-log write FAILED (code=${_rc} line=${_line} target=$CHANNELS_EXITS_LOG)" >&2
+  echo "$(date '+%Y-%m-%d %H:%M:%S') channels.sh exit code=${_rc} line=${CHEXIT_LAST_LINE:-?} cmd=[${CHEXIT_LAST_CMD:-?}] pid=$$" >> "$CHANNELS_EXITS_LOG" 2>/dev/null \
+    || echo "channels.sh: exit-log write FAILED (code=${_rc} line=${CHEXIT_LAST_LINE:-?} target=$CHANNELS_EXITS_LOG)" >&2
 }
-trap 'record_channels_exit "$?" "$LINENO"' EXIT
+# CHEXITLINE910: `$LINENO` inside a trap string is 1 on bash >= 5 (measured on
+# hermes bash 5.2.37: every exit logged line=1, so the row could not say WHICH
+# of the seven exit paths ran -- the whole point of the line field; mac bash
+# 3.2 happened to report the real line, which is why the original review saw
+# 311). The line therefore comes from a DEBUG-trap tracker that records each
+# command's site as it executes; at exit time the last recorded site IS the
+# exit. Three guards, each measured:
+#   - the two `case` filters keep the EXIT handler's own commands from
+#     clobbering the tracked values on bash 3.2 (where BASH_COMMAND names them);
+#   - the same-command latch keeps them on bash 5.x, where the EXIT handler's
+#     commands fire DEBUG with BASH_COMMAND frozen as the exiting command and
+#     BASH_LINENO already reset to 1. Cost of the latch: an identical command
+#     text re-executed consecutively on a DIFFERENT line keeps the first
+#     line's attribution -- acceptable for exit attribution, stated here.
+# `$?` is preserved across the DEBUG trap (measured both platforms: a `false`
+# followed by `echo $?` still prints 1 with the tracker armed).
+set -o functrace
+chexit_track() {
+  case "$BASH_COMMAND" in record_channels_exit*) return 0;; esac
+  case " ${FUNCNAME[*]} " in *" record_channels_exit "*) return 0;; esac
+  [ "$BASH_COMMAND" = "${CHEXIT_LAST_CMD:-}" ] && return 0
+  CHEXIT_LAST_LINE="${BASH_LINENO[0]}"
+  CHEXIT_LAST_CMD="$BASH_COMMAND"
+  return 0
+}
+trap chexit_track DEBUG
+trap 'record_channels_exit "$?"' EXIT
 
 # Positive-control seam for the trap itself (Marveen's stipulation, msg 23453):
 # a deliberate exit through the test path MUST write a row, otherwise a silent

--- a/src/__tests__/channels-exit-log.test.ts
+++ b/src/__tests__/channels-exit-log.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { execFileSync } from 'node:child_process'
-import { readFileSync, mkdtempSync, rmSync, existsSync } from 'node:fs'
+import { readFileSync, writeFileSync, mkdtempSync, rmSync, existsSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 
@@ -33,7 +33,14 @@ function runExitProbe(code: string, logPath: string): number {
 }
 
 describe('channels.sh exit logging (CHEXIT910)', () => {
-  it('POSITIVE CONTROL: a deliberate exit 0 writes a row -- the invisible class', () => {
+  // CHEXITLINE910: the line must be the exit's OWN source line -- `line=\d+`
+  // alone let line=1 pass on bash 5 (where $LINENO in a trap string is always
+  // 1), which is exactly the value that cannot say which exit path ran. The
+  // expected number is read from the script source, so the pin survives edits
+  // above the seam.
+  const probeExitLine = CHANNELS.slice(0, CHANNELS.indexOf('exit "${2:-0}"')).split('\n').length
+
+  it('POSITIVE CONTROL: a deliberate exit 0 writes a row with the REAL exit line -- the invisible class', () => {
     const dir = mkdtempSync(join(tmpdir(), 'chexit-'))
     try {
       const log = join(dir, 'exits.log')
@@ -41,18 +48,44 @@ describe('channels.sh exit logging (CHEXIT910)', () => {
       expect(existsSync(log)).toBe(true)
       const rows = readFileSync(log, 'utf-8').trim().split('\n')
       expect(rows).toHaveLength(1)
-      expect(rows[0]).toMatch(/channels\.sh exit code=0 line=\d+ pid=\d+/)
+      expect(rows[0]).toMatch(new RegExp(`channels\\.sh exit code=0 line=${probeExitLine} cmd=\\[exit "\\$\\{2:-0\\}"\\] pid=\\d+`))
     } finally {
       rmSync(dir, { recursive: true, force: true })
     }
   })
 
-  it('a non-zero exit is recorded with ITS code, and the trap does not clobber the exit status', () => {
+  it('a non-zero exit is recorded with ITS code and line, and the trap does not clobber the exit status', () => {
     const dir = mkdtempSync(join(tmpdir(), 'chexit-'))
     try {
       const log = join(dir, 'exits.log')
       expect(runExitProbe('7', log)).toBe(7)
-      expect(readFileSync(log, 'utf-8')).toMatch(/exit code=7 line=\d+/)
+      expect(readFileSync(log, 'utf-8')).toMatch(new RegExp(`exit code=7 line=${probeExitLine} `))
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('the DEBUG tracker preserves $? for the script itself (real tracker source, sliced)', () => {
+    // A tracker that ate $? would silently rewrite every `if [ $? -eq 0 ]`
+    // decision in the script -- worse than the bug it fixes. Run the REAL
+    // tracker (sliced from the source, same pattern as the never-started
+    // tests) with a failing command and read $? on the next line.
+    const fnStart = CHANNELS.indexOf('chexit_track() {')
+    const fnEnd = CHANNELS.indexOf('\n}', fnStart)
+    const tracker = CHANNELS.slice(fnStart, fnEnd + 2)
+    const dir = mkdtempSync(join(tmpdir(), 'chexit-'))
+    try {
+      const probe = join(dir, 'probe.sh')
+      writeFileSync(probe, [
+        '#!/bin/bash',
+        'set -o functrace',
+        tracker,
+        'trap chexit_track DEBUG',
+        'false',
+        'echo "status=$?"',
+      ].join('\n') + '\n')
+      const out = execFileSync('bash', [probe], { encoding: 'utf-8' }).trim()
+      expect(out).toBe('status=1')
     } finally {
       rmSync(dir, { recursive: true, force: true })
     }


### PR DESCRIPTION
## Mi ez

A #1276 hermes-deployja UTÁNI in-situ visszamérés lelete: a boxon minden naplózott exit `line=1`-et írt, mert bash >= 5 a trap-sztringen belül a `$LINENO`-t mindig 1-re állítja. A line-mező pont azért van, hogy megmondja, a HÉT exit-út közül melyik futott -- és pont azon a platformon nem mondott semmit, ahol a 09-09-i rejtélyes exit-0 történt. A mac bash 3.2 a valós sort adja, ezért látott a review élő próbája 311-et.

## A fix (minden lépése mérve, mindkét platformon)

DEBUG-trap tracker: minden parancs futásakor rögzíti a helyét (`BASH_LINENO[0]`) és szövegét (`BASH_COMMAND`); kilépéskor az utolsó rögzített hely maga az exit. Három őr, mindegyik mért viselkedésre:
- két `case`-szűrő bash 3.2-re (ott a BASH_COMMAND megnevezi az EXIT-handler parancsait);
- azonos-parancs latch bash 5.x-re, ahol az EXIT-handler parancsai a BASH_COMMAND-ot a kilépő parancson BEFAGYVA tüzelik DEBUG-ot, már 1-re állt stackkel -- e nélkül a jó értéket a handler első DEBUG-tüzelése felülírja (mérve: dbg5 stack-dump).
- A latch kimondott ára: azonos szövegű parancs KÖZVETLENÜL egymás után MÁS soron az első sor attribúcióját tartja -- exit-attribúcióhoz elfogadható, a kommentben kimondva.

`$?`-megőrzés mérve mindkét platformon (false után status=1 a trackerrel), és teszt is pinneli a VALÓDI, forrásból szeletelt tracker-kóddal.

## Teszt-tanulság (a saját #1276-os tesztem hibája)

A `line=\d+` assert átengedte a line=1-et a CI linux bashén -- pont ott, ahol a hiba él. A pozitív kontroll most a próba-exit SAJÁT forrássorát asserteli (a forrásból számolva, hogy a pin túlélje a fölötte lévő szerkesztéseket). A régi kóddal ez a teszt linuxon PIROS lenne.

## Verify

- Kézi mérés-sor: bash 3.2 (mac) line=19/valós + bash 5.2.37 (hermes) line=19/valós, kód érintetlen, `$?` megőrizve, végső exit-status átmegy.
- `bash -n` + tsc tiszta; teljes suite **410 fájl, 5240 passed, 1 skipped**.
- Merge + hermes-deploy után az élő `--exit-probe` visszamérése a boxon a záró lépés (a régi kód ott line=1-et adott -- ez a negatív kontroll már mérve van).

Kártya-kontextus: SOAKSUPERV910 mechanizmus-keresés -- e nélkül a következő valós exit sora sem mondaná meg, melyik úton ment el.

🤖 Generated with [Claude Code](https://claude.com/claude-code)