### PR TITLE
fix(limit-monitor): the quota staleness guard gets a ceiling, and a rejected value says so (QUOTAFELSOHATAR910)

### DIFF
--- a/scripts/__tests__/limit-monitor-signals.test.sh
+++ b/scripts/__tests__/limit-monitor-signals.test.sh
@@ -52,6 +52,11 @@ deliver_case() {
   echo "$c"
 }
 run_case() { (cd "$1" && HOME="$1/fakehome" PATH="$1/fakebin:$PATH" bash scripts/limit-monitor.sh >/dev/null 2>&1); }
+# Same, with QUOTA_MAX_AGE_SEC set: that knob reaches the monitor through the
+# process environment, not through .env like MAIN_AGENT_ID, so a case cannot
+# set it by writing a file.
+#   run_case_age <case_dir> <value>
+run_case_age() { (cd "$1" && HOME="$1/fakehome" PATH="$1/fakebin:$PATH" QUOTA_MAX_AGE_SEC="$2" bash scripts/limit-monitor.sh >/dev/null 2>&1); }
 # An alert was RAISED -- deliberately independent of whether it was delivered.
 # The old form grepped only "ALERT wanted", the line for a case with no bot
 # token, so the moment a case could actually deliver, the same true state read
@@ -259,6 +264,65 @@ if [ -s "$CO/store/.limit-monitor-quota-state" ]; then
   pass "a delivered alert does write the dedupe stamp"
 else
   fail "a delivered alert left no dedupe stamp -- alerts would repeat forever"
+fi
+
+echo "(e) QUOTAFELSOHATAR910: the staleness window must have a CEILING, not just a floor"
+# The floor already behaved: any too-small or negative value made a fresh
+# reading look stale, which is loud and harmless. The missing side was the
+# ceiling, and it fails the dangerous way -- one mistyped zero and a DEAD
+# reading passes as fresh, so the monitor alerts on numbers that describe a
+# window which has since rolled over, or stays quiet about a real one. Measured
+# 2026-09-10: QUOTA_MAX_AGE_SEC=216000000 produced no output at all.
+# The fixture below is the shape that actually hurts: a day-old file that still
+# claims a reset in the FUTURE, so with the guard switched off it alerts.
+old_written=$((now - 90000))
+
+C="$(new_case quota_age_too_big)"
+printf '{"written_at":%d,"rate_limits":{"five_hour":{"used_percentage":99,"resets_at":%d}}}\n' "$old_written" "$((now + 3600))" \
+  > "$C/store/.claude-rate-limits.json"
+run_case_age "$C" 216000000
+if alerted "$C"; then
+  fail "an out-of-range QUOTA_MAX_AGE_SEC let a day-old reading raise an alert"
+else
+  pass "an out-of-range QUOTA_MAX_AGE_SEC cannot switch the staleness guard off"
+fi
+if grep -q "felso hatarnal" "$C/store/limit-monitor.log" 2>/dev/null; then
+  pass "the rejected value is named in the log, with what is used instead"
+else
+  fail "the value was rejected SILENTLY -- the operator still believes it applies"
+fi
+
+C="$(new_case quota_age_not_a_number)"
+printf '{"written_at":%d,"rate_limits":{"five_hour":{"used_percentage":99,"resets_at":%d}}}\n' "$old_written" "$((now + 3600))" \
+  > "$C/store/.claude-rate-limits.json"
+run_case_age "$C" abc
+if alerted "$C"; then
+  fail "a non-numeric QUOTA_MAX_AGE_SEC let a day-old reading raise an alert"
+else
+  pass "a non-numeric QUOTA_MAX_AGE_SEC falls back to the default"
+fi
+if grep -q "nem szam" "$C/store/limit-monitor.log" 2>/dev/null; then
+  pass "a non-numeric value is reported instead of dying into /dev/null"
+else
+  fail "a non-numeric value killed the checker silently (traceback swallowed)"
+fi
+
+# Positive control, so neither case above can pass for the wrong reason: a value
+# INSIDE the range must be accepted, and must add no line to the log. Without
+# this a checker that rejected everything would look perfect.
+C="$(new_case quota_age_in_range)"
+printf '{"written_at":%d,"rate_limits":{"five_hour":{"used_percentage":99,"resets_at":%d}}}\n' "$old_written" "$((now + 3600))" \
+  > "$C/store/.claude-rate-limits.json"
+run_case_age "$C" 7200
+if grep -qE "nem szam|felso hatarnal|nem pozitiv" "$C/store/limit-monitor.log" 2>/dev/null; then
+  fail "an in-range QUOTA_MAX_AGE_SEC was rejected -- the guard rejects everything"
+else
+  pass "an in-range QUOTA_MAX_AGE_SEC is accepted without noise"
+fi
+if grep -q "quota file stale" "$C/store/limit-monitor.log" 2>/dev/null; then
+  pass "and it is the value actually in force (the day-old reading is stale)"
+else
+  fail "an in-range value was accepted but not applied"
 fi
 
 echo ""

