### PR TITLE
fix(test-gate): refuse the suite from a transient root instead of going falsely red (SUITETMPPIROS912)

### DIFF
--- a/src/__tests__/setup/assert-not-live-install.ts
+++ b/src/__tests__/setup/assert-not-live-install.ts
@@ -15,6 +15,7 @@
 // worker; per-file guards cannot be forgotten this way).
 import { existsSync } from 'node:fs'
 import { dirname, join } from 'node:path'
+import { homedir } from 'node:os'
 import { fileURLToPath } from 'node:url'
 import { isTmpRootedPath, TMP_ROOT_PREFIXES } from '../../web/tmp-root-prefixes.js'
 
@@ -58,13 +59,23 @@ if (found.length > 0) {
 //
 // Nothing automated runs from here: the only suite runners are the two CI
 // workflows, both on a home-rooted checkout (measured 2026-09-12).
+// DERIVED, never hardcoded. This file ships to every install, so a literal
+// `/Users/<someone>/...` would be wrong on all but one machine -- and there is
+// essentially no such literal left in non-test source. Building it from the running
+// home makes it concrete on every machine, which is what the verify note on #1297
+// actually asked for: a path the reader can paste, not an example to adapt.
+// (Deriving it from the current checkout's NAME was the first attempt and was worse:
+// from a scratchpad worktree it suggested `<home>/wt775-wt`, which is nobody's
+// convention.)
+const suggested = join(homedir(), 'claw-suite')
+
 if (isTmpRootedPath(repoRoot)) {
   throw new Error(
     `REFUSING TO RUN TESTS: ${repoRoot} is on TRANSIENT storage (${TMP_ROOT_PREFIXES.join(', ')}). ` +
       'This is not about losing files: the hook-path registration guard deliberately rejects ' +
       'tmp-rooted hook commands, so the hook and gate test files would go FALSELY RED here, ' +
       'and a false red about the shared baseline is worse than no run at all. ' +
-      'Run from a worktree UNDER YOUR HOME, e.g. `git worktree add ~/claw-test && cd ~/claw-test && npm test`. ' +
+      `Run from a worktree UNDER YOUR HOME: \`git worktree add ${suggested} && cd ${suggested} && npm ci && npm test\`. ` +
       'Fleet agents: your scratchpad is tmp-rooted, so it is never a valid place to measure the suite.',
   )
 }

--- a/src/__tests__/setup/assert-not-live-install.ts
+++ b/src/__tests__/setup/assert-not-live-install.ts
@@ -16,6 +16,7 @@
 import { existsSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { isTmpRootedPath, TMP_ROOT_PREFIXES } from '../../web/tmp-root-prefixes.js'
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..')
 
@@ -38,5 +39,32 @@ if (found.length > 0) {
       'Run it from a git worktree or CI checkout UNDER YOUR HOME (not /tmp!), e.g. ' +
       '`git worktree add ~/claw-test && cd ~/claw-test && npm test`. ' +
       'Not /tmp: the hook-path guard rejects /tmp-prefixed roots, so the gate tests would go falsely red there.',
+  )
+}
+
+// SECOND GATE, same file, same shape: refuse to run from a TRANSIENT root.
+//
+// The message below has warned about /tmp since SUITERED807 -- but only on the
+// live-install branch, which is exactly the path a clean /tmp worktree never
+// takes. From there the suite simply STARTED, and the hook/gate tests went red,
+// with no hint why. On 2026-09-12 that produced nine red files and the reading
+// "the develop branch is broken"; a paired counter-measurement (same file, same
+// commit, two roots) settled it: 4 failed from /tmp, 16/16 green from home.
+//
+// The failure this prevents is a WRONG ANSWER, not a wrong action -- and a wrong
+// answer about the shared baseline is worse than a refusal, because it is quiet
+// and it spreads. So this is a hard failure too, and for the same reason as the
+// live-install gate: a warning printed into a red wall of output is not a gate.
+//
+// Nothing automated runs from here: the only suite runners are the two CI
+// workflows, both on a home-rooted checkout (measured 2026-09-12).
+if (isTmpRootedPath(repoRoot)) {
+  throw new Error(
+    `REFUSING TO RUN TESTS: ${repoRoot} is on TRANSIENT storage (${TMP_ROOT_PREFIXES.join(', ')}). ` +
+      'This is not about losing files: the hook-path registration guard deliberately rejects ' +
+      'tmp-rooted hook commands, so the hook and gate test files would go FALSELY RED here, ' +
+      'and a false red about the shared baseline is worse than no run at all. ' +
+      'Run from a worktree UNDER YOUR HOME, e.g. `git worktree add ~/claw-test && cd ~/claw-test && npm test`. ' +
+      'Fleet agents: your scratchpad is tmp-rooted, so it is never a valid place to measure the suite.',
   )
 }

--- a/src/__tests__/tmp-root-prefixes.test.ts
+++ b/src/__tests__/tmp-root-prefixes.test.ts
@@ -1,0 +1,58 @@
+// SUITETMPPIROS912: the suite gate and the hook-path guard must refuse the SAME
+// transient roots, from ONE list. Two copies drifted apart is exactly how the
+// 2026-09-12 false red happened: the rule was written down (SUITERED807 put it in
+// the live-install message) but nothing measured the running root against it.
+import { describe, it, expect } from 'vitest'
+import { isTmpRootedPath, TMP_ROOT_PREFIXES } from '../web/tmp-root-prefixes.js'
+import { isUnsafeHookCommand } from '../web/agent-scaffold.js'
+
+// A LIST-DRIVEN LOOP CANNOT CATCH A SHRINKING LIST: if someone deletes a prefix,
+// every `for (const p of TMP_ROOT_PREFIXES)` assertion below simply runs one round
+// less and stays green. So the list is ALSO pinned literally. Adding a prefix is a
+// deliberate act and updates this line; losing one goes red.
+const EXPECTED = ['/tmp/', '/var/tmp/', '/private/tmp/', '/dev/shm/']
+
+describe('the shared list itself', () => {
+  it('contains exactly the four transient roots, unchanged', () => {
+    expect([...TMP_ROOT_PREFIXES].sort()).toEqual([...EXPECTED].sort())
+  })
+})
+
+describe('isTmpRootedPath', () => {
+  it('refuses every prefix in the shared list, as a ROOT', () => {
+    for (const p of TMP_ROOT_PREFIXES) {
+      expect(isTmpRootedPath(`${p}some/checkout`), p).toBe(true)
+    }
+  })
+
+  it('refuses the exact scratchpad shape a fleet agent measures from', () => {
+    // The real path from the 2026-09-12 measurement, macOS-resolved.
+    expect(isTmpRootedPath('/private/tmp/claude-501/-Users-marvin-ClaudeClaw-agents-geri/x/scratchpad/mv')).toBe(true)
+  })
+
+  it('allows a home-rooted worktree', () => {
+    expect(isTmpRootedPath('/Users/marvin/claw-test')).toBe(false)
+    expect(isTmpRootedPath('/home/runner/work/marveen/marveen')).toBe(false)
+  })
+
+  it('does NOT refuse a home path that merely CONTAINS a tmp segment', () => {
+    // The guard asks whether the ROOT is transient, not whether the string
+    // mentions tmp anywhere -- otherwise a legitimate ~/tmp-notes/ checkout dies.
+    expect(isTmpRootedPath('/Users/marvin/tmp/claw-test')).toBe(false)
+    expect(isTmpRootedPath('/Users/marvin/var/tmp/claw')).toBe(false)
+  })
+
+  it('handles a trailing slash the same way', () => {
+    expect(isTmpRootedPath('/private/tmp/x/')).toBe(true)
+    expect(isTmpRootedPath('/Users/marvin/x/')).toBe(false)
+  })
+})
+
+describe('the two guards share one list (anti-drift)', () => {
+  it('every prefix the root gate refuses, the hook-command guard also refuses', () => {
+    for (const p of TMP_ROOT_PREFIXES) {
+      expect(isTmpRootedPath(`${p}c`), `root gate: ${p}`).toBe(true)
+      expect(isUnsafeHookCommand(`python3 ${p}hooks/guard.py`), `hook guard: ${p}`).toBe(true)
+    }
+  })
+})

--- a/src/web/agent-scaffold.ts
+++ b/src/web/agent-scaffold.ts
@@ -11,6 +11,7 @@ import { logger } from '../logger.js'
 import { agentDir, agentConfigRoot, listAgentNames, readAgentCapabilities } from './agent-config.js'
 import { resolveProfilePlaceholders, type ProfileTemplate } from './profiles.js'
 import { sanitizeCapabilityTag, CAPABILITY_TAG_MAX_PER_AGENT } from '../prompt-safety.js'
+import { TMP_ROOT_PREFIXES as _TMP_PREFIXES } from './tmp-root-prefixes.js'
 
 // Resolve the base URL agents should use to reach the dashboard API.
 //
@@ -158,7 +159,8 @@ export function agentSettingsPath(name: string): string {
 // When the /tmp directory disappears on the next reboot the referenced script
 // is gone, python3/node exits non-zero, and Claude Code blocks every prompt --
 // the 2026-07-14 silent fleet-freeze incident.
-const _TMP_PREFIXES = ['/tmp/', '/var/tmp/', '/private/tmp/', '/dev/shm/']
+// The list itself lives in tmp-root-prefixes.ts, because the suite gate needs the
+// SAME list and a second copy would drift (2026-09-12).
 
 // Shared hook-entry type used by ensureAgentHooks and upgradeLegacyHookCommands.
 type HookEntry = { matcher?: string; hooks?: Array<{ command?: string; timeout?: number; [k: string]: unknown }> }

--- a/src/web/tmp-root-prefixes.ts
+++ b/src/web/tmp-root-prefixes.ts
@@ -1,0 +1,26 @@
+// SINGLE SOURCE OF TRUTH for the transient-filesystem prefixes.
+//
+// Two separate guards need the same list, and they must never drift apart:
+//
+//  1. `isUnsafeHookCommand` (agent-scaffold.ts) refuses to write a hook command
+//     containing one of these into the shared ~/.claude/settings.json. When /tmp
+//     is cleared on the next reboot the referenced script is gone, the hook exits
+//     non-zero, and Claude Code blocks every prompt -- the 2026-07-14 silent
+//     fleet-freeze incident.
+//
+//  2. The suite gate (src/__tests__/setup/assert-not-live-install.ts) refuses to
+//     RUN from a checkout rooted under one of these, because guard (1) then
+//     rightly rejects the hooks the gate tests register, and those tests go
+//     falsely red -- nine files on 2026-09-12, and the reading that followed was
+//     "the develop branch is broken".
+//
+// The two predicates differ on purpose: (1) scans a command STRING for the prefix
+// anywhere in it, (2) asks whether a ROOT PATH starts with one. Same list, two
+// questions.
+export const TMP_ROOT_PREFIXES = ['/tmp/', '/var/tmp/', '/private/tmp/', '/dev/shm/']
+
+/** True when `p` is a filesystem ROOT living on transient storage. */
+export function isTmpRootedPath(p: string): boolean {
+  const withSlash = p.endsWith('/') ? p : `${p}/`
+  return TMP_ROOT_PREFIXES.some((prefix) => withSlash.startsWith(prefix))
+}


### PR DESCRIPTION
## A lelet

A hook-path or SZANDEKOSAN utasitja el a /tmp-gyokeru hook-parancsokat (a 2026-07-14-i nema flotta-fagyas javitasa). Ez helyes. A kovetkezmeny viszont az, hogy a suite-ot /tmp-gyokeru fabol futtatva a hook- es gate-tesztek pirosak lesznek olyan okbol, aminek semmi kaze a kodhoz.

Ez MAR ISMERT volt: a SUITERED807 beirt rola egy figyelmeztetest. Csakhogy az a figyelmeztetes az ELO-INSTALL elutasitasi uzeneteben all, vagyis pont azon az agon, amit egy tiszta /tmp-worktree SOHA nem er el. Onnan a suite egyszeruen ELINDUL, es csak a pirosak vannak.

2026-09-12-en ez egy review-kort vitt el: kilenc piros fajl, es a beloluk levont kovetkeztetes az volt, hogy "a develop torott". Nem volt az.

## Mi valtozik

- A gyoker-ut ellenorzese bekerul a suite-kapuba, UGYANABBA a fajlba es ugyanabba a kemeny-bukas alakba, mint az elo-install kapu.
- A prefix-lista kulon level-modulba kerul (`src/web/tmp-root-prefixes.ts`), es MINDKET or onnan olvassa. Ket masolat elcsuszna, es a csuszas pont a fajo iranyban lenne nema.
- Az uzenet megnevezi a javitast, es kimondja, hogy a flotta-agensek scratchpadja tmp-gyokeru.

## Miert kemeny bukas, nem figyelmeztetes

A megelozott hiba egy ROSSZ VALASZ, nem egy rossz muvelet. Egy rossz valasz a kozos bazisvonalrol rosszabb, mint a futas megtagadasa: csendes, terjed, es egy VALODI uj regresszio elvegyulne benne. Egy piros falba kiirt figyelmeztetes nem kapu.

## Verify

Parositott meres, UGYANAZ a kod es UGYANAZ a teszt-fajl, ket gyokerbol:

| gyoker | eredmeny |
|---|---|
| home (`/Users/marvin/claw-tmpgate`) | 18/18 zold, a kapu NEM tuzel |
| tmp (`/private/tmp/.../scratchpad`) | a kapu TUZEL, nevesitett elutasitassal |

Teljes suite a home-gyokerbol: **424 fajl, 5402 zold, 0 bukas.**

Semmi automatizalt nem erintett: a suite-ot kizarolag a ket CI-workflow futtatja, mindketto home-gyokeru checkouton (megmerve).

### A tesztek mutacioval visszamerve

| mutacio | varhato | mert |
|---|---|---|
| `startsWith` -> `includes` | a "csak tartalmazza a tmp szot" eset piros | PIROS |
| egy prefix kivetele a listabol | a pinelt-lista eset piros | PIROS |

A listat kulon, SZO SZERINT is pineltem, nem csak vegigiteralok rajta: egy listan hajtott ciklus nem tudja eszrevenni, hogy a lista MEGROVIDULT -- egyszeruen egy korrel kevesebbet fut es zold marad.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
