### PR TITLE
test(voice): make the whisper call extractor paren-balanced (VOICEWHISPER910 follow-up to #1285)

### DIFF
--- a/src/__tests__/voice-whisper-condition-pin.test.ts
+++ b/src/__tests__/voice-whisper-condition-pin.test.ts
@@ -19,9 +19,33 @@ import { join } from 'node:path'
 const ROOT = join(__dirname, '..', '..')
 const SOURCE = join(ROOT, 'scripts', 'voice', '_vtools.py')
 
-/** Every `<model>.transcribe(...)` call with its argument text, multi-line safe. */
+/**
+ * Every `<model>.transcribe(...)` call with its full argument text: multi-line
+ * safe, and paren-balanced, so an argument like `vad_parameters=dict(...)`
+ * placed before the flag does not cut the capture short (a lazy match up to
+ * the first `)` would report a false red there, and a false red is how a
+ * guard gets deleted). `def transcribe(` and the bare `transcribe(` call are
+ * not matched: only the method call on the model carries the leading dot.
+ */
 function transcribeCalls(body: string): string[] {
-  return [...body.matchAll(/\.transcribe\(([\s\S]*?)\)/g)].map((m) => m[1])
+  const calls: string[] = []
+  const open = '.transcribe('
+  let from = 0
+  while (true) {
+    const at = body.indexOf(open, from)
+    if (at < 0) break
+    let depth = 1
+    let i = at + open.length
+    while (i < body.length && depth > 0) {
+      if (body[i] === '(') depth++
+      else if (body[i] === ')') depth--
+      i++
+    }
+    expect(depth, `${SOURCE}: unbalanced parentheses after offset ${at}`).toBe(0)
+    calls.push(body.slice(at + open.length, i - 1))
+    from = i
+  }
+  return calls
 }
 
 describe('VOICEWHISPER910: every whisper call site pins condition_on_previous_text=False', () => {


### PR DESCRIPTION
## What

Follow-up to #1285 (merged as 97beb495): the call extractor in `src/__tests__/voice-whisper-condition-pin.test.ts` becomes paren-balanced.

## Why

Samu's review caveat on #1285 (non-blocking, so the merge went ahead): the lazy match stopped at the first `)`. An argument with nested parentheses placed before the flag (e.g. `vad_parameters=dict(...)`) would have cut the capture short and reported a false red. A false red is how a guard gets deleted, so the extractor now walks the parentheses to the matching close. The four assertions are unchanged.

The fix commit was pushed to the #1285 branch two minutes after the squash, so it never reached develop; this PR carries it on a fresh branch off develop.

## Measured on this head (source mutated, then restored byte-identical)

- flag stripped on the live site (line 79): 1 failed / 3 passed
- flag stripped on the canary site (line 160): 1 failed / 3 passed
- nested paren before the flag, flag present: 4/4 green (the caveat case)
- nested paren before the flag, flag stripped: 1 failed / 3 passed
- baseline 4/4 green, `tsc --noEmit` clean, no em-dash

Refs VOICEWHISPER910.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