--- a/scripts/__tests__/limit-monitor-signals.test.sh
+++ b/scripts/__tests__/limit-monitor-signals.test.sh
@@ -296,10 +296,21 @@ C="$(new_case quota_age_not_a_number)"
 printf '{"written_at":%d,"rate_limits":{"five_hour":{"used_percentage":99,"resets_at":%d}}}\n' "$old_written" "$((now + 3600))" \
   > "$C/store/.claude-rate-limits.json"
 run_case_age "$C" abc
+# NOT "did it stay quiet": on the pre-fix code it stayed quiet too, because the
+# checker died before printing anything. Silence is what both the fallback and
+# the crash look like, so asserting silence would pass for the wrong reason
+# (measured: this exact assertion was green against the old source). What
+# separates them is whether the run reached a VERDICT with the default in
+# force -- the day-old reading must come out stale.
+if grep -q "quota file stale" "$C/store/limit-monitor.log" 2>/dev/null; then
+  pass "a non-numeric QUOTA_MAX_AGE_SEC falls back to the default, and the default is applied"
+else
+  fail "a non-numeric QUOTA_MAX_AGE_SEC left the round without a verdict"
+fi
 if alerted "$C"; then
   fail "a non-numeric QUOTA_MAX_AGE_SEC let a day-old reading raise an alert"
 else
-  pass "a non-numeric QUOTA_MAX_AGE_SEC falls back to the default"
+  pass "and no alert is raised from the day-old reading"
 fi
 if grep -q "nem szam" "$C/store/limit-monitor.log" 2>/dev/null; then
   pass "a non-numeric value is reported instead of dying into /dev/null"

--- a/scripts/lib/quota-check.py
+++ b/scripts/lib/quota-check.py
@@ -23,9 +23,15 @@ DEFAULT_MAX_AGE_SEC = 21600
 # a confident green for a weeks-old number and the monitor stays quiet. Measured
 # on 2026-09-10: a 30-day-old reading with QUOTA_MAX_AGE_SEC=216000000 produced
 # NO output at all, i.e. one mistyped zero silently switches the guard off.
-# The ceiling is not an arbitrary round number: seven days is the longest quota
-# window that exists, so a reading older than that describes a window that has
-# certainly rolled over, whatever the config claims.
+# Where 604800 comes from, stated as what it actually is -- OUR operating
+# decision, not a claim about the provider's product. This monitor tracks
+# exactly two windows, and they are the two its own writer produces:
+# statusline-ratelimit.sh writes rate_limits.five_hour and rate_limits.seven_day,
+# and the loop below reads those same two. Seven days is therefore the longest
+# window WE HAVE A NUMBER FOR, so a reading older than that cannot be checked
+# against anything we track, whatever the config claims. Whether some longer
+# window exists upstream is not measured here and the ceiling does not depend
+# on it: past a week the reading is unusable for this monitor either way.
 MAX_AGE_CEILING_SEC = 604800
 
 
@@ -51,7 +57,7 @@ def resolve_max_age(raw):
             % (value, DEFAULT_MAX_AGE_SEC))
     if value > MAX_AGE_CEILING_SEC:
         return DEFAULT_MAX_AGE_SEC, (
-            "QUOTA_MAX_AGE_SEC=%d nagyobb a %d masodperces felso hatarnal (a leghosszabb kvota-ablak), "
+            "QUOTA_MAX_AGE_SEC=%d nagyobb a %d masodperces felso hatarnal (a leghosszabb ablak, amit ez a monitor kovet), "
             "ezert nem hasznalom; helyette a default %d masodperc"
             % (value, MAX_AGE_CEILING_SEC, DEFAULT_MAX_AGE_SEC))
     return value, None

