### PR TITLE
test(enroll): both enroll paths follow WEB_PORT on a non-default port (INSTUX1 regression)

### DIFF
--- a/scripts/remote-access-enroll.ts
+++ b/scripts/remote-access-enroll.ts
@@ -27,7 +27,7 @@ import { readFileSync } from 'node:fs'
 import { execFileSync } from 'node:child_process'
 import { homedir, hostname, userInfo, networkInterfaces } from 'node:os'
 import { dirname, join } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import { isIP } from 'node:net'
 import {
   validatePublicKeyLine,
@@ -58,7 +58,7 @@ interface Args {
  * manual `remote-enroll` with no --web-port still targets the real port instead
  * of the 3420 default. Explicit --web-port overrides. Falls back to REMOTE_PORT
  * only when .env carries no WEB_PORT (config already applies that default). */
-function defaultWebPort(): number {
+export function defaultWebPort(): number {
   const n = ENV_WEB_PORT
   return Number.isInteger(n) && n >= 1 && n <= 65535 ? n : REMOTE_PORT
 }
@@ -253,7 +253,13 @@ async function main(): Promise<void> {
   process.stdout.write('----- END CONNECTION BUNDLE -----\n')
 }
 
-main().catch((err) => {
-  process.stderr.write(`error: ${err instanceof Error ? err.message : String(err)}\n`)
-  process.exit(1)
-})
+// Import-guard (same idiom as channel-coordinator.ts): run the CLI only when
+// this file IS the invoked script. The INSTUX1 regression test imports
+// defaultWebPort above, and an unguarded main() would execute the whole
+// enrollment (host-key scan, authorized_keys write) at import time.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((err) => {
+    process.stderr.write(`error: ${err instanceof Error ? err.message : String(err)}\n`)
+    process.exit(1)
+  })
+}

--- a/scripts/remote-access-enroll.ts
+++ b/scripts/remote-access-enroll.ts
@@ -23,7 +23,7 @@
 // Pass --no-dashboard-token to emit a token-free bundle (the device user must
 // then obtain the dashboard access URL out of band).
 
-import { readFileSync } from 'node:fs'
+import { readFileSync, realpathSync } from 'node:fs'
 import { execFileSync } from 'node:child_process'
 import { homedir, hostname, userInfo, networkInterfaces } from 'node:os'
 import { dirname, join } from 'node:path'
@@ -253,11 +253,29 @@ async function main(): Promise<void> {
   process.stdout.write('----- END CONNECTION BUNDLE -----\n')
 }
 
