### PR TITLE
fix(heartbeat): the worker injects the metrics block pre-rendered, the round only copies it (HBMETRICSWIRE910)

### DIFF
--- a/src/__tests__/heartbeat-agent-scaffold.test.ts
+++ b/src/__tests__/heartbeat-agent-scaffold.test.ts
@@ -37,14 +37,13 @@ describe('renderHeartbeatClaudeMd', () => {
     expect(out).toContain('"from":"heartbeat"')
   })
 
-  it('uses the supplied store dir (absolute) for the instrument env and the token path', () => {
+  it('uses the supplied store dir only for the step-3 token path -- no instrument env in the prose', () => {
     const out = renderHeartbeatClaudeMd(ID)
-    // The DB path itself no longer appears in the prose: the metrics
-    // instrument derives it from CLAW_STORE_DIR, so the only store-dir
-    // surfaces left are the instrument's env prefix and the step-3
-    // message POST's token read.
-    expect(out).toContain('CLAW_STORE_DIR=/srv/app/store')
+    // HBMETRICSWIRE910: the WORKER runs the instrument, so the prose ships
+    // no CLAW_* env prefix and no DB path -- the only store-dir surface
+    // left is the message POST's token read.
     expect(out).toContain('cat /srv/app/store/.dashboard-token')
+    expect(out).not.toContain('CLAW_STORE_DIR=')
     expect(out).not.toContain('claudeclaw.db')
   })
 
@@ -111,9 +110,10 @@ describe('renderHeartbeatClaudeMd', () => {
     // `priority='urgent' AND status != 'done'`. That instruction was present and
     // correct since #680, and the 09:00 report on 2026-08-04 still listed three
     // `done` cards out of five: a filter the model must re-apply every hour is
-    // not a mechanism. The agent now calls an endpoint that can only return open
-    // cards, so the guarantee moved from "it was told to" to "it cannot".
-    expect(out).toContain('/api/kanban/heartbeat-summary')
+    // not a mechanism. Since HBMETRICSWIRE910 the agent does not even call the
+    // endpoint -- the WORKER does -- so the prose names no queryable surface
+    // for kanban at all.
+    expect(out).not.toContain('/api/kanban/heartbeat-summary')
     expect(out).not.toContain("priority='urgent' AND status != 'done'")
     expect(out).not.toMatch(/SELECT[^\n]*FROM kanban_cards/i)
   })
@@ -132,8 +132,9 @@ describe('renderHeartbeatClaudeMd', () => {
     expect(a).not.toBe(b)
     expect(b).toContain("across Omar's systems")
     expect(b).toContain('"to":"atlas"')
-    expect(b).toContain('CLAW_STORE_DIR=/data/store')
-    expect(b).toContain('bash /data/scripts/heartbeat-metrics.sh')
+    // The instrument path appears as provenance only (no `bash` invocation,
+    // see the runnable-call test below), but it must still be the identity's.
+    expect(b).toContain('/data/scripts/heartbeat-metrics.sh')
     expect(b).toContain('http://localhost:9000/api/messages')
   })
 
@@ -163,57 +164,40 @@ describe('renderHeartbeatClaudeMd', () => {
     expect(out).not.toContain('## Heartbeat YYYY-MM-DD HH:MM')
   })
 
-  it('forbids ANY agent-side calendar fetch -- the instrument is the only source (5E0A32B0)', () => {
+  it('forbids ANY agent-side calendar fetch -- the block is the only source (5E0A32B0 -> HBMETRICSWIRE910)', () => {
     // A month of agent-side fetch variants ended in a fossil: one probe
     // against a nonexistent endpoint, copy-forwarded round after round as
-    // "calendar fetch failed: API error" with zero real attempts.
+    // "calendar fetch failed: API error" with zero real attempts. The
+    // measured-empty vs failed-query distinction now lives in the renderer
+    // (heartbeat-metrics-inject.test.ts); the prose's job is only the ban.
     const out = renderHeartbeatClaudeMd(ID)
-    expect(out).toContain('You never fetch the calendar yourself')
-    expect(out).toContain('/api/heartbeat/calendar')
+    expect(out).toMatch(/NEVER rebuild any of its numbers[\s\S]{0,120}calendar/)
     // The old MCP-tool instructions must be gone -- prose telling the agent
     // to fetch is exactly the surface the fossil grew on.
     expect(out).not.toContain('mcp__server-google-calendar-mcp__list-events')
   })
 
-  it('separates "measured empty" from "failed query" so the two are not reported alike', () => {
-    const out = renderHeartbeatClaudeMd(ID)
-    // no-events may only come from a measured n=0 line...
-    expect(out).toMatch(/no upcoming events[\s\S]{0,40}CALENDAR_EVENTS n=0/)
-    // ...and the failure line only from THIS round's ERROR calendar: line.
-    expect(out).toContain('calendar fetch failed: <reason>')
-    expect(out).toMatch(/calendar fetch failed: <reason>"\s*--\s*ONLY from ERROR calendar: of THIS round/)
-  })
-
-  it('pins the mechanical freshness check on the instrument ts= stamp', () => {
+  it('pins the freshness surface on the worker-stamped ts, carried into the report', () => {
     // The anti-fossil prose existed before 5E0A32B0 and was ignored; the
-    // ts=-vs-step-0-clock comparison is the mechanical form of it.
+    // mechanical form is now the `merve:` line that copies the block's
+    // worker-stamped ts into the digest, so staleness is visible to the
+    // READER instead of depending on the round's arithmetic.
     const out = renderHeartbeatClaudeMd(ID)
-    expect(out).toMatch(/ts=.*stamp[\s\S]{0,120}same\s+hour as the step-0 clock/)
-    expect(out).toContain('stale instrument')
+    expect(out).toContain('merve:')
+    expect(out).toMatch(/ts= value from the block/)
+    expect(out).toMatch(/two timestamps side by side ARE the finding/)
   })
 
-  // Same investigation: the Tasks section read the `scheduled_tasks` table,
-  // which holds 0 rows on this deployment while /api/schedules lists 25
-  // enabled entries -- so every report said "active: 0, next: (none
-  // scheduled)". A line that is always the same stops being read, which is
-  // the failure this file already warns about elsewhere.
-  it('reads the schedule count from the live registry, not the empty table', () => {
+  // Same investigation: the Tasks section once read the `scheduled_tasks`
+  // table, which holds 0 rows on this deployment -- every report said
+  // "active: 0". The live-registry read now lives in the instrument (its own
+  // conformance test pins it); the prose must simply ship NO schedule or
+  // task_runs query surface at all.
+  it('ships no schedules or task_runs query surface in the prose', () => {
     const out = renderHeartbeatClaudeMd(ID)
-    expect(out).toContain('http://localhost:3420/api/schedules')
+    expect(out).not.toContain('/api/schedules')
     expect(out).not.toContain('count active rows in')
     expect(out).not.toContain('next_run_at')
-  })
-
-  it('names the task_runs milliseconds trap but ships no runnable SQL for it', () => {
-    // ts is epoch MILLISECONDS; a seconds comparison matches every row and
-    // silently turns "last hour" into "since the beginning". This assertion
-    // REPLACES the older one that required the literal
-    // `(unixepoch()-3600)*1000` query in the prose: the cutoff now lives in
-    // scripts/heartbeat-metrics.sh (asserted by its own conformance test),
-    // and the prose only names the trap so nobody re-derives it by hand.
-    const out = renderHeartbeatClaudeMd(ID)
-    expect(out).toContain('MILLISECONDS')
-    expect(out).toMatch(/\*1000[^\n]*cutoff/)
     expect(out).not.toMatch(/sqlite3 [^\n]*task_runs/)
   })
 })
@@ -246,30 +230,26 @@ describe('shouldBootHeartbeatAgent', () => {
 // computed server-side (countNewHotMemories, served as
 // counts.new_hot_memories_1h on /api/kanban/heartbeat-summary) and the
 // scaffold tells the agent to COPY it -- there is no query left to rewrite.
-describe('hot-memory metric is an endpoint number, never an agent-run query (HBMEMBLIND819)', () => {
-  it('points the agent at counts.new_hot_memories_1h from the heartbeat-summary call', () => {
-    const out = renderHeartbeatClaudeMd(ID)
-    expect(out).toContain('counts.new_hot_memories_1h')
-  })
-
+describe('hot-memory metric is never an agent-run query (HBMEMBLIND819 -> HBMETRICSWIRE910)', () => {
   it('ships NO runnable hot-memory SQL anywhere in the prompt', () => {
     const out = renderHeartbeatClaudeMd(ID)
     // The exact surface that drifted twice: a memories/hot query the agent
     // could run (and, measured, rewrite). Shape-agnostic: any SQL touching
-    // the memories table near a hot filter is out of contract.
+    // the memories table near a hot filter is out of contract. Since the
+    // worker injects the numbers, even the endpoint field name is gone.
     expect(out).not.toMatch(/FROM memories[\s\S]{0,120}category='hot'/)
     expect(out).not.toContain('do not rewrite the query')
+    expect(out).not.toContain('counts.new_hot_memories_1h')
   })
 
-  it('degrades a missing field to "no data", never to a self-run query or a zero', () => {
-    // Phrase updated with the instrument contract: the missing-field case
-    // now surfaces as an ERROR line from the script, and the report writes
-    // "nincs adat (muszer-hiba)" -- the load-bearing part is that the
-    // degradation path exists and is named, and that fabricating a 0 is
-    // called out as the defect.
+  it('names the fabricated-zero defect and keeps muszer-hiba lines verbatim', () => {
+    // The degradation path (ERROR line -> muszer-hiba in the block) now
+    // renders worker-side; the prose's remaining duty is to forbid the round
+    // from "fixing" it: a failure line is a measured result to copy through,
+    // and a 0 the block does not contain is always the round's defect.
     const out = renderHeartbeatClaudeMd(ID)
-    expect(out).toContain('nincs adat (muszer-hiba)')
-    expect(out).toMatch(/fabricated 0 is the defect/)
+    expect(out).toMatch(/muszer-hiba[\s\S]{0,200}IS the measured result/)
+    expect(out).toMatch(/fabricated 0/)
   })
 })
 
@@ -312,14 +292,14 @@ describe('no unfalsifiable warnings metric (HBWARN807)', () => {
 })
 
 describe('instrument-fed calendar (5E0A32B0, supersedes HBCALMCP808)', () => {
-  it('the calendar section names the instrument lines it may be built from', () => {
+  it('ships no instrument line vocabulary -- the block arrives pre-rendered', () => {
     const md = renderHeartbeatClaudeMd(ID)
-    // With the fetch moved server-side, the ToolSearch/deferred-MCP protocol
-    // (HBCALMCP808) has no remaining subject; what replaces it is the line
-    // vocabulary of the instrument, which is the ONLY sanctioned source.
-    expect(md).toContain('CALENDAR_EVENTS')
-    expect(md).toContain('CAL_EVENT')
-    expect(md).toContain('ERROR calendar:')
+    // With HBMETRICSWIRE910 the round never parses instrument output, so the
+    // line vocabulary (CALENDAR_EVENTS / CAL_EVENT / ERROR calendar:) left
+    // the prose too -- it lives in heartbeat-metrics-inject.ts and its
+    // tests. Prose mentioning parse rules is prose that can be recomposed.
+    expect(md).not.toContain('CALENDAR_EVENTS')
+    expect(md).not.toContain('CAL_EVENT')
     expect(md).not.toContain('ToolSearch')
   })
 })
@@ -339,56 +319,45 @@ describe('instrument-fed calendar (5E0A32B0, supersedes HBCALMCP808)', () => {
 // extraction now lives in scripts/heartbeat-metrics.sh (its own conformance
 // test exercises it); the prose ships NO extractor at all, only the
 // instrument call and the sentinel rule.
-describe('metrics come from the on-disk instrument, never from prose the agent can recompose', () => {
-  it('ships the instrument call with identity-derived env and path', () => {
+// HBMETRICSWIRE910: the fourth failed layer of the same metric ended the
+// run-it-yourself contract entirely. The prompt now carries the numbers
+// PRE-RENDERED by the worker; the sentinel rule, the extractor, and the
+// heredoc ban all moved out of the prose (into heartbeat-metrics-inject.ts,
+// where the tests exercise them as code, not as instructions).
+describe('metrics arrive pre-rendered in the prompt, never via prose the agent can recompose', () => {
+  it('ships NO runnable instrument call -- the path appears as provenance only', () => {
     const out = renderHeartbeatClaudeMd(ID)
-    expect(out).toContain(
-      'CLAW_STORE_DIR=/srv/app/store CLAW_DASHBOARD_ORIGIN=http://localhost:3420'
-    )
-    expect(out).toContain('bash /srv/app/scripts/heartbeat-metrics.sh')
+    expect(out).toContain('/srv/app/scripts/heartbeat-metrics.sh')
+    expect(out).not.toMatch(/bash [^\n]*heartbeat-metrics\.sh/)
+    expect(out).not.toContain('CLAW_DASHBOARD_ORIGIN=')
   })
 
-  it('ships NO runnable extractor -- the copy-surface that drifted three times', () => {
+  it('ships NO runnable extractor and no endpoint to fetch', () => {
     const out = renderHeartbeatClaudeMd(ID)
     expect(out).not.toContain('python3 -c "import json,urllib.request')
     expect(out).not.toMatch(/COUNTS urgent=%s/)
-    // The endpoint may be NAMED (as the server-side source of the numbers)
-    // but never fetched from the prose.
-    expect(out).toContain('/api/kanban/heartbeat-summary')
+    expect(out).not.toContain('/api/kanban/heartbeat-summary')
     expect(out).not.toMatch(/curl[^\n]*heartbeat-summary/)
   })
 
-  it('states the sentinel rule: known sentinel or instrument failure, never "looks like output"', () => {
+  it('states the block rule: marker-led block or muszer-hiba, never "looks like a report"', () => {
     const out = renderHeartbeatClaudeMd(ID)
-    expect(out).toContain('HB_METRICS_V1')
-    // The unknown-version branch is named explicitly (a future V2 under
-    // these instructions must read as instrument failure, not be accepted
-    // silently) -- Marveen's stipulation on HBMEMBLIND819, 2026-08-25.
-    expect(out).toContain('HB_METRICS_V2')
+    expect(out).toContain('[HB-METRIKA-BLOKK')
     expect(out).toContain('muszer-hiba')
-    expect(out).toMatch(/NEVER write 0/)
+    // The missing-block branch is named explicitly: no marker in the prompt
+    // means the report says so in every section, never a self-measured fill.
+    expect(out).toMatch(/hianyzo metrika-blokk/)
+    expect(out).toMatch(/copied VERBATIM/)
   })
 
-  it('the ONLY python3-heredoc mention is the quoted example inside the ban text', () => {
+  it('bans self-measurement class-wide and names the measured history', () => {
     const out = renderHeartbeatClaudeMd(ID)
-    // The ban must quote the forbidden shape (so the agent can recognise
-    // it), and NOTHING else in the prompt may contain one. Class-level, not
-    // variant-enumerated: on one line, `python3` is never followed by `<<`
-    // outside the ban sentence.
-    const matches = [...out.matchAll(/python3[^\n]*<</g)]
-    expect(matches.length).toBe(1)
-    const banStart = out.indexOf('THE SENTINEL RULE (HBMEMBLIND819)')
-    expect(banStart).toBeGreaterThanOrEqual(0)
-    const banEnd = out.indexOf('If the output contains', banStart)
-    expect(banEnd).toBeGreaterThan(banStart)
-    const idx = matches[0].index ?? -1
-    expect(idx).toBeGreaterThan(banStart)
-    expect(idx).toBeLessThan(banEnd)
-  })
-
-  it('names the heredoc incident so the ban survives paraphrase', () => {
-    const out = renderHeartbeatClaudeMd(ID)
-    expect(out).toContain('HBHEREDOC819')
-    expect(out).toMatch(/heredoc becomes python3's stdin/)
+    // Class-level ban (curl/python3/sqlite3/du/ls/stat/calendar), plus the
+    // four dated failures that justify it -- the history is what keeps the
+    // ban from being "simplified" away in a later edit.
+    expect(out).toMatch(/NEVER rebuild any of its numbers/)
+    expect(out).toContain('HBMEMBLIND807')
+    expect(out).toContain('HBMEMBLIND819')
+    expect(out).toMatch(/du-shaped DB\s+size 488/)
   })
 })

--- a/src/__tests__/heartbeat-db-size.test.ts
+++ b/src/__tests__/heartbeat-db-size.test.ts
@@ -66,19 +66,20 @@ describe('wiring contract: endpoint -> agent, never agent -> du/stat', () => {
     expect(KANBAN.slice(start, end)).toMatch(/buildHeartbeatSummaryResponse\([\s\S]*getDbFileSizeMb\(\)/)
   })
 
-  it('the scaffold names counts.db_size_mb as the ONLY source and forbids self-measurement', () => {
-    expect(SCAFFOLD).toMatch(/counts\.db_size_mb/)
-    // The extractor moved from the prose into scripts/heartbeat-metrics.sh
-    // (HBMEMBLIND819 third contract): the measured-output surface and the
-    // missing-field handling are asserted on the SCRIPT now. Older-build
-    // tolerance flipped on purpose: a missing field is an ERROR line + a
-    // non-zero exit, never a silently absent (or zeroed) value.
+  it('db_size flows script -> worker renderer; the scaffold only bans self-measurement', () => {
+    // HBMETRICSWIRE910: the field name left the prose (the agent never sees
+    // COUNTS anymore); the consuming surface is the worker-side renderer.
     const METRICS = readFileSync(join(ROOT, 'scripts', 'heartbeat-metrics.sh'), 'utf-8')
     expect(METRICS).toMatch(/db_size_mb=%s/)
     expect(METRICS).toMatch(/required = \[[^\]]*'db_size_mb'/)
-    // The drifted surface itself: the template placeholder with no source.
+    const INJECT = readFileSync(join(ROOT, 'src', 'web', 'heartbeat-metrics-inject.ts'), 'utf-8')
+    expect(INJECT).toMatch(/db_size_mb/)
+    // The drifted surface itself: a template placeholder with no source.
     expect(SCAFFOLD).not.toMatch(/DB size: <X> MB/)
-    // Missing/null degrades to "no data", never to a self-run measurement.
-    expect(SCAFFOLD).toMatch(/nincs adat \(muszer-hiba\)/)
+    expect(SCAFFOLD).not.toMatch(/counts\.db_size_mb/)
+    // The prose's remaining duty: the class-wide self-measurement ban, du
+    // and stat named (the 2026-09-10/11 fingerprint was a du-shaped size).
+    expect(SCAFFOLD).toMatch(/du \/ ls \/ stat/)
+    expect(SCAFFOLD).toMatch(/du-shaped DB\s+size 488/)
   })
 })

--- a/src/__tests__/heartbeat-hot-memory-count.test.ts
+++ b/src/__tests__/heartbeat-hot-memory-count.test.ts
@@ -100,14 +100,15 @@ describe('wiring contract: the number flows endpoint -> agent, never agent -> qu
     expect(builder).toMatch(/new_hot_memories_1h:\s*newHotMemories1h/)
   })
 
-  it('the scaffold tells the agent to COPY the field and forbids running a query for it', () => {
-    expect(SCAFFOLD).toMatch(/counts\.new_hot_memories_1h/)
-    // The memory bullet must not prescribe (or even show) a runnable
-    // hot-memory SQL anymore -- that is the exact surface that drifted twice.
+  it('the field flows endpoint -> worker renderer; the agent prose carries no query surface', () => {
+    // HBMETRICSWIRE910: the consuming surface moved from the prose to the
+    // worker-side renderer; the prose must not even name the field, let
+    // alone show a runnable query -- the exact surface that drifted twice.
+    const INJECT = readFileSync(join(ROOT, 'src', 'web', 'heartbeat-metrics-inject.ts'), 'utf-8')
+    expect(INJECT).toMatch(/new_hot_memories_1h/)
+    expect(SCAFFOLD).not.toMatch(/counts\.new_hot_memories_1h/)
     expect(SCAFFOLD).not.toMatch(/FROM memories[\s\S]{0,120}category='hot'/)
-    // Missing field degrades to "no data", never to a self-run query or a 0.
-    // (Phrase updated with the HBMEMBLIND819 third contract: the missing
-    // field now surfaces as the instrument's ERROR line.)
-    expect(SCAFFOLD).toMatch(/nincs adat \(muszer-hiba\)/)
+    // A failure arrives as a muszer-hiba line the round must carry verbatim.
+    expect(SCAFFOLD).toMatch(/muszer-hiba/)
   })
 })

--- a/src/__tests__/heartbeat-metrics-inject.test.ts
+++ b/src/__tests__/heartbeat-metrics-inject.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from 'vitest'
+import {
+  renderHeartbeatMetricsBlock,
+  HB_METRICS_BLOCK_MARKER,
+  HB_METRICS_SENTINEL,
+} from '../web/heartbeat-metrics-inject.js'
+
+// A full, healthy instrument output in the exact line vocabulary of
+// scripts/heartbeat-metrics.sh (its own conformance test pins that side).
+const HAPPY = [
+  'HB_METRICS_V1 ts=2026-09-11 11:00',
+  'COUNTS urgent=2 in_progress=1 waiting=371 planned=545 new_hot_memories_1h=0 db_size_mb=474.4 waiting_shown=2',
+  'URGENT CARDA CARDA (URGENT): first urgent title',
+  'URGENT CARDB CARDB: second one',
+  'WAITING CARDC CARDC: a waiting card',
+  'WAITING CARDD CARDD: another waiting card',
+  'CALENDAR_EVENTS n=2 window=2h',
+  'CAL_EVENT all-day Stay somewhere nice attendees=1',
+  'CAL_EVENT 08:00 Új esemény',
+  'SCHEDULES enabled=34',
+  'TASK_RUNS_1H total=41 fired=12 skipped=29',
+].join('\n')
+
+describe('renderHeartbeatMetricsBlock -- happy path', () => {
+  const out = renderHeartbeatMetricsBlock(HAPPY)
+
+  it('opens with the marker line carrying the INSTRUMENT ts, not wall clock', () => {
+    expect(out.startsWith(`${HB_METRICS_BLOCK_MARKER} ts=2026-09-11 11:00`)).toBe(true)
+  })
+
+  it('renders every number from COUNTS and nowhere else', () => {
+    expect(out).toContain('- urgent: 2 (CARDA, CARDB)')
+    expect(out).toContain('- in_progress: 1')
+    expect(out).toContain('- waiting: 371 (2 legfrissebb: CARDC, CARDD)')
+    expect(out).toContain('- planned: 545')
+    expect(out).toContain('- DB size: 474.4 MB')
+    expect(out).toContain('- new hot memories (1h): 0')
+  })
+
+  it('carries the TASK_RUNS_1H line verbatim -- the *1000 cutoff stays un-rederivable', () => {
+    expect(out).toContain('- last hour: TASK_RUNS_1H total=41 fired=12 skipped=29')
+  })
+
+  it('renders calendar events with time and attendee suffix folded to parentheses', () => {
+    expect(out).toContain('- all-day -- Stay somewhere nice (attendees=1)')
+    expect(out).toContain('- 08:00 -- Új esemény')
+  })
+
+  it('renders the schedules count from the SCHEDULES line', () => {
+    expect(out).toContain('- enabled schedules: 34')
+  })
+
+  it('contains no muszer-hiba line when everything measured', () => {
+    // The header MENTIONS muszer-hiba (it instructs that such a line travels
+    // unchanged); what must be absent is an actual failure line.
+    expect(out).not.toContain('- muszer-hiba')
+  })
+})
+
+describe('measured empty vs failed query stay DIFFERENT lines (5E0A32B0)', () => {
+  it('CALENDAR_EVENTS n=0 renders "no upcoming events"', () => {
+    const raw = [
+      'HB_METRICS_V1 ts=2026-09-11 12:00',
+      'COUNTS urgent=0 in_progress=0 waiting=1 planned=2 new_hot_memories_1h=0 db_size_mb=100 waiting_shown=1',
+      'WAITING X X: t',
+      'CALENDAR_EVENTS n=0 window=2h',
+      'SCHEDULES enabled=1',
+      'TASK_RUNS_1H total=0',
+    ].join('\n')
+    const out = renderHeartbeatMetricsBlock(raw)
+    expect(out).toContain('- no upcoming events')
+    expect(out).not.toContain('calendar fetch failed')
+  })
+
+  it('ERROR calendar renders the failure with its reason verbatim', () => {
+    const raw = [
+      'HB_METRICS_V1 ts=2026-09-11 12:00',
+      'COUNTS urgent=0 in_progress=0 waiting=1 planned=2 new_hot_memories_1h=0 db_size_mb=100 waiting_shown=1',
+      'ERROR calendar: token expired for calendar scope',
+      'SCHEDULES enabled=1',
+      'TASK_RUNS_1H total=0',
+    ].join('\n')
+    const out = renderHeartbeatMetricsBlock(raw)
+    expect(out).toContain('- calendar fetch failed: token expired for calendar scope')
+    expect(out).not.toContain('no upcoming events')
+  })
+})
+
+describe('fail-closed rendering -- a value the instrument did not print never becomes a number', () => {
+  it('ERROR summary poisons kanban AND memory sections, leaves tasks intact', () => {
+    const raw = [
+      'HB_METRICS_V1 ts=2026-09-11 12:00',
+      'ERROR summary: missing/null fields: db_size_mb',
+      'CALENDAR_EVENTS n=0 window=2h',
+      'SCHEDULES enabled=5',
+      'TASK_RUNS_1H total=3 fired=3',
+    ].join('\n')
+    const out = renderHeartbeatMetricsBlock(raw)
+    expect(out).toContain('### Kanban\n- muszer-hiba: ERROR summary: missing/null fields: db_size_mb')
+    expect(out).toContain('### Memory / system\n- muszer-hiba: ERROR summary: missing/null fields: db_size_mb')
+    expect(out).toContain('- enabled schedules: 5')
+    expect(out).toContain('- no upcoming events')
+    // The load-bearing negative: no fabricated zero anywhere.
+    expect(out).not.toMatch(/DB size: 0/)
+    expect(out).not.toMatch(/urgent: 0/)
+  })
+
+  it('ERROR token (API-wide) surfaces in every API-backed section that has no data', () => {
+    const raw = [
+      'HB_METRICS_V1 ts=2026-09-11 12:00',
+      'ERROR token: cannot read .dashboard-token: boom',
+      'TASK_RUNS_1H total=3 fired=3',
+    ].join('\n')
+    const out = renderHeartbeatMetricsBlock(raw)
+    const hits = out.match(/muszer-hiba: ERROR token/g) ?? []
+    // calendar + kanban + schedules + memory = 4 sections; task_runs measured.
+    expect(hits.length).toBe(4)
+    expect(out).toContain('- last hour: TASK_RUNS_1H total=3 fired=3')
+  })
+})
+
+describe('the sentinel rule lives here now -- unknown output is instrument failure', () => {
+  it('a non-sentinel first line renders muszer-hiba with that literal line in EVERY section', () => {
+    const out = renderHeartbeatMetricsBlock('bash: /x/heartbeat-metrics.sh: No such file or directory')
+    const hits = out.match(/- muszer-hiba: bash: \/x\/heartbeat-metrics\.sh: No such file or directory/g) ?? []
+    expect(hits.length).toBe(4)
+  })
+
+  it('a FUTURE sentinel version reads as instrument failure, never accepted as "looks right"', () => {
+    // Marveen's stipulation on HBMEMBLIND819 (2026-08-25), carried over: the
+    // known-version check must fail closed on V2 under V1 code.
+    const out = renderHeartbeatMetricsBlock(HAPPY.replace(HB_METRICS_SENTINEL, 'HB_METRICS_V2'))
+    expect(out).toMatch(/muszer-hiba: HB_METRICS_V2 ts=2026-09-11 11:00/)
+    expect(out).not.toContain('- urgent: 2')
+  })
+
+  it('empty output renders the named empty-output failure', () => {
+    const out = renderHeartbeatMetricsBlock('   \n')
+    expect(out).toMatch(/muszer-hiba: \(empty instrument output\)/)
+  })
+
+  it('null input (spawn error / timeout) carries the supplied reason', () => {
+    const out = renderHeartbeatMetricsBlock(null, 'instrument timeout after 30000 ms')
+    const hits = out.match(/- muszer-hiba: instrument timeout after 30000 ms/g) ?? []
+    expect(hits.length).toBe(4)
+  })
+})
+
+describe('block header contract', () => {
+  it('tells the round the sections are final and muszer-hiba travels unchanged', () => {
+    const out = renderHeartbeatMetricsBlock(HAPPY)
+    expect(out).toContain('VEGLEGES torzse')
+    expect(out).toMatch(/muszer-hiba\s*\n?sor is VALTOZATLANUL/)
+  })
+
+  it('contains no em-dash (project style rule)', () => {
+    expect(renderHeartbeatMetricsBlock(HAPPY)).not.toContain(String.fromCharCode(0x2014))
+    expect(renderHeartbeatMetricsBlock(null, 'x')).not.toContain(String.fromCharCode(0x2014))
+  })
+})

--- a/src/__tests__/heartbeat-metrics-script.test.ts
+++ b/src/__tests__/heartbeat-metrics-script.test.ts
@@ -133,14 +133,15 @@ describe('path binding (a rename must fail in CI, not at 22:00 on the host)', ()
     expect(src).toMatch(/'scripts',\s*'heartbeat-metrics\.sh'/)
   })
 
-  it('script and scaffold agree on the sentinel version', () => {
-    // The reporter accepts ONLY the known sentinel; if the script ever
-    // bumps to V2, the prose must move in the same commit or every round
-    // reads as instrument failure.
+  it('script and the worker-side renderer agree on the sentinel version', () => {
+    // The consumer moved from the prose to heartbeat-metrics-inject.ts
+    // (HBMETRICSWIRE910); the invariant is unchanged: if the script ever
+    // bumps to V2, the renderer must move in the same commit or every round
+    // carries an instrument-failure block.
     const script = readFileSync(SCRIPT, 'utf8')
-    const scaffold = readFileSync(join(REPO_ROOT, 'src', 'web', 'heartbeat-agent-scaffold.ts'), 'utf8')
+    const inject = readFileSync(join(REPO_ROOT, 'src', 'web', 'heartbeat-metrics-inject.ts'), 'utf8')
     expect(script).toContain('echo "HB_METRICS_V1 ')
-    expect(scaffold).toContain('HB_METRICS_V1')
+    expect(inject).toContain("HB_METRICS_SENTINEL = 'HB_METRICS_V1'")
   })
 })
 

--- a/src/__tests__/heartbeat-summary-truncation-safe.test.ts
+++ b/src/__tests__/heartbeat-summary-truncation-safe.test.ts
@@ -90,12 +90,16 @@ describe('wiring: the endpoint serves the pure builder, the scaffold forbids cou
     expect(handler).toMatch(/countPlannedKanbanCards\(\)/)
   })
 
-  it('the scaffold says numbers come from the COUNTS line only and names the drift incident', () => {
-    // Wording moved with the HBMEMBLIND819 third contract: the copy-surface
-    // is now the instrument's COUNTS line (fed by counts.*), and the ban on
-    // counting the capped lists is stated next to it.
-    expect(SCAFFOLD).toMatch(/EVERY number comes from this line and nowhere else/)
-    expect(SCAFFOLD).toMatch(/HBKANBANDRIFT819/)
-    expect(SCAFFOLD).toMatch(/counting list items once\s+reported waiting: 12 against a real 280/)
+  it('the count/list separation moved into the worker renderer; the prose carries no COUNTS surface', () => {
+    // HBMETRICSWIRE910: the agent never sees a COUNTS line to (mis)count
+    // from -- the renderer prints the count from COUNTS and appends the
+    // capped id list as a parenthetical only. The behavioural pin lives in
+    // heartbeat-metrics-inject.test.ts (waiting: 371 rendered beside 2
+    // WAITING lines, the HBKANBANDRIFT819 shape); here we pin that the
+    // prose retired the countable surface instead of re-instructing it.
+    expect(SCAFFOLD).not.toMatch(/EVERY number comes from this line/)
+    expect(SCAFFOLD).not.toContain('COUNTS')
+    const INJECT = readFileSync(join(ROOT, 'src', 'web', 'heartbeat-metrics-inject.ts'), 'utf-8')
+    expect(INJECT).toMatch(/HBKANBANDRIFT819/)
   })
 })

--- a/src/__tests__/heartbeat-urgent-open-only.test.ts
+++ b/src/__tests__/heartbeat-urgent-open-only.test.ts
@@ -135,27 +135,38 @@ describe('there is ONE definition, and both consumers read it', () => {
   })
 })
 
-describe('the heartbeat AGENT is handed the list, not a filter to re-apply', () => {
+describe('the heartbeat AGENT is handed the rendered block, not a filter to re-apply', () => {
+  // HBMETRICSWIRE910: the kanban fetch moved out of the agent prose
+  // entirely -- the WORKER's instrument calls the endpoint, the worker-side
+  // renderer prints the final lines, and the agent copies the block.
   const SCAFFOLD_SRC = readFileSync(join(ROOT, 'src', 'web', 'heartbeat-agent-scaffold.ts'), 'utf-8')
-  // The kanban step lives inside the single Metrics instrument bullet since
-  // the HBMEMBLIND819 third contract; the window is that bullet's own bounds.
-  const kanbanBlock = SCAFFOLD_SRC.slice(
-    SCAFFOLD_SRC.indexOf('- **Metrics ('),
-    SCAFFOLD_SRC.indexOf('2. **Format**'),
-  )
 
-  it('the kanban step is one endpoint call', () => {
-    expect(kanbanBlock).toContain('/api/kanban/heartbeat-summary')
+  it('the endpoint call lives in the instrument, not in the agent prose', () => {
+    const script = readFileSync(join(ROOT, 'scripts', 'heartbeat-metrics.sh'), 'utf-8')
+    expect(script).toContain('/api/kanban/heartbeat-summary')
+    expect(SCAFFOLD_SRC).not.toContain('/api/kanban/heartbeat-summary')
   })
 
-  it('that step no longer asks the agent to compose SQL or to run sqlite3', () => {
-    expect(kanbanBlock).not.toMatch(/sqlite3 \$\{id\.storeDir\}/)
-    expect(kanbanBlock).not.toMatch(/SELECT .* FROM kanban_cards/i)
-    expect(kanbanBlock).not.toMatch(/status != 'done'/)
+  it('the prose no longer asks the agent to compose SQL or to run sqlite3', () => {
+    expect(SCAFFOLD_SRC).not.toMatch(/sqlite3 \$\{id\.storeDir\}/)
+    expect(SCAFFOLD_SRC).not.toMatch(/SELECT .* FROM kanban_cards/i)
+    expect(SCAFFOLD_SRC).not.toMatch(/status != 'done'/)
   })
 
-  it('it says out loud that an empty list stays empty', () => {
-    expect(kanbanBlock).toMatch(/report it as empty/i)
-    expect(kanbanBlock).toMatch(/Do not widen the query|do not fall back|do not fill/i)
+  it('an empty list stays empty in the rendered block -- nothing to fill it with', async () => {
+    // Pin 3 of this file, carried to the new mechanism: an empty urgent list
+    // renders as a bare count with NO parenthetical, and there is no prose
+    // step left where an agent could pad it with closed cards.
+    const { renderHeartbeatMetricsBlock } = await import('../web/heartbeat-metrics-inject.js')
+    const out = renderHeartbeatMetricsBlock([
+      'HB_METRICS_V1 ts=2026-09-11 12:00',
+      'COUNTS urgent=0 in_progress=0 waiting=0 planned=3 new_hot_memories_1h=0 db_size_mb=100 waiting_shown=0',
+      'CALENDAR_EVENTS n=0 window=2h',
+      'SCHEDULES enabled=1',
+      'TASK_RUNS_1H total=0',
+    ].join('\n'))
+    expect(out).toContain('- urgent: 0\n')
+    expect(out).toContain('- waiting: 0\n')
+    expect(out).not.toContain('- muszer-hiba')
   })
 })

--- a/src/web/heartbeat-agent-scaffold.ts
+++ b/src/web/heartbeat-agent-scaffold.ts
@@ -51,6 +51,7 @@ import {
 import { resolveDashboardOrigin } from './agent-scaffold.js'
 import { logger } from '../logger.js'
 import { CHANNEL_PLUGIN_IDS } from './plugin-ids.js'
+import { HB_METRICS_BLOCK_MARKER } from './heartbeat-metrics-inject.js'
 
 const HEARTBEAT_AGENT_NAME = HEARTBEAT_AGENT_ID
 const HEARTBEAT_AGENT_DIR = join(PROJECT_ROOT, 'agents', HEARTBEAT_AGENT_NAME)
@@ -100,10 +101,10 @@ export interface HeartbeatIdentity {
   // Google Calendar account to summarise (display only), or '' to let the
   // server use whatever account it is authenticated as.
   calendarAccount: string
-  // Absolute path to scripts/heartbeat-metrics.sh -- the round's single
-  // callable instrument (HBMEMBLIND819 third contract). The rendered
-  // CLAUDE.md references this path and nothing else about how the
-  // numbers are produced, so there is no command prose left to
+  // Absolute path to scripts/heartbeat-metrics.sh. Since HBMETRICSWIRE910
+  // the WORKER runs it at prompt-build time (heartbeat-metrics-inject.ts);
+  // the rendered CLAUDE.md names the path only as provenance -- the round
+  // itself is forbidden to run it, so there is no command prose left to
   // recompose.
   metricsScript: string
 }
@@ -182,139 +183,59 @@ When you receive the heartbeat prompt:
    1h") is read against it, so an hour of drift silently moves the
    window as well as the label.
 
-1. **Collect** the data -- everything, calendar included, comes from
-   the ONE instrument below:
-   - **Calendar (next 2 hours)** -- comes from the SAME instrument as
-     every other number: the \`CALENDAR_EVENTS\` / \`CAL_EVENT\` /
-     \`ERROR calendar:\` lines of its output (measured server-side on
-     \`${id.dashboardOrigin}/api/heartbeat/calendar\`
-     ${calendarTarget}). You never fetch the calendar yourself: no MCP
-     tool, no curl, no python -- the history of every agent-side fetch
-     variant is a month of migrating symptoms (HBCALMCP808 "tool not
-     available"; then 5E0A32B0: one probe against a NONEXISTENT
-     endpoint on 2026-09-02 15:00 whose failure line was copy-forwarded
-     for a day as "calendar fetch failed: API error" with ZERO real
-     attempts -- the digest lied about the fact of measurement itself).
+1. **Find the measured block in THIS prompt.** Every number -- calendar,
+   kanban, tasks, memory, DB size -- arrives PRE-RENDERED in the prompt
+   itself, in a block that starts with the marker line
+   \`${HB_METRICS_BLOCK_MARKER} ts=...\`. The WORKER already ran the
+   on-disk instrument (\`${id.metricsScript}\`, every number measured
+   server-side on \`${id.dashboardOrigin}\`; the calendar ${calendarTarget})
+   at prompt-build time and rendered its output into the FINAL report
+   sections.
 
-     The two calendar end-states are DIFFERENT lines, keep them apart:
-     \`CALENDAR_EVENTS n=0\` is a MEASURED empty calendar -> report
-     "no upcoming events"; \`ERROR calendar: <reason>\` is a failed
-     query -> report "calendar fetch failed: <reason>" with the reason
-     verbatim, so the main agent can act on it (an expired token must
-     surface as an expired token, not as a quiet free morning).
-   - **Metrics (kanban + tasks + memory + DB size)** -- ONE fixed,
-     on-disk instrument. Run it EXACTLY as written and copy its output
-     lines VERBATIM into the report sections below; never recompose any
-     of its measurements yourself:
+   THE BLOCK RULE (HBMETRICSWIRE910, supersedes the old sentinel rule):
+   your report's body is that block's sections, copied VERBATIM. You
+   never run the instrument, and you NEVER rebuild any of its numbers
+   with your own curl / python3 / sqlite3 / du / ls / stat / calendar
+   call -- not even a correct-looking one-liner. Measured history of
+   the alternative, four failed instruction layers on the same metric:
+   HBMEMBLIND807 (self-composed SQL, false 0), HBMEMBLIND819
+   (recomposed with wrong agent_id, 14/14 rounds false 0), 2026-08-24
+   (truncated format string, false 0), and 2026-09-10/11 (du-shaped DB
+   size 488 vs the instrument's 473.6, shipped even by a fresh-context
+   round WHILE the run-it-yourself instruction stood). The worker-side
+   injection exists because instructing this step was measured not to
+   hold; re-measuring "to be sure" is the defect, not diligence.
 
-     \`\`\`bash
-     CLAW_STORE_DIR=${id.storeDir} CLAW_DASHBOARD_ORIGIN=${id.dashboardOrigin} CLAW_TZ=${APP_TZ} bash ${id.metricsScript}
-     \`\`\`
+   A \`muszer-hiba: ...\` line inside the block IS the measured result:
+   copy it through unchanged. The instrument and the renderer are
+   fail-closed -- a value they could not measure never appears as 0,
+   so a fabricated 0 (or any number not present in the block) is
+   always a defect in YOUR round.
 
-     THE SENTINEL RULE (HBMEMBLIND819): a number may enter your report
-     ONLY from an output whose FIRST line starts with the known
-     sentinel \`HB_METRICS_V1\`. Anything else -- an unknown or newer
-     sentinel (a future \`HB_METRICS_V2\` under these instructions
-     included), "No such file or directory", a shell error, empty
-     output -- is an INSTRUMENT FAILURE: put the literal first line of
-     what you got into EVERY affected section as
-     \`muszer-hiba: <line>\`. NEVER write 0 for a value the instrument
-     did not print, and NEVER rebuild these numbers with your own
-     curl / python3 / sqlite3 / du / ls / stat -- not even a
-     correct-looking one-liner. That includes the pipe+heredoc shape
-     that produced HBHEREDOC819 (\`echo "$X" | python3 << 'PY'\` loses
-     the piped data silently: the heredoc becomes python3's stdin).
-
-     If the output contains \`ERROR <section>: <reason>\` lines, copy
-     each into its section verbatim as \`muszer-hiba: ERROR ...\` and
-     use the lines that ARE present -- partial output is fine, silence
-     and substitution are not. The instrument is fail-closed: a
-     missing or null field never prints as 0, so
-     \`new hot memories (1h): nincs adat (muszer-hiba)\` is the honest
-     report and a fabricated 0 is the defect.
-
-     Why a fixed script and not a prescribed command, measured three
-     times on the SAME metric: 2026-08-07 (HBMEMBLIND807) a prose
-     bullet let the round compose its own SQL (reported 0 beside 3 hot
-     memories); the fix prescribed a ready-made query, and 2026-08-19
-     (HBMEMBLIND819) post-compact rounds reconstructed it with the
-     wrong agent_id (14/14 rounds a false 0); the next fix shipped a
-     ready-made one-liner, and 2026-08-24 22:00 a round re-composed
-     THAT with a truncated format string, so the missing field printed
-     as 0 again. A prescription you must re-copy every hour is not a
-     mechanism; a script on disk has nothing to recompose.
-
-     What the lines mean, and where each number is allowed to come from:
-     - \`COUNTS ...\` -- kanban totals plus \`counts.new_hot_memories_1h\`
-       and \`counts.db_size_mb\`, all computed server-side on
-       \`${id.dashboardOrigin}/api/kanban/heartbeat-summary\` and copied
-       through. EVERY number comes from this line and nowhere else
-       (HBKANBANDRIFT819: the URGENT/WAITING lists are capped and
-       their titles truncated BY DESIGN -- counting list items once
-       reported waiting: 12 against a real 280).
-     - \`URGENT <id> <title>\` / \`WAITING <id> <title>\` -- only
-       UNFINISHED cards, never \`done\`, \`planned\` included. If a
-       list is empty, report it as empty: do not widen the query, do
-       not fill the line with closed cards. An empty urgent list is
-       the good news, and a report nobody can trust to be empty is a
-       report nobody reads.
-     - \`SCHEDULES enabled=N\` -- the live registry
-       (\`${id.dashboardOrigin}/api/schedules\`), NOT the
-       \`scheduled_tasks\` table (empty on this deployment; a count
-       from it reports 0 forever).
-     - \`TASK_RUNS_1H ...\` -- what actually ran in the last hour.
-       \`task_runs.ts\` is in MILLISECONDS and the script bakes the
-       \`*1000\` cutoff in -- exactly the kind of trap that must never
-       be re-derived by hand.
-     HBWARN807 still holds: there is NO warnings metric here on
-     purpose. The old bullet pointed at a source that does not exist
-     (memories has no status column, the store has no such log table),
-     so the line could only ever say 'none' -- an unfalsifiable metric
-     is zero evidence wearing the costume of a check. If a warnings
-     line ever returns, it must come as a field of this instrument's
-     output, backed by a real source.
+   If the prompt contains NO \`${HB_METRICS_BLOCK_MARKER}\` marker at
+   all, that itself is the finding: send the report with
+   \`muszer-hiba: hianyzo metrika-blokk (worker-injektalas kimaradt)\`
+   as every section's only line. Do not fill in anything yourself.
 
 2. **Format** the result as a single inter-agent message:
 
    \`\`\`
    ## Heartbeat <the string step 0 measured> (${APP_TZ})
+   merve: <the ts= value from the block's marker line>
 
-   ### Calendar (next 2h)
-   - HH:MM -- <summary> (attendees=N)   <one line per CAL_EVENT, verbatim>
-   - <or: "no upcoming events"          -- ONLY from CALENDAR_EVENTS n=0>
-   - <or: "calendar fetch failed: <reason>" -- ONLY from ERROR calendar: of THIS round>
-
-   ### Kanban
-   - urgent: <N from COUNTS> (<short titles from the URGENT lines>)
-   - in_progress: <N from COUNTS>
-   - waiting: <N from COUNTS> (<short titles from the WAITING lines>)
-   - planned: <N from COUNTS>
-
-   ### Tasks
-   - enabled schedules: <N from SCHEDULES>
-   - last hour: <the TASK_RUNS_1H line, verbatim>
-
-   ### Memory / system
-   - DB size: <db_size_mb from COUNTS> MB
-   - new hot memories (1h): <new_hot_memories_1h from COUNTS>
+   <the block's sections, from "### Calendar (next 2h)" to the end,
+    VERBATIM -- no line added, dropped, reworded or renumbered>
    \`\`\`
 
-   Every line above is a MEASUREMENT of this round, never a memory of
-   an earlier one. Run the instrument again and report what it returns
-   now, even when you are sure nothing changed -- especially then.
-   A value carried over from an earlier round makes its line constant,
-   and a line that always says the same thing stops being read -- at
-   which point a real change looks exactly like the noise around it.
-   This is not hypothetical: between 2026-09-02 15:00 and 2026-09-03
-   09:00 every round re-sent "calendar fetch failed: API error" from
-   the previous round's text while making no calendar attempt at all
-   (5E0A32B0) -- the reader believed a query had failed THAT morning
-   when no query had happened. FRESHNESS CHECK, mechanical: the
-   instrument's own \`ts=\` stamp (sentinel line) must fall in the same
-   hour as the step-0 clock string. If it does not, the output in your
-   context is a PREVIOUS round's -- run the instrument again; if the
-   re-run still mismatches, report \`muszer-hiba: stale instrument
-   output (ts=<value>)\` in every section instead of any number.
+   The \`merve:\` line is the reader's freshness check: it carries the
+   ts the WORKER stamped at prompt-build. If it differs from the step-0
+   clock by more than the current hour, the prompt sat parked before
+   you ran -- still report the block verbatim (it is the measurement
+   that was taken), the two timestamps side by side ARE the finding.
+   Never substitute a value remembered from an earlier round: a stale
+   value is indistinguishable from a fresh one once it is in the
+   message (5E0A32B0: a copy-forwarded failure line masked a day of
+   zero real calendar attempts).
 
 3. **Send** that string to the main agent via the dashboard API:
 

--- a/src/web/heartbeat-metrics-inject.ts
+++ b/src/web/heartbeat-metrics-inject.ts
@@ -1,0 +1,280 @@
+// Worker-side heartbeat metrics injection (HBMETRICSWIRE910).
+//
+// Why the WORKER runs the instrument, measured: the hourly heartbeat round
+// (a Haiku agent driven by its CLAUDE.md) was instructed four separate times
+// to run scripts/heartbeat-metrics.sh and copy its output verbatim, and the
+// digest still shipped fabricated numbers -- 2026-09-10 19:00-22:00 every
+// round reported a du-shaped DB size (488) against the instrument's apparent
+// size (473.6), plus hot=0 beside a measured 1. Marveen's pre-registered
+// natural experiment (card HBMETRICSWIRE910, comment 2026-09-10 22:10)
+// resolved to outcome (a): the FIRST round of a fresh session (2026-09-11
+// 09:01) still said 488, so the drift is not context decay -- the round
+// recomposes numbers no matter how fresh it is, and some rounds (11:00 the
+// same day) comply while others do not. An instruction obeyed
+// probabilistically is not a mechanism (HBGATEWIRE826). So the scheduler
+// process runs the instrument at prompt-build time and injects the metric
+// sections PRE-RENDERED in their final report form; the round's only job is
+// to wrap the block in the report header and send it.
+//
+// Fail-closed, carried IN THE TEXT: when the instrument cannot be run or its
+// output does not open with the known sentinel, the injected block itself
+// carries `muszer-hiba: <literal first line>` in every section. The digest
+// then transports the failure without relying on the round's discipline --
+// a sloppy copy of a failure block is still a visible failure, never a
+// fabricated zero and never the previous hour's numbers.
+
+import { execFile } from 'node:child_process'
+import { join } from 'node:path'
+import {
+  PROJECT_ROOT,
+  WEB_PORT,
+  DASHBOARD_PUBLIC_URL,
+  AGENT_API_ORIGIN,
+  STORE_DIR,
+  APP_TZ,
+} from '../config.js'
+import { resolveDashboardOrigin } from './agent-scaffold.js'
+import { logger } from '../logger.js'
+
+export const HB_METRICS_SENTINEL = 'HB_METRICS_V1'
+
+// The marker the heartbeat agent's CLAUDE.md keys on. Kept as an exported
+// constant so the scaffold renderer and the tests reference the SAME string
+// -- a hand-copied marker that drifts is exactly the failure class this
+// module exists to close.
+export const HB_METRICS_BLOCK_MARKER = '[HB-METRIKA-BLOKK'
+
+// How long the instrument may run at prompt-build time. The script's own
+// HTTP calls time out at 10s each; 30s covers the worst honest case, and a
+// hung instrument must not wedge the scheduler tick.
+export const HB_METRICS_TIMEOUT_MS = 30_000
+
+interface ParsedMetrics {
+  ts: string | null
+  counts: Record<string, string> | null
+  waitingShown: string | null
+  urgentIds: string[]
+  waitingIds: string[]
+  calendarN: number | null
+  calEvents: string[] // rendered "- <time> -- <summary>" lines
+  schedulesEnabled: string | null
+  taskRuns: string | null // the TASK_RUNS_1H line, verbatim
+  errors: Map<string, string> // section -> full ERROR line
+}
+
+function parseInstrumentOutput(lines: string[]): ParsedMetrics {
+  const p: ParsedMetrics = {
+    ts: null,
+    counts: null,
+    waitingShown: null,
+    urgentIds: [],
+    waitingIds: [],
+    calendarN: null,
+    calEvents: [],
+    schedulesEnabled: null,
+    taskRuns: null,
+    errors: new Map(),
+  }
+  const tsMatch = lines[0]?.match(/^HB_METRICS_V1 ts=(.+)$/)
+  p.ts = tsMatch ? tsMatch[1] : null
+  for (const line of lines) {
+    if (line.startsWith('COUNTS ')) {
+      const counts: Record<string, string> = {}
+      for (const m of line.slice('COUNTS '.length).matchAll(/(\w+)=(\S+)/g)) {
+        counts[m[1]] = m[2]
+      }
+      p.counts = counts
+      p.waitingShown = counts['waiting_shown'] ?? null
+    } else if (line.startsWith('URGENT ')) {
+      const id = line.split(/\s+/)[1]
+      if (id) p.urgentIds.push(id)
+    } else if (line.startsWith('WAITING ')) {
+      const id = line.split(/\s+/)[1]
+      if (id) p.waitingIds.push(id)
+    } else if (line.startsWith('CALENDAR_EVENTS ')) {
+      const m = line.match(/n=(\d+)/)
+      p.calendarN = m ? Number(m[1]) : null
+    } else if (line.startsWith('CAL_EVENT ')) {
+      // "CAL_EVENT <HH:MM|all-day> <summary...>[ attendees=N]"
+      const rest = line.slice('CAL_EVENT '.length)
+      const sp = rest.indexOf(' ')
+      const time = sp === -1 ? rest : rest.slice(0, sp)
+      let summary = sp === -1 ? '' : rest.slice(sp + 1)
+      const att = summary.match(/\s+attendees=(\d+)$/)
+      if (att) summary = summary.slice(0, att.index) + ` (attendees=${att[1]})`
+      p.calEvents.push(`- ${time} -- ${summary}`)
+    } else if (line.startsWith('SCHEDULES ')) {
+      const m = line.match(/enabled=(\d+)/)
+      p.schedulesEnabled = m ? m[1] : null
+    } else if (line.startsWith('TASK_RUNS_1H ')) {
+      p.taskRuns = line
+    } else if (line.startsWith('ERROR ')) {
+      const m = line.match(/^ERROR (\S+?):/)
+      if (m) p.errors.set(m[1].replace(/:$/, ''), line)
+    }
+  }
+  return p
+}
+
+// One muszer-hiba line for a section whose data is absent: prefer the
+// section's own ERROR line, then the API-wide token error, then the literal
+// first output line -- the reader always sees WHAT the instrument said, never
+// a substituted value.
+function hibaLine(p: ParsedMetrics, section: string, firstLine: string): string {
+  const own = p.errors.get(section)
+  if (own) return `- muszer-hiba: ${own}`
+  const token = p.errors.get('token')
+  if (token) return `- muszer-hiba: ${token}`
+  return `- muszer-hiba: ${firstLine}`
+}
+
+function renderSections(p: ParsedMetrics, firstLine: string): string {
+  const out: string[] = []
+
+  out.push('### Calendar (next 2h)')
+  if (p.errors.has('calendar')) {
+    const reason = p.errors.get('calendar')!.replace(/^ERROR calendar:\s*/, '')
+    out.push(`- calendar fetch failed: ${reason}`)
+  } else if (p.calendarN === 0) {
+    out.push('- no upcoming events')
+  } else if (p.calEvents.length > 0) {
+    out.push(...p.calEvents)
+  } else {
+    out.push(hibaLine(p, 'calendar', firstLine))
+  }
+
+  out.push('')
+  out.push('### Kanban')
+  // Counts come from the COUNTS line, never from the length of the capped
+  // URGENT/WAITING lists (HBKANBANDRIFT819: counting list items once
+  // reported waiting: 12 against a real 280) -- the lists only annotate.
+  if (p.counts && p.counts['urgent'] != null) {
+    const c = p.counts
+    const urgent = p.urgentIds.length ? ` (${p.urgentIds.join(', ')})` : ''
+    const shown = p.waitingShown && p.waitingIds.length
+      ? ` (${p.waitingShown} legfrissebb: ${p.waitingIds.join(', ')})`
+      : ''
+    out.push(`- urgent: ${c['urgent']}${urgent}`)
+    out.push(`- in_progress: ${c['in_progress']}`)
+    out.push(`- waiting: ${c['waiting']}${shown}`)
+    out.push(`- planned: ${c['planned']}`)
+  } else {
+    out.push(hibaLine(p, 'summary', firstLine))
+  }
+
+  out.push('')
+  out.push('### Tasks')
+  out.push(p.schedulesEnabled != null
+    ? `- enabled schedules: ${p.schedulesEnabled}`
+    : hibaLine(p, 'schedules', firstLine))
+  out.push(p.taskRuns != null
+    ? `- last hour: ${p.taskRuns}`
+    : hibaLine(p, 'task_runs', firstLine))
+
+  out.push('')
+  out.push('### Memory / system')
+  if (p.counts && p.counts['db_size_mb'] != null) {
+    out.push(`- DB size: ${p.counts['db_size_mb']} MB`)
+    out.push(`- new hot memories (1h): ${p.counts['new_hot_memories_1h']}`)
+  } else {
+    out.push(hibaLine(p, 'summary', firstLine))
+  }
+
+  return out.join('\n')
+}
+
+// Every section reduced to the same single failure line -- the shape a total
+// instrument failure (no sentinel, spawn error, timeout) renders as.
+function renderFailureSections(firstLine: string): string {
+  const hiba = `- muszer-hiba: ${firstLine}`
+  return [
+    '### Calendar (next 2h)', hiba, '',
+    '### Kanban', hiba, '',
+    '### Tasks', hiba, '',
+    '### Memory / system', hiba,
+  ].join('\n')
+}
+
+/**
+ * Pure renderer: instrument stdout (or a failure reason when it could not be
+ * run) -> the final-form block injected into the heartbeat prompt. Exported
+ * for unit tests; collectHeartbeatMetricsBlock() is the runtime entry.
+ *
+ * The sentinel rule lives HERE now (moved from the round's instructions): a
+ * number enters the block only from an output whose first line starts with
+ * HB_METRICS_V1. Anything else renders as muszer-hiba carrying the literal
+ * first line.
+ */
+export function renderHeartbeatMetricsBlock(raw: string | null, failureReason?: string): string {
+  const now = new Date().toLocaleString('sv-SE', { timeZone: APP_TZ }).slice(0, 16)
+  let body: string
+  let tsLabel = now
+  if (raw == null) {
+    body = renderFailureSections(failureReason ?? 'instrument did not run')
+  } else {
+    const lines = raw.split('\n').map(l => l.trimEnd()).filter((l, i) => l.length > 0 || i === 0)
+    const firstLine = (lines[0] ?? '').trim() || '(empty instrument output)'
+    if (!firstLine.startsWith(HB_METRICS_SENTINEL + ' ')) {
+      body = renderFailureSections(firstLine)
+    } else {
+      const parsed = parseInstrumentOutput(lines)
+      if (parsed.ts) tsLabel = parsed.ts
+      body = renderSections(parsed, firstLine)
+    }
+  }
+  return (
+    `${HB_METRICS_BLOCK_MARKER} ts=${tsLabel} -- a worker merte prompt-osszeallitaskor]\n` +
+    'Az alabbi szekciok a jelentes VEGLEGES torzse. Masold be VALTOZATLANUL,\n' +
+    'szamot, cimet, sort nem irhatsz at es nem merhetsz ujra. A muszer-hiba\n' +
+    'sor is VALTOZATLANUL megy tovabb -- az a mert eredmeny.\n\n' +
+    body
+  )
+}
+
+/**
+ * Run the on-disk instrument and render the block. Never throws and never
+ * returns null: a spawn error, timeout or bad output becomes a muszer-hiba
+ * block, so the scheduler tick always has something to inject and the digest
+ * always says what happened.
+ *
+ * Non-zero exit with usable stdout is NOT a failure here: the script is
+ * fail-closed per section (partial output carries its own ERROR lines), so
+ * stdout is rendered whenever it opens with the sentinel.
+ */
+export function collectHeartbeatMetricsBlock(): Promise<string> {
+  const script = join(PROJECT_ROOT, 'scripts', 'heartbeat-metrics.sh')
+  const origin = resolveDashboardOrigin(DASHBOARD_PUBLIC_URL, WEB_PORT, AGENT_API_ORIGIN)
+  return new Promise(resolve => {
+    execFile(
+      'bash',
+      [script],
+      {
+        env: {
+          ...process.env,
+          CLAW_STORE_DIR: STORE_DIR,
+          CLAW_DASHBOARD_ORIGIN: origin,
+          CLAW_TZ: APP_TZ,
+        },
+        timeout: HB_METRICS_TIMEOUT_MS,
+        maxBuffer: 1024 * 1024,
+      },
+      (err, stdout) => {
+        const out = typeof stdout === 'string' ? stdout : ''
+        if (out.trim().length > 0) {
+          // Partial-but-sentineled output is the instrument speaking; the
+          // renderer decides section by section. Log the exit for the record.
+          if (err) {
+            logger.warn({ err: String(err) }, 'heartbeat metrics instrument exited non-zero; rendering its (fail-closed) output')
+          }
+          resolve(renderHeartbeatMetricsBlock(out))
+        } else {
+          const reason = err
+            ? (err.killed ? `instrument timeout after ${HB_METRICS_TIMEOUT_MS} ms` : String(err.message ?? err).split('\n')[0])
+            : '(empty instrument output)'
+          logger.error({ reason }, 'heartbeat metrics instrument produced no output')
+          resolve(renderHeartbeatMetricsBlock(null, reason))
+        }
+      },
+    )
+  })
+}

--- a/src/web/schedule-runner.ts
+++ b/src/web/schedule-runner.ts
@@ -1,5 +1,6 @@
 import { join, isAbsolute } from 'node:path'
 import { checkTaskMcpRequirements } from './schedule-mcp-precheck.js'
+import { collectHeartbeatMetricsBlock } from './heartbeat-metrics-inject.js'
 import { existsSync, readFileSync } from 'node:fs'
 import { spawnSync } from 'node:child_process'
 import { atomicWriteFileSync } from './atomic-write.js'
@@ -895,9 +896,24 @@ async function attemptFireTask(
     // Use the scheduled-task framing instead: tags are still scrubbed (so a
     // poisoned body cannot smuggle a fake security tag) but the preamble marks
     // it as a task-to-execute with the standard escalate-if-dangerous guard.
-    const taskBody = preCheckPrefix
-      ? `[Pre-check eredmeny]\n${preCheckPrefix}\n\n[Feladat]\n${task.prompt}`
+    //
+    // HBMETRICSWIRE910: for a heartbeat task flagged injectMetrics, the
+    // runner executes the on-disk instrument NOW and appends its output in
+    // final report form. Inside the scrubbed body on purpose: the block
+    // carries kanban titles (operator-adjacent but free text), so it gets the
+    // same tag-scrub as the rest of the task body. collectHeartbeatMetricsBlock
+    // never throws and never returns empty -- an instrument failure arrives as
+    // a muszer-hiba block, which is a result to deliver, not a reason to skip.
+    let metricsBlock: string | null = null
+    if (task.type === 'heartbeat' && task.injectMetrics) {
+      metricsBlock = await collectHeartbeatMetricsBlock()
+    }
+    const promptWithMetrics = metricsBlock
+      ? `${task.prompt}\n\n${metricsBlock}`
       : task.prompt
+    const taskBody = preCheckPrefix
+      ? `[Pre-check eredmeny]\n${preCheckPrefix}\n\n[Feladat]\n${promptWithMetrics}`
+      : promptWithMetrics
     const fullPrompt =
       SCHEDULED_TASK_PREAMBLE + '\n' +
       prefix.trimEnd() + '\n\n' +

--- a/src/web/scheduled-tasks-io.ts
+++ b/src/web/scheduled-tasks-io.ts
@@ -113,6 +113,13 @@ export interface ScheduledTask {
   // target session before injecting the prompt; a dead server defers the task
   // with a reasoned alert instead of a silent runtime failure.
   requires?: { mcp_servers?: string[] }
+  // type='heartbeat' only (HBMETRICSWIRE910): the runner executes
+  // scripts/heartbeat-metrics.sh at prompt-build time and appends its output
+  // PRE-RENDERED in final report form to the prompt. The receiving round
+  // copies the block verbatim instead of running the instrument itself --
+  // instructing the round to run it was measured failing 4 separate times
+  // (fabricated numbers with the instruction standing).
+  injectMetrics?: boolean
 }
 
 function readFileOr(path: string, fallback: string): string {
@@ -145,7 +152,7 @@ export function readScheduledTask(taskName: string): ScheduledTask | null {
   const skillContent = hasSkill ? readFileOr(skillPath, '') : ''
   const { name, description, body } = parseSkillMdFrontmatter(skillContent)
 
-  let config: { schedule?: string; agent?: string; enabled?: boolean; createdAt?: number; type?: string; skipIfBusy?: boolean; requiresDesktop?: boolean; forceSend?: boolean; targetSession?: string; description?: string; command?: string; timeoutMs?: number; failThreshold?: number; preCheck?: string; catchUpMaxAgeMinutes?: unknown; stuckAfterMinutes?: unknown; requires?: { mcp_servers?: unknown } } = {}
+  let config: { schedule?: string; agent?: string; enabled?: boolean; createdAt?: number; type?: string; skipIfBusy?: boolean; requiresDesktop?: boolean; forceSend?: boolean; targetSession?: string; description?: string; command?: string; timeoutMs?: number; failThreshold?: number; preCheck?: string; catchUpMaxAgeMinutes?: unknown; stuckAfterMinutes?: unknown; requires?: { mcp_servers?: unknown }; injectMetrics?: unknown } = {}
   try {
     config = JSON.parse(readFileOr(configPath, '{}'))
   } catch { /* use defaults */ }
@@ -170,6 +177,7 @@ export function readScheduledTask(taskName: string): ScheduledTask | null {
     catchUpMaxAgeMinutes: parseCatchUpMaxAge(config.catchUpMaxAgeMinutes),
     stuckAfterMinutes: parseFiniteMinutes(config.stuckAfterMinutes),
     requires: parseRequires(config.requires),
+    injectMetrics: config.injectMetrics === true,
   }
 }
 
@@ -210,7 +218,7 @@ export function listScheduledTasks(): ScheduledTask[] {
 
 export function writeScheduledTask(
   taskName: string,
-  data: { description?: string; prompt?: string; schedule?: string; agent?: string; enabled?: boolean; type?: string; skipIfBusy?: boolean; forceSend?: boolean; targetSession?: string; command?: string; timeoutMs?: number; failThreshold?: number; preCheck?: string; catchUpMaxAgeMinutes?: number; stuckAfterMinutes?: number },
+  data: { description?: string; prompt?: string; schedule?: string; agent?: string; enabled?: boolean; type?: string; skipIfBusy?: boolean; forceSend?: boolean; targetSession?: string; command?: string; timeoutMs?: number; failThreshold?: number; preCheck?: string; catchUpMaxAgeMinutes?: number; stuckAfterMinutes?: number; injectMetrics?: boolean },
 ): void {
   const dir = join(SCHEDULED_TASKS_DIR, taskName)
   mkdirSync(dir, { recursive: true })
@@ -246,6 +254,7 @@ export function writeScheduledTask(
   if (data.preCheck !== undefined) config.preCheck = data.preCheck
   if (data.catchUpMaxAgeMinutes !== undefined) config.catchUpMaxAgeMinutes = data.catchUpMaxAgeMinutes
   if (data.stuckAfterMinutes !== undefined) config.stuckAfterMinutes = data.stuckAfterMinutes
+  if (data.injectMetrics !== undefined) config.injectMetrics = data.injectMetrics
   if (data.description !== undefined) config.description = data.description
   if (!config.createdAt) config.createdAt = Math.floor(Date.now() / 1000)
   atomicWriteFileSync(configPath, JSON.stringify(config, null, 2))


### PR DESCRIPTION
## The live bug

The hourly heartbeat digest ships fabricated numbers WHILE the run-the-instrument instruction stands. Measured 2026-09-10 19:00-22:00: every digest said DB size 488 MB (a du-shaped value) against the instrument's 473.6 (apparent size), plus hot=0 beside a measured 1 and in_progress off by one.

Marveen's pre-registered natural experiment (card comment, 2026-09-10 22:10) resolved to **outcome (a)**: the heartbeat agent restarted at 22:09 with fresh context, and its first digest (09-11 09:01) still said 488 -- so the drift is NOT context decay; the round recomposes numbers no matter how fresh it is, and compliance is nondeterministic (the 11:00 round the same morning got 474.4 right). Fourth failed instruction layer on the same metric (HBMEMBLIND807, HBMEMBLIND819, 2026-08-24, now this). An instruction obeyed probabilistically is not a mechanism.

## The fix

- **`src/web/heartbeat-metrics-inject.ts`** (new): runs `scripts/heartbeat-metrics.sh` at prompt-build time (30s timeout, CLAW_* env) and renders its sentinel output into the FINAL report sections. The sentinel rule moved here from the prose: unknown first line (a future `HB_METRICS_V2` included), spawn error, timeout or empty output all render as `muszer-hiba: <literal first line>` in every section -- **fail-closed carried in the text**, so even a sloppy round transports the failure, never a fabricated zero.
- **`schedule-runner.ts`**: heartbeat tasks flagged `injectMetrics` in task-config.json get the block appended to the (tag-scrubbed) task body.
- **`scheduled-tasks-io.ts`**: the `injectMetrics` flag (default false).
- **`heartbeat-agent-scaffold.ts`** (rendered CLAUDE.md): every runnable surface removed -- no instrument call, no endpoint names, no extractor vocabulary, no COUNTS parsing. What remains: copy the marker-led block verbatim, `merve:` freshness line from the worker-stamped ts, missing-marker => `muszer-hiba: hianyzo metrika-blokk` in every section, and the class-wide self-measurement ban with the four dated failures.

## Tests

- New `heartbeat-metrics-inject.test.ts` (17 cases): happy path, measured-empty vs failed-query calendar (5E0A32B0), ERROR summary/token fail-closed poisoning, non-sentinel/V2/empty/timeout failure shapes, count-vs-capped-list separation (HBKANBANDRIFT819 shape), no-em-dash.
- Six existing contract-test files updated: the properties they pinned (sentinel agreement, endpoint-not-in-prose, empty-list-stays-empty, fabricated-zero ban) are re-pinned against the new mechanism instead of deleted.
- Full suite: 416 files, 5319 passed, tsc clean.

## After merge (stays with Samu, on the card)

Deploy = host update + dashboard restart, then the four acceptance criteria measured ON THE RUNNING WORKER (HBGATEWIRE826 trap): live-round digest == injected block number-for-number; du-fingerprint gone; negative control (broken instrument -> muszer-hiba lines in the sent digest); plus setting `injectMetrics: true` on the live hourly-heartbeat task-config and updating its SKILL.md. The merge is NOT the fix being live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)