### PR TITLE
fix(hooks): resolve git-common-dir against the installer's own repo, not the caller cwd

### DIFF
--- a/scripts/install-git-guard-hook.sh
+++ b/scripts/install-git-guard-hook.sh
@@ -10,7 +10,15 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-HOOK_DIR="$(cd "$(git -C "$ROOT" rev-parse --git-common-dir)" && pwd)/hooks"
+# `rev-parse --git-common-dir` answers RELATIVE TO THE REPO (".git"), so the
+# `git -C "$ROOT"` above only looks safe: resolving that answer with a bare `cd`
+# resolves it against the CALLER's cwd. Measured: started from another checkout
+# this installer wrote the force-push guard into THAT repository and printed its
+# success line, leaving this repo unprotected -- silent non-enforcement, which
+# is the one failure a guard must not have.
+GIT_COMMON_DIR="$(git -C "$ROOT" rev-parse --git-common-dir)"
+case "$GIT_COMMON_DIR" in /*) ;; *) GIT_COMMON_DIR="$ROOT/$GIT_COMMON_DIR" ;; esac
+HOOK_DIR="$(cd "$GIT_COMMON_DIR" && pwd)/hooks"
 DISPATCH="$HOOK_DIR/pre-push"
 GUARD="$HOOK_DIR/pre-push.d/10-no-force-push-protected"
 MARK="marveen-pre-push-dispatcher"

--- a/scripts/install-prod-tree-guard-hook.sh
+++ b/scripts/install-prod-tree-guard-hook.sh
@@ -27,7 +27,15 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-HOOK_DIR="$(cd "$(git -C "$ROOT" rev-parse --git-common-dir)" && pwd)/hooks"
+# `rev-parse --git-common-dir` answers RELATIVE TO THE REPO (".git"), so the
+# `git -C "$ROOT"` above only looks safe: resolving that answer with a bare `cd`
+# resolves it against the CALLER's cwd. Measured: started from another checkout
+# this installer wrote the guard into THAT repository and printed its success
+# line, leaving the tree it was meant to protect unguarded -- the silent
+# non-enforcement this hook exists to prevent.
+GIT_COMMON_DIR="$(git -C "$ROOT" rev-parse --git-common-dir)"
+case "$GIT_COMMON_DIR" in /*) ;; *) GIT_COMMON_DIR="$ROOT/$GIT_COMMON_DIR" ;; esac
+HOOK_DIR="$(cd "$GIT_COMMON_DIR" && pwd)/hooks"
 DISPATCH="$HOOK_DIR/pre-commit"
 GUARD="$HOOK_DIR/pre-commit.d/05-prod-tree-guard"
 DISPATCH_MARK="marveen-pre-commit-dispatcher"

--- a/scripts/install-secret-gate-hook.sh
+++ b/scripts/install-secret-gate-hook.sh
@@ -8,7 +8,15 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-HOOK_DIR="$(cd "$(git -C "$ROOT" rev-parse --git-common-dir)" && pwd)/hooks"
+# `rev-parse --git-common-dir` answers RELATIVE TO THE REPO (".git"), so the
+# `git -C "$ROOT"` above only looks safe: resolving that answer with a bare `cd`
+# resolves it against the CALLER's cwd. Measured: started from another checkout
+# this installer wrote the secret gate into THAT repository and printed its
+# success line, leaving this repo unprotected -- silent non-enforcement, which
+# is the one failure a guard must not have.
+GIT_COMMON_DIR="$(git -C "$ROOT" rev-parse --git-common-dir)"
+case "$GIT_COMMON_DIR" in /*) ;; *) GIT_COMMON_DIR="$ROOT/$GIT_COMMON_DIR" ;; esac
+HOOK_DIR="$(cd "$GIT_COMMON_DIR" && pwd)/hooks"
 DISPATCH="$HOOK_DIR/pre-commit"
 GUARD="$HOOK_DIR/pre-commit.d/10-secret-gate"
 MARK="marveen-pre-commit-dispatcher"

--- a/src/__tests__/hook-installer-cwd-independence.test.ts
+++ b/src/__tests__/hook-installer-cwd-independence.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, afterAll } from 'vitest'
+import { execFileSync, spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, cpSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+// Every git-hook installer must land its hooks in the repository it BELONGS TO,
+// whatever directory it happens to be started from.
+//
+// The shape that fails looks correct: `git -C "$ROOT" rev-parse --git-common-dir`
+// asks the right repository, but the ANSWER is relative to that repository
+// (".git"), so resolving it with a bare `cd` resolves it against the CALLER's
+// cwd. Measured on all three installers at 47d352b: started from another
+// checkout, each one wrote its hooks into THAT repository's .git/hooks, printed
+// its success line and exited 0 -- while the repo it was meant to protect got
+// nothing. A guard that reports success and protects nothing is the one failure
+// mode these guards exist to prevent.
+//
+// Measured behaviourally, not by text match: an installer whose comment
+// describes the right path and whose code writes the wrong one is exactly the
+// failure being pinned. The same resolution already shipped in
+// install-graphify-refresh-hook.sh; this file keeps it fixed for all three.
+
+const ROOT = process.cwd()
+
+/** Each installer with the hook file that proves it ran, and the dispatcher it
+ *  writes alongside. Both are asserted, because a chain entry without its
+ *  dispatcher never runs either. */
+const INSTALLERS = [
+  {
+    script: 'install-prod-tree-guard-hook.sh',
+    guard: join('.git', 'hooks', 'pre-commit.d', '05-prod-tree-guard'),
+    dispatcher: join('.git', 'hooks', 'pre-commit'),
+  },
+  {
+    script: 'install-git-guard-hook.sh',
+    guard: join('.git', 'hooks', 'pre-push.d', '10-no-force-push-protected'),
+    dispatcher: join('.git', 'hooks', 'pre-push'),
+  },
+  {
+    script: 'install-secret-gate-hook.sh',
+    guard: join('.git', 'hooks', 'pre-commit.d', '10-secret-gate'),
+    dispatcher: join('.git', 'hooks', 'pre-commit'),
+  },
+] as const
+
+const stage = mkdtempSync(join(tmpdir(), 'hookcwd-'))
+afterAll(() => rmSync(stage, { recursive: true, force: true }))
+
+let n = 0
+/** A throwaway git repo carrying a copy of one installer under scripts/. */
+function makeRepo(label: string, script?: string): string {
+  const repo = join(stage, `${label}-${n++}`)
+  mkdirSync(join(repo, 'scripts'), { recursive: true })
+  mkdirSync(join(repo, 'store'), { recursive: true })
+  execFileSync('git', ['-C', repo, 'init', '-q', '-b', 'develop'])
+  writeFileSync(join(repo, 'x.txt'), 'x')
+  execFileSync('git', ['-C', repo, 'add', '.'])
+  execFileSync('git', ['-C', repo, '-c', 'user.email=t@t', '-c', 'user.name=t', 'commit', '-qm', 'init'])
+  if (script) cpSync(join(ROOT, 'scripts', script), join(repo, 'scripts', script))
+  writeFileSync(join(repo, 'store', '.dashboard-token'), 'test-token\n')
+  return repo
+}
+
+const install = (repo: string, script: string, cwd: string) =>
+  spawnSync('/bin/bash', [join(repo, 'scripts', script)], { cwd, encoding: 'utf-8', timeout: 20000 })
+
+describe.each(INSTALLERS)('$script: the install target is the repo, not the caller cwd', ({ script, guard, dispatcher }) => {
+  it('NEGATIVE CONTROL: started from the repo root it installs into that repo (unchanged behaviour)', () => {
+    const repo = makeRepo('root', script)
+    const r = install(repo, script, repo)
+    expect(r.status).toBe(0)
+    expect(existsSync(join(repo, guard))).toBe(true)
+    expect(existsSync(join(repo, dispatcher))).toBe(true)
+  })
+
+  it('started from a SUBDIRECTORY of its own repo it still installs into that repo', () => {
+    const repo = makeRepo('subdir', script)
+    const sub = join(repo, 'src', 'deep')
+    mkdirSync(sub, { recursive: true })
+    const r = install(repo, script, sub)
+    expect(r.status).toBe(0)
+    expect(existsSync(join(repo, guard))).toBe(true)
+  })
+
+  it('started from a NON-GIT directory it still installs into its own repo', () => {
+    const repo = makeRepo('nongit', script)
+    const outside = mkdtempSync(join(stage, 'plain-'))
+    const r = install(repo, script, outside)
+    expect(r.status).toBe(0)
+    expect(existsSync(join(repo, guard))).toBe(true)
+  })
+
+  it('started from ANOTHER checkout it guards its OWN repo and leaves the foreign one untouched', () => {
+    const repo = makeRepo('own', script)
+    const foreign = makeRepo('foreign')
+    const r = install(repo, script, foreign)
+    expect(r.status).toBe(0)
+    expect(existsSync(join(repo, guard))).toBe(true)
+    // The contamination half: hooks written into someone else's .git are worse
+    // than no hooks -- they block operations in a repo that never asked for it,
+    // and they are invisible there (nothing in that repo's tree mentions them).
+    expect(existsSync(join(foreign, guard))).toBe(false)
+    expect(existsSync(join(foreign, dispatcher))).toBe(false)
+  })
+
+  it('started from a LINKED WORKTREE of another repo (where .git is a FILE) it does not fail', () => {
+    const repo = makeRepo('wt-own', script)
+    const other = makeRepo('wt-other')
+    const wt = join(stage, `wt-linked-${n++}`)
+    execFileSync('git', ['-C', other, 'worktree', 'add', '-q', '-b', `probe-${n}`, wt])
+    const r = install(repo, script, wt)
+    expect(r.status).toBe(0)
+    expect(existsSync(join(repo, guard))).toBe(true)
+  })
+})

