### PR TITLE
test(voice): pin condition_on_previous_text=False at both whisper call sites (VOICEWHISPER910)

### DIFF
--- a/src/__tests__/voice-whisper-condition-pin.test.ts
+++ b/src/__tests__/voice-whisper-condition-pin.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+// VOICEWHISPER910: faster-whisper's `condition_on_previous_text` defaults to
+// True, and on a Hungarian voice message with a silent or noisy tail that
+// feeds the model its own previous output, so the transcript loops on one
+// phrase. The fix (#1268) passes `condition_on_previous_text=False` at BOTH
+// call sites in scripts/voice/_vtools.py: the live inbound path (_whisper)
+// and the canary self-test. If either site loses the flag, the loop is back
+// on that path while the other keeps the "fixed" report honest-looking.
+//
+// The behavioural test that proves the loop (scripts/voice/test_vtools_repetition.py)
+// needs the voice venv, piper and ffmpeg, so nothing runs it automatically
+// (measured 2026-09-10: no reference to it anywhere, and its skip exits 0).
+// This file is the cheap pin that DOES run under `npm test`: it asserts far
+// less (the flag is present, not that the loop is gone), but it runs on every
+// PR. Keep the expensive one as the manual proof.
+const ROOT = join(__dirname, '..', '..')
+const SOURCE = join(ROOT, 'scripts', 'voice', '_vtools.py')
+
+/** Every `<model>.transcribe(...)` call with its argument text, multi-line safe. */
+function transcribeCalls(body: string): string[] {
+  return [...body.matchAll(/\.transcribe\(([\s\S]*?)\)/g)].map((m) => m[1])
+}
+
+describe('VOICEWHISPER910: every whisper call site pins condition_on_previous_text=False', () => {
+  const body = readFileSync(SOURCE, 'utf-8')
+  const calls = transcribeCalls(body)
+
+  it('finds both known call sites (live path and canary), so a silently removed site fails too', () => {
+    expect(calls.length, `${SOURCE}: expected the live _whisper call and the canary call`).toBeGreaterThanOrEqual(2)
+  })
+
+  it.each(calls.map((args, i) => [i + 1, args] as const))(
+    'call site %i carries condition_on_previous_text=False',
+    (_i, args) => {
+      expect(args.replace(/\s+/g, '')).toContain('condition_on_previous_text=False')
+    },
+  )
+
+  it('still transcribes Hungarian (the flag was added next to language="hu", not instead of it)', () => {
+    for (const args of calls) expect(args).toContain('language="hu"')
+  })
+})


### PR DESCRIPTION
## What

A cheap, env-free vitest pin for the VOICEWHISPER910 fix (#1268): every `.transcribe(` call in `scripts/voice/_vtools.py` must carry `condition_on_previous_text=False` (and still `language="hu"`), and both known call sites (live inbound path and canary) must exist.

## Why

The behavioural test shipped with #1268 (`scripts/voice/test_vtools_repetition.py`) proves the loop is gone, but it needs the voice venv, piper and ffmpeg. Measured 2026-09-10: nothing references it, the CI test workflow does not run it, and its skip exits 0. So the fix had no regression guard that actually runs. This file runs under `npm test` on every PR. It asserts less than the behavioural test (flag present, not loop absent); the expensive one stays the manual proof.

## Measured

- Fixed tree (`e02b5977`): 4/4 green.
- Negative control: stripping the flag from the canary call site (line 160) turns `call site 2` red, 1 failed / 3 passed; restoring makes it 4/4 again.
- `tsc --noEmit` clean, no em-dash in the file.

Refs VOICEWHISPER910 (kanban card; closes it once merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
