### PR TITLE
fix(context-guard): resume prompt re-reads the restart window, with observable ack (ORSICTX912 v1)

### DIFF
--- a/src/__tests__/context-guard-resume-prompt.test.ts
+++ b/src/__tests__/context-guard-resume-prompt.test.ts
@@ -61,6 +61,35 @@ describe('resumePrompt carries the prod-tree constraint on every variant', () =>
   })
 })
 
+// ORSICTX912 (2026-09-12): msg 23670 was delivered seven seconds after the
+// guard kill started, into the dying session. The queue said delivered, the
+// fresh session never looked back, and completed_at is unused (0/37 measured)
+// so the loss was invisible. The resume prompt is the fresh session's ONLY
+// context, so the re-read instruction must be present on EVERY variant, and
+// it must demand an OBSERVABLE trace (ack to the sender) -- an instruction
+// whose success cannot be observed would run into the same blindness.
+describe('resumePrompt carries the restart-window re-read on every variant', () => {
+  const variants = [
+    ['without a handoff', () => resumePrompt('samu', '/x/HANDOFF.md', false)],
+    ['with a fresh handoff', () => resumePrompt('samu', '/x/HANDOFF.md', true)],
+    ['with a stale handoff', () => resumePrompt('samu', '/x/HANDOFF.md', true, 42)],
+    ['with unmeasurable freshness', () => resumePrompt('samu', '/x/HANDOFF.md', true, 'unknown')],
+    ['main agent', () => resumePrompt('marveen', '/x/HANDOFF.md', true)],
+  ] as const
+  for (const [label, make] of variants) {
+    it(label, () => {
+      const p = make()
+      expect(p).toContain('RESTART-ABLAK')
+      // The queue re-read names the concrete endpoint, not a vague "check".
+      expect(p).toContain('api/messages?agent=')
+      // The observable trace: an ack to the SENDER, required even when the
+      // item needs no work -- this is what makes the v1 measurable at all.
+      expect(p).toContain('nyugtát a feladónak')
+      expect(p).toContain('akkor is, ha nincs belőle teendő')
+    })
+  }
+})
+
 // Review msg 14197: the main agent's channel is the OWNER's Telegram, and
 // session meta must never go there (standing owner preference; a 3am status
 // notice went out exactly this way on 2026-08-05). The closing line is

--- a/src/web/context-guard-runner.ts
+++ b/src/web/context-guard-runner.ts
@@ -181,6 +181,18 @@ export function resumePrompt(
     base + source +
     `Utána ellenőrizd a kanban tábládat (in_progress kártyák, assignee=${name}) és a hot memóriáidat, ` +
     `és FOLYTASD a megkezdett munkát magadtól. Ne kezdd elölről ami a handoff szerint már kész. ` +
+    // ORSICTX912: msg 23670 was delivered SEVEN SECONDS after the guard kill
+    // started, into the dying session -- the queue marked it delivered, the
+    // fresh session had no reason to look, and completed_at is unused (0/37
+    // measured), so the loss is invisible from the queue. The re-read must
+    // ride in the resume prompt (the fresh session's only context), and the
+    // ack-to-sender is the OBSERVABLE trace: without it, verifying this very
+    // instruction would run into the same blindness it exists to fix.
+    `RESTART-ABLAK: az előző session utolsó ~15 percében kézbesített inter-agent üzenet elveszhetett. ` +
+    `Olvasd vissza a saját sorodat erre az ablakra (GET /api/messages?agent=${name}, created_at szerint szűrve), ` +
+    `és minden ott talált, még el nem intézett kérést kezelj újként. KÖTELEZŐ MEGFIGYELHETŐ NYOM: minden ` +
+    `visszaolvasott tételről küldj rövid nyugtát a feladónak ("[RESTART-ABLAK] <id> felvéve a friss sessionben"), ` +
+    `akkor is, ha nincs belőle teendő -- e nélkül a visszaolvasás a sorból láthatatlan. ` +
     // RESPAWNZAJ822/PRODFAAG822: a fresh session acting on a resume goal is
     // exactly the actor that branch-switched and committed on the live prod
     // tree (2026-08-22 10:10, PR #1036 duplicate). The constraint must ride in


### PR DESCRIPTION
Measured shape (ORSICTX912): on Orsi's five guard restarts in 48h, four windows were empty and one message (23670) was delivered SEVEN SECONDS after the guard kill started, into the dying session. The queue marked it delivered, the fresh session had no reason to look back, and `completed_at` is unused (0/37 measured), so the loss is invisible from the queue.

**v1 (this PR)**: the resume prompt -- the fresh session's only context -- now instructs a re-read of the agent's own queue for the ~15 minutes before the restart, and requires a short ack to the sender for every re-read item, even when no work follows. The ack is the observable trace: without it, verifying this instruction would run into the same blindness it fixes. Pinned on every prompt variant (5 new tests).

**Explicitly NOT closure** (Marveen's condition, msg 24162): an instruction in a prompt is not a mechanism. The gap stays open until a live guard restart confirms the behaviour end-to-end; router-side re-delivery (v2, with dedup) only on a measured v1 failure.

34/34 targeted tests green, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)