### PR TITLE
feat(context-guard): daily-handoff trigger tier, and drop the auto-restart handoff field that was never wired

### DIFF
--- a/src/__tests__/agent-put-fields.test.ts
+++ b/src/__tests__/agent-put-fields.test.ts
@@ -183,6 +183,11 @@ describe('checkConfigPutFields', () => {
       'enabled', 'saturationRestart', 'actPct', 'hardPct',
       'limitTokens', 'cooldownMinutes', 'handoffTimeoutMinutes',
       'idleFlushEnabled', 'idleFlushTokens', 'idleMinutes',
+      // Daily-handoff tier. Listed here because the dashboard must be able to
+      // SAVE them: a field with a default that never reaches the endpoint's
+      // known set is refused by checkConfigPutFields, which is the mismatch
+      // this pin exists to catch.
+      'dailyHandoffEnabled', 'dailyHandoffTime',
     ])
   })
 })

--- a/src/__tests__/agent-put-fields.test.ts
+++ b/src/__tests__/agent-put-fields.test.ts
@@ -1,7 +1,14 @@
 import { describe, it, expect } from 'vitest'
 import { checkAgentPutFields, checkConfigPutFields, AGENT_PUT_WRITABLE_FIELDS } from '../web/agent-put-fields.js'
 import { DEFAULT_CONTEXT_GUARD } from '../context-guard.js'
