### PR TITLE
fix(vault): vault-resolve fails loud -- three worlds, three outcomes (VAULTNEMA912)

### DIFF
--- a/scripts/vault-env-wrapper.sh
+++ b/scripts/vault-env-wrapper.sh
@@ -29,7 +29,20 @@ for var in $(env | grep '=vault:' | cut -d= -f1); do
 done
 
 if [ -n "$REFS" ]; then
-  RESOLVED=$(printf '%s' "$REFS" | "$NODE" "$PROJECT_ROOT/scripts/vault-resolve.mjs")
+  # VAULTNEMA912: vault-resolve now fails LOUD (exit 2 = malformed ref line,
+  # exit 3 = missing secret) instead of silent success. DELIBERATE CHOICE
+  # (option a, measured with Marveen): the MCP server still starts. This
+  # wrapper's job is launching; a stale vault: reference must not become a
+  # fleet-wide startup failure. The truth goes to stderr (vault-resolve has
+  # already named the offending label/line there), and the RESOLVED SUBSET is
+  # still exported -- vault-resolve keeps printing the good lines in a mixed
+  # batch. The `|| RC=$?` shape is what keeps `set -e` from killing the
+  # wrapper before `exec` under the new contract.
+  RC=0
+  RESOLVED=$(printf '%s' "$REFS" | "$NODE" "$PROJECT_ROOT/scripts/vault-resolve.mjs") || RC=$?
+  if [ "$RC" -ne 0 ]; then
+    echo "vault-env-wrapper: vault-resolve exit $RC -- not every vault: reference resolved; starting anyway with the resolved subset" >&2
+  fi
   while IFS='=' read -r key value; do
     [ -n "$key" ] && export "$key"="$value"
   done <<< "$RESOLVED"

--- a/scripts/vault-resolve.mjs
+++ b/scripts/vault-resolve.mjs
@@ -1,6 +1,23 @@
 #!/usr/bin/env node
 // Resolve vault secret IDs to plaintext values.
 // Reads "ENV_VAR=secret_id" lines from stdin, outputs "ENV_VAR=value" lines.
+//
+// VAULTNEMA912: this script used to close THREE different worlds with the
+// same observable outcome -- exit 0 and empty stdout: a correct call, an
+// unknown label, and a malformed line (no '='). A caller could not tell them
+// apart, and one real round concluded from the silence that "the vault gives
+// no output" and reported a nonexistent outage (Orsi, community-watch #261).
+// Failures are loud now, and the worlds stay distinguishable:
+//   exit 0  every line resolved; stdout carries ENV_VAR=value lines, nothing
+//           is ever logged on the success path
+//   exit 2  at least one malformed input line (missing '=') -- the CALLER's
+//           bug; the offending line is echoed to stderr (caller-provided
+//           text, never vault content)
+//   exit 3  at least one label had no secret -- stderr names the LABEL only,
+//           NEVER the value of any secret
+// Malformed input takes precedence over missing labels in the exit code.
+// Resolved lines are still printed even when another line fails, so a
+// multi-secret caller sees every problem in one run.
 import { createRequire } from 'node:module'
 import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -18,14 +35,30 @@ const input = await new Promise(resolve => {
   process.stdin.on('end', () => resolve(data))
 })
 
+let malformed = 0
+let missing = 0
 for (const line of input.trim().split('\n')) {
   if (!line.trim()) continue
   const eq = line.indexOf('=')
-  if (eq < 0) continue
+  if (eq < 0) {
+    // The line is caller-provided text (an env var name and/or a label),
+    // never a vault value, so echoing it is safe and names the exact bug.
+    process.stderr.write(`vault-resolve: malformed line (no '='), expected ENV_VAR=secret_id: ${line}\n`)
+    malformed++
+    continue
+  }
   const envVar = line.slice(0, eq)
   const secretId = line.slice(eq + 1)
   const value = getSecret(secretId)
   if (value !== null) {
     process.stdout.write(`${envVar}=${value}\n`)
+  } else {
+    // Label only -- the value does not exist, and even if it did, values
+    // must never reach stderr.
+    process.stderr.write(`vault-resolve: no secret in the vault for label: ${secretId}\n`)
+    missing++
   }
 }
+
+if (malformed > 0) process.exit(2)
+if (missing > 0) process.exit(3)

