### PR TITLE
fix(usage): 401 no-retry + Codex snapshot freshness (USAGE401DIAG910 b+c)

### DIFF
--- a/scripts/__tests__/usage-collect.test.py
+++ b/scripts/__tests__/usage-collect.test.py
@@ -954,6 +954,23 @@ class TestCodexSnapshotFreshness(unittest.TestCase):
             self.assertIsNotNone(result["snapshot_age_hours"])
             self.assertAlmostEqual(result["snapshot_age_hours"], 3.0, delta=0.2)
 
+    def test_collect_codex_no_rate_limits_fails_closed_with_named_state(self):
+        # Regression guard (Marveen review of #1287): the edit that added the
+        # timestamp capture must NOT drop the "no rate_limits entries" raise.
+        # An empty/absent rate_limits payload must fail closed (ok False) with a
+        # message that NAMES THE STATE ("rate_limits") -- so a later round sees
+        # "look at the rollout file", not a bare Python AttributeError.
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "rollout-x.jsonl")
+            with open(path, "w", encoding="utf-8") as f:
+                # a line that mentions rate_limits (so the scan enters the branch)
+                # but whose payload rate_limits is empty -> rate_limits stays None
+                f.write(json.dumps({"type": "event", "payload": {"rate_limits": {}}}) + "\n")
+            with patch.object(uc.glob, "glob", return_value=[path]):
+                result = uc.collect_codex()
+            self.assertFalse(result["ok"])
+            self.assertIn("rate_limits", result.get("error", ""))
+
     def test_collect_codex_no_timestamp_leaves_snapshot_at_none(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = self._rollout(tmp, None)

--- a/scripts/__tests__/usage-collect.test.py
+++ b/scripts/__tests__/usage-collect.test.py
@@ -88,6 +88,14 @@ class TestParseIsoToEpoch(unittest.TestCase):
         expected = datetime(2026, 7, 22, 16, 29, 59, 627285, tzinfo=timezone.utc).timestamp()
         self.assertAlmostEqual(epoch, expected, delta=0.001)
 
+    def test_z_suffix_parses(self):
+        # USAGE401DIAG910: Codex event timestamps end in 'Z'; fromisoformat
+        # rejects that on Python < 3.11, so the parser normalises it.
+        epoch = uc._parse_iso_to_epoch("2026-04-26T12:03:04.051Z")
+        self.assertIsNotNone(epoch)
+        # 2026-04-26T12:03:04Z == the same instant as +00:00
+        self.assertAlmostEqual(epoch, uc._parse_iso_to_epoch("2026-04-26T12:03:04.051+00:00"), places=3)
+
     def test_iso_without_offset_assumes_utc(self):
         epoch = uc._parse_iso_to_epoch("2026-07-22T16:29:59")
         expected = datetime(2026, 7, 22, 16, 29, 59, tzinfo=timezone.utc).timestamp()
@@ -233,6 +241,19 @@ class TestCollectClaudeAuthoritative(unittest.TestCase):
         self.assertEqual(err_kind, "permanent")
         self.assertIn("403", err)
 
+    def test_401_returns_permanent_kind(self):
+        # USAGE401DIAG910: 401 (expired/invalid token) must NOT be transient --
+        # a transient classification serves the stale authoritative cache and
+        # hides that the token needs refreshing. It was misclassified before.
+        http_err = urllib.error.HTTPError("https://api.anthropic.com/api/oauth/usage", 401, "Unauthorized", {}, None)
+        with patch.object(uc, "_read_claude_token", return_value=("fake-token", "test")), \
+             patch.object(uc, "_claude_cli_version", return_value="1.2.3"), \
+             patch("urllib.request.urlopen", side_effect=http_err):
+            windows, err, err_kind = uc._collect_claude_authoritative()
+        self.assertIsNone(windows)
+        self.assertEqual(err_kind, "permanent")
+        self.assertIn("401", err)
+
     def test_429_returns_transient_kind(self):
         http_err = urllib.error.HTTPError("https://api.anthropic.com/api/oauth/usage", 429, "Too Many Requests", {}, None)
         with patch.object(uc, "_read_claude_token", return_value=("fake-token", "test")), \
@@ -360,6 +381,28 @@ class TestCollectClaudeCacheFallback(unittest.TestCase):
             self.assertEqual(result["windows"], cached_windows)
             self.assertIn("cache_age_minutes", result)
             self.assertLess(result["cache_age_minutes"], 10)
+
+    def test_401_with_fresh_cache_still_falls_back_to_estimate(self):
+        # USAGE401DIAG910, the load-bearing case: even with a FRESH cache, a 401
+        # must NOT be served from it (that would report the last good numbers as
+        # current and mask the expired token). It goes to the estimate instead.
+        with tempfile.TemporaryDirectory() as tmp:
+            latest_path = os.path.join(tmp, "usage-latest.json")
+            fresh_ts = (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat()
+            self._write_latest(latest_path, "authoritative", {"five_hour": {"used_percent": 11.0, "resets_at": 1234.0}}, fresh_ts)
+
+            http_err = urllib.error.HTTPError("url", 401, "Unauthorized", {}, None)
+            with patch.object(uc, "LATEST_PATH", latest_path), \
+                 patch.object(uc, "_read_claude_token", return_value=("fake-token", "test")), \
+                 patch.object(uc, "_claude_cli_version", return_value="1.2.3"), \
+                 patch("urllib.request.urlopen", side_effect=http_err), \
+                 patch.object(uc, "_collect_claude_estimate", return_value={"seven_day_est_tokens": 42}) as mock_estimate:
+                result = uc.collect_claude()
+
+            mock_estimate.assert_called_once()
+            self.assertEqual(result["source"], "estimate")
+            self.assertNotEqual(result["source"], "authoritative_cached")
+            self.assertIn("401", result.get("auth_error", ""))
 
     def test_429_with_stale_cache_falls_back_to_estimate(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -880,6 +923,77 @@ class TestClaudeTokenSources(unittest.TestCase):
         with patch.object(uc.sys, "platform", "linux"), \
              patch.object(uc.os.path, "exists", return_value=False):
             self.assertEqual(uc._read_claude_token(), (None, None))
+
+
+class TestCodexSnapshotFreshness(unittest.TestCase):
+    """USAGE401DIAG910 (c): the Codex numbers come from a rollout file on disk,
+    which can be hours or months old. collect_codex() must capture the event's
+    timestamp, and render_summary() must show the numbers WITH their age -- or
+    say the freshness is unknown -- so no % is read as current when it is not."""
+
+    def _rollout(self, tmp, ts):
+        path = os.path.join(tmp, "rollout-x.jsonl")
+        event = {"type": "event", "payload": {"rate_limits": {
+            "plan_type": "pro",
+            "primary": {"used_percent": 12.5, "window_minutes": 10080, "resets_at": 1234.0},
+        }}}
+        if ts is not None:
+            event["timestamp"] = ts
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(json.dumps(event) + "\n")
+        return path
+
+    def test_collect_codex_captures_snapshot_at_and_age(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ts = (datetime.now(timezone.utc) - timedelta(hours=3)).isoformat().replace("+00:00", "Z")
+            path = self._rollout(tmp, ts)
+            with patch.object(uc.glob, "glob", return_value=[path]):
+                result = uc.collect_codex()
+            self.assertTrue(result["ok"])
+            self.assertEqual(result["snapshot_at"], ts)
+            self.assertIsNotNone(result["snapshot_age_hours"])
+            self.assertAlmostEqual(result["snapshot_age_hours"], 3.0, delta=0.2)
+
+    def test_collect_codex_no_timestamp_leaves_snapshot_at_none(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._rollout(tmp, None)
+            with patch.object(uc.glob, "glob", return_value=[path]):
+                result = uc.collect_codex()
+            self.assertTrue(result["ok"])
+            self.assertIsNone(result["snapshot_at"])
+            self.assertIsNone(result["snapshot_age_hours"])
+
+    def _snapshot(self, codex):
+        return {
+            "generated_at_local": "2026-09-11 14:00:00 CEST",
+            "codex": codex,
+            "claude": {"ok": True, "source": "estimate", "files_scanned": 0},
+        }
+
+    def test_render_shows_stale_marker_for_old_snapshot(self):
+        codex = {"ok": True, "source": "authoritative", "plan_type": "pro",
+                 "windows": {"weekly": {"used_percent": 12.5, "window_minutes": 10080, "resets_at": 1234.0}},
+                 "snapshot_at": "2026-04-26T12:03:04.051Z", "snapshot_age_hours": 24 * 138.0}
+        out = uc.render_summary(self._snapshot(codex))
+        self.assertIn("snapshot:", out)
+        self.assertIn("[STALE]", out)
+        self.assertIn("days old", out)
+
+    def test_render_says_freshness_unknown_without_timestamp(self):
+        codex = {"ok": True, "source": "authoritative", "plan_type": "pro",
+                 "windows": {"weekly": {"used_percent": 12.5, "window_minutes": 10080, "resets_at": 1234.0}},
+                 "snapshot_at": None, "snapshot_age_hours": None}
+        out = uc.render_summary(self._snapshot(codex))
+        self.assertIn("freshness unknown", out)
+
+    def test_render_fresh_snapshot_has_no_stale_marker(self):
+        codex = {"ok": True, "source": "authoritative", "plan_type": "pro",
+                 "windows": {"weekly": {"used_percent": 12.5, "window_minutes": 10080, "resets_at": 1234.0}},
+                 "snapshot_at": "2026-09-11T12:00:00Z", "snapshot_age_hours": 2.0}
+        out = uc.render_summary(self._snapshot(codex))
+        self.assertIn("snapshot:", out)
+        self.assertNotIn("[STALE]", out)
+        self.assertIn("h old", out)
 
 
 if __name__ == "__main__":

--- a/scripts/usage-collect.py
+++ b/scripts/usage-collect.py
@@ -287,6 +287,9 @@ def collect_codex():
                     # as current when it is not.
                     rate_limits_ts = obj.get("timestamp")
 
+        if rate_limits is None:
+            raise ValueError("no rate_limits entries in newest rollout file")
+
         windows = {}
         for key in ("primary", "secondary"):
             w = rate_limits.get(key)

--- a/scripts/usage-collect.py
+++ b/scripts/usage-collect.py
@@ -142,8 +142,12 @@ def _parse_iso_to_epoch(value):
     resets_at fields) into a unix epoch float. Returns None on failure."""
     if not isinstance(value, str):
         return None
+    # Python < 3.11's fromisoformat rejects a trailing 'Z' (Codex event
+    # timestamps use it, e.g. "2026-04-26T12:03:04.051Z"); normalise it so the
+    # parse works across interpreter versions, not just the host's 3.14.
+    normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
     try:
-        dt = datetime.fromisoformat(value)
+        dt = datetime.fromisoformat(normalized)
     except ValueError:
         return None
     if dt.tzinfo is None:
@@ -264,6 +268,7 @@ def collect_codex():
         newest = max(files, key=os.path.getmtime)
 
         rate_limits = None
+        rate_limits_ts = None
         with open(newest, "r", encoding="utf-8", errors="ignore") as f:
             for line in f:
                 if '"rate_limits"' not in line:
@@ -275,9 +280,12 @@ def collect_codex():
                 rl = obj.get("payload", {}).get("rate_limits")
                 if rl:
                     rate_limits = rl  # keep the LAST match
-
-        if rate_limits is None:
-            raise ValueError("no rate_limits entries in newest rollout file")
+                    # ...and the event's own timestamp, so the summary can say
+                    # HOW OLD these numbers are (USAGE401DIAG910). The Codex
+                    # rollout is read from disk, not a live call: the newest
+                    # file can be months old, and a bare percentage then reads
+                    # as current when it is not.
+                    rate_limits_ts = obj.get("timestamp")
 
         windows = {}
         for key in ("primary", "secondary"):
@@ -300,6 +308,17 @@ def collect_codex():
         result["plan_type"] = rate_limits.get("plan_type")
         result["windows"] = windows
         result["source_file"] = newest
+        # Freshness of the numbers (USAGE401DIAG910). snapshot_at is the ISO
+        # timestamp of the rate_limits event; snapshot_age_hours is relative to
+        # now. Both may be None if the event carried no timestamp -- the summary
+        # then says the freshness is unknown rather than showing the % alone.
+        result["snapshot_at"] = rate_limits_ts
+        result["snapshot_age_hours"] = None
+        if rate_limits_ts:
+            snap_epoch = _parse_iso_to_epoch(rate_limits_ts)
+            if snap_epoch is not None:
+                age_h = (datetime.now(timezone.utc).timestamp() - snap_epoch) / 3600.0
+                result["snapshot_age_hours"] = round(age_h, 1)
     except Exception as e:
         result["ok"] = False
         result["error"] = str(e)
@@ -391,7 +410,13 @@ def _collect_claude_authoritative():
     """Return (windows_dict, None, None) on success.
     On failure: (None, error_str, error_kind) where error_kind is one of:
       'no_token'  -- no credentials at all, never worth a cache/retry
-      'permanent' -- HTTP 403 (real scope/auth problem, not transient)
+      'permanent' -- HTTP 401/403: an expired/invalid token (401) or a real
+                     scope problem (403). NOT transient, and crucially NOT
+                     cache-servable: a retry from the last authoritative
+                     snapshot would hand back a stale number and hide the fact
+                     that the token needs refreshing (USAGE401DIAG910). 401 was
+                     previously misclassified as transient, so an expired token
+                     kept reporting the last good numbers as if current.
       'transient' -- 429 / 5xx / timeout / network error / unparseable
                      response -- safe to serve from cache if fresh enough
     """
@@ -411,7 +436,10 @@ def _collect_claude_authoritative():
         with urllib.request.urlopen(req, timeout=10) as resp:
             data = json.loads(resp.read())
     except urllib.error.HTTPError as e:
-        kind = "permanent" if e.code == 403 else "transient"
+        # 401 (expired/invalid token) and 403 (scope) are both no-retry: serving
+        # the stale authoritative cache would mask the auth problem. 401 needs a
+        # token refresh, 403 a scope fix -- the HTTP code below tells them apart.
+        kind = "permanent" if e.code in (401, 403) else "transient"
         return None, f"HTTP {e.code} ({token_source} token)", kind
     except Exception as e:
         return None, f"{type(e).__name__}: {e}", "transient"
@@ -624,6 +652,24 @@ def render_summary(snapshot):
     else:
         plan = codex.get("plan_type") or "?"
         windows = codex.get("windows", {})
+        # Freshness FIRST, so no % is read without its age (USAGE401DIAG910).
+        # The Codex numbers come from a rollout file on disk, which can be
+        # hours or months old; a bare percentage would read as current.
+        snap_at = codex.get("snapshot_at")
+        age_h = codex.get("snapshot_age_hours")
+        if snap_at:
+            local_str, _ = fmt_reset(_parse_iso_to_epoch(snap_at))
+            if isinstance(age_h, (int, float)):
+                if age_h >= 24:
+                    age_desc = f"{age_h / 24:.1f} days old"
+                else:
+                    age_desc = f"{age_h:.1f} h old"
+                stale = "  [STALE]" if age_h >= 24 else ""
+                lines.append(f"  snapshot: {local_str} ({age_desc}){stale}")
+            else:
+                lines.append(f"  snapshot: {local_str} (age unknown)")
+        else:
+            lines.append("  snapshot: freshness unknown -- the rollout event carried no timestamp; the numbers below may be stale")
         if not windows:
             lines.append("  no rate_limits data available")
         for label, w in windows.items():


### PR DESCRIPTION
Owner-independent code portion of USAGE401DIAG910 (samu). The keychain-token refresh (a) and the end-to-end re-measure stay for the owner-present round; this stages (b) and (c) so that round is just merge + refresh + confirm.

## (b) 401 is no-retry, not cache-served

`_collect_claude_authoritative` classified HTTP 401 as `transient`, so an expired/invalid token served the last authoritative snapshot from cache (`source: authoritative_cached`) and reported stale numbers as current -- masking that the token needs refreshing. 401 now joins 403 as `permanent` (no-retry, no cache-serve): `collect_claude` falls to the estimate and records `auth_error: HTTP 401`.

**Verified live:** the current expired keychain token now yields `source: estimate` with `auth_error: HTTP 401 (keychain token)` -- before this it would have been served as `authoritative_cached`.

## (c) Codex snapshot freshness

The Codex numbers are read from the newest `~/.codex/sessions/.../rollout-*.jsonl` on disk, which can be months old. `collect_codex` now captures the rate_limits event's `timestamp` (`snapshot_at` + `snapshot_age_hours`), and `render_summary` prints a freshness line before the percentages: `snapshot: <date> (<age>) [STALE]` (STALE at >= 24h), or `freshness unknown` if the event had no timestamp -- so no % reads as current without its age.

**Verified live:** the newest rollout is **138 days old**; the summary now shows `snapshot: 2026-04-26 14:03 CEST (138.0 days old) [STALE]` instead of a bare percentage.

`_parse_iso_to_epoch` also normalises a trailing `Z` (Codex timestamps use it) so it parses on Python < 3.11, not just the host's 3.14.

## Tests

90 unit tests pass (8 new): 401 classification, 401-with-fresh-cache-still-estimates (the load-bearing case), Z-suffix parse, Codex snapshot capture (with/without timestamp), and render freshness/STALE/unknown lines. Scripts-only change -- takes effect on pull, no build/restart.

Not for this PR: the newsletter rewrite that consumes the freshness (USAGE401HIRLEVEL910, Marveen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)