### PR TITLE
fix(usage-collect test): stop a test from opening and leaking the real credentials file

### DIFF
--- a/scripts/__tests__/usage-collect.test.py
+++ b/scripts/__tests__/usage-collect.test.py
@@ -823,8 +823,13 @@ class TestClaudeTokenSources(unittest.TestCase):
 
     def test_keychain_beats_env_file(self):
         """The .env token answers 403, so it must never win over the keychain."""
+        # `exists` must NOT be True for the credentials path: expanduser is real,
+        # so a blanket True opens the machine's own ~/.claude/.credentials.json
+        # and assertEqual prints its token on failure (a real-token leak on any
+        # host that HAS the file). Say the intent instead: credentials absent,
+        # env present -- keychain still wins over env.
         with patch.object(uc.sys, "platform", "darwin"), \
-             patch.object(uc.os.path, "exists", return_value=True), \
+             patch.object(uc.os.path, "exists", side_effect=lambda p: p == self._tmp.name), \
              patch.object(uc, "ENV_PATH", self._tmp.name), \
              patch.object(uc.subprocess, "run", return_value=self._security_ok()):
             token, source = uc._read_claude_token()


### PR DESCRIPTION
Two external installs (v1.37.0 forks) reproduced this before it was fixed here.

## The bug class
A unit test that stubs `os.path.exists` to `True` for ALL paths while leaving `os.path.expanduser` real makes the code under test resolve and OPEN the machine's own `~/.claude/.credentials.json`. `_read_claude_token()` (scripts/usage-collect.py:349) then returns the live OAuth token, the `assertEqual` fails, and unittest prints the token in the failure diff.

- On macOS the file does not exist (the token lives in the Keychain), so the branch's `open()` raises, the code falls through to the keychain, and the test is green. That is why it hid.
- On any host where `~/.claude/.credentials.json` exists (Linux), the test writes the live OAuth token to the test output, and from there into a CI log.

The one leaking test is `scripts/__tests__/usage-collect.test.py::test_keychain_beats_env_file` (line 827): `patch.object(uc.os.path, "exists", return_value=True)`.

## The fix
The test's only intent is that the `.env` token must not beat the keychain, which needs **credentials absent, env present**. It stubbed "everything exists" instead. The `exists` stub now reflects the intent (`side_effect`: only the temp `.env` path exists), matching the sibling `test_keychain_used_when_credentials_file_absent`. The real credentials file is never touched.

## Verification
- **Reproduced with no real secret:** a disposable `HOME` with `.claude/.credentials.json` carrying `LEAK-CANARY-ABC123`. Before the fix the canary appears in the failure diff; after, the file passes with the canary never read.
- **Negative control both ways:** fixed + canary HOME -> green, canary absent from output; revert the fix -> canary reappears.
- **Wider sweep:** this was the only blanket `os.path.exists` stub in the python tests. A behavioural pass ran every python test under a sentinel-seeded HOME (covering `.credentials.json`, `settings.json`, the telegram `.env` and the env file); no test echoed any sentinel, so no other test leaks a real-HOME secret.

## Note on our own CI
`npm test` is `vitest run` (TS only), and the CI workflow runs no python-unittest step, so this test does not run in our GitHub Actions CI and has not leaked there. The exposure is a direct python run on a Linux host that has the credentials file (a developer machine, an install, or a fork whose CI runs the python tests).

Base is `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)