--- a/scripts/lib/quota-check.py
+++ b/scripts/lib/quota-check.py
@@ -10,11 +10,60 @@ exits 2 at parse time and Linux CI (bash >= 4) is structurally blind to it
 (measured on the PR #1080 verify). With the body in its own file the
 hazard class is gone and comments may use normal punctuation.
 """
-import json, os, time
+import json, os, sys, time
+
+# The ONE place the staleness window is decided for the measured quota path.
+# limit-monitor.sh used to carry its own copy of the default; it no longer does,
+# so these two numbers cannot drift apart from the code that enforces them.
+DEFAULT_MAX_AGE_SEC = 21600
+
+# QUOTAFELSOHATAR910. The guard had a floor but no CEILING, and the missing side
+# is the dangerous one: too small only makes a fresh reading look stale (loud,
+# harmless), while too large makes a DEAD reading look fresh -- the strip shows
+# a confident green for a weeks-old number and the monitor stays quiet. Measured
+# on 2026-09-10: a 30-day-old reading with QUOTA_MAX_AGE_SEC=216000000 produced
+# NO output at all, i.e. one mistyped zero silently switches the guard off.
+# The ceiling is not an arbitrary round number: seven days is the longest quota
+# window that exists, so a reading older than that describes a window that has
+# certainly rolled over, whatever the config claims.
+MAX_AGE_CEILING_SEC = 604800
+
+
+def resolve_max_age(raw):
+    """Return (seconds, note). A note means the value was rejected.
+
+    Rejected values fall back to the default and SAY SO on stderr (the monitor
+    logs it). Silently repairing a bad config would keep exactly the silence
+    this guard exists to remove: the operator would go on believing the number
+    they typed is the number in force.
+    """
+    if raw is None or raw.strip() == "":
+        return DEFAULT_MAX_AGE_SEC, None
+    try:
+        value = int(raw)
+    except ValueError:
+        return DEFAULT_MAX_AGE_SEC, (
+            "QUOTA_MAX_AGE_SEC=%r nem szam, ezert nem hasznalom; helyette a default %d masodperc"
+            % (raw, DEFAULT_MAX_AGE_SEC))
+    if value <= 0:
+        return DEFAULT_MAX_AGE_SEC, (
+            "QUOTA_MAX_AGE_SEC=%d nem pozitiv, ezert nem hasznalom; helyette a default %d masodperc"
+            % (value, DEFAULT_MAX_AGE_SEC))
+    if value > MAX_AGE_CEILING_SEC:
+        return DEFAULT_MAX_AGE_SEC, (
+            "QUOTA_MAX_AGE_SEC=%d nagyobb a %d masodperces felso hatarnal (a leghosszabb kvota-ablak), "
+            "ezert nem hasznalom; helyette a default %d masodperc"
+            % (value, MAX_AGE_CEILING_SEC, DEFAULT_MAX_AGE_SEC))
+    return value, None
+
 
 path = os.environ["QUOTA_FILE"]
 warn = float(os.environ["QUOTA_WARN_PCT"])
-max_age = int(os.environ["QUOTA_MAX_AGE_SEC"])
+max_age, max_age_note = resolve_max_age(os.environ.get("QUOTA_MAX_AGE_SEC"))
+if max_age_note:
+    # stderr, not stdout: stdout carries the single STALE / EXPIRED / HIT line
+    # the monitor parses, and a second line there would break its `case`.
+    print(max_age_note, file=sys.stderr)
 try:
     d = json.load(open(path))
 except Exception:

--- a/scripts/limit-monitor.sh
+++ b/scripts/limit-monitor.sh
@@ -96,7 +96,10 @@ QUOTA_FILE="$STORE/.claude-rate-limits.json"
 QUOTA_WARN_PCT="${QUOTA_WARN_PCT:-90}"
 # Older than this and the numbers describe a window that may have reset since;
 # alerting on them would cry wolf, so they are logged and skipped instead.
-QUOTA_MAX_AGE_SEC="${QUOTA_MAX_AGE_SEC:-21600}"
+# QUOTAFELSOHATAR910: the default and the accepted RANGE both live in
+# quota-check.py now, and this line no longer carries a second copy of the
+# number. An unset value reaches the checker empty and it applies its own
+# default; an out-of-range or non-numeric one is rejected THERE, out loud.
 
 if [ -s "$QUOTA_FILE" ] && command -v python3 >/dev/null 2>&1; then
   QUOTA_CHECK="$INSTALL_DIR/scripts/lib/quota-check.py"
@@ -107,7 +110,18 @@ if [ -s "$QUOTA_FILE" ] && command -v python3 >/dev/null 2>&1; then
     log "quota-check.py hianyzik ($QUOTA_CHECK), a mert quota-ut EZEN A KORON KIMARAD -- a text-fallback fut tovabb"
     QUOTA_OUT=""
   else
-    QUOTA_OUT="$(QUOTA_FILE="$QUOTA_FILE" QUOTA_WARN_PCT="$QUOTA_WARN_PCT" QUOTA_MAX_AGE_SEC="$QUOTA_MAX_AGE_SEC" python3 "$QUOTA_CHECK" 2>/dev/null)"
+    # stderr is CAPTURED, not discarded. It used to go to /dev/null, which made
+    # two very different things look identical from here: a healthy run with
+    # nothing to report, and a checker that died on the first line (a
+    # non-numeric QUOTA_MAX_AGE_SEC raised a traceback). Both left QUOTA_OUT
+    # empty, and the `case` below has no empty branch -- so the measured quota
+    # path could drop out of a round without a single word in the log.
+    QUOTA_ERR="$STORE/.quota-check.stderr"
+    QUOTA_OUT="$(QUOTA_FILE="$QUOTA_FILE" QUOTA_WARN_PCT="$QUOTA_WARN_PCT" QUOTA_MAX_AGE_SEC="${QUOTA_MAX_AGE_SEC:-}" python3 "$QUOTA_CHECK" 2>"$QUOTA_ERR")"
+    if [ -s "$QUOTA_ERR" ]; then
+      log "quota-check.py uzenete: $(tr '\n' ' ' < "$QUOTA_ERR")"
+    fi
+    rm -f "$QUOTA_ERR"
   fi
   case "$QUOTA_OUT" in
     STALE*)


### PR DESCRIPTION
`QUOTA_MAX_AGE_SEC` had a floor but no ceiling, and the missing side is the dangerous one. Too small only makes a fresh reading look stale: loud and harmless. Too large makes a **dead** reading look fresh, so the quota strip shows a confident green for a weeks-old number and the monitor stays quiet.

Measured on the existing path on 2026-09-10, before any of this:

| `QUOTA_MAX_AGE_SEC` | 30-day-old reading | |
|---|---|---|
| `21600` | `STALE 2592000` | correct |
| `216000000` | *no output at all* | the guard is silently off |
| `0` / `-5` | `STALE 2592011` | fails safe |
| `abc` | traceback | a second gap, below |

One mistyped zero switches the guard off, and nothing says so.

### The second gap

A non-numeric value killed `quota-check.py` with a traceback, `limit-monitor.sh` sent stderr to `/dev/null`, and the `case` on the output has no empty branch. A healthy round and a dead checker were byte-identical from the log's point of view, in a script that elsewhere takes care to say the opposite out loud ("an alert withheld must not look the same as a quiet, healthy reading").

### What changed

- `quota-check.py` owns the default **and** the accepted range. `limit-monitor.sh` no longer carries a second copy of the number, so the two cannot drift apart.
- The ceiling is `604800`, stated as what it actually is: our operating decision, not a claim about the provider's product. This monitor tracks exactly two windows, and they are the two its own writer produces -- `statusline-ratelimit.sh` writes `rate_limits.five_hour` and `rate_limits.seven_day`, and the checker reads those same two. Seven days is therefore the longest window we have a number for, so a reading older than that cannot be checked against anything we track. Whether a longer window exists upstream is not measured here and the ceiling does not depend on it.
- A rejected value falls back to the default **and says so** on stderr, which the monitor writes to its log. Silently repairing a bad config would keep exactly the silence this guard exists to remove: the operator would go on believing the number they typed is the number in force.
- stderr is captured rather than discarded, so a checker that dies leaves a trace.

### Tests

Seven new cases in `scripts/__tests__/limit-monitor-signals.test.sh` (discovered by the CI runner automatically). The fixture is the shape that actually hurts: a day-old file that still claims a reset in the future, so with the guard off it raises an alert.

Every regression assertion was run against the **pre-fix source** to confirm it fails there. That control earned its keep: `a non-numeric QUOTA_MAX_AGE_SEC falls back to the default` passed against the old code too, because the checker died before printing anything and a crash looks exactly like a quiet round. It now asserts that the run reached a verdict with the default in force, which the old source cannot produce. Two positive controls check that an in-range value is accepted, applied, and adds no noise.

### Not in this PR

`DEFAULT_MAX_AGE_SEC = 21600` also exists in `src/web/quota.ts` on the open #1229, bound to the shell only by a comment ("Same default as QUOTA_MAX_AGE_SEC in scripts/limit-monitor.sh"). That is a third copy of the number and it should not stay a comment, but #1229 is not merged, so there is nothing here to unify with yet. Flagged on its card instead.

Also worth knowing: this knob reaches the monitor through the process environment only, not through `.env` like `MAIN_AGENT_ID`. That bounds who can trip it, and it is unchanged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

