### PR TITLE
fix(channels): the isolated-config contract rides fd 3, not stdout (CFGCONTRACT912)

### DIFF
--- a/scripts/channel-watchdog.sh
+++ b/scripts/channel-watchdog.sh
@@ -186,7 +186,16 @@ MODEL_FLAG=""
 # via ps/pane history otherwise).
 CFG_ENV=""
 if [ -n "$NODE_BIN" ] && [ -f "$INSTALL_DIR/dist/web/agent-process.js" ]; then
-  _cfg_line="$("$NODE_BIN" "$INSTALL_DIR/scripts/main-agent-isolated-config.mjs" "$CHANNEL_PROVIDER" 2>>"$STORE/channels-failures.log" || true)"
+  # Contract on fd 3, never stdout -- see scripts/main-agent-isolated-config.mjs
+  # and channels.sh: the helper imports a pino-logging module that writes to fd 1
+  # from a worker thread, and one such line silently dropped the main agent back
+  # onto the shared ~/.claude on 2026-09-12. This caller must stay in step with
+  # channels.sh, or a watchdog respawn reintroduces exactly that outage.
+  _cfg_raw="$("$NODE_BIN" "$INSTALL_DIR/scripts/main-agent-isolated-config.mjs" "$CHANNEL_PROVIDER" 3>&1 2>>"$STORE/channels-failures.log" 1>&2 || true)"
+  _cfg_line="$(printf '%s\n' "$_cfg_raw" | grep -m1 -E '^(explicit|isolated)	/' || true)"
+  if [ -n "$_cfg_raw" ] && [ -z "$_cfg_line" ]; then
+    log "WARN main-agent-isolated-config.mjs printed output with NO contract line -- respawn without isolation"
+  fi
   _cfg_mode="${_cfg_line%%	*}"
   _cfg_dir="${_cfg_line#*	}"
   if [ -n "$_cfg_line" ] && [ -d "$_cfg_dir" ]; then
@@ -197,7 +206,7 @@ if [ -n "$NODE_BIN" ] && [ -f "$INSTALL_DIR/dist/web/agent-process.js" ]; then
     fi
     log "main-agent $_cfg_mode CLAUDE_CONFIG_DIR=$_cfg_dir"
   fi
-  unset _cfg_line _cfg_mode _cfg_dir
+  unset _cfg_raw _cfg_line _cfg_mode _cfg_dir
 fi
 
 # Full PATH with .bun/bin -- without it the respawned bun telegram bridge does

--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -629,7 +629,23 @@ CFG_ENV=""
 mkdir -p "$INSTALL_DIR/store" 2>/dev/null || true
 _node_bin="$(command -v node || true)"
 if [ -n "$_node_bin" ] && [ -f "$INSTALL_DIR/dist/web/agent-process.js" ]; then
-  _cfg_line="$("$_node_bin" "$INSTALL_DIR/scripts/main-agent-isolated-config.mjs" "$CHANNEL_PROVIDER" 2>>"$INSTALL_DIR/store/channels-failures.log" || true)"
+  # The helper's stdout is a CONTRACT ("<mode>\t<path>", or nothing), but it
+  # imports a dist module that logs through pino -- whose default destination is
+  # fd 1 (from a worker thread, so the script cannot intercept it). On 2026-09-12 one such line ("kept target-only settings keys", newly
+  # firing because #1218 added `permissions` to the isolated settings.json only)
+  # rode along on stdout, `_cfg_dir` became a multi-line value, `[ -d ]` failed,
+  # and the main agent silently dropped to the shared ~/.claude -- losing both the
+  # fleet-token auth and its own Bash egress deny. The contract now rides fd 3
+  # (`3>&1 2>>log 1>&2` below, so the module's own stdout AND stderr both land in
+  # the failures log); this filter is the fail-safe that does not depend on that,
+  # for ANY future writer to the contract descriptor. Anything that is not the contract line is ignored,
+  # and a non-empty output with no contract line in it is reported LOUDLY, because
+  # that is the shape that silently disables isolation.
+  _cfg_raw="$("$_node_bin" "$INSTALL_DIR/scripts/main-agent-isolated-config.mjs" "$CHANNEL_PROVIDER" 3>&1 2>>"$INSTALL_DIR/store/channels-failures.log" 1>&2 || true)"
+  _cfg_line="$(printf '%s\n' "$_cfg_raw" | grep -m1 -E '^(explicit|isolated)	/' || true)"
+  if [ -n "$_cfg_raw" ] && [ -z "$_cfg_line" ]; then
+    echo "$(date '+%Y-%m-%d %H:%M:%S') channels.sh: WARN main-agent-isolated-config.mjs printed output with NO contract line -- isolation skipped. Raw first line: $(printf '%s\n' "$_cfg_raw" | head -1)" >> "$INSTALL_DIR/store/channels-failures.log"
+  fi
   _cfg_mode="${_cfg_line%%	*}"
   _cfg_dir="${_cfg_line#*	}"
   if [ -n "$_cfg_line" ] && [ -d "$_cfg_dir" ]; then