--- a/src/__tests__/vault-resolve-loud-failures.test.ts
+++ b/src/__tests__/vault-resolve-loud-failures.test.ts
@@ -1,0 +1,105 @@
+// VAULTNEMA912: vault-resolve.mjs closed three different worlds with the same
+// outcome -- exit 0, empty stdout: a correct call, an unknown label, and a
+// malformed line (missing '='). Measured harm: a community-watch round called
+// it with the third shape, read the silence as "the vault gives no output",
+// and reported a nonexistent outage while the vault was healthy.
+//
+// These tests run the REAL script as a child process against a stubbed
+// dist/web/vault.js, because the script derives its project root from its own
+// file path (__dirname/..) -- so the fixture rebuilds that layout in a temp
+// dir rather than importing the script's internals. What is pinned:
+//   - the three worlds get three DISTINGUISHABLE outcomes (0 / 2 / 3),
+//   - stderr names the malformed line and the missing LABEL,
+//   - no secret VALUE ever reaches stderr, on any path,
+//   - the success path stays silent on stderr (no logging),
+//   - a mixed batch still resolves the good lines and malformed wins the exit.
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { execFile } from 'node:child_process'
+import { mkdtempSync, mkdirSync, copyFileSync, writeFileSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+const ROOT = mkdtempSync(join(tmpdir(), 'vault-resolve-test-'))
+const SECRET_VALUE = 'sv-3f6f1e2b-not-a-real-secret'
+
+function run(stdin: string): Promise<{ code: number; stdout: string; stderr: string }> {
+  return new Promise(resolve => {
+    const child = execFile(
+      process.execPath,
+      [join(ROOT, 'scripts', 'vault-resolve.mjs')],
+      (error, stdout, stderr) => {
+        const code = error && typeof (error as NodeJS.ErrnoException & { code?: number }).code === 'number'
+          ? ((error as unknown as { code: number }).code)
+          : error ? 1 : 0
+        resolve({ code, stdout, stderr })
+      },
+    )
+    child.stdin!.end(stdin)
+  })
+}
+
+beforeAll(() => {
+  mkdirSync(join(ROOT, 'scripts'), { recursive: true })
+  mkdirSync(join(ROOT, 'dist', 'web'), { recursive: true })
+  copyFileSync(
+    join(process.cwd(), 'scripts', 'vault-resolve.mjs'),
+    join(ROOT, 'scripts', 'vault-resolve.mjs'),
+  )
+  // The stub mirrors the real contract: a known label resolves, anything
+  // else returns null. The value is a fixture string, not vault content.
+  writeFileSync(
+    join(ROOT, 'dist', 'web', 'vault.js'),
+    `export function getSecret(id) { return id === 'KNOWN-LABEL' ? '${SECRET_VALUE}' : null }\n`,
+  )
+})
+
+afterAll(() => {
+  rmSync(ROOT, { recursive: true, force: true })
+})
+
+describe('vault-resolve: the three worlds are distinguishable', () => {
+  it('world 1 -- correct call: exit 0, the pair on stdout, SILENT stderr', async () => {
+    const r = await run('PAT=KNOWN-LABEL\n')
+    expect(r.code).toBe(0)
+    expect(r.stdout).toBe(`PAT=${SECRET_VALUE}\n`)
+    expect(r.stderr).toBe('')
+  })
+
+  it('world 2 -- malformed line (no =): exit 2, the line named on stderr', async () => {
+    const r = await run('KNOWN-LABEL\n')
+    expect(r.code).toBe(2)
+    expect(r.stdout).toBe('')
+    expect(r.stderr).toContain("malformed line (no '=')")
+    expect(r.stderr).toContain('KNOWN-LABEL')
+  })
+
+  it('world 3 -- unknown label: exit 3, the LABEL named on stderr', async () => {
+    const r = await run('PAT=NO-SUCH-LABEL\n')
+    expect(r.code).toBe(3)
+    expect(r.stdout).toBe('')
+    expect(r.stderr).toContain('no secret in the vault for label: NO-SUCH-LABEL')
+  })
+
+  it('no path ever writes a secret VALUE to stderr', async () => {
+    for (const stdin of ['PAT=KNOWN-LABEL\n', 'KNOWN-LABEL\n', 'PAT=NO-SUCH-LABEL\n',
+                         'A=KNOWN-LABEL\nbad-line\nB=NO-SUCH-LABEL\n']) {
+      const r = await run(stdin)
+      expect(r.stderr).not.toContain(SECRET_VALUE)
+    }
+  })
+
+  it('mixed batch: good lines still resolve, every failure is reported, malformed wins the exit', async () => {
+    const r = await run('A=KNOWN-LABEL\nbad-line\nB=NO-SUCH-LABEL\n')
+    expect(r.code).toBe(2)
+    expect(r.stdout).toBe(`A=${SECRET_VALUE}\n`)
+    expect(r.stderr).toContain('bad-line')
+    expect(r.stderr).toContain('NO-SUCH-LABEL')
+  })
+
+  it('blank lines stay ignored (not promoted to malformed)', async () => {
+    const r = await run('\nPAT=KNOWN-LABEL\n\n')
+    expect(r.code).toBe(0)
+    expect(r.stderr).toBe('')
+  })
+})


### PR DESCRIPTION
Marveen's measured shape: `vault-resolve.mjs` answered a correct call, an unknown label, AND a malformed line (missing `=`) with the same observable outcome -- exit 0, empty stdout. A real round (community watch #261) hit the malformed shape and reported a nonexistent vault outage from the silence.

**The fix** keeps the three worlds distinguishable:
- malformed line -> stderr naming the caller-provided line + **exit 2** (the caller's bug, said immediately);
- missing secret -> stderr naming the **label only, never a value** + **exit 3**;
- success -> unchanged, and deliberately silent (nothing logs on the happy path).

Mixed batches still resolve every good line and report every failure in one run; malformed wins the exit code. Blank lines stay ignored.

**Tests** (6, all green): the real script runs as a child process against a stubbed `dist/web/vault.js` in a temp layout (the script derives its root from its own path, so the fixture rebuilds that layout instead of importing internals). Pinned: the 0/2/3 split, the stderr wording, the no-value-on-stderr invariant on every path, and the silent success path.

Related family: the same silent-empty collapse was fixed this morning in the hermes-soak sentinel's pattern grep (two loud branches). A sweep for other scripts with the same shape is a separate card-worthy item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)