--- a/src/__tests__/send-honesty-final.test.ts
+++ b/src/__tests__/send-honesty-final.test.ts
@@ -81,8 +81,10 @@ describe('generated prod-tree post-checkout hook: honest alert delivery', () => 
     execFileSync('git', ['-C', repo, '-c', 'user.email=t@t', '-c', 'user.name=t', 'commit', '-qm', 'init'])
     cpSync(join(ROOT, 'scripts', 'install-prod-tree-guard-hook.sh'), join(repo, 'scripts', 'install-prod-tree-guard-hook.sh'))
     writeFileSync(join(repo, 'store', '.dashboard-token'), 'test-token\n')
-    // git-common-dir returns a RELATIVE .git from inside the repo, so the
-    // installer must run with the repo root as cwd (it does in production).
+    // The repo root as cwd is the production shape (update.sh cd-s there), kept
+    // here deliberately. The installer no longer DEPENDS on it -- it resolves
+    // git-common-dir against its own root -- and that independence is pinned
+    // separately in hook-installer-cwd-independence.test.ts.
     const r = spawnSync('/bin/bash', [join(repo, 'scripts', 'install-prod-tree-guard-hook.sh')], { cwd: repo, encoding: 'utf-8', timeout: 20000 })
     expect(r.status).toBe(0)
     const hook = join(repo, '.git', 'hooks', 'post-checkout')


### PR DESCRIPTION
## A változtatás típusa / Type of change
- [x] Hibajavítás (bugfix)

## Rövid leírás / Summary
HU: Mind a három git-hook telepítő (`install-prod-tree-guard-hook.sh`, `install-git-guard-hook.sh`, `install-secret-gate-hook.sh`) a `git rev-parse --git-common-dir` válaszát csupasz `cd`-vel oldotta fel. A `git -C "$ROOT"` jelenléte megtévesztő: a kérdés a helyes repót címzi, a VÁLASZ viszont a repóhoz képest relatív (".git"), ezért a `cd` a HÍVÓ könyvtárához oldja fel. Mérve: idegen checkout gyökeréből indítva mindhárom telepítő az IDEGEN repó `.git/hooks` mappájába írta a hookot, kiírta a sikeres sorát és exit 0-val lépett ki, miközben a védendő fa védtelen maradt. Nem-git könyvtárból `cd: .git: No such file or directory`, idegen linkelt worktree-ből (ahol a `.git` egy fájl) `Not a directory`. A javítás a relatív választ `$ROOT`-hoz normalizálja, ugyanúgy, ahogy az `install-graphify-refresh-hook.sh` már teszi. A frissítési út nem volt érintett (az `update.sh` előbb belép a telepítési könyvtárba), tehát éles üzemzavar nem keletkezett; a kitettség a kézi vagy ágens általi indítás más könyvtárból.

EN: All three git-hook installers asked `git rev-parse --git-common-dir` with `-C "$ROOT"` and then resolved the answer with a bare `cd`. The `git -C` only makes the shape look safe: the answer is relative TO THE REPO (".git"), so the `cd` resolves it against the CALLER's cwd. Measured: started from a foreign checkout root, each installer wrote its hooks into THAT repository's `.git/hooks`, printed its success line and exited 0, while the repo it was meant to protect got nothing. From a plain directory they die with "cd: .git: No such file or directory"; from a linked worktree (where `.git` is a FILE) with "Not a directory". The fix normalises the relative answer against `$ROOT`, the same resolution `install-graphify-refresh-hook.sh` already carries. The update path is unaffected (`update.sh` cd-s into the install dir first), so this was never a live production failure; the exposure is any hand or agent invocation from another cwd.

## Kapcsolódó issue / Related issue
Nincs nyitott GitHub issue -- kanban #1234.

## Ellenőrzőlista / Checklist
- [x] Piros próba először: a javítás előtti szövegen (47d352b) telepítőnként pontosan 4-4-4 eset bukik a 15-ből; a 3 zöld a telepítőnkénti, gyökérből futtatott negatív kontroll. A javítás után 15/15 zöld.
- [x] Az új teszt viselkedés-alapú, nem szöveg-illesztés: a telepítő ténylegesen lefut, és utána a `.git` tartalmát nézzük. Öt eset telepítőnként: gyökér, alkönyvtár, nem-git könyvtár, idegen checkout (az idegen `.git` érintetlenségével együtt) és idegen linkelt worktree.
- [x] A teljes halmaz kimondva: hat `scripts/install-*hook*.sh` szkript van, háromban állt a minta (mind javítva), három nem érintett. A hármat mérés zárta ki, nem olvasás: mindegyik kétszer futott, a repó gyökeréből és egy idegen checkout gyökeréből, külön sandbox HOME-ba, és a keletkezett fa bájtra azonos a HOME normalizálása után. Egy szándékosan cwd-függő kontroll-telepítő ugyanezen a szondán eltérést adott.
- [x] Kapuk: `npm run typecheck` tiszta, `npm test` 5267 zöld / 1 skipped, `npm run syntax-check` tiszta.
- [x] docs/ frissítés: nem szükséges (a viselkedés nem változik a dokumentált úton, a telepítők belső útfeloldása javul).
- [x] Nincs beégetett szenzitív adat.
- [x] Saját, beszédes nevű branch: fix/hook-installer-git-common-dir
