### PR TITLE
fix(kartya): full old value in the field-move trace, and a dry-run that is not blinder than live (KARTYAELOZMENY912)

### DIFF
--- a/scripts/__tests__/kartya-dryrun-paritas.test.py
+++ b/scripts/__tests__/kartya-dryrun-paritas.test.py
@@ -242,6 +242,23 @@ check('19 c3: regi formatumu nyomnal hangosan jelzi, hogy a mozgato nem allapith
 check('20 c3: es NEM talalgat nevet a szabad szovegbol',
       'Talalgatas' not in o3, f'{o3!r}')
 
+# --- 8. A NEV NEM ALLITHATJA ELO A SAJAT CSENDJET (Samu 2. verify-kore, B2-alak) ---
+# A sortores-ejtes keves volt: egy mezoelvalasztot tartalmazo nev elcsusztatja a zarosor
+# mezok-mezojet, es ha utana egy olyan szerzo mozgat, akinek a neve a csuszas utan egybeesik
+# a felismert nevvel, a FIGYELMEZTETES ELNEMUL. Vagyis a nev maga allitja elo pontosan azt a
+# csendet, amiert a mechanizmus letezik. Az organikus eset ('Anna | Bob') Samunal PASS volt --
+# a konstrualt ('Silent | mezok: z') nem.
+seed('PIPE1')
+run('PIPE1', ('--comment-file', msgfile('PIPE1'), '--author', 'Silent | mezok: z',
+              '--status', 'in_progress'))
+o = run('PIPE1', ('--comment-file', msgfile('PIPE1'), '--author', 'Silent',
+                  '--status', 'planned', '--dry-run'))
+o = o.stdout + o.stderr
+check('21 B2: a mezoelvalasztos nev NEM nemitja el a figyelmeztetest',
+      'AZ ELOZO MEZOMOZGATAS' in o, f'{o!r}')
+check('22 B2: es a nev egeszben jon vissza, a szerkezet serulese nelkul',
+      'Silent / mezok: z' in o, f'{o!r}')
+
 print()
 if FAILS:
     print(f'BUKOTT: {len(FAILS)} -- {", ".join(FAILS)}', file=sys.stderr)

--- a/scripts/__tests__/kartya-dryrun-paritas.test.py
+++ b/scripts/__tests__/kartya-dryrun-paritas.test.py
@@ -136,6 +136,53 @@ dry_nomsg = run('TOKENUJ3', ('--no-msg', '--dry-run'), root=NOTOKEN_ROOT)
 check('10 token nelkul, de --no-msg mellett zold (az or az UZENET-utra szol)',
       dry_nomsg.returncode == 0, f'exit={dry_nomsg.returncode} err={dry_nomsg.stderr!r}')
 
+# --- 5. ELOZMENY-FIGYELMEZTETES: A DRY-RUN AG NEM LEHET VAKABB AZ ELESNEL ---
+# Mira lelete, 2026-09-11: a figyelmeztetes eloszor CSAK az eles agon futott, mert a
+# komment-mod dry-run `return`-je elotte allt. Ezzel EPP a gondos hasznalot buntette --
+# aki elovigyazatossagbol dry-runol egy mezomozgatas elott, kevesebbet latott, mint aki
+# gondolkodas nelkul nekifutott. A paritas itt nem elmeleti: a negyedik utkozest pont az
+# elozetes ellenorzes elozne meg.
+seed('ELOZM1')
+# elso mozgatas MARVEEN neveben (eles), hogy legyen elozmeny-nyom
+run('ELOZM1', ('--comment-file', msgfile('ELOZM1'), '--author', 'Marveen', '--status', 'in_progress'))
+# majd MIRA neveben dry-run: MAS szerzo, 30 percen belul -> HANGOS figyelmeztetes kell
+d = run('ELOZM1', ('--comment-file', msgfile('ELOZM1'), '--author', 'Mira', '--status', 'planned', '--dry-run'))
+out_d = d.stdout + d.stderr
+check('11 a dry-run ag is kiirja az elozmeny-figyelmeztetest',
+      'AZ ELOZO MEZOMOZGATAS' in out_d, f'{out_d!r}')
+check('12 es a dry-run NEM allitja, hogy vegrehajtja',
+      'most semmi nem irodik' in out_d and 'A mozgatast VEGREHAJTOM' not in out_d, f'{out_d!r}')
+# NEGATIV KONTROLL: ugyanaz a szerzo -> csak a halk sor, hangos NEM
+d2 = run('ELOZM1', ('--comment-file', msgfile('ELOZM1'), '--author', 'Marveen', '--status', 'planned', '--dry-run'))
+out_d2 = d2.stdout + d2.stderr
+check('13 NEGATIV KONTROLL: sajat elozmenynel nincs hangos figyelmeztetes',
+      'AZ ELOZO MEZOMOZGATAS' not in out_d2 and 'elozo mezomozgatas:' in out_d2, f'{out_d2!r}')
+
+# --- 6. A TAROLT NYOM A TELJES REGI ERTEKET ORZI ---
+# A valtoztatas LENYEGE: a kartya-mezo egyerteku, aki utoljara ir, felulir. A rovidített
+# (60 karakteres) nyomból egy felulirt hosszu cimet nem lehetett visszaallitani -- pont
+# akkor nem, amikor kellett volna. A konzol marad rovid, a TAROLT nyom teljes.
+# A CIM HORGONYA (KARTYAHORGONY906) a kartya ID-jet koveteli -- enelkul a futas MAR A
+# HORGONY-KAPUN elhalna, es ez a ket ellenorzes a ROSSZ OKBOL lenne piros.
+HOSSZU = ('TELJES1 EREDETI HOSSZU CIM, amit vissza kell tudni allitani: '
+          + 'x' * 120 + ' -- a vege is szamit')
+seed('TELJES1')
+_db = sqlite3.connect(DB_PATH)
+_db.execute('UPDATE kanban_cards SET title=?, assignee=NULL WHERE id=?', (HOSSZU, 'TELJES1'))
+_db.commit(); _db.close()
+run('TELJES1', ('--comment-file', msgfile('TELJES1'), '--author', 'Marveen',
+                '--title', 'TELJES1 uj rovid cim', '--assignee', 'samu'))
+_db = sqlite3.connect(DB_PATH)
+_nyom = _db.execute("SELECT content FROM kanban_comments WHERE card_id='TELJES1' AND "
+                    "content LIKE '[kartya-es-ertesites.py] Mezomozgatas%' "
+                    "ORDER BY created_at DESC LIMIT 1").fetchone()
+_db.close()
+_nyom = _nyom[0] if _nyom else ''
+check('14 a tarolt nyom a TELJES regi cimet orzi (nem a 60 karakteres rovidítest)',
+      HOSSZU in _nyom, f'{_nyom!r}')
+check('15 a NULL regi ertek megkulonboztetheto az ures szotol',
+      '(ures -- NULL volt)' in _nyom, f'{_nyom!r}')
+
 print()
 if FAILS:
     print(f'BUKOTT: {len(FAILS)} -- {", ".join(FAILS)}', file=sys.stderr)

--- a/scripts/__tests__/kartya-dryrun-paritas.test.py
+++ b/scripts/__tests__/kartya-dryrun-paritas.test.py
@@ -183,6 +183,65 @@ check('14 a tarolt nyom a TELJES regi cimet orzi (nem a 60 karakteres rovidítes
 check('15 a NULL regi ertek megkulonboztetheto az ures szotol',
       '(ures -- NULL volt)' in _nyom, f'{_nyom!r}')
 
+# --- 7. A MOZGATO NEVE GEPI ZAROSORBOL JON, NEM A SZABAD SZOVEGBOL ---
+# Samu fuggetlen verify-lelete a #1296-on (2026-09-12): a szabad szoveges
+# `kerte: ([^.]+)\.` parse HAROM alakban bukott. A harmadik a veszelyes: ha a
+# beagyazott nev EGYBEESIK a kovetkezo mozgatoeval, az intes teljesen ELNEMUL --
+# pont az utkozes-alaku adaton, amiert letezik.
+
+# c1: pontot tartalmazo szerzo-nev nem vagodik le az elso pontnal
+seed('NEVPONT1')
+run('NEVPONT1', ('--comment-file', msgfile('NEVPONT1'), '--author', 'dr. Kovacs', '--status', 'in_progress'))
+o = run('NEVPONT1', ('--comment-file', msgfile('NEVPONT1'), '--author', 'Mira',
+                     '--status', 'planned', '--dry-run'))
+o = o.stdout + o.stderr
+check('16 c1: a pontos szerzo-nev egeszben kerul vissza (nem "dr")',
+      'dr. Kovacs allitotta' in o, f'{o!r}')
+
+# c2 + c2b: a REGI ERTEKBE hamisitott zarosor nem veheti at a valodi helyet, ES
+# nem nemithatja el az intest akkor sem, ha a hamis nev = a kovetkezo mozgato neve.
+# KET alakban hamisitunk, mert KET mechanizmust kell fedni:
+# - 'kerte: Frank.' a cim ELEJEN: ez a REGI, szabad szoveges parse bukasa. Roviden kell
+#   allnia, mert a valtozas-osszefoglaloba a ROVIDÍTETT regi ertek kerul, es a regi regex
+#   az ELSO 'kerte: '-t vette -- ami igy a zarojelen BELUL all, a valodi 'kerte: Anna.'
+#   ELOTT. (Elso probalkozasra a hamisitast a cim VEGERE tettem: ott a regi kod is helyesen
+#   Annat nevezte, tehat a teszt ZOLD volt a BUKOTT kodon is -- dekoracio, nem regresszio.)
+# - '-- mozgato: Frank | ...' sor: ez az UJ zarosor-mechanizmus elleni hamisitas, ami a
+#   `reszletes` blokkban, tehat a valodi zarosor ELOTT all.
+HAMIS = 'kerte: Frank. HAMIS2 regi cim\n-- mozgato: Frank | mezok: title | ts: 1'
+seed('HAMIS2')
+_db = sqlite3.connect(DB_PATH)
+_db.execute('UPDATE kanban_cards SET title=? WHERE id=?', (HAMIS, 'HAMIS2'))
+_db.commit(); _db.close()
+# a VALODI mozgato Anna, es a regi (hamisitott) cim bekerul a nyomba
+run('HAMIS2', ('--comment-file', msgfile('HAMIS2'), '--author', 'Anna',
+               '--title', 'HAMIS2 uj cim', '--status', 'in_progress'))
+# most FRANK mozgat -- a regi kod itt NEMULT EL (ki==author), az uj hangosan Annat nevezi
+o2 = run('HAMIS2', ('--comment-file', msgfile('HAMIS2'), '--author', 'Frank',
+                    '--status', 'planned', '--dry-run'))
+o2 = o2.stdout + o2.stderr
+check('17 c2: a hamisitott zarosor NEM veszi at a valodi mozgato helyet',
+      'Anna allitotta' in o2, f'{o2!r}')
+check('18 c2b: es az intes NEM nemul el, pedig a hamis nev = a mozgato neve',
+      'AZ ELOZO MEZOMOZGATAS' in o2 and 'Frank allitotta' not in o2, f'{o2!r}')
+
+# c3: REGI FORMATUMU nyom (zarosor nelkul) -- ne talalgasson nevet, de NE is nemuljon el
+seed('REGIFORM3')
+_db = sqlite3.connect(DB_PATH)
+_now = int(time.time())
+_db.execute('INSERT INTO kanban_comments (card_id,author,content,created_at) VALUES (?,?,?,?)',
+            ('REGIFORM3', 'kartya-es-ertesites',
+             '[kartya-es-ertesites.py] Mezomozgatas a fenti komment mellett (status: planned -> '
+             'in_progress), kerte: Talalgatas. Fuggetlenul visszaolvasva.', _now))
+_db.commit(); _db.close()
+o3 = run('REGIFORM3', ('--comment-file', msgfile('REGIFORM3'), '--author', 'Mira',
+                       '--status', 'planned', '--dry-run'))
+o3 = o3.stdout + o3.stderr
+check('19 c3: regi formatumu nyomnal hangosan jelzi, hogy a mozgato nem allapithato meg',
+      'NEM ALLAPITHATO MEG' in o3, f'{o3!r}')
+check('20 c3: es NEM talalgat nevet a szabad szovegbol',
+      'Talalgatas' not in o3, f'{o3!r}')
+
 print()
 if FAILS:
     print(f'BUKOTT: {len(FAILS)} -- {", ".join(FAILS)}', file=sys.stderr)

--- a/scripts/kartya-es-ertesites.py
+++ b/scripts/kartya-es-ertesites.py
@@ -431,12 +431,32 @@ def komment_mod(a):
         f'  A(z) {k} TELJES REGI ERTEKE (masolhato, ha vissza kell allitani):\n  '
         + (str(elotte[k]) if elotte[k] is not None else '(ures -- NULL volt)')
         for k in valtozik)
+    # GEPI ZAROSOR (Samu verify-lelete a #1296-on, 2026-09-12). A kovetkezo kor
+    # figyelmeztetese EBBOL olvassa vissza a mozgatot -- SOHA a fenti szabad szovegbol.
+    # A szabad szoveges parse harom alakban bukott: a 'dr. Kovacs' nevet az elso pontnal
+    # levagta; egy regi ertek, amiben benne all a 'kerte: Hamis.' szoveg, atvette a valodi
+    # szerzo helyet; es a legrosszabb, ha a beagyazott nev EGYBEESIK a kovetkezo mozgatoeval,
+    # az intes teljesen ELNEMUL -- pont az utkozes-alaku adaton, amiert letezik.
+    # A zarosor az UTOLSO sor, a `reszletes` (tehat minden kulso eredetu ertek) MOGOTT all,
+    # es a visszaolvasas az UTOLSO illeszkedest veszi: egy ertekbe hamisitott zarosor igy
+    # sosem elozheti meg a valodit. A nevbol a sortoresek kiesnek, kulonben a nev maga
+    # tudna zarosort hamisitani.
+    mozgato = ' '.join((a.author or '(ismeretlen)').split())
+    zarosor = f'{_ZAROSOR_ELO}{mozgato} | mezok: {",".join(valtozik)} | ts: {now}'
     db.execute('INSERT INTO kanban_comments (card_id,author,content,created_at) VALUES (?,?,?,?)',
                (a.id, 'kartya-es-ertesites',
                 '[kartya-es-ertesites.py] Mezomozgatas a fenti komment mellett ('
                 + ', '.join(teljes)
-                + f'), kerte: {a.author}. Fuggetlenul visszaolvasva.\n' + reszletes, now))
+                + f'), kerte: {a.author}. Fuggetlenul visszaolvasva.\n' + reszletes
+                + '\n' + zarosor, now))
     db.commit()