-// Import-guard (same idiom as channel-coordinator.ts): run the CLI only when
-// this file IS the invoked script. The INSTUX1 regression test imports
-// defaultWebPort above, and an unguarded main() would execute the whole
-// enrollment (host-key scan, authorized_keys write) at import time.
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+// Import-guard (channel-coordinator idiom): run the CLI only when this file
+// IS the invoked script. The INSTUX1 regression test imports defaultWebPort
+// above, and an unguarded main() would execute the whole enrollment
+// (host-key scan, authorized_keys write) at import time.
+//
+// Realpath on BOTH sides (Marveen review, msg 23506, measured): a bare URL
+// comparison silently no-ops when the script is invoked through a SYMLINKED
+// ABSOLUTE path -- exit 0, zero output, and the installer reads that as
+// "no bundle", which is exactly the silent-failure family this card exists
+// for. On a realpath failure fall back to the URL comparison rather than
+// going silent: an exotic fs must degrade to the old behaviour, not to a
+// CLI that never runs.
+function isInvokedDirectly(): boolean {
+  const argv1 = process.argv[1]
+  if (!argv1) return false
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(import.meta.url))
+  } catch {
+    return import.meta.url === pathToFileURL(argv1).href
+  }
+}
+
+if (isInvokedDirectly()) {
   main().catch((err) => {
     process.stderr.write(`error: ${err instanceof Error ? err.message : String(err)}\n`)
     process.exit(1)

--- a/src/__tests__/enroll-port-follows-web-port.test.ts
+++ b/src/__tests__/enroll-port-follows-web-port.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest'
 import { execFileSync } from 'node:child_process'
-import { mkdtempSync, rmSync, readFileSync, existsSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, rmSync, readFileSync, existsSync, writeFileSync, symlinkSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { randomBytes, randomUUID } from 'node:crypto'
@@ -137,5 +137,36 @@ describe('INSTUX1: enroll paths follow WEB_PORT on a NON-default port', () => {
     const outcome = await bridgeEnroll({ keyLine: line, name: 'Port próba' }, testDeps())
     const bundle = decodeBundle(outcome.bundle)
     expect(bundle.remotePort).toBe(PORT)
+  })
+
+  it('the import-guard still runs main() through a SYMLINKED absolute path (realpath guard)', () => {
+    // Marveen review (msg 23506, measured): a bare URL comparison silently
+    // no-ops on a symlinked ABSOLUTE invocation -- exit 0, zero output, which
+    // the installer reads as "no bundle": the exact silent-failure family of
+    // this card. The guard therefore realpaths both sides; this test invokes
+    // that precise shape. main() running shows as the usage error on stderr
+    // with exit 1 -- a silent guard shows as exit 0 with neither.
+    // Negative control (performed and reverted): argv[1] left un-realpathed
+    // in the guard -> this test goes RED (exit 0, empty stderr).
+    const dir = mkdtempSync(join(tmpdir(), 'enroll-symlink-'))
+    try {
+      symlinkSync(ROOT, join(dir, 'repo'))
+      const script = join(dir, 'repo', 'scripts', 'remote-access-enroll.ts')
+      let stderr = ''
+      let status = 0
+      try {
+        execFileSync(join(ROOT, 'node_modules', '.bin', 'tsx'), [script], {
+          encoding: 'utf-8', timeout: 30_000, stdio: ['ignore', 'pipe', 'pipe'],
+        })
+      } catch (e) {
+        const err = e as { status?: number; stderr?: string }
+        status = err.status ?? -1
+        stderr = err.stderr ?? ''
+      }
+      expect(status).toBe(1)
+      expect(stderr).toContain('missing public key line')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
   })
 })

--- a/src/__tests__/enroll-port-follows-web-port.test.ts
+++ b/src/__tests__/enroll-port-follows-web-port.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, rmSync, readFileSync, existsSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { randomBytes, randomUUID } from 'node:crypto'
+
+// INSTUX1 regression (Marveen msg 23503): BOTH enroll paths must follow the
+// install's real WEB_PORT into the permitopen restriction AND the connection
+// bundle. The original defect: the enrolled key's permitopen targeted a
+// hardcoded 3420 while the dashboard ran elsewhere -- the tunnel opened a dead
+// port and the app said "dashboard not running" forever.
+//
+// Everything here runs on a NON-DEFAULT port (3421). Asserting on 3420 proves
+// nothing: that is exactly where the hardcode and the variable coincide
+// (PORTCHAIN1's own header). The PORTCHAIN1 suite covers ten other callers but
+// NOT these two enroll paths, and RESTRICT_OPTIONS-shaped assertions in
+// bridge-enroll.test.ts are 3420-shaped for the same reason.
+//
+// NEGATIVE CONTROL (performed by hand before merge, both flips, then reverted):
+//   - defaultWebPort() body replaced with `return REMOTE_PORT`  -> the CLI
+//     test below goes RED (3420 !== 3421);
+//   - bridge-enroll.ts:189 reverted to `buildRestrictedLine(parsed)` and
+//     :209 to `webPort: REMOTE_PORT` -> the bridge tests below go RED.
+// A test that stays green under the restored hardcode would not be measuring
+// the fix; the flip results are recorded in the PR.
+
+const PORT = 3421
+
+// The config mock must be in place BEFORE bridge-enroll.js (and the CLI
+// module) resolve their imports. Everything else in config is the real value:
+// only WEB_PORT simulates an install whose .env selects a non-default port.
+vi.mock('../config.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../config.js')>()),
+  WEB_PORT: 3421,
+}))
+
+import { initDatabase, getDb } from '../db.js'
+import { bridgeEnroll, type BridgeEnrollDeps } from '../web/bridge-enroll.js'
+import { decodeBundle } from '../remote-enroll-core.js'
+import { _clearDeviceKeyCacheForTest } from '../web/auth-device-keys.js'
+
+const ROOT = join(__dirname, '..', '..')
+
+function makeKeyLine(installId = randomUUID()): { line: string; installId: string } {
+  const type = Buffer.from('ssh-ed25519', 'utf8')
+  const key = randomBytes(32)
+  const blob = Buffer.concat([
+    Buffer.from([0, 0, 0, type.length]), type,
+    Buffer.from([0, 0, 0, 32]), key,
+  ])
+  return { line: `ssh-ed25519 ${blob.toString('base64')} marveen-remote:${installId}`, installId }
+}
+
+const HOST_KEY_B64 = Buffer.concat([
+  Buffer.from([0, 0, 0, 11]), Buffer.from('ssh-ed25519', 'utf8'),
+  Buffer.from([0, 0, 0, 32]), randomBytes(32),
+]).toString('base64')
+
+let sshDir: string
+
+function testDeps(overrides: Partial<BridgeEnrollDeps> = {}): BridgeEnrollDeps {
+  return {
+    sshDir,
+    readFile: () => null,
+    keyscan: async () => `127.0.0.1 ssh-ed25519 ${HOST_KEY_B64}`,
+    ...overrides,
+  }
+}
+
+function authKeysContent(): string {
+  const p = join(sshDir, 'authorized_keys')
+  return existsSync(p) ? readFileSync(p, 'utf8') : ''
+}
+
+beforeAll(() => {
+  process.env.NODE_ENV = 'test'
+  initDatabase(':memory:')
+})
+
+beforeEach(() => {
+  sshDir = mkdtempSync(join(tmpdir(), 'enroll-port-test-'))
+  _clearDeviceKeyCacheForTest()
+  getDb().prepare('DELETE FROM device_keys').run()
+  getDb().prepare('DELETE FROM config_change_log').run()
+})
+
+afterEach(() => {
+  rmSync(sshDir, { recursive: true, force: true })
+})
+
+describe('INSTUX1: enroll paths follow WEB_PORT on a NON-default port', () => {
+  it('CLI defaultWebPort() resolves 3421 from a sandbox .env through the REAL config chain', () => {
+    // Subprocess on purpose: CLAUDECLAW_ENV_DIR (env.ts test escape hatch) is
+    // read at import time, so a fresh tsx process exercises the FULL
+    // resolution the CLI really uses (.env -> config.WEB_PORT ->
+    // defaultWebPort) with no mock in the path. The import-guard keeps main()
+    // from running on import.
+    const dir = mkdtempSync(join(tmpdir(), 'enroll-cli-env-'))
+    try {
+      writeFileSync(join(dir, '.env'), `WEB_PORT=${PORT}\n`)
+      const script = join(ROOT, 'scripts', 'remote-access-enroll.ts')
+      const out = execFileSync(
+        join(ROOT, 'node_modules', '.bin', 'tsx'),
+        ['-e', `import(${JSON.stringify(script)}).then(m => console.log(m.defaultWebPort()))`],
+        { env: { ...process.env, CLAUDECLAW_ENV_DIR: dir }, encoding: 'utf-8', timeout: 30_000 },
+      ).trim()
+      expect(out).toBe(String(PORT))
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('CLI wiring: args.webPort feeds BOTH the restricted line and the bundle (source pin)', () => {
+    // main() cannot be executed here without a live sshd/host key, so the two
+    // call sites that carry defaultWebPort() into the outputs are pinned in
+    // source. The executed half above plus these pins together go red on the
+    // historical defect shape (webPort ignored / restricted line built on the
+    // default): verified by the negative-control flips in the header.
+    const src = readFileSync(join(ROOT, 'scripts', 'remote-access-enroll.ts'), 'utf8')
+    expect(src).toMatch(/webPort: defaultWebPort\(\)/)
+    expect(src).toMatch(/buildRestrictedLine\(parsed, args\.webPort\)/)
+    expect(src).toMatch(/webPort: args\.webPort/)
+  })
+
+  it('bridge pairing writes permitopen on 3421 and NO 3420 anywhere in authorized_keys', async () => {
+    const { line } = makeKeyLine()
+    const outcome = await bridgeEnroll({ keyLine: line, name: 'Port próba' }, testDeps())
+    expect(outcome.action).toBe('added')
+    const content = authKeysContent()
+    expect(content).toContain(`permitopen="127.0.0.1:${PORT}"`)
+    expect(content).not.toContain(':3420')
+  })
+
+  it('bridge pairing embeds 3421 as the bundle remotePort', async () => {
+    const { line } = makeKeyLine()
+    const outcome = await bridgeEnroll({ keyLine: line, name: 'Port próba' }, testDeps())
+    const bundle = decodeBundle(outcome.bundle)
+    expect(bundle.remotePort).toBe(PORT)
+  })
+})


### PR DESCRIPTION
## Mi ez

Marveen kérése (msg 23503): az INSTUX1-zárás teherhordó sora őrizetlen volt -- a remote-access-enroll-t egyetlen teszt sem említi, a PORTCHAIN1 tíz hívót fed, de az enroll-utakat nem, a bridge-enroll.test.ts pedig a RESTRICT_OPTIONS (=3420) alakot asserteli, pont ahol a hardkód és a változó egybeesik.

## A teszt (minden assert 3421-en)

- **CLI-ág, executálva, mock nélkül**: tsx subprocess sandbox `.env`-vel (`CLAUDECLAW_ENV_DIR` -- az env.ts saját teszt-escape-hatch-e), a VALÓDI feloldási láncon át (.env → config.WEB_PORT → defaultWebPort) → 3421. A main() két továbbító hívóhelye (`buildRestrictedLine(parsed, args.webPort)` + `webPort: args.webPort`) forrás-pinben, mert a main élő sshd/host-kulcs nélkül nem futtatható -- a hatókör kimondva a tesztben.
- **Bridge-ág, executálva**: `bridgeEnroll` a meglévő harness-mintával, config-mock WEB_PORT=3421 → az authorized_keys sor `permitopen="127.0.0.1:3421"` ÉS sehol `:3420`; a dekódolt bundle `remotePort===3421`.

## Negatív kontrollok (mindhárom lefuttatva, majd visszaállítva)

| Flip | Eredmény |
|---|---|
| `defaultWebPort()` → `return REMOTE_PORT` | CLI-teszt **PIROS** (subprocess-úton újramérve is) |
| bridge-enroll: `buildRestrictedLine(parsed)` + `webPort` elhagyva | mindkét bridge-teszt **PIROS** |
| CLI hívóhely: `buildRestrictedLine(parsed)` | forrás-pin **PIROS** |

## SUT-változás (minimális, a tesztelhetőségért)

`remote-access-enroll.ts`: `defaultWebPort` exportálva + a `main()` a channel-coordinator argv-guard idiómája mögé került, hogy egy teszt-import ne futtasson éles enrollmentet. A közvetlen CLI-hívás változatlan (tsx smoke: a usage-hiba ugyanúgy jön).

## Verify

tsc tiszta; teljes suite **410 fájl, 5244 passed, 1 skipped**. A PR #13-hoz (marveen-bridge-installer) nem nyúltam.

Kártya: INSTUX1. Base: develop (7b9fda46).

🤖 Generated with [Claude Code](https://claude.com/claude-code)