@@ -707,7 +723,7 @@ if [ -n "$_node_bin" ] && [ -f "$INSTALL_DIR/dist/web/agent-process.js" ]; then
       unset _guard_port _guard_http
     fi
   fi
-  unset _cfg_line _cfg_mode _cfg_dir
+  unset _cfg_raw _cfg_line _cfg_mode _cfg_dir
 fi
 unset _node_bin
 

--- a/scripts/main-agent-isolated-config.mjs
+++ b/scripts/main-agent-isolated-config.mjs
@@ -20,9 +20,29 @@
 // Usage: node scripts/main-agent-isolated-config.mjs [provider]
 import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { writeSync, fstatSync } from 'node:fs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const projectRoot = join(__dirname, '..')
+
+// THE CONTRACT DOES NOT TRAVEL ON STDOUT (2026-09-12 outage). The imported dist
+// module logs through pino, and pino writes to fd 1 from its own handle -- a
+// pino-pretty transport does it from a WORKER THREAD, so patching
+// process.stdout.write in this thread does not catch it (measured). One such
+// line ("isolated-config: kept target-only settings keys", newly firing because
+// #1218 added `permissions` to the isolated settings.json only) was enough to
+// make channels.sh's `[ -d "$_cfg_dir" ]` fail on a multi-line value, and the
+// main agent silently kept the shared ~/.claude -- losing BOTH the stable
+// fleet-token auth (401 risk) and the isolated dir's own Bash egress deny.
+//
+// So the callers hand us a THIRD descriptor for the contract (`3>&1 2>>log 1>&2`)
+// and let fd 1 and 2 both land in channels-failures.log: the module's diagnostics
+// stay readable -- they are deliberately loud, see agent-process.ts -- while
+// nothing it prints can reach the contract. Run by hand without that redirection
+// (no fd 3), we fall back to stdout so the script stays usable interactively.
+let CONTRACT_FD = 3
+try { fstatSync(CONTRACT_FD) } catch { CONTRACT_FD = 1 }
+const emitContract = (line) => writeSync(CONTRACT_FD, line)
 
 const { ensureMainAgentIsolatedConfigDir, resolveMainAgentConfigDir } = await import(
   join(projectRoot, 'dist', 'web', 'agent-process.js')
@@ -35,9 +55,9 @@ const { ensureMainAgentIsolatedConfigDir, resolveMainAgentConfigDir } = await im
 // while an `isolated` dir carries none and needs the fleet setup-token exported.
 const explicit = resolveMainAgentConfigDir()
 if (explicit) {
-  process.stdout.write(`explicit\t${explicit}\n`)
+  emitContract(`explicit\t${explicit}\n`)
 } else {
   const provider = process.argv[2] || undefined
   const dir = ensureMainAgentIsolatedConfigDir(provider)
-  if (dir) process.stdout.write(`isolated\t${dir}\n`)
+  if (dir) emitContract(`isolated\t${dir}\n`)
 }

--- a/src/__tests__/main-agent-config-dir.test.ts
+++ b/src/__tests__/main-agent-config-dir.test.ts
@@ -65,6 +65,7 @@ describe('resolveMainAgentConfigDir', () => {
 describe('launcher wiring', () => {
   const HELPER = readFileSync(join(__dirname, '../../scripts/main-agent-isolated-config.mjs'), 'utf-8')
   const CHANNELS = readFileSync(join(__dirname, '../../scripts/channels.sh'), 'utf-8')
+  const WATCHDOG = readFileSync(join(__dirname, '../../scripts/channel-watchdog.sh'), 'utf-8')
 
   it('the helper prefers the explicit dir over the isolated one', () => {
     expect(HELPER).toMatch(/const explicit = resolveMainAgentConfigDir\(\)[\s\S]*if \(explicit\)/)
@@ -73,6 +74,31 @@ describe('launcher wiring', () => {
   it('the helper tags each path with its mode so the caller knows how to authenticate', () => {
     expect(HELPER).toMatch(/explicit\\t/)
     expect(HELPER).toMatch(/isolated\\t/)
+  })
+
+  // 2026-09-12 outage. The helper imports a pino-logging dist module, and pino
+  // writes to fd 1 from its own handle (a pino-pretty transport does it from a
+  // worker thread, so the script cannot intercept it). When #1218 added
+  // `permissions` to the isolated settings.json only, the resulting
+  // "kept target-only settings keys" line rode along on stdout, `_cfg_dir`
+  // became multi-line, `[ -d ]` failed, and the main agent silently kept the
+  // shared ~/.claude -- losing both the fleet-token auth and its own egress deny.
+  it('the contract rides fd 3, not stdout, so a library log line cannot break it', () => {
+    expect(HELPER).toMatch(/let CONTRACT_FD = 3/)
+    expect(HELPER).toMatch(/writeSync\(CONTRACT_FD/)
+    // stdout stays a usable fallback for a hand-run, but nothing writes the
+    // contract through process.stdout.write -- patching it does not catch pino.
+    expect(HELPER).not.toMatch(/process\.stdout\.write\(`(explicit|isolated)/)
+  })
+
+  it('every caller opens fd 3 AND filters for a contract line', () => {
+    // Both files spawn the helper; a caller that drifts reintroduces the outage
+    // on exactly the path that matters (channel-watchdog.sh respawns when the
+    // dashboard is down).
+    for (const [name, sh] of [['channels.sh', CHANNELS], ['channel-watchdog.sh', WATCHDOG]] as const) {
+      expect(sh, name).toMatch(/main-agent-isolated-config\.mjs[^\n]*3>&1/)
+      expect(sh, name).toMatch(/grep -m1 -E '\^\(explicit\|isolated\)/)
+    }
   })
 
   it('channels.sh never injects the fleet token for an explicit dir', () => {


### PR DESCRIPTION
## Mi történt

A 2026-09-12 01:52-es induláskor a fő channels-agent a KÖZÖS `~/.claude` alól indult, pedig az izoláció be van kapcsolva. A `channels-sh-guard` riasztott, de a **diagnózisa téves**: azt írta, a `MAIN_AGENT_ISOLATED_CONFIG` elveszett. Nem veszett el.

Mérve:
- `store/config-overrides.json` **és** `.env` 23. sor is tartalmazza a `MAIN_AGENT_ISOLATED_CONFIG=1`-et, a fájlok mtime-ja jóval az indulás előtti. A guard javasolt teendője (állítsd vissza a beállítást) semmit nem változtatott volna.
- `scripts/main-agent-isolated-config.mjs` **hat sort** ír a stdout-ra, nem egyet: a szerződés-sort, plusz egy pino-rekordot az importált dist modulból (`isolated-config: kept target-only settings keys`). Ez a rekord csak azóta tüzel, hogy a **#1218** a `permissions` blokkot **kizárólag** az izolált `settings.json`-be tette, a közös `~/.claude`-ba nem.
- `channels.sh` az első tab utáni **mindent** útvonalnak vesz, így a `[ -d "$_cfg_dir" ]` egy többsoros értéken bukott, a `CFG_ENV` üres maradt, és az indulás visszaesett a közös rootra.

## Amit a visszaesés elvesz, az kettő, nem egy

1. a hosszú életű flotta-token alapú auth (a 2026-07-23-as néma kiesés alakja),
2. **és a Bash egress deny**, ami csak az izolált dir `settings.json`-jében él.

## A javítás

A szerződés lekerül a stdout-ról: a hívók **fd 3**-at nyitnak neki (`3>&1 2>>log 1>&2`), így a modul stdout-ja és stderr-je is a `channels-failures.log`-ba megy (a szándékosan hangos diagnosztika megmarad), a szerződéshez viszont semmi nem fér hozzá, amit a modul ír.

A `process.stdout.write` foltozása **nem elég**, és először azt próbáltam: a pino-pretty transport worker-szálból ír az 1-es leíróra (mérve).

`channel-watchdog.sh` ugyanennek a parse-nak a **másolatát** hordozta, tehát egy dashboard-down respawn pont a recovery-úton hozta vissza a hibát. Most mindkét hívó fd 3-at nyit és jól formált szerződés-sorra szűr, és a nem-üres, szerződés-sor nélküli kimenet **hangosan** naplózódik ahelyett, hogy némán kikapcsolná az izolációt.

## Teszt

`src/__tests__/main-agent-config-dir.test.ts` két új esete. Mutációval igazolva: a javítás előtti szkripteken pontosan ez a kettő megy pirosra, a másik nyolc zöld marad. A szomszédos szerződés-suite-ok (`channel-stability-contract`, `main-agent-isolated-config`, `settings-store`) 46/46 zöld.

🤖 Generated with [Claude Code](https://claude.com/claude-code)