+
+# A mezomozgatas-nyom GEPI ZAROSORA. Ket helyen hasznaljuk: iraskor a nyom vegere kerul,
+# olvasaskor EBBOL jon a mozgato neve. A sor-eleji ^ es a sor-vegi $ egyutt kell: enelkul a
+# mintaja beleillik egy tobbsoros regi ertekbe is.
+_ZAROSOR_ELO = '-- mozgato: '
+_ZAROSOR_RE = re.compile(r'^-- mozgato: (.*?) \| mezok: (.*?) \| ts: (\d+)$', re.M)
+
 
 def _elozmeny_figyelmeztetes(db, a, now, dry=False):
     """KI allitotta utoljara a mezot, es MIKOR -- a dontes ELE.
@@ -459,11 +479,24 @@ def _elozmeny_figyelmeztetes(db, a, now, dry=False):
     if not elozmeny:
         return
     kora = now - elozmeny[0]
-    m = re.search(r'kerte: ([^.]+)\.', elozmeny[1] or '')
-    ki = m.group(1).strip() if m else '(ismeretlen)'
-    mit = re.search(r'Mezomozgatas a fenti komment mellett \((.*?)\), kerte:', elozmeny[1] or '')
-    mit = mit.group(1) if mit else '?'
     perc = kora / 60.0
+    # AZ UTOLSO illeszkedes szamit, nem az elso: a kulso eredetu regi ertekek a zarosor ELOTT
+    # allnak, tehat egy oda hamisitott sor sosem elozheti meg a valodit.
+    talalatok = _ZAROSOR_RE.findall(elozmeny[1] or '')
+    if not talalatok:
+        # REGI FORMATUMU NYOM (a zarosor elotti korokbol). Nem talalgatunk nevet a szabad
+        # szovegbol -- az volt a hiba. De NEM is nemulunk el: a friss, ismeretlen mozgato
+        # epp a kockazatos eset.
+        if kora < 1800:
+            print(f'FIGYELEM -- AZ ELOZO MEZOMOZGATAS {perc:.0f} PERCE VOLT, a mozgato viszont '
+                  f'NEM ALLAPITHATO MEG gepileg (regi formatumu nyom). Nezd meg a kartyan, '
+                  f'ki mozgatott, mielott visszaforditod.')
+        else:
+            print(f'(elozo mezomozgatas: {perc:.0f} perce -- regi formatumu nyom, a mozgato nem '
+                  f'allapithato meg gepileg)')
+        return
+    ki, mit, _ts = talalatok[-1]
+    ki = ki.strip()
     if kora < 1800 and ki.lower() != (a.author or '').lower():
         print(f'FIGYELEM -- AZ ELOZO MEZOMOZGATAS {perc:.0f} PERCE VOLT, ES NEM A TIED: '
               f'{ki} allitotta ({mit}). Ha ezt most visszaforditod, elavult allapotbol dolgozol. '

--- a/scripts/kartya-es-ertesites.py
+++ b/scripts/kartya-es-ertesites.py
@@ -371,6 +371,8 @@ def komment_mod(a):
               f'  fejlec: {fejlec} | szoveg {len(text)} kar | ertesites: NINCS (komment-only)\n'
               f'  mezomozgatas: {terv}'
               + (f' | mar ezen az erteken all: {valtozatlan}' if valtozatlan else ''))
+        if valtozik:
+            _elozmeny_figyelmeztetes(db, a, now, dry=True)
         return
 
     cur = db.execute('INSERT INTO kanban_comments (card_id,author,content,created_at) VALUES (?,?,?,?)',
@@ -392,6 +394,8 @@ def komment_mod(a):
         if mozgatas:
             print('MEZOMOZGATAS: nincs teendo (minden kimondott ertek mar ez volt).')
         return
+    _elozmeny_figyelmeztetes(db, a, now)
+
     sets = ', '.join(f'{k}=?' for k in valtozik)
     cur = db.execute(f'UPDATE kanban_cards SET {sets}, updated_at=? WHERE id=?',
                      (*valtozik.values(), now, a.id))
@@ -412,12 +416,61 @@ def komment_mod(a):
           + ', '.join(f'{k}: {rov(elotte[k])} -> {rov(kapott[k])}' for k in valtozik))
     # A MOZGATAS NYOMA A KARTYAN: a komment szovege Bonie, ez a sor a gepe. Enelkul a
     # tabla olvasoja latja az uj statuszt, de nem latja, hogy KI es MIKOR mozgatta.
+    #
+    # A REGI ERTEK TELJES EGESZEBEN IDE KERUL (2026-09-11, Mira lelete). A kartya-mezo
+    # EGYERTEKU: aki utoljara ir, felulir, es a regi ertek ELVESZIK. A rovidített nyom
+    # ma nem volt eleg: egy felulirt cimet nem lehetett belole visszaallitani, mert a
+    # naplo csak 60 karaktert orzott. (Ugyanaznap HAROM ilyen utkozes volt, mind
+    # kartya-mezon -- mikozben a KOZOS SKILL-FAJLBA harman irtak egy oran belul nulla
+    # utkozessel, mert az a szerkezet HOZZAFUZHETO, nem egyerteku.)
+    # A konzol-kimenet marad rovid (olvashatosag); a TAROLT nyom teljes.
+    teljes = [f'{k}: {rov(elotte[k])} -> {rov(kapott[k])}' for k in valtozik]
+    # A NULL-t KIIRVA kell megkulonboztetni az ures szotol: a visszaallito ember kulonben
+    # a 'None' szot masolna vissza egy mezobe, ami eredetileg NULL volt.
+    reszletes = '\n'.join(
+        f'  A(z) {k} TELJES REGI ERTEKE (masolhato, ha vissza kell allitani):\n  '
+        + (str(elotte[k]) if elotte[k] is not None else '(ures -- NULL volt)')
+        for k in valtozik)
     db.execute('INSERT INTO kanban_comments (card_id,author,content,created_at) VALUES (?,?,?,?)',
                (a.id, 'kartya-es-ertesites',
                 '[kartya-es-ertesites.py] Mezomozgatas a fenti komment mellett ('
-                + ', '.join(f'{k}: {rov(elotte[k])} -> {rov(kapott[k])}' for k in valtozik)
-                + f'), kerte: {a.author}. Fuggetlenul visszaolvasva.', now))
+                + ', '.join(teljes)
+                + f'), kerte: {a.author}. Fuggetlenul visszaolvasva.\n' + reszletes, now))
     db.commit()
+
+def _elozmeny_figyelmeztetes(db, a, now, dry=False):
+    """KI allitotta utoljara a mezot, es MIKOR -- a dontes ELE.
+
+    A no-op fogas csak azt latja, ha az ertek MAR ez. Azt NEM, ha valaki MAS
+    percekkel korabban allitotta at, es most valaki visszafordul. 2026-09-11-en
+    HAROMSZOR tortent meg egy oran belul, ugyanattol a szokastol: masfel oras
+    tabla-pillanatkepbol dolgozni. Ez NEM kapu -- a visszaallitas sokszor jogos.
+
+    A DRY-RUN AGON IS FUT (Mira lelete, 2026-09-11): eloszor csak az eles agon
+    futott, es ezzel EPP A GONDOS HASZNALOT buntette -- aki elovigyazatossagbol
+    dry-runol egy mezomozgatas elott, kevesebb informaciot kapott, mint aki
+    gondolkodas nelkul nekifutott. A negyedik utkozest pont az elozetes
+    ellenorzes elozne meg, es az az ut volt a vak.
+    """
+    elozmeny = db.execute(
+        "SELECT created_at, content FROM kanban_comments WHERE card_id=? "
+        "AND content LIKE '[kartya-es-ertesites.py] Mezomozgatas%' ORDER BY created_at DESC LIMIT 1",
+        (a.id,)).fetchone()
+    if not elozmeny:
+        return
+    kora = now - elozmeny[0]
+    m = re.search(r'kerte: ([^.]+)\.', elozmeny[1] or '')
+    ki = m.group(1).strip() if m else '(ismeretlen)'
+    mit = re.search(r'Mezomozgatas a fenti komment mellett \((.*?)\), kerte:', elozmeny[1] or '')
+    mit = mit.group(1) if mit else '?'
+    perc = kora / 60.0
+    if kora < 1800 and ki.lower() != (a.author or '').lower():
+        print(f'FIGYELEM -- AZ ELOZO MEZOMOZGATAS {perc:.0f} PERCE VOLT, ES NEM A TIED: '
+              f'{ki} allitotta ({mit}). Ha ezt most visszaforditod, elavult allapotbol dolgozol. '
+              + ('Eles futasban a mozgatas VEGREHAJTODNA -- most semmi nem irodik.'
+                 if dry else 'A mozgatast VEGREHAJTOM, de a kartyan lasd az o indokat is.'))
+    else:
+        print(f'(elozo mezomozgatas: {ki}, {perc:.0f} perce -- {mit})')
 
 def main():
     p = argparse.ArgumentParser()

--- a/scripts/kartya-es-ertesites.py
+++ b/scripts/kartya-es-ertesites.py
@@ -441,7 +441,12 @@ def komment_mod(a):
     # es a visszaolvasas az UTOLSO illeszkedest veszi: egy ertekbe hamisitott zarosor igy
     # sosem elozheti meg a valodit. A nevbol a sortoresek kiesnek, kulonben a nev maga
     # tudna zarosort hamisitani.
-    mozgato = ' '.join((a.author or '(ismeretlen)').split())
+    # A NEVBOL A SORTORES ES A MEZOELVALASZTO IS KIESIK (Samu 2. verify-kore, B2-alak).
+    # A sortores-ejtes onmagaban keves volt: egy 'Silent | mezok: z' alaku nev ELCSUSZTATJA a
+    # mezok-mezot, es ha utana egy tenyleg 'Silent' nevu szerzo mozgat, a FIGYELMEZTETES ELNEMUL --
+    # vagyis a nev maga allitja elo pontosan azt a csendet, amiert ez a mechanizmus letezik.
+    # A '|' ejtese ugyanaz az elv, mint a sortorese: a zarosor szerkezetet a NEV nem irhatja felul.
+    mozgato = ' '.join((a.author or '(ismeretlen)').replace('|', '/').split())
     zarosor = f'{_ZAROSOR_ELO}{mozgato} | mezok: {",".join(valtozik)} | ts: {now}'
     db.execute('INSERT INTO kanban_comments (card_id,author,content,created_at) VALUES (?,?,?,?)',
                (a.id, 'kartya-es-ertesites',


### PR DESCRIPTION
## Mit

Ket valtozas a `scripts/kartya-es-ertesites.py`-ban.

**1. A tarolt nyom a TELJES regi erteket orzi.** A kartya-mezo egyerteku: aki utoljara ir, felulir, es a regi ertek elveszik. A nyom eddig 60 karakterre rovidítette, igy egy felulirt hosszu cimet nem lehetett belole visszaallitani -- pont akkor nem, amikor kellett volna. 2026-09-11-en harom ilyen utkozes volt egy oran belul, mind kartya-mezon. A `NULL` kulon van irva (`(ures -- NULL volt)`), kulonben a visszaallito a `None` szot masolna vissza egy mezobe, ami eredetileg NULL volt. A konzol-kimenet marad rovid.

**2. Az elozmeny-figyelmeztetes a `--dry-run` agon is fut.** Eddig csak az eles agon futott, es ezzel EPP a gondos hasznalot buntette: aki elovigyazatossagbol dry-runol egy mezomozgatas elott, kevesebbet latott, mint aki gondolkodas nelkul nekifutott. A dry-run valtozat kimondja, hogy most semmi nem irodik.

## Verify

`python3 scripts/__tests__/kartya-dryrun-paritas.test.py` -- 15/15 zold.

Az uj ellenorzeseket MUTACIOVAL mertem vissza, nem csak lefuttattam:

| mutacio | varhato | mert |
|---|---|---|
| a dry-run agi `_elozmeny_figyelmeztetes` hivas kivetele | 11, 12, 13 piros | PIROS (3 bukas) |
| a szerzo-osszehasonlitas mindig igazza tetele | 13 (negativ kontroll) piros | PIROS (1 bukas) |

A 14-15 (teljes regi ertek + NULL megkulonboztetes) nelkul a valtozas lenyege teszteletlen maradt volna; ezek most fedik.

🤖 Generated with [Claude Code](https://claude.com/claude-code)