-import { DEFAULT_AUTO_RESTART } from '../auto-restart.js'
+import { DEFAULT_AUTO_RESTART, LEGACY_AUTO_RESTART_FIELDS } from '../auto-restart.js'
+import { EventEmitter } from 'node:events'
+import { mkdirSync, readFileSync, writeFileSync, rmSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { beforeAll, afterAll } from 'vitest'
+import { MAIN_AGENT_ID, PROJECT_ROOT, STORE_DIR } from '../config.js'
+import { tryHandleAgents } from '../web/routes/agents.js'
+import type { RouteContext } from '../web/routes/types.js'
 
 // PUT /api/agents/:name answered 200 {ok:true} to fields it did not understand
 // and quietly dropped them. A securityProfile was set that way four times on
@@ -132,10 +139,9 @@ describe('checkConfigPutFields', () => {
   it('accepts the exact payloads the dashboard sends', () => {
     // Pinned from the real call sites in web/app.js. These are the only live
     // callers of these two endpoints, so a check that rejects one of them
-    // breaks the settings pane -- and the auto-restart payload carries
-    // `handoff`, a field the UI sends on every save and nothing else does.
+    // breaks the settings pane.
     expect(checkConfigPutFields(
-      { enabled: true, mode: 'fresh', dailyTime: '03:00', intervalHours: null, handoff: false },
+      { enabled: true, mode: 'fresh', dailyTime: '03:00', intervalHours: null },
       Object.keys(DEFAULT_AUTO_RESTART),
     ).ok).toBe(true)
     // The idle-flush save merges its three fields over a freshly-read config,
@@ -144,6 +150,23 @@ describe('checkConfigPutFields', () => {
       { ...DEFAULT_CONTEXT_GUARD, idleFlushEnabled: true, idleFlushTokens: 400_000, idleMinutes: 20 },
       guardFields,
     ).ok).toBe(true)
+  })
+
+  // The auto-restart endpoint's known set is the config keys PLUS the legacy
+  // ones. `handoff` used to be a stored field that the UI sent
+  // on every save; removing it from the config would make the endpoint reject
+  // the payload of any dashboard page still open in a browser with the old
+  // app.js -- a save failing with a 400 for a field WE sent. It is accepted
+  // here and dropped by normalizeAutoRestartConfig: tolerated, never stored.
+  it('still accepts an auto-restart payload from a stale dashboard page', () => {
+    const endpointFields = [...Object.keys(DEFAULT_AUTO_RESTART), ...LEGACY_AUTO_RESTART_FIELDS]
+    expect(checkConfigPutFields(
+      { enabled: true, mode: 'fresh', dailyTime: '03:00', intervalHours: null, handoff: false },
+      endpointFields,
+    ).ok).toBe(true)
+    // Tolerating the legacy key must not turn the check into a pushover: a real
+    // typo is still rejected.
+    expect(checkConfigPutFields({ enabled: true, handof: false }, endpointFields).ok).toBe(false)
   })
 
   it('rejects a body that is not an object at all', () => {
@@ -161,5 +184,66 @@ describe('checkConfigPutFields', () => {
       'limitTokens', 'cooldownMinutes', 'handoffTimeoutMinutes',
       'idleFlushEnabled', 'idleFlushTokens', 'idleMinutes',
     ])
+  })
+})
+
+
+// The field-list checks above prove what the ENDPOINT'S KNOWN SET does. They say
+// nothing about which set the route actually passes -- measured: dropping
+// LEGACY_AUTO_RESTART_FIELDS from the call site left every one of them green.
+// So drive the route itself: a stale dashboard page's payload must still save.
+async function putAutoRestart(name: string, body: unknown): Promise<{ status: number; body: any }> {
+  const req = new EventEmitter() as unknown as RouteContext['req']
+  ;(req as unknown as { headers: Record<string, string> }).headers = {}
+  const out: { status: number; body: any } = { status: 0, body: null }
+  const res = {
+    writeHead(status: number) { out.status = status; return res },
+    end(chunk?: string) { if (chunk) out.body = JSON.parse(chunk) },
+    setHeader() {},
+  }
+  const url = new URL(`http://localhost:3420/api/agents/${encodeURIComponent(name)}/auto-restart`)
+  process.nextTick(() => {
+    ;(req as unknown as EventEmitter).emit('data', Buffer.from(JSON.stringify(body)))
+    ;(req as unknown as EventEmitter).emit('end')
+  })
+  const handled = await tryHandleAgents(
+    { req, res, path: url.pathname, method: 'PUT', url } as unknown as RouteContext,
+    join(PROJECT_ROOT, 'web'),
+  )
+  expect(handled).toBe(true)
+  return { status: out.status || 200, body: out.body }
+}
+
+// The route writes the real store file, so save and restore it: a developer
+// running the suite in a checkout that has one must not find their own
+// auto-restart config rewritten by a test.
+const STORE_FILE = join(STORE_DIR, 'auto-restart.json')
+let storeBefore: string | null = null
+
+beforeAll(() => {
+  mkdirSync(STORE_DIR, { recursive: true })
+  storeBefore = existsSync(STORE_FILE) ? readFileSync(STORE_FILE, 'utf-8') : null
+})
+
+afterAll(() => {
+  if (storeBefore !== null) writeFileSync(STORE_FILE, storeBefore)
+  else rmSync(STORE_FILE, { force: true })
+})
+
+describe('PUT /api/agents/:name/auto-restart -- the legacy handoff key', () => {
+  it('saves a payload carrying the removed field instead of 400-ing on it', async () => {
+    const r = await putAutoRestart(MAIN_AGENT_ID, {
+      enabled: false, mode: 'continue', dailyTime: null, intervalHours: null, handoff: false,
+    })
+    expect(r.status).toBe(200)
+    expect(r.body?.ok).toBe(true)
+    // Accepted, and dropped: the stored config must not carry it back.
+    expect('handoff' in (r.body?.autoRestart ?? {})).toBe(false)
+  })
+
+  it('still rejects a genuinely unknown field', async () => {
+    const r = await putAutoRestart(MAIN_AGENT_ID, { enabled: false, handof: false })
+    expect(r.status).toBe(400)
+    expect(r.body?.rejected).toEqual(['handof'])
   })
 })

--- a/src/__tests__/auto-restart.test.ts
+++ b/src/__tests__/auto-restart.test.ts
@@ -163,17 +163,27 @@ describe('the auto-restart config carries no unwired handoff switch', () => {
   it('no code on the restart path reads a handoff field', () => {
     const stripComments = (src: string): string =>
       src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1')
-    const files = [
-      'src/auto-restart.ts',
-      'src/web/auto-restart-runner.ts',
-      'src/web/agent-process.ts',
-    ]
-    for (const f of files) {
+    // Zero mentions at all: neither of these files has any business naming a
+    // handoff, and the only tolerated exception is the legacy-key list, which
+    // exists to ACCEPT the field at the API edge and then throw it away.
+    for (const f of ['src/auto-restart.ts', 'src/web/agent-process.ts']) {
       const code = stripComments(readFileSync(join(ROOT, f), 'utf-8'))
-      // The one allowed mention is the legacy-key list itself, which exists to
-      // ACCEPT the field at the API edge and then throw it away.
       const hits = code.split('\n').filter((l) => /handoff/i.test(l) && !l.includes('LEGACY_AUTO_RESTART_FIELDS'))
       expect(hits, `${f} references handoff on the restart path`).toEqual([])
     }
+    // The runner is different since the daily-handoff tier landed: it must
+    // NAME the guard's tier in order to stand aside for it, so a blanket
+    // "no line says handoff" would forbid the very delegation that keeps the
+    // two mechanisms from double-restarting one agent.
+    //
+    // The claim being defended was never "the word is absent" -- it is that no
+    // handoff FIELD of the auto-restart config can influence the restart. So
+    // match the field-access shapes (`cfg.handoff`, `handoff:`, `'handoff'`)
+    // rather than the word, and let a named call into the guard through.
+    // Verified by mutation: restoring `if (cfg.handoff)` here fails this.
+    const runner = stripComments(readFileSync(join(ROOT, 'src/web/auto-restart-runner.ts'), 'utf-8'))
+    const fieldShape = /(\.\s*handoff\b|\bhandoff\s*:|['"`]handoff['"`])/i
+    const fieldHits = runner.split('\n').filter((l) => fieldShape.test(l) && !l.includes('LEGACY_AUTO_RESTART_FIELDS'))
+    expect(fieldHits, 'auto-restart-runner.ts reads a handoff field').toEqual([])
   })
 })

--- a/src/__tests__/auto-restart.test.ts
+++ b/src/__tests__/auto-restart.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import {
   parseHHMM,
   normalizeAutoRestartConfig,
@@ -9,6 +11,9 @@ import {
   OPEN_QUESTION_DEFERRAL_CAP_MS,
   DEFAULT_AUTO_RESTART,
 } from '../auto-restart.js'
+
+// Repo root from this test file: src/__tests__ -> ../..
+const ROOT = join(__dirname, '..', '..')
 
 describe('parseHHMM', () => {
   it('parses valid times to minutes since midnight', () => {
@@ -31,12 +36,12 @@ describe('normalizeAutoRestartConfig', () => {
     expect(normalizeAutoRestartConfig({})).toEqual(DEFAULT_AUTO_RESTART)
   })
   it('keeps a valid daily config and clears interval (daily wins)', () => {
-    const c = normalizeAutoRestartConfig({ enabled: true, mode: 'fresh', dailyTime: '03:00', intervalHours: 6, handoff: true })
-    expect(c).toEqual({ enabled: true, mode: 'fresh', dailyTime: '03:00', intervalHours: null, handoff: true, openQuestionDeferralCapHours: 24 })
+    const c = normalizeAutoRestartConfig({ enabled: true, mode: 'fresh', dailyTime: '03:00', intervalHours: 6 })
+    expect(c).toEqual({ enabled: true, mode: 'fresh', dailyTime: '03:00', intervalHours: null, openQuestionDeferralCapHours: 24 })
   })
   it('keeps a valid interval config when no daily time', () => {
     const c = normalizeAutoRestartConfig({ enabled: true, mode: 'continue', intervalHours: 8 })
-    expect(c).toEqual({ enabled: true, mode: 'continue', dailyTime: null, intervalHours: 8, handoff: false, openQuestionDeferralCapHours: 24 })
+    expect(c).toEqual({ enabled: true, mode: 'continue', dailyTime: null, intervalHours: 8, openQuestionDeferralCapHours: 24 })
   })
   it('drops an invalid dailyTime and non-positive interval', () => {
     const c = normalizeAutoRestartConfig({ enabled: true, dailyTime: '99:99', intervalHours: 0 })
@@ -129,5 +134,46 @@ describe('deferralOverride', () => {
   it('respects an explicit cap argument', () => {
     expect(deferralOverride('open-question', now - 2 * day, now, 3 * day)).toBe(false)
     expect(deferralOverride('open-question', now - 3 * day, now, 3 * day)).toBe(true)
+  })
+})
+
+
+// The `handoff` field was declared here as "Phase 2" and never wired: it sat in
+// every agent's stored config, the PUT accepted it and a GET echoed it back,
+// while the restart path never read it. It has been removed, and these
+// guard the removal from both directions -- that the key is gone, and that no
+// key like it can quietly come back and be believed.
+describe('the auto-restart config carries no unwired handoff switch', () => {
+  it('drops a legacy handoff key instead of storing it', () => {
+    const c = normalizeAutoRestartConfig({ enabled: true, mode: 'fresh', dailyTime: '04:00', handoff: true })
+    expect('handoff' in c).toBe(false)
+    // The rest of the config still normalizes exactly as before.
+    expect(c).toEqual({ enabled: true, mode: 'fresh', dailyTime: '04:00', intervalHours: null, openQuestionDeferralCapHours: 24 })
+  })
+
+  it('has no handoff-shaped key under ANY name in the defaults', () => {
+    expect(Object.keys(DEFAULT_AUTO_RESTART).filter((k) => /handoff/i.test(k))).toEqual([])
+  })
+
+  // The claim this file cannot make from behavior: a config field can only
+  // influence the restart if some code on the restart path READS it, and there
+  // is no runtime path here to observe its absence. So assert the absence
+  // structurally, on the executable source with comments stripped -- the prose
+  // above deliberately says "handoff" many times, and only code counts.
+  it('no code on the restart path reads a handoff field', () => {
+    const stripComments = (src: string): string =>
+      src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1')
+    const files = [
+      'src/auto-restart.ts',
+      'src/web/auto-restart-runner.ts',
+      'src/web/agent-process.ts',
+    ]
+    for (const f of files) {
+      const code = stripComments(readFileSync(join(ROOT, f), 'utf-8'))
+      // The one allowed mention is the legacy-key list itself, which exists to
+      // ACCEPT the field at the API edge and then throw it away.
+      const hits = code.split('\n').filter((l) => /handoff/i.test(l) && !l.includes('LEGACY_AUTO_RESTART_FIELDS'))
+      expect(hits, `${f} references handoff on the restart path`).toEqual([])
+    }
   })
 })

--- a/src/__tests__/context-guard-daily-tier.test.ts
+++ b/src/__tests__/context-guard-daily-tier.test.ts
@@ -1,0 +1,287 @@
+// The context-guard's DAILY-HANDOFF tier.
+//
+// The gap it closes: a nightly fresh restart drops whatever context the session
+// was holding, because nothing on the auto-restart path writes a HANDOFF.md --
+// while a context-driven guard restart always does. The fix is a fourth trigger
+// on the EXISTING guard rather than a handoff flag on the auto-restart config
+// -- one owner for HANDOFF.md, one state machine, one timeout.
+//
+// Two failure branches are exercised on purpose, because the handoff path is
+// mostly error handling and error handling is where the bugs outlive everyone:
+//   - the handoff never arrives (must still restart, and say it went without one)
+//   - the tier is the ONLY one armed (must not be short-circuited as "disabled")
+import { describe, it, expect } from 'vitest'
+import {
+  decideGuard,
+  normalizeContextGuardConfig,
+  dailyHandoffArmed,
+  dailyHandoffDue,
+  DAILY_HANDOFF_REASON_PREFIX,
+  IDLE_FLUSH_REASON_PREFIX,
+  DEFAULT_CONTEXT_GUARD,
+  INITIAL_GUARD_STATE,
+  type ContextGuardConfig,
+  type GuardInputs,
+  type GuardState,
+} from '../context-guard.js'
+import { dailyHandoffPrompt } from '../web/context-guard-runner.js'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+const src = (rel: string): string => readFileSync(join(ROOT, rel), 'utf-8')
+
+const NOW = new Date('2026-09-10T09:00:00').getTime()
+const MIDNIGHT = new Date('2026-09-10T00:00:00').getTime()
+
+/** Only the daily tier armed: the configuration this feature actually ships in. */
+const DAILY_ONLY: ContextGuardConfig = {
+  ...DEFAULT_CONTEXT_GUARD,
+  enabled: false,
+  saturationRestart: false,
+  idleFlushEnabled: false,
+  dailyHandoffEnabled: true,
+  dailyHandoffTime: '04:00',
+}
+
+function inputs(overrides: Partial<GuardInputs> = {}): GuardInputs {
+  return {
+    nowMs: NOW,
+    pct: null,
+    running: true,
+    paneIdle: true,
+    paneBusy: false,
+    sessionReady: false,
+    handoffMtime: null,
+    paneSaturated: false,
+    contextTokens: null,
+    idleMs: null,
+    dailyHandoffDue: false,
+    ...overrides,
+  }
+}
+
+describe('dailyHandoffArmed -- the single predicate both sides read', () => {
+  it('is armed only when enabled AND the time parses', () => {
+    expect(dailyHandoffArmed(DAILY_ONLY)).toBe(true)
+    expect(dailyHandoffArmed({ ...DAILY_ONLY, dailyHandoffEnabled: false })).toBe(false)
+  })
+
+  // The trap this predicate exists for: the auto-restart runner stands aside
+  // for an ARMED tier. If "enabled with no time" counted as armed, the nightly
+  // restart would be deleted outright and silently -- strictly worse than the
+  // state this whole change fixes.
+  it('is NOT armed when enabled with no usable time', () => {
+    expect(dailyHandoffArmed({ ...DAILY_ONLY, dailyHandoffTime: null })).toBe(false)
+    expect(dailyHandoffArmed({ ...DAILY_ONLY, dailyHandoffTime: '25:99' })).toBe(false)
+    expect(dailyHandoffArmed({ ...DAILY_ONLY, dailyHandoffTime: 'reggel' })).toBe(false)
+  })
+})
+
+describe('dailyHandoffDue -- same due-semantics as the nightly restart', () => {
+  it('is not due before the slot, and due after it', () => {
+    const beforeSlot = new Date('2026-09-10T03:00:00').getTime()
+    expect(dailyHandoffDue(DAILY_ONLY, MIDNIGHT, null, beforeSlot)).toBe(false)
+    expect(dailyHandoffDue(DAILY_ONLY, MIDNIGHT, null, NOW)).toBe(true)
+  })
+
+  it('does not fire twice for the same slot', () => {
+    const served = new Date('2026-09-10T04:00:30').getTime()
+    expect(dailyHandoffDue(DAILY_ONLY, MIDNIGHT, served, NOW)).toBe(false)
+  })
+
+  it('is due again the next day', () => {
+    const servedYesterday = new Date('2026-09-09T04:00:30').getTime()
+    expect(dailyHandoffDue(DAILY_ONLY, MIDNIGHT, servedYesterday, NOW)).toBe(true)
+  })
+
+  it('is never due when the tier is not armed', () => {
+    expect(dailyHandoffDue({ ...DAILY_ONLY, dailyHandoffTime: null }, MIDNIGHT, null, NOW)).toBe(false)
+    expect(dailyHandoffDue({ ...DAILY_ONLY, dailyHandoffEnabled: false }, MIDNIGHT, null, NOW)).toBe(false)
+  })
+})
+
+describe('normalizeContextGuardConfig -- the daily fields', () => {
+  it('defaults to off with no time, and only an explicit true enables', () => {
+    const c = normalizeContextGuardConfig({})
+    expect(c.dailyHandoffEnabled).toBe(false)
+    expect(c.dailyHandoffTime).toBe(null)
+    expect(normalizeContextGuardConfig({ dailyHandoffEnabled: 'true' }).dailyHandoffEnabled).toBe(false)
+  })
+
+  it('keeps a valid HH:MM and nulls anything else', () => {
+    expect(normalizeContextGuardConfig({ dailyHandoffTime: ' 04:00 ' }).dailyHandoffTime).toBe('04:00')
+    expect(normalizeContextGuardConfig({ dailyHandoffTime: '4 ora' }).dailyHandoffTime).toBe(null)
+    expect(normalizeContextGuardConfig({ dailyHandoffTime: 400 }).dailyHandoffTime).toBe(null)
+  })
+})
+
+describe('decideGuard -- the daily tier', () => {
+  it('requests a handoff when the slot is due, and enters await-handoff with a deadline', () => {
+    const d = decideGuard(INITIAL_GUARD_STATE, inputs({ dailyHandoffDue: true }), DAILY_ONLY)
+    expect(d.action).toBe('request-handoff')
+    expect(d.reason.startsWith(DAILY_HANDOFF_REASON_PREFIX)).toBe(true)
+    expect(d.nextState.phase).toBe('await-handoff')
+    expect(d.nextState.deadlineMs).toBe(NOW + DAILY_ONLY.handoffTimeoutMinutes * 60_000)
+  })
+
+  it('does nothing when the slot is not due', () => {
+    expect(decideGuard(INITIAL_GUARD_STATE, inputs(), DAILY_ONLY).action).toBe('none')
+  })
+
+  // Deliberately NOT gated on paneIdle, unlike the idle-flush tier: this one
+  // has a slot to keep. await-handoff is what refuses to cut a live turn.
+  it('still requests the handoff from a busy agent', () => {
+    const d = decideGuard(INITIAL_GUARD_STATE, inputs({ dailyHandoffDue: true, paneIdle: false, paneBusy: true }), DAILY_ONLY)
+    expect(d.action).toBe('request-handoff')
+    expect(d.reason.startsWith(DAILY_HANDOFF_REASON_PREFIX)).toBe(true)
+  })
+
+  it('ranks BELOW the wedge tiers: a session at the hard threshold restarts on that reason', () => {
+    const cfg = { ...DAILY_ONLY, enabled: true }
+    const d = decideGuard(INITIAL_GUARD_STATE, inputs({ dailyHandoffDue: true, pct: 0.99 }), cfg)
+    expect(d.action).toBe('restart')
+    expect(d.reason).toContain('hard threshold')
+  })
+
+  it('ranks BELOW the idle-flush tier: a heavy quiet session flushes on that reason', () => {
+    const cfg = { ...DAILY_ONLY, idleFlushEnabled: true }
+    const d = decideGuard(
+      INITIAL_GUARD_STATE,
+      inputs({ dailyHandoffDue: true, contextTokens: 500_000, idleMs: 30 * 60_000 }),
+      cfg,
+    )
+    expect(d.action).toBe('request-handoff')
+    expect(d.reason.startsWith(IDLE_FLUSH_REASON_PREFIX)).toBe(true)
+  })
+
+  // Failure branch 1: the tier is the only one armed. Before the fix the
+  // "everything disabled" short-circuit swallowed it and the tier could never
+  // fire at all.
+  it('is not swallowed by the all-disabled short-circuit when it is the only tier armed', () => {
+    const d = decideGuard(INITIAL_GUARD_STATE, inputs({ dailyHandoffDue: true }), DAILY_ONLY)
+    expect(d.reason).not.toBe('disabled')
+    expect(d.action).toBe('request-handoff')
+  })
+})
+
+describe('decideGuard -- the daily tier mid-sequence (failure branches)', () => {
+  const awaiting: GuardState = {
+    phase: 'await-handoff',
+    handoffMtimeAtRequest: null,
+    deadlineMs: NOW + 60_000,
+    cooldownUntilMs: 0,
+    saturatedStreak: 0,
+    handoffStaleMinutes: null,
+  }
+
+  // Failure branch 2, and the one that made this tier need its own line in the
+  // stand-down guard: a daily-only agent must not be stood down on the very
+  // next sweep after its handoff was requested.
+  it('does not stand down during await-handoff when only the daily tier is armed', () => {
+    const d = decideGuard(awaiting, inputs(), DAILY_ONLY)
+    expect(d.reason).not.toBe('guard disabled during await-handoff')
+    expect(d.nextState.phase).toBe('await-handoff')
+  })
+
+  // Failure branch 3: the agent never writes the handoff. The restart must
+  // STILL happen -- a nightly restart that waits forever is worse than one
+  // that loses context -- and the reason must say it went without one.
+  it('force-restarts when the handoff never arrives, and says so', () => {
+    const past: GuardState = { ...awaiting, deadlineMs: NOW - 1 }
+    const d = decideGuard(past, inputs({ handoffMtime: null }), DAILY_ONLY)
+    expect(d.action).toBe('restart')
+    expect(d.reason).toBe('handoff timeout -- force restart')
+  })
+
+  it('but never cuts a live turn: a busy pane defers the timeout restart', () => {
+    const past: GuardState = { ...awaiting, deadlineMs: NOW - 1 }
+    const d = decideGuard(past, inputs({ paneIdle: false, paneBusy: true }), DAILY_ONLY)
+    expect(d.action).toBe('none')
+    expect(d.reason).toContain('deferring restart')
+  })
+
+  // Existence is not freshness: the handoff must post-date the request. A
+  // HANDOFF.md left on disk by an earlier session, weeks old, must not satisfy
+  // the wait.
+  it('an OLD handoff on disk does not satisfy the wait', () => {
+    const withStamp: GuardState = { ...awaiting, handoffMtimeAtRequest: NOW - 1_000 }
+    const d = decideGuard(withStamp, inputs({ handoffMtime: NOW - 5_000 }), DAILY_ONLY)
+    expect(d.action).toBe('none')
+    expect(d.reason).toBe('waiting for handoff')
+  })
+
+  it('a handoff written AFTER the request restarts the agent', () => {
+    const withStamp: GuardState = { ...awaiting, handoffMtimeAtRequest: NOW - 5_000 }
+    const d = decideGuard(withStamp, inputs({ handoffMtime: NOW - 1_000 }), DAILY_ONLY)
+    expect(d.action).toBe('restart')
+    expect(d.nextState.phase).toBe('await-ready')
+  })
+})
+
+describe('dailyHandoffPrompt', () => {
+  it('states a scheduled restart, names the time and the path, and claims no emergency', () => {
+    const p = dailyHandoffPrompt('04:00', '/tmp/agent/HANDOFF.md')
+    expect(p).toContain('04:00')
+    expect(p).toContain('/tmp/agent/HANDOFF.md')
+    expect(p).toContain('nem vészhelyzet')
+    // The act-tier wording would be a lie here: this session is nowhere near
+    // its context limit, and telling it otherwise provokes exactly the
+    // panicked mid-task abandonment the separate wording exists to avoid.
+    expect(p).not.toContain('kritikus')
+  })
+})
+
+// The three wiring facts that live in runner code -- fs, tmux and a 60s sweep
+// away from any unit test. Asserted structurally, the same way the auto-restart
+// suite asserts the absence of a handoff read: there is no runtime path here to
+// observe, and "the pure predicate is correct" says nothing about whether the
+// runner calls it. Each of these was verified by mutation.
+describe('runner wiring', () => {
+  it('the nightly auto-restart stands aside for an ARMED daily tier, before computing its own due slot', () => {
+    const code = src('src/web/auto-restart-runner.ts')
+    expect(code).toContain('dailyHandoffArmed(readContextGuardConfig(name))')
+    // Order matters: standing aside after the due computation would still let
+    // this runner restart the agent on the same tick the guard asks for a
+    // handoff -- exactly the double-restart the delegation exists to prevent.
+    //
+    // Anchor on the CALL SITE, not on the bare identifier: the import line at
+    // the top of the file precedes everything, so `indexOf('dailyHandoffArmed(')`
+    // passed no matter where the check actually sat (measured -- this
+    // assertion was blind to a mutation that moved the block below the due
+    // computation until the anchor was narrowed).
+    expect(code.indexOf('dailyHandoffArmed(readContextGuardConfig(name))'))
+      .toBeLessThan(code.indexOf('const dueAt = computeDueAt('))
+  })
+
+  it('the guard marks the daily slot served, so a failed prompt cannot re-fire it every sweep', () => {
+    const code = src('src/web/context-guard-runner.ts')
+    // The two lines must be ADJACENT, not merely both present: the same
+    // `lastDailyHandoff.set(name, nowMs)` call also implements seed-on-first-
+    // sight further up, so a `toContain` on it alone stayed green when the
+    // mark-served line was deleted (measured).
+    expect(code).toContain(
+      'if (decision.reason.startsWith(DAILY_HANDOFF_REASON_PREFIX)) {\n' +
+      '    lastDailyHandoff.set(name, nowMs)\n' +
+      '  }',
+    )
+  })
+
+  it('the daily reason selects the scheduled wording, not the act tier percentage prompt', () => {
+    const code = src('src/web/context-guard-runner.ts')
+    expect(code).toContain('dailyHandoffPrompt(cfg.dailyHandoffTime')
+  })
+
+  // The runner keeps its OWN copy of the "fully disarmed" condition, ahead of
+  // decideGuard. The daily tier was missing from it: an agent with the
+  // saturation net off and the daily tier on was dropped before the state
+  // machine ever ran, silently. Found by reading the early returns, not by a
+  // failing test -- which is why this assertion exists now.
+  it('the runner does not treat a daily-only agent as fully disarmed', () => {
+    const code = src('src/web/context-guard-runner.ts')
+    expect(code).toContain(
+      'if (!cfg.enabled && !cfg.saturationRestart && !cfg.idleFlushEnabled && !cfg.dailyHandoffEnabled) {',
+    )
+  })
+})

--- a/src/__tests__/context-guard.test.ts
+++ b/src/__tests__/context-guard.test.ts
@@ -31,6 +31,10 @@ function inputs(overrides: Partial<GuardInputs> = {}): GuardInputs {
     sessionReady: false,
     handoffMtime: null,
     paneSaturated: false,
+    // The daily tier defaults to not-due for the same reason the idle probes
+    // default to unmeasurable: every pre-existing case below must keep
+    // describing an agent this tier cannot act on.
+    dailyHandoffDue: false,
     // Idle-flush probes default to unmeasurable, so every pre-existing case
     // below describes an agent the idle tier cannot act on. That keeps this
     // helper's change from silently arming a new tier under the old tests.

--- a/src/auto-restart.ts
+++ b/src/auto-restart.ts
@@ -41,8 +41,6 @@ export interface AutoRestartConfig {
   /** Restart every N hours, or null. Exactly one of dailyTime/intervalHours is
    *  meaningful; dailyTime wins if both are somehow set. */
   intervalHours: number | null
-  /** Phase 2: run the handoff skill to persist context before a fresh restart. */
-  handoff: boolean
   /** Hours an unanswered inbound question may keep deferring a due restart
    *  before the restart proceeds anyway. See OPEN_QUESTION_DEFERRAL_CAP_HOURS. */
   openQuestionDeferralCapHours: number
@@ -50,12 +48,35 @@ export interface AutoRestartConfig {
 
 export const OPEN_QUESTION_DEFERRAL_CAP_HOURS = 24
 
+/**
+ * Config keys this endpoint still ACCEPTS but no longer stores.
+ *
+ * `handoff` was declared here as "Phase 2: run the handoff skill before a fresh
+ * restart" and was never wired: the restart path (auto-restart-runner,
+ * agent-process) contained zero references to it, and performRestart passed only
+ * `{ fresh }`. So the field read as a switch -- it is in every agent's stored
+ * config, the PUT accepted it, a GET echoed it back -- while setting it to true
+ * changed nothing. That is worse than a missing feature: the obvious remedy for a
+ * nightly restart losing uncommitted context is "turn handoff on for the working
+ * agents", and it would have looked done while doing nothing.
+ *
+ * Handoffs have ONE owner, and it is not this module: the context-guard writes
+ * HANDOFF.md through its own await-handoff state machine, with a timeout and a
+ * staleness refresh. Do not re-add a handoff flag here without wiring it; if the
+ * nightly restart should request a handoff, that belongs in the context-guard as
+ * another trigger, not as a second machine racing the first over the same file.
+ *
+ * Kept in the accepted set purely so an already-loaded dashboard page (whose
+ * cached app.js still sends `handoff: false`) does not start failing its save
+ * with a 400. normalizeAutoRestartConfig drops it, so it is never persisted.
+ */
+export const LEGACY_AUTO_RESTART_FIELDS = ['handoff'] as const
+
 export const DEFAULT_AUTO_RESTART: AutoRestartConfig = {
   enabled: false,
   mode: 'continue',
   dailyTime: null,
   intervalHours: null,
-  handoff: false,
   openQuestionDeferralCapHours: OPEN_QUESTION_DEFERRAL_CAP_HOURS,
 }
 
@@ -96,7 +117,6 @@ export function normalizeAutoRestartConfig(raw: unknown): AutoRestartConfig {
     mode,
     dailyTime,
     intervalHours,
-    handoff: o.handoff === true,
     openQuestionDeferralCapHours,
   }
 }

--- a/src/auto-restart.ts
+++ b/src/auto-restart.ts
@@ -155,6 +155,20 @@ export function dailyDueAtMs(
 }
 
 /**
+ * Start-of-local-day timestamp for the day containing `nowMs`.
+ *
+ * Lives here, next to dailyDueAtMs, because TWO runners now schedule on a
+ * daily wall-clock slot: the nightly auto-restart and the context-guard's
+ * daily-handoff tier. A second private copy of this would be a second place
+ * for a midnight boundary to drift.
+ */
+export function localMidnightMs(nowMs: number): number {
+  const d = new Date(nowMs)
+  d.setHours(0, 0, 0, 0)
+  return d.getTime()
+}
+
+/**
  * Why a due restart must still be deferred, or null when it may proceed.
  * Pure so the invariants are unit-testable:
  *   - a busy pane defers (never cut off a live turn), and

--- a/src/context-guard.ts
+++ b/src/context-guard.ts
@@ -20,6 +20,13 @@
 // This module is dependency-free (no clock, tmux, or fs) so the state machine
 // is unit-testable. The I/O lives in src/web/context-guard-runner.ts.
 
+// The daily-handoff tier reuses the auto-restart module's PURE due-helpers
+// (parseHHMM / dailyDueAtMs / restartDue) rather than restating the schedule
+// arithmetic: two copies of "is this daily slot due" would be two places to
+// get a midnight boundary wrong. Those helpers touch no clock or fs, so the
+// dependency-free property above still holds.
+import { parseHHMM, dailyDueAtMs, restartDue } from './auto-restart.js'
+
 export interface ContextGuardConfig {
   /** Master toggle for the PROACTIVE tiers (actPct handoff / hardPct restart).
    *  Default FALSE: opt-in per agent. (The original rationale -- avoiding a
@@ -57,6 +64,17 @@ export interface ContextGuardConfig {
   idleFlushTokens: number
   /** How long the session must have been quiet before the idle tier acts. */
   idleMinutes: number
+  /** Daily-handoff tier: at a fixed wall-clock time, hand the session off and
+   *  restart it -- the scheduled counterpart of the three context-driven
+   *  tiers. Independent of `enabled` and default FALSE, like the idle tier:
+   *  it answers a third question (is this session a DAY old), and turning it
+   *  on ends a conversation on a timetable rather than on a measurement. */
+  dailyHandoffEnabled: boolean
+  /** Local wall-clock time (HH:MM) the daily tier fires at; null = unset.
+   *  Unset is NOT a silent no-op for the operator: dailyHandoffArmed() is
+   *  false, so the auto-restart runner keeps its own nightly restart instead
+   *  of standing aside for a tier that can never fire. */
+  dailyHandoffTime: string | null
 }
 
 export const DEFAULT_CONTEXT_GUARD: ContextGuardConfig = {
@@ -106,6 +124,12 @@ export const DEFAULT_CONTEXT_GUARD: ContextGuardConfig = {
   // "quieter than this is not a working turn" boundary rather than a second
   // invented figure.
   idleMinutes: 20,
+  dailyHandoffEnabled: false,
+  // No default time. A default here would be a schedule nobody chose, and the
+  // arming predicate treats null as "not armed", so an operator who enables
+  // the tier without naming a time keeps the old nightly restart rather than
+  // losing it to a tier that never fires.
+  dailyHandoffTime: null,
 }
 
 /** Coerce arbitrary parsed JSON into a safe, fully-populated config. */
@@ -139,6 +163,11 @@ export function normalizeContextGuardConfig(raw: unknown): ContextGuardConfig {
     idleFlushEnabled: o.idleFlushEnabled === true, // default-off (opt-in), like `enabled`
     idleFlushTokens,
     idleMinutes: mins(o.idleMinutes, DEFAULT_CONTEXT_GUARD.idleMinutes),
+    dailyHandoffEnabled: o.dailyHandoffEnabled === true, // default-off (opt-in), like the other tiers
+    // Same shape as normalizeAutoRestartConfig's dailyTime: a value that does
+    // not parse as HH:MM becomes null rather than being carried through, so a
+    // typo disarms the tier instead of scheduling it at an unreadable time.
+    dailyHandoffTime: parseHHMM(o.dailyHandoffTime) !== null ? (o.dailyHandoffTime as string).trim() : null,
   }
 }
 
@@ -307,6 +336,11 @@ export interface GuardInputs {
    *  writes nothing while it runs -- so it is only ever read together with
    *  paneIdle. See readTranscriptMtimeFromProjectDir. */
   idleMs: number | null
+  /** The configured daily slot has come round and has not been served yet.
+   *  Computed by the runner with dailyHandoffDue(), which needs a local
+   *  midnight and the last-served stamp -- neither of which belongs in this
+   *  clock-free module's decision function. */
+  dailyHandoffDue: boolean
 }
 
 /**
@@ -329,6 +363,48 @@ export const IDLE_FLUSH_REASON_PREFIX = 'idle-flush'
  * context is critical" may be false.
  */
 export const STALE_REFRESH_REASON_PREFIX = 'stale-handoff-refresh'
+
+/**
+ * Reason prefix for the scheduled daily handoff. A fourth wording again: this
+ * agent's session is neither near its limit nor expensive nor finished, it is
+ * simply a day old, and telling it otherwise would be false. The runner
+ * matches this constant to pick the prompt.
+ */
+export const DAILY_HANDOFF_REASON_PREFIX = 'daily-handoff'
+
+/**
+ * Whether the daily tier can actually fire for this config.
+ *
+ * ONE predicate, two readers: the tier itself, and the auto-restart runner
+ * deciding whether to stand aside. They must never disagree -- an auto-restart
+ * that stands down for a tier that cannot fire silently removes the nightly
+ * restart, which is strictly worse than the state this whole change is fixing.
+ * "Enabled" is therefore not enough: an unparseable or absent time disarms it.
+ */
+export function dailyHandoffArmed(cfg: ContextGuardConfig): boolean {
+  return cfg.dailyHandoffEnabled && parseHHMM(cfg.dailyHandoffTime) !== null
+}
+
+/**
+ * Is the configured daily slot due and unserved?
+ *
+ * `lastRunMs` is the last time this tier fired for the agent (null = never /
+ * not yet seeded). The comparison is delegated to restartDue, the same
+ * predicate the nightly auto-restart uses, so "due" means exactly what it
+ * already means elsewhere in the fleet: past the slot, and not already served
+ * for that slot.
+ */
+export function dailyHandoffDue(
+  cfg: ContextGuardConfig,
+  localMidnightMs: number,
+  lastRunMs: number | null,
+  nowMs: number,
+): boolean {
+  if (!dailyHandoffArmed(cfg)) return false
+  const mins = parseHHMM(cfg.dailyHandoffTime)
+  if (mins === null) return false
+  return restartDue(lastRunMs, nowMs, dailyDueAtMs(localMidnightMs, mins))
+}
 
 /** Slack between HANDOFF.md's mtime and the last transcript activity before
  *  the handoff counts as stale. The handoff-writing turn itself touches the
@@ -423,7 +499,7 @@ export function decideGuard(
   const none = (reason: string, next: GuardState = state): GuardDecision =>
     ({ action: 'none', reason, nextState: next })
 
-  if (!cfg.enabled && !cfg.saturationRestart && !cfg.idleFlushEnabled) {
+  if (!cfg.enabled && !cfg.saturationRestart && !cfg.idleFlushEnabled && !cfg.dailyHandoffEnabled) {
     return none('disabled', INITIAL_GUARD_STATE)
   }
 
@@ -463,14 +539,34 @@ export function decideGuard(
         const flush = decideIdleFlush(nowMs, inputs, cfg, cleared, none)
         if (flush) return flush
       }
+      // Daily tier, ranked LAST. The three tiers above answer measured
+      // questions -- is this session about to break, is it expensive, is it
+      // finished -- and any of them is a better reason to state than "it is
+      // 04:00". This one exists for the sessions none of them ever reach: an
+      // agent below every threshold still carries a day of context into a
+      // nightly fresh restart that would otherwise drop it on the floor.
+      //
+      // Deliberately NOT gated on paneIdle. Unlike the idle tier, which only
+      // wants finished sessions, this one has a slot to keep: a busy agent
+      // gets the request and answers it after its turn, and await-handoff
+      // already refuses to cut a live turn.
+      if (cfg.dailyHandoffEnabled && inputs.dailyHandoffDue) {
+        return handoffRequest(
+          nowMs, inputs, cfg,
+          `${DAILY_HANDOFF_REASON_PREFIX} (scheduled ${cfg.dailyHandoffTime})`,
+        )
+      }
       if (!cfg.enabled) return none('proactive guard disabled (saturation net armed)', cleared)
       if (inputs.pct === null) return none('context unmeasurable', cleared)
       return none('below threshold', cleared)
     }
 
     case 'await-handoff': {
-      if (!cfg.enabled && !cfg.idleFlushEnabled) {
+      if (!cfg.enabled && !cfg.idleFlushEnabled && !cfg.dailyHandoffEnabled) {
         // Operator disabled the proactive guard mid-sequence; stand down.
+        // Every tier that can ENTER this phase has to appear here: omitting
+        // one would stand the sequence down on the sweep after it started,
+        // for an agent whose only armed tier is the missing one.
         return cooldown(nowMs, cfg, 'guard disabled during await-handoff')
       }
       if (!inputs.running) {

--- a/src/web/auto-restart-runner.ts
+++ b/src/web/auto-restart-runner.ts
@@ -13,8 +13,11 @@ import { MAIN_CHANNELS_SESSION } from './main-agent.js'
 import { respawnMainSessionFresh } from './channel-monitor.js'
 import { paneLooksIdle } from '../pane-state.js'
 import { readAutoRestartConfig } from './auto-restart-store.js'
-import { restartDue, dailyDueAtMs, parseHHMM, mainRestartMechanism, restartBlockedBy, deferralOverride, type AutoRestartConfig } from '../auto-restart.js'
+import { restartDue, dailyDueAtMs, localMidnightMs, parseHHMM, mainRestartMechanism, restartBlockedBy, deferralOverride, type AutoRestartConfig } from '../auto-restart.js'
 import { hasOpenInboundQuestion } from '../db.js'
+import { readContextGuardConfig } from './context-guard-store.js'
+import { getHardGuardPhase } from './context-guard-runner.js'
+import { dailyHandoffArmed } from '../context-guard.js'
 
 // Drives per-agent scheduled restarts (see src/auto-restart.ts for the why and
 // the pure due-logic). Mirrors the other watcher loops: a 60s sweep, started
@@ -43,11 +46,10 @@ const lastRestart = new Map<string, number>()
 // extra window -- never overriding early.
 const openQuestionDeferrals = new Map<string, { sinceMs: number; count: number }>()
 
-function localMidnightMs(nowMs: number): number {
-  const d = new Date(nowMs)
-  d.setHours(0, 0, 0, 0)
-  return d.getTime()
-}
+// Agents whose stand-down for the guard's daily tier has already been logged.
+// The condition is steady state, not an event: without this the runner would
+// write the same line every 60 seconds, 1440 times a day, per agent.
+const guardOwnedLogged = new Set<string>()
 
 function computeDueAt(cfg: AutoRestartConfig, name: string, nowMs: number): number | null {
   if (cfg.dailyTime) {
@@ -126,6 +128,38 @@ async function checkAgent(name: string, nowMs: number): Promise<void> {
   // restart cycles running sessions on a schedule; it does not resurrect dead
   // ones, matching the prior local behavior).
   if (name !== MAIN_AGENT_ID && agentRunState(name) !== 'running') return
+
+  // ONE OWNER PER NIGHTLY RESTART.
+  //
+  // When the context-guard's daily-handoff tier is armed for this agent, that
+  // tier runs the nightly cycle: it asks for a HANDOFF.md, waits out its own
+  // bounded timeout, restarts (with or without the handoff, saying which), and
+  // injects the resume prompt. A second nightly restart from here would cut
+  // that sequence in half -- most likely exactly while the agent is writing
+  // the handoff we asked for.
+  //
+  // ARMED, not merely enabled. An enabled tier whose time is missing or
+  // unparseable can never fire, and standing aside for it would delete the
+  // nightly restart outright and silently. dailyHandoffArmed is the single
+  // predicate both sides read, so they cannot drift into that gap.
+  if (dailyHandoffArmed(readContextGuardConfig(name))) {
+    if (!guardOwnedLogged.has(name)) {
+      guardOwnedLogged.add(name)
+      logger.info({ name }, 'auto-restart: context-guard daily-handoff tier armed, standing aside (it owns the nightly restart)')
+    }
+    return
+  }
+  guardOwnedLogged.delete(name)
+
+  // Stand aside while the guard is mid-sequence for ANY of its tiers, armed
+  // daily tier or not. Same interlock the soft restart gate already uses: two
+  // mechanisms must never touch one pane at once, and the guard is the one
+  // holding a HANDOFF.md request out to the agent right now.
+  const guardPhase = getHardGuardPhase(name)
+  if (guardPhase === 'await-handoff' || guardPhase === 'await-ready') {
+    logger.debug({ name, guardPhase }, 'auto-restart: context-guard mid-sequence, deferring to next tick')
+    return
+  }
 
   // Seed on first sight so a daily slot that already elapsed before boot does
   // not fire now.

--- a/src/web/context-guard-runner.ts
+++ b/src/web/context-guard-runner.ts
@@ -19,6 +19,7 @@ import { MAIN_CHANNELS_SESSION } from './main-agent.js'
 import { detectPaneState, paneShowsContextSaturation } from '../pane-state.js'
 import { readContextTokensFromProjectDir, readActiveModelFromProjectDir, readTranscriptMtimeFromProjectDir } from './active-model.js'
 import { readContextGuardConfig } from './context-guard-store.js'
+import { localMidnightMs } from '../auto-restart.js'
 import { recordRescueFailure, clearRescueFailures } from './rescue-failure-tracker.js'
 import { createAgentMessage } from '../db.js'
 import {
@@ -26,6 +27,8 @@ import {
   contextLimitForModel,
   calibrateLimit,
   handoffStaleMinutes,
+  dailyHandoffDue,
+  DAILY_HANDOFF_REASON_PREFIX,
   IDLE_FLUSH_REASON_PREFIX,
   INITIAL_GUARD_STATE,
   STALE_REFRESH_REASON_PREFIX,
@@ -53,6 +56,15 @@ const INTERVAL_MS = 300_000
 // agent at 'idle', which is safe -- the worst case is a repeated handoff
 // request, and cooldown prevents restart loops within a run.
 const guardStates = new Map<string, GuardState>()
+
+// agent name -> when the daily-handoff tier last fired (ms). Seeded on first
+// sight WITHOUT firing, so a slot that already passed before the dashboard
+// started does not trigger a handoff cycle at boot -- the same seed rule, for
+// the same reason, as the nightly auto-restart's lastRestart map. In-memory
+// like that one: a dashboard restart re-seeds and at worst skips one slot,
+// which is the safe direction (a missed daily handoff costs one day of
+// context; a spurious one ends a live conversation).
+const lastDailyHandoff = new Map<string, number>()
 const remoteSkipLogged = new Set<string>()
 
 // Per-agent observed-context high-water mark, persisted across dashboard
@@ -130,6 +142,27 @@ export function idleFlushHandoffPrompt(tokens: number, idleMinutes: number, hand
     `[CONTEXT-GUARD] Rutin karbantartás, nem vészhelyzet. A sessionöd kontextusa ~${Math.round(tokens / 1000)}k token, ` +
     `és ${idleMinutes} perce nincs benne aktivitás, ezért friss kontextussal indítalak újra -- így olcsóbb és gyorsabb lesz a következő kör. ` +
     `EGYETLEN dolgod: írj HANDOFF.md-t a /handoff skill struktúrája szerint ide: ${handoffPath} ` +
+    `(Goal / Current Progress / What Worked / What Didn't Work / Next Steps, konkrét fájl-útvonalakkal és kanban kártya-azonosítókkal). ` +
+    `Ha nincs félbehagyott feladatod, írd bele hogy nincs -- az is teljes értékű válasz. ` +
+    `Utána ÁLLJ MEG; a rendszer újraindít és a HANDOFF.md-ből folytatod.`
+  )
+}
+
+/**
+ * Handoff request for the daily tier.
+ *
+ * A fourth wording, for the same reason the idle tier needed a third: this
+ * agent's context is not critical (the act tier would have fired) and not
+ * expensive (the idle tier would have), so both of those texts would state
+ * something untrue about its session. What IS true is the only thing this
+ * prompt claims: the scheduled restart is about to happen, and whatever is
+ * not written down will not survive it.
+ */
+export function dailyHandoffPrompt(atTime: string, handoffPath: string): string {
+  return (
+    `[CONTEXT-GUARD] Ütemezett napi újraindítás (${atTime}), nem vészhelyzet és nem hiba. ` +
+    `A sessionöd hamarosan friss kontextussal indul újra, és ami nincs leírva, az nem éli túl. ` +
+    `EGYETLEN dolgod ebben a körben: írj HANDOFF.md-t a /handoff skill struktúrája szerint ide: ${handoffPath} ` +
     `(Goal / Current Progress / What Worked / What Didn't Work / Next Steps, konkrét fájl-útvonalakkal és kanban kártya-azonosítókkal). ` +
     `Ha nincs félbehagyott feladatod, írd bele hogy nincs -- az is teljes értékű válasz. ` +
     `Utána ÁLLJ MEG; a rendszer újraindít és a HANDOFF.md-ből folytatod.`
@@ -294,10 +327,17 @@ async function checkAgent(name: string, nowMs: number): Promise<void> {
   const cfg = readContextGuardConfig(name)
   const state = guardStates.get(name) ?? INITIAL_GUARD_STATE
 
-  // Fully disarmed only when BOTH the proactive tiers and the always-on
-  // saturation net are off; the net alone keeps the sweep alive so a
-  // 100%-context pane (which dispatch refuses to prompt) still gets rescued.
-  if (!cfg.enabled && !cfg.saturationRestart && !cfg.idleFlushEnabled) {
+  // Fully disarmed only when EVERY tier and the always-on saturation net are
+  // off; the net alone keeps the sweep alive so a 100%-context pane (which
+  // dispatch refuses to prompt) still gets rescued.
+  //
+  // Every tier that can act has to appear in this list. This is the THIRD
+  // copy of the same condition (decideGuard's short-circuit and its
+  // await-handoff stand-down are the other two), and the daily tier was
+  // missing from exactly this one: an operator who turned the saturation net
+  // off and the daily tier on would have been skipped here, before
+  // decideGuard ever saw the agent, with no log line to say so.
+  if (!cfg.enabled && !cfg.saturationRestart && !cfg.idleFlushEnabled && !cfg.dailyHandoffEnabled) {
     guardStates.delete(name)
     return
   }
@@ -347,9 +387,30 @@ async function checkAgent(name: string, nowMs: number): Promise<void> {
     // (handoffStaleMinutes) needs the transcript mtime on every decision path
     // that can restart, and the probe is a single stat().
     idleMs: running && needPct ? measureIdleMs(name, nowMs) : null,
+    // Seed-on-first-sight: an agent we have not seen this process is recorded
+    // as served NOW and is never due on the same sweep. dailyHandoffDue is
+    // therefore false on the first tick by construction, not by luck.
+    dailyHandoffDue: (() => {
+      if (!running || state.phase !== 'idle') return false
+      const last = lastDailyHandoff.get(name)
+      if (last === undefined) {
+        lastDailyHandoff.set(name, nowMs)
+        return false
+      }
+      return dailyHandoffDue(cfg, localMidnightMs(nowMs), last, nowMs)
+    })(),
   }
 
   const decision = decideGuard(state, inputs, cfg)
+
+  // Mark the slot served at DECISION time, not after the prompt lands. If the
+  // directive fails to send, the machine is already in await-handoff and its
+  // timeout force-restarts the agent anyway -- the slot really was consumed.
+  // Marking it later would let a send failure re-fire the tier every sweep
+  // until midnight.
+  if (decision.reason.startsWith(DAILY_HANDOFF_REASON_PREFIX)) {
+    lastDailyHandoff.set(name, nowMs)
+  }
 
   // Post-respawn grace for the main session. Making the Linux restart path work
   // (above) also makes it repeatable: measured on 2026-07-26, the saturation net
@@ -424,7 +485,12 @@ async function checkAgent(name: string, nowMs: number): Promise<void> {
               // tiers, so the alarming percentage-based prompt would read "~0%
               // -- critical". The idle tier states the token count it measured.
               ? idleFlushHandoffPrompt(inputs.contextTokens ?? 0, cfg.idleMinutes, handoffPathFor(name))
-              : handoffPrompt(pctRound ?? 0, handoffPathFor(name)),
+              : decision.reason.startsWith(DAILY_HANDOFF_REASON_PREFIX)
+                // Same trap as the idle tier: pct is null for a daily-only
+                // agent, so the percentage prompt would announce "~0% --
+                // critical" at 04:00 to a session that is perfectly healthy.
+                ? dailyHandoffPrompt(cfg.dailyHandoffTime ?? '', handoffPathFor(name))
+                : handoffPrompt(pctRound ?? 0, handoffPathFor(name)),
         )
         break
       case 'restart': {

--- a/src/web/routes/agents.ts
+++ b/src/web/routes/agents.ts
@@ -124,7 +124,7 @@ import type { ContextGuardConfig } from '../../context-guard.js'
 // Derived from the DEFAULT config objects, not hand-listed: a field added to
 // the interface is added to its default too, so the accepted-key set cannot
 // drift away from what normalize*Config() actually reads.
-import { DEFAULT_AUTO_RESTART } from '../../auto-restart.js'
+import { DEFAULT_AUTO_RESTART, LEGACY_AUTO_RESTART_FIELDS } from '../../auto-restart.js'
 import { DEFAULT_CONTEXT_GUARD } from '../../context-guard.js'
 import { setStoreWriteActor } from '../../store-watcher.js'
 import { attemptChannelMcpReconnect } from '../channel-mcp-reconnect.js'
@@ -1464,7 +1464,10 @@ export async function tryHandleAgents(ctx: RouteContext, webDir: string): Promis
     const body = await readBody(req)
     let data: unknown
     try { data = JSON.parse(body.toString()) } catch { json(res, { error: 'invalid JSON' }, 400); return true }
-    const arFields = checkConfigPutFields(data, Object.keys(DEFAULT_AUTO_RESTART))
+    // Legacy keys are accepted (and dropped by normalization), never stored --
+    // see LEGACY_AUTO_RESTART_FIELDS for why rejecting them would break a save
+    // from a dashboard page that is already open.
+    const arFields = checkConfigPutFields(data, [...Object.keys(DEFAULT_AUTO_RESTART), ...LEGACY_AUTO_RESTART_FIELDS])
     if (!arFields.ok) {
       json(res, { error: arFields.message, rejected: arFields.rejected, known: Object.keys(DEFAULT_AUTO_RESTART) }, 400)
       return true

--- a/web/app.js
+++ b/web/app.js
@@ -4793,7 +4793,6 @@ document.getElementById('saveAutoRestartBtn').addEventListener('click', async ()
     mode: document.getElementById('arMode').value === 'fresh' ? 'fresh' : 'continue',
     dailyTime: schedKind === 'daily' ? document.getElementById('arDailyTime').value : null,
     intervalHours: schedKind === 'interval' ? Number(document.getElementById('arIntervalHours').value) : null,
-    handoff: false,
   }
   try {
     const res = await fetch(`/api/agents/${encodeURIComponent(id)}/auto-restart`, {


### PR DESCRIPTION
## A változtatás típusa / Type of change

- [x] Bug fix (hibajavítás / bug fix)
- [x] Új funkció (feature / new feature)

## Rövid leírás / Summary

A nightly auto-restart does a fresh restart and writes no `HANDOFF.md`, so a
session that was below every context threshold still loses a day of working
context. A context-driven guard restart, on the same install, always produces
one. The difference is not a missing flag on the auto-restart config: handoffs
have exactly one owner, the context-guard's `await-handoff` state machine, with
its request, timeout, staleness refresh and resume prompt.

Two commits:

**1. `fix(auto-restart)`: drop the handoff field that looked like a switch.**
`handoff` was declared in the auto-restart config as "Phase 2: run the handoff
skill before a fresh restart" and was never wired. The restart path held zero
references to it and `performRestart` passed only `{ fresh }` -- yet it sat in
every stored config, the PUT accepted it and a GET echoed it back. Turning it on
was a complete "it worked" experience with no effect, which is worse than a
missing feature: it is the obvious remedy for exactly this bug, and it does
nothing. The key is still ACCEPTED at the API edge (a dashboard page open with
the old `app.js` must not get a 400 for a field we shipped) and dropped by
`normalizeAutoRestartConfig` -- tolerated, never stored.

**2. `feat(context-guard)`: add a daily-handoff trigger tier.** A fourth trigger
on the EXISTING state machine, not a second machine racing it over the same
file. `ContextGuardConfig` gains `dailyHandoffEnabled` and `dailyHandoffTime`.

Design points worth review:

- **Ranked last in the idle phase.** The three tiers above it answer measured
  questions (about to break, expensive, finished); any of them is a better
  reason to state than "the clock says so".
- **Not gated on `paneIdle`,** unlike the idle tier: this one has a slot to
  keep, and `await-handoff` already refuses to cut a live turn.
- **No default time.** A default here is a schedule nobody chose. The arming
  predicate treats `null` as not armed, so enabling the tier without a time
  keeps the old nightly restart rather than losing it to a tier that can never
  fire.
- **The nightly restart stands aside for an ARMED tier,** via one predicate both
  sides read. Armed, not merely enabled -- standing aside for an enabled tier
  with no usable time would delete the nightly restart outright and silently.
- **The "everything disabled" short-circuit exists in three places** and the new
  tier had to be added to all three. It was missing from the runner's copy,
  which would have dropped a daily-only agent before the state machine ever ran.
  Found by reading the early returns, not by a failing test, so it is pinned now.
- **Schedule arithmetic is reused, not restated:** the tier calls the
  auto-restart module's pure `parseHHMM` / `dailyDueAtMs` / `restartDue`, and
  `localMidnightMs` moved there so both runners share one day boundary.
- **The scheduled request gets its own wording.** The act tier's "your context
  is critical" is false for a session this tier fires on.

Three wiring facts live in runner code, a sweep away from any unit test, so they
are asserted structurally on the source and each was verified by mutation.

## Kapcsolódó issue / Related issue

Nincs / N/A

## Ellenőrzőlista / Checklist

- [x] Kipróbáltam a módosítást a lokális környezetben (Telegram/Slack + dashboard), az ágensek hiba nélkül kommunikálnak. / Tested locally (Telegram/Slack + dashboard); the agents communicate without errors.
- [x] Frissítettem a `docs/` mappát, ha a változtatás érinti a telepítést vagy az architektúrát. / Updated `docs/` if the change affects installation or architecture.
      <sub>No docs change was needed: `docs/config-reference.md` lists `store/auto-restart.json` at file level and names no removed field, and the context-guard config is not documented field by field. Installation is unaffected.</sub>
- [x] A kód nem tartalmaz beleégetett szenzitív adatot (API kulcs, token, személyes adat). / No hardcoded secrets (API keys, tokens, personal data).
- [x] Saját, beszédes nevű branch-ről nyitom (nem közvetlenül `develop`-ra). / Opened from an own, descriptively named branch (not directly on `develop`).

## Titok-kapu / Secret gate

- [x] Nincs a valtoztatasban bizonyitek-/artefaktum-mappa, titok-alaku string vagy idezett csatorna-uzenet.
      / No evidence or artifact directory, secret-shaped string, or quoted channel message in this change.

### Verification

`npm run typecheck`, `npm run syntax-check` and `npm run test` (423 files,
5395 passed, 1 skipped) all green on the rebased branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
