### PR TITLE
feat(claude-plans): rotate endpoint + channels.sh dynamic configDir + heartbeat wiring (PR2c)

### DIFF
--- a/docs/superpowers/specs/2026-09-11-claude-key-rotation-design.md
+++ b/docs/superpowers/specs/2026-09-11-claude-key-rotation-design.md
@@ -454,6 +454,74 @@ classifier részeket fedik, a live restartot nem.
    rejtett szűrési szabály amit ki kellene találni.
 
 Implementáció ELINDULT 2026-09-12: PR2a (`src/claude-plan-rotation.ts` +
-`src/__tests__/claude-plan-rotation.test.ts`) kész, tesztek zöldek,
-`tsc --noEmit` tiszta. PR2b/PR2c (write API, UI, wiring, agentenkénti state)
-még nincs elkezdve.
+`src/__tests__/claude-plan-rotation.test.ts`) kész. PR2b (write API +
+dashboard UI, `src/web/routes/claude-plans.ts`, `src/web/claude-plans-state.ts`
+olvasó fele) szintén kész. PR2c most készült el -- lásd alább a menet közben
+hozott döntéseket.
+
+## 11. PR2c döntések (implementáció közben, 2026-09-12)
+
+A tervben nyitva hagyott vagy pontatlanul rögzített pontok, amiket az
+implementáció közben kellett eldönteni (a "MIND ELDÖNTVE" #1-#5 kérdéseket
+NEM nyitottuk újra -- ezek azok alkalmazását pontosítják):
+
+1. **`claude-plans-state.json` sémája ténylegesen agentenkénti lett**:
+   `activePlanId: string|null` -> `activePlanByAgent: Record<string,string>`
+   (döntés #1 megvalósítása). A PR2b-ben már megépült dashboard kártya-UI
+   (`web/app.js`) ehhez igazítva: a "aktív" jelzés a fő agent
+   (`activePlanByAgent[mainAgentId()]`) bejegyzését nézi.
+2. **A heartbeat wiring EBBEN a PR-ben csak a FŐ (channels.sh) agentre köti be
+   a tényleges rotációt.** A state-séma agentenkénti (1. pont), és a
+   `POST /api/claude-plans/rotate` route agent-agnosztikus (bármelyik agentId-t
+   elfogad, sub-agent esetén `writeAgentClaudePlan` + `restartAgentProcess`-en
+   megy át) -- de a `scripts/claude-plan-rotate-check.ts` heartbeat-script
+   MAGA egyelőre csak a fő agentre fut le, nem loopol végig minden sub-agenten.
+   A teljes sub-agent-loop (minden csatornás sub-agent saját heartbeat-ciklusa)
+   külön, gyors follow-up, nem ebbe a (már így is legkockázatosabb) PR-be
+   csomagolva.
+3. **Ki hívja ténylegesen a rotate endpointot és küldi a Telegram-jelzést**:
+   a design 6.6 ezt "a heartbeat" feladataként írja le, a 6.4 viszont
+   kifejezetten a c3po `reply` tool-t követeli meg a jelzéshez -- egy sima
+   node-script nem tud MCP tool-t hívni. Megoldás: a heartbeat-script
+   (`claude-plan-rotate-check.ts`) csak DÖNT és a state-et frissíti, majd egy
+   strukturált sort ír stdout-ra (`ROTATE ...` / `NO_ALTERNATIVE ...` / semmi).
+   Az ágens (akinek a scheduled task prompt-ja meghívja a scriptet) olvassa ezt
+   és MAGA küldi a Telegram-jelzést, majd (ROTATE esetén) hívja a
+   `POST /api/claude-plans/rotate`-ot -- ugyanaz a minta, mint a meglévő
+   `scripts/hooks/ledger-live-drain.py` OPEN_QUESTION heartbeat.
+4. **A "bootstrap" kérdés (6.5/4 megjegyzése) külön kód nélkül oldódott meg**:
+   egy agent ELSŐ plan-hozzárendelése ugyanaz a művelet mint egy későbbi
+   rotáció (`applyRotation` akkor is csak beszúr, ha korábban nem volt aktív
+   plan) -- nincs külön "bootstrap" endpoint/ág. Ebből következik: a heartbeat
+   script NEM tud magától elindulni egy olyan agentre, akinek még sosem volt
+   `activePlanByAgent` bejegyzése (nem tudja kitalálni melyik plan-t futtatja
+   ÉPPEN) -- ehhez Attilának egyszer, kézzel kell hívnia a rotate endpointot
+   a jelenleg futó plan id-jével, utána a heartbeat már karbantartja.
+5. **`channels.sh` dinamikus configDir-ága a meglévő `explicit`/`isolated`
+   kontraktust bővíti egy HARMADIK móddal (`rotated`)**, nem külön ágat épít:
+   `scripts/main-agent-isolated-config.mjs` új
+   `resolveMainAgentRotatedConfigDir()`-t hív (agent-process.ts), és
+   `rotated\t<dir>`-t ír a fd3 kontraktusra, ha a state egy planre mutat. A
+   `rotated` mód a `explicit`-tel EGY ágon fut `channels.sh`-ban (nincs fleet
+   token injektálva, mert a plan configDir-ja saját, valódi bejelentkezést
+   hordoz -- design 6.5/4). Precedencia: explicit > rotated > isolated.
+   FONTOS: a `channels.sh`-n kívül két másik respawn-út (`channel-watchdog.sh`,
+   `stuck-modal-guard.sh`) IS lekérdezi ugyanezt a kontraktust
+   (CFGDIR686/`main-config-dir-parity.test.ts` erre külön strukturális
+   tesztet is tart fenn) -- mindkettőt frissítettük, különben egy watchdog-
+   respawn néma módon visszaejtette volna a rotált identitást a megosztott
+   `~/.claude`-ra.
+6. **Ismert, nem javított, e PR-től független rés**: `stuck-modal-guard.sh`
+   a kontraktust NEM a fd3-on olvassa (nincs `3>&1 ... 1>&2` átirányítása),
+   ellentétben `channels.sh`/`channel-watchdog.sh`-val a CFGCONTRACT912
+   javítás (#1289) után. Ez azt jelenti, hogy egy pino log-sor ugyanúgy
+   eltörheti nála a kontraktust, mint a 2026-09-12-i csatorna-kiesésben --
+   csak épp a `explicit`/`isolated`/`rotated` egyikére sem specifikus, tehát
+   nem ez a PR vezette be. Külön, gyors fix-jelölt egy jövőbeli PR-nek.
+7. **A reaktív (429-alapú azonnali) út (6.3 kiegészítés) csak a pure
+   detektor szintjéig készült el** (`isQuotaExceededError` a
+   `claude-plan-rotation.ts`-ben, tesztelve). A tényleges élő
+   tmux/session-kimenet figyelése (hol/hogyan halásszuk ki a 429-et a futó
+   `claude` process outputjából) NINCS bekötve -- ez élő, futó session
+   kimenetének feldolgozását jelentené, nagyobb és kockázatosabb darab, külön
+   follow-up-nak jelölve.

--- a/scripts/channel-watchdog.sh
+++ b/scripts/channel-watchdog.sh
@@ -192,14 +192,14 @@ if [ -n "$NODE_BIN" ] && [ -f "$INSTALL_DIR/dist/web/agent-process.js" ]; then
   # onto the shared ~/.claude on 2026-09-12. This caller must stay in step with
   # channels.sh, or a watchdog respawn reintroduces exactly that outage.
   _cfg_raw="$("$NODE_BIN" "$INSTALL_DIR/scripts/main-agent-isolated-config.mjs" "$CHANNEL_PROVIDER" 3>&1 2>>"$STORE/channels-failures.log" 1>&2 || true)"
-  _cfg_line="$(printf '%s\n' "$_cfg_raw" | grep -m1 -E '^(explicit|isolated)	/' || true)"
+  _cfg_line="$(printf '%s\n' "$_cfg_raw" | grep -m1 -E '^(explicit|rotated|isolated)	/' || true)"
   if [ -n "$_cfg_raw" ] && [ -z "$_cfg_line" ]; then
     log "WARN main-agent-isolated-config.mjs printed output with NO contract line -- respawn without isolation"
   fi
   _cfg_mode="${_cfg_line%%	*}"
   _cfg_dir="${_cfg_line#*	}"
   if [ -n "$_cfg_line" ] && [ -d "$_cfg_dir" ]; then
-    if [ "$_cfg_mode" = "explicit" ]; then
+    if [ "$_cfg_mode" = "explicit" ] || [ "$_cfg_mode" = "rotated" ]; then
       CFG_ENV="export CLAUDE_CONFIG_DIR='$_cfg_dir' && "
     else
       CFG_ENV="export CLAUDE_CONFIG_DIR='$_cfg_dir' && export CLAUDE_CODE_OAUTH_TOKEN=\"\$(cat '$INSTALL_DIR/store/.claude-oauth-token')\" && "

--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -642,14 +642,17 @@ if [ -n "$_node_bin" ] && [ -f "$INSTALL_DIR/dist/web/agent-process.js" ]; then
   # and a non-empty output with no contract line in it is reported LOUDLY, because
   # that is the shape that silently disables isolation.
   _cfg_raw="$("$_node_bin" "$INSTALL_DIR/scripts/main-agent-isolated-config.mjs" "$CHANNEL_PROVIDER" 3>&1 2>>"$INSTALL_DIR/store/channels-failures.log" 1>&2 || true)"
-  _cfg_line="$(printf '%s\n' "$_cfg_raw" | grep -m1 -E '^(explicit|isolated)	/' || true)"
+  _cfg_line="$(printf '%s\n' "$_cfg_raw" | grep -m1 -E '^(explicit|rotated|isolated)	/' || true)"
   if [ -n "$_cfg_raw" ] && [ -z "$_cfg_line" ]; then
     echo "$(date '+%Y-%m-%d %H:%M:%S') channels.sh: WARN main-agent-isolated-config.mjs printed output with NO contract line -- isolation skipped. Raw first line: $(printf '%s\n' "$_cfg_raw" | head -1)" >> "$INSTALL_DIR/store/channels-failures.log"
   fi
   _cfg_mode="${_cfg_line%%	*}"
   _cfg_dir="${_cfg_line#*	}"
   if [ -n "$_cfg_line" ] && [ -d "$_cfg_dir" ]; then
-    if [ "$_cfg_mode" = "explicit" ]; then
+    if [ "$_cfg_mode" = "explicit" ] || [ "$_cfg_mode" = "rotated" ]; then
+      # Both carry their OWN .credentials.json (an operator-logged-in dir for
+      # `explicit`, a registered plan's dir for `rotated` -- design 6.5/4) --
+      # neither wants the fleet token injected below.
       CFG_ENV="export CLAUDE_CONFIG_DIR='$_cfg_dir' && "
     else
       # Seed the token from the SAME 0600 file the isolated dir is gated on, so

--- a/scripts/claude-plan-rotate-check.ts
+++ b/scripts/claude-plan-rotate-check.ts
@@ -1,0 +1,84 @@
+#!/usr/bin/env -S npx tsx
+// Heartbeat entry point for Claude plan rotation (PR2c, design 6.6).
+//
+// Intended caller: a `heartbeat`-type scheduled task (see the project
+// CLAUDE.md "Ütemezett feladatok" section), e.g. every 10 minutes:
+//
+//   npx tsx scripts/claude-plan-rotate-check.ts
+//
+// Design 6.6 lists four heartbeat steps: (1) run usage-collect.py --json,
+// (2) feed it to the decision logic, (3) update the state side-car, (4) if
+// the decision is "rotate", call POST /api/claude-plans/rotate AND send the
+// Telegram signal. This script does (1)-(3) (via decideAndRecord in
+// src/claude-plan-rotate-heartbeat.ts, unit-tested there) and prints a
+// single structured line for (4) instead of doing it itself, for the same
+// reason design 6.4 requires: the Telegram signal MUST go through the c3po
+// `reply` tool, which only an agent turn has access to -- a plain node
+// script cannot call it. So the scheduled task's prompt (authored by the
+// operator, same as every other heartbeat in this fleet) is expected to:
+//   1. run this script;
+//   2. if it printed a ROTATE line: send the Telegram signal via `reply`
+//      FIRST (design 6.4/1's ordering requirement), THEN
+//      POST /api/claude-plans/rotate with { targetPlanId };
+//   3. if it printed a NO_ALTERNATIVE line: send the Telegram signal (design
+//      6.4/2) and do nothing else;
+//   4. if it printed nothing: stay silent.
+// This mirrors the fleet's existing OPEN_QUESTION heartbeat pattern
+// (scripts/hooks/ledger-live-drain.py) rather than inventing a new one.
+//
+// Scope note (flagged in the PR description): this wires the MAIN channels
+// agent only. Design decision #1 (2026-09-12) says sub-agents should
+// eventually rotate too and sized the state schema for it
+// (activePlanByAgent, already keyed per agent) -- but looping this script
+// over every sub-agent, each with its own restart semantics
+// (writeAgentClaudePlan + restartAgentProcess instead of
+// hardRestartMarveenChannels), is deferred as a fast follow-up rather than
+// bundled into the riskiest PR in this series.
+import { execFileSync } from 'node:child_process'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { decideAndRecord } from '../src/claude-plan-rotate-heartbeat.js'
+import { readClaudePlans } from '../src/web/claude-plans.js'
+import { readClaudePlansState, writeClaudePlansState } from '../src/web/claude-plans-state.js'
+import { getEffectiveSettingValue } from '../src/settings-store.js'
+import { MAIN_AGENT_ID } from '../src/config.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const PROJECT_ROOT = join(__dirname, '..')
+
+function settingIsOn(key: string): boolean {
+  try { return String(getEffectiveSettingValue(key)) === '1' } catch { return false }
+}
+
+function main(): void {
+  let raw: unknown
+  try {
+    const out = execFileSync('python3', [join(PROJECT_ROOT, 'scripts', 'usage-collect.py'), '--json'], {
+      cwd: PROJECT_ROOT,
+      encoding: 'utf-8',
+      timeout: 30_000,
+    })
+    raw = JSON.parse(out)
+  } catch (err) {
+    // Fail open and silent on stdout (no action taken), loud on stderr (shows
+    // up in the scheduled task's failure log) -- mirrors quota-snapshot.ts's
+    // "everything degrades to null" rule.
+    console.error('claude-plan-rotate-check: usage-collect.py failed:', err instanceof Error ? err.message : err)
+    return
+  }
+
+  if (!settingIsOn('CLAUDE_ROTATION_ENABLED') || !settingIsOn('MAIN_AGENT_ISOLATED_CONFIG')) return
+
+  const result = decideAndRecord({
+    agentId: MAIN_AGENT_ID,
+    plans: readClaudePlans(),
+    state: readClaudePlansState(),
+    usageCollectRaw: raw,
+    nowMs: Date.now(),
+  })
+
+  if (result.nextState) writeClaudePlansState(result.nextState)
+  if (result.printLine) console.log(result.printLine)
+}
+
+main()

--- a/scripts/main-agent-isolated-config.mjs
+++ b/scripts/main-agent-isolated-config.mjs
@@ -44,20 +44,34 @@ let CONTRACT_FD = 3
 try { fstatSync(CONTRACT_FD) } catch { CONTRACT_FD = 1 }
 const emitContract = (line) => writeSync(CONTRACT_FD, line)
 
-const { ensureMainAgentIsolatedConfigDir, resolveMainAgentConfigDir } = await import(
+const { ensureMainAgentIsolatedConfigDir, resolveMainAgentConfigDir, resolveMainAgentRotatedConfigDir } = await import(
   join(projectRoot, 'dist', 'web', 'agent-process.js')
 )
 
 // Output contract (consumed by scripts/channels.sh): "<mode>\t<path>", or nothing
-// at all when neither path applies. The mode decides how the caller authenticates
-// the agent: an `explicit` dir carries its OWN .credentials.json (login already
-// done there -- do NOT inject the fleet token, that would swap the identity),
-// while an `isolated` dir carries none and needs the fleet setup-token exported.
+// at all when none of the three paths apply. The mode decides how the caller
+// authenticates the agent:
+//   explicit -- MAIN_AGENT_CONFIG_DIR, a dir the operator logged into by hand.
+//   rotated  -- (PR2c) store/claude-plans-state.json points the main agent at
+//               a registered plan. Also carries ITS OWN .credentials.json
+//               (design 6.5/4: every plan is a real, already-logged-in dir),
+//               so it needs the exact same "do not inject the fleet token"
+//               handling as `explicit` -- see resolveMainAgentRotatedConfigDir.
+//   isolated -- the credential-less flotta dir, needs the fleet setup-token.
+// Precedence: explicit wins outright (it is a deliberate, permanent identity
+// choice, never part of the rotation pool -- design 6.2). Rotated wins over
+// plain isolated because a recorded rotation is a stronger, more specific
+// signal than the generic flotta fallback.
 const explicit = resolveMainAgentConfigDir()
 if (explicit) {
   emitContract(`explicit\t${explicit}\n`)
 } else {
-  const provider = process.argv[2] || undefined
-  const dir = ensureMainAgentIsolatedConfigDir(provider)
-  if (dir) emitContract(`isolated\t${dir}\n`)
+  const rotated = resolveMainAgentRotatedConfigDir()
+  if (rotated) {
+    emitContract(`rotated\t${rotated}\n`)
+  } else {
+    const provider = process.argv[2] || undefined
+    const dir = ensureMainAgentIsolatedConfigDir(provider)
+    if (dir) emitContract(`isolated\t${dir}\n`)
+  }
 }

--- a/scripts/stuck-modal-guard.sh
+++ b/scripts/stuck-modal-guard.sh
@@ -301,7 +301,7 @@ run_guard() {
     _cfg_mode="${_cfg_line%%	*}"
     _cfg_dir="${_cfg_line#*	}"
     if [ -n "$_cfg_line" ] && [ -d "$_cfg_dir" ]; then
-      if [ "$_cfg_mode" = "explicit" ]; then
+      if [ "$_cfg_mode" = "explicit" ] || [ "$_cfg_mode" = "rotated" ]; then
         CFG_ENV="export CLAUDE_CONFIG_DIR='$_cfg_dir' && "
       else
         CFG_ENV="export CLAUDE_CONFIG_DIR='$_cfg_dir' && export CLAUDE_CODE_OAUTH_TOKEN=\"\$(cat '$INSTALL_DIR/store/.claude-oauth-token')\" && "

--- a/src/__tests__/claude-plan-rotate-check.test.ts
+++ b/src/__tests__/claude-plan-rotate-check.test.ts
@@ -1,0 +1,187 @@
+// PR2c: decideAndRecord (src/claude-plan-rotate-heartbeat.ts), the pure core
+// that scripts/claude-plan-rotate-check.ts's heartbeat wrapper calls (design
+// 6.3 + 6.6), tested end to end with fixture inputs -- no fs, no
+// child_process, no settings-store. Mirrors quota-gate-wiring.test.ts's
+// spirit: the collector's on-disk JSON shape in, a decision out.
+import { describe, it, expect } from 'vitest'
+import { decideAndRecord } from '../claude-plan-rotate-heartbeat.js'
+import type { ClaudePlan } from '../web/claude-plans.js'
+import type { ClaudePlansState } from '../web/claude-plans-state.js'
+
+const NOW = Date.UTC(2026, 8, 12, 12, 0, 0)
+const NOW_S = NOW / 1000
+
+function plan(over: Partial<ClaudePlan> = {}): ClaudePlan {
+  return {
+    id: 'pro',
+    label: 'Personal PRO',
+    configDir: '/opt/claude-pro',
+    planType: 'personal',
+    channelsAllowed: true,
+    ...over,
+  }
+}
+
+function usageCollect(overrides: Partial<{ source: string; usedPercent: number; resetsAt: number }> = {}) {
+  const { source = 'authoritative', usedPercent = 10, resetsAt = NOW_S + 3600 } = overrides
+  return {
+    generated_at: new Date(NOW).toISOString(),
+    claude: {
+      provider: 'claude',
+      source,
+      ok: true,
+      windows: {
+        five_hour: { used_percent: usedPercent, resets_at: resetsAt },
+        seven_day: { used_percent: 20, resets_at: resetsAt + 6 * 24 * 3600 },
+      },
+    },
+  }
+}
+
+const EMPTY_STATE: ClaudePlansState = { activePlanByAgent: {}, plans: {} }
+
+describe('decideAndRecord: preconditions (design 6.2)', () => {
+  it('no-ops with fewer than 2 registered plans', () => {
+    const result = decideAndRecord({
+      agentId: 'marveen',
+      plans: [plan()],
+      state: EMPTY_STATE,
+      usageCollectRaw: usageCollect(),
+      nowMs: NOW,
+    })
+    expect(result).toEqual({ printLine: null, nextState: null })
+  })
+
+  it('no-ops when the agent has no active plan recorded yet (bootstrap gap)', () => {
+    const result = decideAndRecord({
+      agentId: 'marveen',
+      plans: [plan({ id: 'pro' }), plan({ id: 'team', label: 'Team' })],
+      state: EMPTY_STATE,
+      usageCollectRaw: usageCollect(),
+      nowMs: NOW,
+    })
+    expect(result).toEqual({ printLine: null, nextState: null })
+  })
+
+  it('no-ops when the recorded active plan id no longer resolves (deleted/renamed)', () => {
+    const state: ClaudePlansState = { activePlanByAgent: { marveen: 'gone' }, plans: {} }
+    const result = decideAndRecord({
+      agentId: 'marveen',
+      plans: [plan({ id: 'pro' }), plan({ id: 'team', label: 'Team' })],
+      state,
+      usageCollectRaw: usageCollect(),
+      nowMs: NOW,
+    })
+    expect(result).toEqual({ printLine: null, nextState: null })
+  })
+})
+
+describe('decideAndRecord: snapshot trust (fail open, mirrors quota-gate.ts)', () => {
+  const twoPlansState: ClaudePlansState = { activePlanByAgent: { marveen: 'pro' }, plans: {} }
+  const plans = [plan({ id: 'pro' }), plan({ id: 'team', label: 'Team' })]
+
+  it('no-ops on an untrusted source (estimate)', () => {
+    const result = decideAndRecord({
+      agentId: 'marveen', plans, state: twoPlansState,
+      usageCollectRaw: usageCollect({ source: 'estimate', usedPercent: 99 }),
+      nowMs: NOW,
+    })
+    expect(result).toEqual({ printLine: null, nextState: null })
+  })
+
+  it('no-ops on a snapshot with no claude section at all', () => {
+    const result = decideAndRecord({
+      agentId: 'marveen', plans, state: twoPlansState,
+      usageCollectRaw: { generated_at: new Date(NOW).toISOString() },
+      nowMs: NOW,
+    })
+    expect(result).toEqual({ printLine: null, nextState: null })
+  })
+})
+
+describe('decideAndRecord: quiet ticks still record telemetry', () => {
+  it('records the observation but prints nothing when under pressure', () => {
+    const state: ClaudePlansState = { activePlanByAgent: { marveen: 'pro' }, plans: {} }
+    const plans = [plan({ id: 'pro' }), plan({ id: 'team', label: 'Team' })]
+    const result = decideAndRecord({
+      agentId: 'marveen', plans, state,
+      usageCollectRaw: usageCollect({ usedPercent: 42 }),
+      nowMs: NOW,
+    })
+    expect(result.printLine).toBeNull()
+    expect(result.nextState).not.toBeNull()
+    expect(result.nextState?.activePlanByAgent.marveen).toBe('pro')
+    expect(result.nextState?.plans.pro.windows.five_hour.usedPercent).toBe(42)
+    expect(result.nextState?.plans.pro.windows.seven_day?.usedPercent).toBe(20)
+  })
+
+  it('records telemetry but prints nothing when near reset', () => {
+    const state: ClaudePlansState = { activePlanByAgent: { marveen: 'pro' }, plans: {} }
+    const plans = [plan({ id: 'pro' }), plan({ id: 'team', label: 'Team' })]
+    const result = decideAndRecord({
+      agentId: 'marveen', plans, state,
+      usageCollectRaw: usageCollect({ usedPercent: 95, resetsAt: NOW_S + 10 * 60 }),
+      nowMs: NOW,
+    })
+    expect(result.printLine).toBeNull()
+    expect(result.nextState).not.toBeNull()
+  })
+})
+
+describe('decideAndRecord: rotate and no-alternative print exactly one structured line', () => {
+  it('prints a ROTATE line naming the target and current labels/pct', () => {
+    const state: ClaudePlansState = { activePlanByAgent: { marveen: 'pro' }, plans: {} }
+    const plans = [plan({ id: 'pro', label: 'Personal PRO' }), plan({ id: 'team', label: 'Team Seat' })]
+    const result = decideAndRecord({
+      agentId: 'marveen', plans, state,
+      usageCollectRaw: usageCollect({ usedPercent: 95, resetsAt: NOW_S + 3600 }),
+      nowMs: NOW,
+    })
+    expect(result.printLine).toBe(
+      'ROTATE agent=marveen target=team targetLabel=Team Seat currentLabel=Personal PRO currentPct=95 resetsInMin=60',
+    )
+    expect(result.nextState?.activePlanByAgent.marveen).toBe('pro') // rotation itself is applied by the caller, not here
+  })
+
+  it('excludes a plan with channelsAllowed=false from candidacy', () => {
+    const state: ClaudePlansState = { activePlanByAgent: { marveen: 'pro' }, plans: {} }
+    const plans = [plan({ id: 'pro' }), plan({ id: 'team', label: 'Team', channelsAllowed: false })]
+    const result = decideAndRecord({
+      agentId: 'marveen', plans, state,
+      usageCollectRaw: usageCollect({ usedPercent: 95, resetsAt: NOW_S + 3600 }),
+      nowMs: NOW,
+    })
+    expect(result.printLine).toContain('NO_ALTERNATIVE')
+  })
+
+  it('prints a NO_ALTERNATIVE line when the only other plan is not channels-eligible', () => {
+    const state: ClaudePlansState = {
+      activePlanByAgent: { marveen: 'pro' },
+      plans: { team: { observedAt: NOW - 1000, source: 'authoritative', windows: { five_hour: { usedPercent: 96, resetsAt: NOW_S + 100 } } } },
+    }
+    const plans = [plan({ id: 'pro', label: 'Personal PRO' }), plan({ id: 'team', label: 'Team Seat', channelsAllowed: false })]
+    const result = decideAndRecord({
+      agentId: 'marveen', plans, state,
+      usageCollectRaw: usageCollect({ usedPercent: 95, resetsAt: NOW_S + 3600 }),
+      nowMs: NOW,
+    })
+    expect(result.printLine).toBe('NO_ALTERNATIVE agent=marveen currentLabel=Personal PRO currentPct=95 resetsInMin=60')
+  })
+
+  it('picks the plan with the most estimated free headroom among several candidates', () => {
+    const state: ClaudePlansState = {
+      activePlanByAgent: { marveen: 'pro' },
+      plans: {
+        team: { observedAt: NOW - 1000, source: 'authoritative', windows: { five_hour: { usedPercent: 80, resetsAt: NOW_S + 100 } } },
+        third: { observedAt: NOW - 1000, source: 'authoritative', windows: { five_hour: { usedPercent: 10, resetsAt: NOW_S + 100 } } },
+      },
+    }
+    const plans = [plan({ id: 'pro' }), plan({ id: 'team', label: 'Team' }), plan({ id: 'third', label: 'Third' })]
+    const result = decideAndRecord({
+      agentId: 'marveen', plans, state,
+      usageCollectRaw: usageCollect({ usedPercent: 95, resetsAt: NOW_S + 3600 }),
+      nowMs: NOW,
+    })
+    expect(result.printLine).toContain('target=third')
+  })
+})

--- a/src/__tests__/claude-plan-rotation.test.ts
+++ b/src/__tests__/claude-plan-rotation.test.ts
@@ -3,6 +3,7 @@ import {
   estimateWindowFree,
   pickRotationTarget,
   decideRotationAction,
+  isQuotaExceededError,
   ROTATION_GATE,
   type ObservedWindow,
   type RotationCandidate,
@@ -136,5 +137,26 @@ describe('decideRotationAction', () => {
       nowMs: NOW,
     })
     expect(result.action).toBe('no-alternative')
+  })
+})
+
+describe('isQuotaExceededError', () => {
+  it.each([
+    'HTTP 429 Too Many Requests',
+    'Error: quota exceeded for this window',
+    'quota_exceeded',
+    'Usage limit reached for your plan',
+    'rate limit exceeded, retry later',
+  ])('matches a real quota-exhaustion signal: %s', (text) => {
+    expect(isQuotaExceededError(text)).toBe(true)
+  })
+
+  it.each([
+    '',
+    'connection refused',
+    'the file limit for this directory was 42 entries',
+    'a random 4295 in some unrelated log line',
+  ])('does not match unrelated text: %s', (text) => {
+    expect(isQuotaExceededError(text)).toBe(false)
   })
 })

--- a/src/__tests__/claude-plans-routes.test.ts
+++ b/src/__tests__/claude-plans-routes.test.ts
@@ -1,9 +1,11 @@
-// PR2b route wiring: POST/PUT/DELETE /api/claude-plans and GET .../state,
-// exercised through tryHandleClaudePlans() directly (mirrors
-// approvals-notify.test.ts's fake req/res harness). PROJECT_ROOT points at a
-// real temp dir so the CRUD round-trips through the actual atomic-write path.
+// PR2b route wiring: POST/PUT/DELETE /api/claude-plans and GET .../state.
+// PR2c adds POST .../rotate, exercised through tryHandleClaudePlans() directly
+// (mirrors approvals-notify.test.ts's fake req/res harness). PROJECT_ROOT
+// points at a real temp dir so the CRUD round-trips through the actual
+// atomic-write path. hardRestartMarveenChannels/restartAgentProcess are
+// mocked -- this test must NEVER touch a real tmux session or process.
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { mkdtempSync, rmSync, existsSync } from 'node:fs'
+import { mkdtempSync, rmSync, existsSync, mkdirSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 
@@ -11,8 +13,27 @@ const tmpRoot = mkdtempSync(join(tmpdir(), 'marveen-claude-plans-routes-test-'))
 
 vi.mock('../config.js', () => ({ PROJECT_ROOT: tmpRoot, MAIN_AGENT_ID: 'agent-a', DEFAULT_AGENT_MODEL: 'claude-opus-5' }))
 
+let rotationEnabled = '0'
+let mainIsolated = '0'
+vi.mock('../settings-store.js', () => ({
+  getEffectiveSettingValue: (key: string) => {
+    if (key === 'CLAUDE_ROTATION_ENABLED') return rotationEnabled
+    if (key === 'MAIN_AGENT_ISOLATED_CONFIG') return mainIsolated
+    return ''
+  },
+}))
+
+const hardRestartMarveenChannels = vi.fn((): { ok: boolean; error?: string } => ({ ok: true }))
+vi.mock('../web/channel-monitor.js', () => ({ hardRestartMarveenChannels: () => hardRestartMarveenChannels() }))
+
+const restartAgentProcess = vi.fn(
+  async (_name: string): Promise<{ ok: boolean; pid?: number; error?: string }> => ({ ok: true, pid: 123 }),
+)
+vi.mock('../web/agent-process.js', () => ({ restartAgentProcess: (name: string) => restartAgentProcess(name) }))
+
 const { tryHandleClaudePlans } = await import('../web/routes/claude-plans.js')
 const { CLAUDE_PLANS_PATH } = await import('../web/claude-plans.js')
+const { CLAUDE_PLANS_STATE_PATH } = await import('../web/claude-plans-state.js')
 
 function fakeCtx(method: string, path: string, body?: unknown): { ctx: any; out: { status: number; body: any } } {
   const out: { status: number; body: any } = { status: 0, body: null }
@@ -130,13 +151,148 @@ describe('tryHandleClaudePlans', () => {
   it('GET .../state reports an empty state when nothing has ever rotated', async () => {
     const { ctx, out } = fakeCtx('GET', '/api/claude-plans/state')
     expect(await tryHandleClaudePlans(ctx)).toBe(true)
-    expect(out.body).toEqual({ activePlanId: null, plans: {} })
+    expect(out.body).toEqual({ activePlanByAgent: {}, plans: {} })
   })
 
   it('a plan literally named "state" cannot shadow the state route', async () => {
     await tryHandleClaudePlans(fakeCtx('POST', '/api/claude-plans', plan({ id: 'state' })).ctx)
     const { ctx, out } = fakeCtx('GET', '/api/claude-plans/state')
     await tryHandleClaudePlans(ctx)
-    expect(out.body).toEqual({ activePlanId: null, plans: {} })
+    expect(out.body).toEqual({ activePlanByAgent: {}, plans: {} })
+  })
+})
+
+describe('POST /api/claude-plans/rotate (PR2c)', () => {
+  const agentsDir = join(tmpRoot, 'agents')
+
+  beforeEach(() => {
+    if (existsSync(CLAUDE_PLANS_PATH)) rmSync(CLAUDE_PLANS_PATH)
+    if (existsSync(CLAUDE_PLANS_STATE_PATH)) rmSync(CLAUDE_PLANS_STATE_PATH)
+    if (existsSync(agentsDir)) rmSync(agentsDir, { recursive: true, force: true })
+    rotationEnabled = '1'
+    mainIsolated = '1'
+    hardRestartMarveenChannels.mockClear().mockReturnValue({ ok: true })
+    restartAgentProcess.mockClear().mockResolvedValue({ ok: true, pid: 123 })
+  })
+
+  async function seedTwoPlans() {
+    await tryHandleClaudePlans(fakeCtx('POST', '/api/claude-plans', plan({ id: 'pro', label: 'Personal PRO' })).ctx)
+    await tryHandleClaudePlans(fakeCtx('POST', '/api/claude-plans', plan({ id: 'team', label: 'Team Seat' })).ctx)
+  }
+
+  it('rejects with 400 when targetPlanId is missing', async () => {
+    const { ctx, out } = fakeCtx('POST', '/api/claude-plans/rotate', {})
+    await tryHandleClaudePlans(ctx)
+    expect(out.status).toBe(400)
+  })
+
+  it('rejects with 400 for an unknown targetPlanId', async () => {
+    await seedTwoPlans()
+    const { ctx, out } = fakeCtx('POST', '/api/claude-plans/rotate', { targetPlanId: 'nope' })
+    await tryHandleClaudePlans(ctx)
+    expect(out.status).toBe(400)
+    expect(hardRestartMarveenChannels).not.toHaveBeenCalled()
+  })
+
+  it('rejects with 400 when the target plan does not allow channels', async () => {
+    await tryHandleClaudePlans(fakeCtx('POST', '/api/claude-plans', plan({ id: 'pro' })).ctx)
+    await tryHandleClaudePlans(fakeCtx('POST', '/api/claude-plans', plan({ id: 'team', label: 'Team', channelsAllowed: false })).ctx)
+    const { ctx, out } = fakeCtx('POST', '/api/claude-plans/rotate', { targetPlanId: 'team' })
+    await tryHandleClaudePlans(ctx)
+    expect(out.status).toBe(400)
+  })
+
+  it('rejects with 409 when CLAUDE_ROTATION_ENABLED is off', async () => {
+    await seedTwoPlans()
+    rotationEnabled = '0'
+    const { ctx, out } = fakeCtx('POST', '/api/claude-plans/rotate', { targetPlanId: 'team' })
+    await tryHandleClaudePlans(ctx)
+    expect(out.status).toBe(409)
+    expect(hardRestartMarveenChannels).not.toHaveBeenCalled()
+  })
+
+  it('rejects with 409 for the main agent when MAIN_AGENT_ISOLATED_CONFIG is off', async () => {
+    await seedTwoPlans()
+    mainIsolated = '0'
+    const { ctx, out } = fakeCtx('POST', '/api/claude-plans/rotate', { targetPlanId: 'team' })
+    await tryHandleClaudePlans(ctx)
+    expect(out.status).toBe(409)
+    expect(hardRestartMarveenChannels).not.toHaveBeenCalled()
+  })
+
+  it('rejects with 409 for the main agent with fewer than 2 registered plans', async () => {
+    await tryHandleClaudePlans(fakeCtx('POST', '/api/claude-plans', plan({ id: 'pro' })).ctx)
+    const { ctx, out } = fakeCtx('POST', '/api/claude-plans/rotate', { targetPlanId: 'pro' })
+    await tryHandleClaudePlans(ctx)
+    expect(out.status).toBe(409)
+  })
+
+  it('happy path (main agent, default agentId): writes state THEN restarts, in that order', async () => {
+    await seedTwoPlans()
+    const order: string[] = []
+    hardRestartMarveenChannels.mockImplementation(() => { order.push('restart'); return { ok: true } })
+    const { ctx, out } = fakeCtx('POST', '/api/claude-plans/rotate', { targetPlanId: 'team' })
+    await tryHandleClaudePlans(ctx)
+    expect(out.status).toBe(200)
+    expect(out.body).toEqual({ ok: true, agentId: 'agent-a', activePlanId: 'team' })
+    expect(hardRestartMarveenChannels).toHaveBeenCalledTimes(1)
+
+    const state = fakeCtx('GET', '/api/claude-plans/state')
+    await tryHandleClaudePlans(state.ctx)
+    expect(state.out.body.activePlanByAgent).toEqual({ 'agent-a': 'team' })
+  })
+
+  it('this is also how a first-ever assignment happens -- no separate bootstrap path', async () => {
+    // No prior activePlanByAgent entry for agent-a: applyRotation just adds one.
+    await seedTwoPlans()
+    const { ctx } = fakeCtx('POST', '/api/claude-plans/rotate', { targetPlanId: 'pro' })
+    await tryHandleClaudePlans(ctx)
+    const state = fakeCtx('GET', '/api/claude-plans/state')
+    await tryHandleClaudePlans(state.ctx)
+    expect(state.out.body.activePlanByAgent['agent-a']).toBe('pro')
+  })
+
+  it('returns 500 and does not report ok when the main-agent restart fails', async () => {
+    await seedTwoPlans()
+    hardRestartMarveenChannels.mockReturnValue({ ok: false, error: 'launchctl boom' })
+    const { ctx, out } = fakeCtx('POST', '/api/claude-plans/rotate', { targetPlanId: 'team' })
+    await tryHandleClaudePlans(ctx)
+    expect(out.status).toBe(500)
+    expect(out.body.error).toContain('launchctl boom')
+  })
+
+  it('sub-agent path: 404 when the agent does not exist', async () => {
+    await seedTwoPlans()
+    const { ctx, out } = fakeCtx('POST', '/api/claude-plans/rotate', { agentId: 'devy', targetPlanId: 'team' })
+    await tryHandleClaudePlans(ctx)
+    expect(out.status).toBe(404)
+    expect(restartAgentProcess).not.toHaveBeenCalled()
+  })
+
+  it('sub-agent path: writes claudePlan + restarts via restartAgentProcess, not the main-agent path', async () => {
+    await seedTwoPlans()
+    mkdirSync(join(agentsDir, 'devy'), { recursive: true })
+    const { ctx, out } = fakeCtx('POST', '/api/claude-plans/rotate', { agentId: 'devy', targetPlanId: 'team' })
+    await tryHandleClaudePlans(ctx)
+    expect(out.status).toBe(200)
+    expect(out.body).toEqual({ ok: true, agentId: 'devy', activePlanId: 'team' })
+    expect(restartAgentProcess).toHaveBeenCalledWith('devy')
+    expect(hardRestartMarveenChannels).not.toHaveBeenCalled()
+
+    const state = fakeCtx('GET', '/api/claude-plans/state')
+    await tryHandleClaudePlans(state.ctx)
+    expect(state.out.body.activePlanByAgent.devy).toBe('team')
+  })
+
+  it('sub-agent path is NOT gated on MAIN_AGENT_ISOLATED_CONFIG or the 2-plan minimum', async () => {
+    // Only design 6.2's main-agent precondition mentions isolation; a
+    // sub-agent's claudePlan field is a normal per-agent setting already,
+    // unrelated to the main agent's auth mode.
+    await tryHandleClaudePlans(fakeCtx('POST', '/api/claude-plans', plan({ id: 'pro' })).ctx)
+    mainIsolated = '0'
+    mkdirSync(join(agentsDir, 'devy'), { recursive: true })
+    const { ctx, out } = fakeCtx('POST', '/api/claude-plans/rotate', { agentId: 'devy', targetPlanId: 'pro' })
+    await tryHandleClaudePlans(ctx)
+    expect(out.status).toBe(200)
   })
 })

--- a/src/__tests__/claude-plans-state.test.ts
+++ b/src/__tests__/claude-plans-state.test.ts
@@ -1,9 +1,9 @@
-// PR2b: readClaudePlansState(), the reader for the not-yet-written (PR2c)
-// store/claude-plans-state.json rotation side-car. Nothing writes this file
-// yet, so these tests only cover: missing file, malformed content, and a
-// well-formed snapshot read back verbatim.
+// PR2b: readClaudePlansState(), the reader for store/claude-plans-state.json.
+// PR2c: writeClaudePlansState() + the pure recordObservation()/applyRotation()
+// transitions, finalizing the schema per design decision #1 (2026-09-12):
+// activePlanId -> activePlanByAgent, keyed by agent id.
 import { describe, it, expect, vi } from 'vitest'
-import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, readdirSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 
@@ -11,31 +11,37 @@ const tmpRoot = mkdtempSync(join(tmpdir(), 'marveen-claude-plans-state-test-'))
 
 vi.mock('../config.js', () => ({ PROJECT_ROOT: tmpRoot }))
 
-const { readClaudePlansState, CLAUDE_PLANS_STATE_PATH } = await import('../web/claude-plans-state.js')
+const {
+  readClaudePlansState,
+  writeClaudePlansState,
+  recordObservation,
+  applyRotation,
+  CLAUDE_PLANS_STATE_PATH,
+} = await import('../web/claude-plans-state.js')
 
 describe('readClaudePlansState', () => {
   it('returns an empty state when the file does not exist', () => {
-    expect(readClaudePlansState()).toEqual({ activePlanId: null, plans: {} })
+    expect(readClaudePlansState()).toEqual({ activePlanByAgent: {}, plans: {} })
   })
 
   it('returns an empty state on unparseable JSON', () => {
     mkdirSync(join(tmpRoot, 'store'), { recursive: true })
     writeFileSync(CLAUDE_PLANS_STATE_PATH, 'not json')
-    expect(readClaudePlansState()).toEqual({ activePlanId: null, plans: {} })
+    expect(readClaudePlansState()).toEqual({ activePlanByAgent: {}, plans: {} })
   })
 
   it('returns an empty state when the JSON is not an object (array, null, primitive)', () => {
     writeFileSync(CLAUDE_PLANS_STATE_PATH, '[]')
-    expect(readClaudePlansState()).toEqual({ activePlanId: null, plans: {} })
+    expect(readClaudePlansState()).toEqual({ activePlanByAgent: {}, plans: {} })
     writeFileSync(CLAUDE_PLANS_STATE_PATH, 'null')
-    expect(readClaudePlansState()).toEqual({ activePlanId: null, plans: {} })
+    expect(readClaudePlansState()).toEqual({ activePlanByAgent: {}, plans: {} })
     writeFileSync(CLAUDE_PLANS_STATE_PATH, '"pro"')
-    expect(readClaudePlansState()).toEqual({ activePlanId: null, plans: {} })
+    expect(readClaudePlansState()).toEqual({ activePlanByAgent: {}, plans: {} })
   })
 
   it('reads a well-formed snapshot back verbatim', () => {
     const snapshot = {
-      activePlanId: 'pro',
+      activePlanByAgent: { marveen: 'pro', devy: 'team' },
       plans: {
         pro: { observedAt: 1_700_000_000_000, source: 'authoritative', windows: { five_hour: { usedPercent: 42, resetsAt: 1_700_010_000 } } },
         team: { observedAt: 1_699_000_000_000, source: 'authoritative_cached', windows: {} },
@@ -45,11 +51,79 @@ describe('readClaudePlansState', () => {
     expect(readClaudePlansState()).toEqual(snapshot)
   })
 
-  it('defaults a missing/bad-typed activePlanId or plans key rather than throwing', () => {
-    writeFileSync(CLAUDE_PLANS_STATE_PATH, JSON.stringify({ activePlanId: 42, plans: 'nope' }))
-    expect(readClaudePlansState()).toEqual({ activePlanId: null, plans: {} })
+  it('defaults a missing/bad-typed activePlanByAgent or plans key rather than throwing', () => {
+    writeFileSync(CLAUDE_PLANS_STATE_PATH, JSON.stringify({ activePlanByAgent: 42, plans: 'nope' }))
+    expect(readClaudePlansState()).toEqual({ activePlanByAgent: {}, plans: {} })
 
     writeFileSync(CLAUDE_PLANS_STATE_PATH, JSON.stringify({}))
-    expect(readClaudePlansState()).toEqual({ activePlanId: null, plans: {} })
+    expect(readClaudePlansState()).toEqual({ activePlanByAgent: {}, plans: {} })
+  })
+
+  it('drops activePlanByAgent when any value is not a string', () => {
+    writeFileSync(CLAUDE_PLANS_STATE_PATH, JSON.stringify({ activePlanByAgent: { marveen: 42 }, plans: {} }))
+    expect(readClaudePlansState()).toEqual({ activePlanByAgent: {}, plans: {} })
+  })
+})
+
+describe('writeClaudePlansState', () => {
+  it('creates store/ and writes the file atomically (readable back)', () => {
+    const state = { activePlanByAgent: { marveen: 'pro' }, plans: {} }
+    writeClaudePlansState(state)
+    expect(JSON.parse(readFileSync(CLAUDE_PLANS_STATE_PATH, 'utf8'))).toEqual(state)
+    expect(readClaudePlansState()).toEqual(state)
+  })
+
+  it('leaves no .tmp file behind after a successful write', () => {
+    writeClaudePlansState({ activePlanByAgent: {}, plans: {} })
+    const leftovers = readdirSync(join(tmpRoot, 'store')).filter((f: string) => f.includes('.tmp'))
+    expect(leftovers).toEqual([])
+  })
+})
+
+describe('recordObservation', () => {
+  it('sets the agent active on the plan and records its window snapshot', () => {
+    const before = { activePlanByAgent: {}, plans: {} }
+    const observed = { observedAt: 123, source: 'authoritative', windows: { five_hour: { usedPercent: 10, resetsAt: 456 } } }
+    const after = recordObservation(before, 'marveen', 'pro', observed)
+    expect(after).toEqual({ activePlanByAgent: { marveen: 'pro' }, plans: { pro: observed } })
+  })
+
+  it('does not mutate the input state (pure)', () => {
+    const before = { activePlanByAgent: { marveen: 'pro' }, plans: { pro: { observedAt: 1, source: 'x', windows: {} } } }
+    const snapshot = JSON.parse(JSON.stringify(before))
+    recordObservation(before, 'marveen', 'pro', { observedAt: 2, source: 'y', windows: {} })
+    expect(before).toEqual(snapshot)
+  })
+
+  it('leaves other agents and other plans untouched', () => {
+    const before = {
+      activePlanByAgent: { marveen: 'pro', devy: 'team' },
+      plans: { team: { observedAt: 1, source: 'authoritative', windows: {} } },
+    }
+    const after = recordObservation(before, 'marveen', 'pro', { observedAt: 2, source: 'authoritative', windows: {} })
+    expect(after.activePlanByAgent.devy).toBe('team')
+    expect(after.plans.team).toEqual(before.plans.team)
+  })
+})
+
+describe('applyRotation', () => {
+  it('points the agent at the target plan, leaving plans untouched', () => {
+    const before = { activePlanByAgent: { marveen: 'pro' }, plans: { pro: { observedAt: 1, source: 'x', windows: {} } } }
+    const after = applyRotation(before, 'marveen', 'team')
+    expect(after.activePlanByAgent).toEqual({ marveen: 'team' })
+    expect(after.plans).toEqual(before.plans)
+  })
+
+  it('adds a fresh entry for an agent with no prior active plan (the bootstrap case)', () => {
+    const before = { activePlanByAgent: {}, plans: {} }
+    const after = applyRotation(before, 'marveen', 'pro')
+    expect(after.activePlanByAgent).toEqual({ marveen: 'pro' })
+  })
+
+  it('does not mutate the input state (pure)', () => {
+    const before = { activePlanByAgent: { marveen: 'pro' }, plans: {} }
+    const snapshot = JSON.parse(JSON.stringify(before))
+    applyRotation(before, 'marveen', 'team')
+    expect(before).toEqual(snapshot)
   })
 })

--- a/src/__tests__/main-agent-config-dir.test.ts
+++ b/src/__tests__/main-agent-config-dir.test.ts
@@ -67,12 +67,20 @@ describe('launcher wiring', () => {
   const CHANNELS = readFileSync(join(__dirname, '../../scripts/channels.sh'), 'utf-8')
   const WATCHDOG = readFileSync(join(__dirname, '../../scripts/channel-watchdog.sh'), 'utf-8')
 
-  it('the helper prefers the explicit dir over the isolated one', () => {
-    expect(HELPER).toMatch(/const explicit = resolveMainAgentConfigDir\(\)[\s\S]*if \(explicit\)/)
+  it('the helper prefers explicit over rotated over isolated', () => {
+    // explicit (an operator's own separate login) always wins: design 6.2
+    // says it is never part of the rotation pool. rotated (PR2c, a
+    // registered plan the state side-car points the main agent at) wins over
+    // the generic isolated flotta fallback because it is the more specific
+    // signal.
+    expect(HELPER).toMatch(
+      /const explicit = resolveMainAgentConfigDir\(\)[\s\S]*if \(explicit\)[\s\S]*const rotated = resolveMainAgentRotatedConfigDir\(\)[\s\S]*if \(rotated\)/,
+    )
   })
 
   it('the helper tags each path with its mode so the caller knows how to authenticate', () => {
     expect(HELPER).toMatch(/explicit\\t/)
+    expect(HELPER).toMatch(/rotated\\t/)
     expect(HELPER).toMatch(/isolated\\t/)
   })
 
@@ -88,25 +96,30 @@ describe('launcher wiring', () => {
     expect(HELPER).toMatch(/writeSync\(CONTRACT_FD/)
     // stdout stays a usable fallback for a hand-run, but nothing writes the
     // contract through process.stdout.write -- patching it does not catch pino.
-    expect(HELPER).not.toMatch(/process\.stdout\.write\(`(explicit|isolated)/)
+    expect(HELPER).not.toMatch(/process\.stdout\.write\(`(explicit|rotated|isolated)/)
   })
 
-  it('every caller opens fd 3 AND filters for a contract line', () => {
+  it('every caller opens fd 3 AND filters for a contract line, including the rotated mode (PR2c)', () => {
     // Both files spawn the helper; a caller that drifts reintroduces the outage
     // on exactly the path that matters (channel-watchdog.sh respawns when the
-    // dashboard is down).
+    // dashboard is down). A caller whose filter still only matches
+    // explicit|isolated would silently drop a rotated plan back onto either
+    // the shared ~/.claude or the wrong (fleet-token) auth mode -- exactly the
+    // outage class this contract exists to prevent, just for the new mode.
     for (const [name, sh] of [['channels.sh', CHANNELS], ['channel-watchdog.sh', WATCHDOG]] as const) {
       expect(sh, name).toMatch(/main-agent-isolated-config\.mjs[^\n]*3>&1/)
-      expect(sh, name).toMatch(/grep -m1 -E '\^\(explicit\|isolated\)/)
+      expect(sh, name).toMatch(/grep -m1 -E '\^\(explicit\|rotated\|isolated\)/)
     }
   })
 
-  it('channels.sh never injects the fleet token for an explicit dir', () => {
-    // The explicit dir carries its OWN .credentials.json -- exporting the fleet
-    // token there would silently authenticate the bot as the fleet.
-    const explicitBranch = CHANNELS.match(/if \[ "\$_cfg_mode" = "explicit" \]; then\n([\s\S]*?)\n\s*else/)
-    expect(explicitBranch).not.toBeNull()
-    expect(explicitBranch?.[1]).not.toMatch(/CLAUDE_CODE_OAUTH_TOKEN/)
-    expect(explicitBranch?.[1]).toMatch(/CLAUDE_CONFIG_DIR/)
+  it('channels.sh never injects the fleet token for an explicit OR rotated dir', () => {
+    // Both carry their OWN .credentials.json (an operator-logged-in dir for
+    // explicit, a registered plan's dir for rotated -- design 6.5/4) --
+    // exporting the fleet token for either would silently authenticate the
+    // bot as the fleet identity instead.
+    const branch = CHANNELS.match(/if \[ "\$_cfg_mode" = "explicit" \] \|\| \[ "\$_cfg_mode" = "rotated" \]; then\n([\s\S]*?)\n\s*else/)
+    expect(branch).not.toBeNull()
+    expect(branch?.[1]).not.toMatch(/CLAUDE_CODE_OAUTH_TOKEN/)
+    expect(branch?.[1]).toMatch(/CLAUDE_CONFIG_DIR/)
   })
 })

--- a/src/__tests__/main-agent-rotated-config-dir.test.ts
+++ b/src/__tests__/main-agent-rotated-config-dir.test.ts
@@ -1,0 +1,70 @@
+// resolveMainAgentRotatedConfigDir (PR2c, design 6.5/4): the main agent's
+// CLAUDE_CONFIG_DIR when the rotation side-car has recorded an active plan
+// for it. Sibling of resolveMainAgentConfigDir's tests in
+// main-agent-config-dir.test.ts, gated the same way rotation itself is
+// (design 6.2): MAIN_AGENT_ISOLATED_CONFIG=1 AND 2+ registered plans.
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { MAIN_AGENT_ID } from '../config.js'
+
+let isolationSetting = ''
+vi.mock('../settings-store.js', async (orig) => {
+  const actual = await orig<typeof import('../settings-store.js')>()
+  return {
+    ...actual,
+    getEffectiveSettingValue: (key: string) =>
+      key === 'MAIN_AGENT_ISOLATED_CONFIG' ? isolationSetting : actual.getEffectiveSettingValue(key),
+  }
+})
+
+let plans: Array<{ id: string; configDir: string }> = []
+vi.mock('../web/claude-plans.js', () => ({
+  readClaudePlans: () => plans,
+  getClaudePlan: (id: string | null | undefined) => plans.find((p) => p.id === id) ?? null,
+}))
+
+let activePlanByAgent: Record<string, string> = {}
+vi.mock('../web/claude-plans-state.js', () => ({
+  readClaudePlansState: () => ({ activePlanByAgent, plans: {} }),
+}))
+
+const { resolveMainAgentRotatedConfigDir } = await import('../web/agent-process.js')
+
+beforeEach(() => {
+  isolationSetting = '1'
+  plans = [
+    { id: 'pro', configDir: '/opt/claude-pro' },
+    { id: 'team', configDir: '/opt/claude-team' },
+  ]
+  activePlanByAgent = { [MAIN_AGENT_ID]: 'team' }
+})
+
+describe('resolveMainAgentRotatedConfigDir', () => {
+  it('returns the active plan configDir when isolation is on and 2+ plans exist', () => {
+    expect(resolveMainAgentRotatedConfigDir()).toBe('/opt/claude-team')
+  })
+
+  it('returns null when MAIN_AGENT_ISOLATED_CONFIG is off', () => {
+    isolationSetting = '0'
+    expect(resolveMainAgentRotatedConfigDir()).toBeNull()
+  })
+
+  it('returns null with fewer than 2 registered plans, even with a stale active entry', () => {
+    plans = [{ id: 'team', configDir: '/opt/claude-team' }]
+    expect(resolveMainAgentRotatedConfigDir()).toBeNull()
+  })
+
+  it('returns null when no plan is active for the main agent yet (bootstrap gap)', () => {
+    activePlanByAgent = {}
+    expect(resolveMainAgentRotatedConfigDir()).toBeNull()
+  })
+
+  it('returns null when the recorded active plan id no longer resolves (deleted/renamed)', () => {
+    activePlanByAgent = { [MAIN_AGENT_ID]: 'gone' }
+    expect(resolveMainAgentRotatedConfigDir()).toBeNull()
+  })
+
+  it('is keyed by MAIN_AGENT_ID, not any sub-agent entry in the same state file', () => {
+    activePlanByAgent = { someSubAgent: 'pro' }
+    expect(resolveMainAgentRotatedConfigDir()).toBeNull()
+  })
+})

--- a/src/claude-plan-rotate-heartbeat.ts
+++ b/src/claude-plan-rotate-heartbeat.ts
@@ -1,0 +1,122 @@
+// Pure core for the plan-rotation heartbeat (PR2c, design 6.3 + 6.6). No fs,
+// no child_process, no settings-store -- scripts/claude-plan-rotate-check.ts
+// is the thin IO wrapper that collects these inputs and calls decideAndRecord.
+// Split into its own src/ module (rather than living directly in the scripts/
+// entry point) so it unit-tests under tsc's rootDir=src, the same reason
+// quota-gate.ts's decision logic lives under src/ instead of inside a script.
+import { parseQuotaSnapshot } from './quota-snapshot.js'
+import { decideRotationAction, estimateWindowFree, type RotationCandidate } from './claude-plan-rotation.js'
+import type { ClaudePlan } from './web/claude-plans.js'
+import {
+  recordObservation,
+  type ClaudePlansState,
+  type ObservedPlanState,
+} from './web/claude-plans-state.js'
+
+export interface RotateCheckResult {
+  /** The single structured line to print on stdout, or null to stay silent. */
+  printLine: string | null
+  /** State to persist. null when nothing changed (e.g. gated off, no plan
+   *  assigned yet) -- the caller must not write in that case, to avoid
+   *  bumping the file's mtime for no reason. */
+  nextState: ClaudePlansState | null
+}
+
+const roundMin = (ms: number) => Math.round(ms / 60_000)
+
+/**
+ * Everything design 6.3/6.6 decides, given the already-collected inputs:
+ * the registered plans, the current state side-car, and the raw
+ * usage-collect.py --json output. Preconditions (design 6.2) and the
+ * proactive gate (design 6.3) are both applied here; the caller is only
+ * responsible for IO (spawning usage-collect.py, reading/writing the state
+ * file, printing the result).
+ */
+export function decideAndRecord(input: {
+  agentId: string
+  plans: ClaudePlan[]
+  state: ClaudePlansState
+  usageCollectRaw: unknown
+  nowMs: number
+}): RotateCheckResult {
+  const { agentId, plans, state, usageCollectRaw, nowMs } = input
+
+  // Design 6.2 precondition: rotation only means anything with 2+ registered
+  // plans. Below that, strict no-op -- existing single-plan installs must see
+  // zero behavior change.
+  if (plans.length < 2) return { printLine: null, nextState: null }
+
+  const activePlanId = state.activePlanByAgent[agentId]
+  // Bootstrap gap (design 6.5/4 open question, resolved in the PR
+  // description): the very first assignment for an agent is not something
+  // this heartbeat can guess -- it has no way to know which registered
+  // plan's configDir the agent is CURRENTLY running from. That first
+  // assignment is a one-time manual POST /api/claude-plans/rotate call;
+  // after that, this heartbeat maintains it.
+  if (!activePlanId) return { printLine: null, nextState: null }
+
+  const activePlan = plans.find((p) => p.id === activePlanId)
+  if (!activePlan) return { printLine: null, nextState: null }
+
+  const snapshot = parseQuotaSnapshot(usageCollectRaw)
+  // Same fail-open rule as quota-gate.ts: an untrusted/missing/incomplete
+  // snapshot is not evidence of pressure, so never act on it.
+  const trustedSources = ['authoritative', 'authoritative_cached']
+  if (!snapshot || !trustedSources.includes((snapshot.source ?? '').toLowerCase())) {
+    return { printLine: null, nextState: null }
+  }
+  const fiveHour = snapshot.windows?.five_hour
+  if (!fiveHour || typeof fiveHour.used_percent !== 'number' || typeof fiveHour.resets_at !== 'number') {
+    return { printLine: null, nextState: null }
+  }
+  const sevenDay = snapshot.windows?.seven_day
+
+  const observed: ObservedPlanState = {
+    observedAt: nowMs,
+    source: snapshot.source ?? 'unknown',
+    windows: {
+      five_hour: { usedPercent: fiveHour.used_percent, resetsAt: fiveHour.resets_at },
+      ...(sevenDay && typeof sevenDay.used_percent === 'number' && typeof sevenDay.resets_at === 'number'
+        ? { seven_day: { usedPercent: sevenDay.used_percent, resetsAt: sevenDay.resets_at } }
+        : {}),
+    },
+  }
+  // Telemetry is recorded on every trustworthy tick, independent of whether a
+  // rotation decision follows -- the dashboard's "last known %" badge should
+  // stay current even on a quiet cycle.
+  const stateWithObservation = recordObservation(state, agentId, activePlanId, observed)
+
+  const candidates: RotationCandidate[] = plans
+    .filter((p) => p.id !== activePlanId && p.channelsAllowed)
+    .map((p) => {
+      const lastObserved = stateWithObservation.plans[p.id]?.windows?.five_hour
+      return { planId: p.id, freeFivePct: estimateWindowFree(lastObserved, nowMs) }
+    })
+
+  const decision = decideRotationAction({
+    activePlanId,
+    activeFiveHour: { usedPercent: fiveHour.used_percent, resetsAt: fiveHour.resets_at },
+    candidates,
+    nowMs,
+  })
+
+  const resetsInMin = roundMin(fiveHour.resets_at * 1000 - nowMs)
+  const pct = Math.round(fiveHour.used_percent)
+
+  if (decision.action === 'rotate') {
+    const target = plans.find((p) => p.id === decision.targetPlanId)
+    return {
+      printLine: `ROTATE agent=${agentId} target=${decision.targetPlanId} targetLabel=${target?.label ?? decision.targetPlanId} currentLabel=${activePlan.label} currentPct=${pct} resetsInMin=${resetsInMin}`,
+      nextState: stateWithObservation,
+    }
+  }
+  if (decision.action === 'no-alternative') {
+    return {
+      printLine: `NO_ALTERNATIVE agent=${agentId} currentLabel=${activePlan.label} currentPct=${pct} resetsInMin=${resetsInMin}`,
+      nextState: stateWithObservation,
+    }
+  }
+  // no-pressure / near-reset: quiet tick, but the observation is still worth
+  // keeping so the dashboard badge does not go stale.
+  return { printLine: null, nextState: stateWithObservation }
+}

--- a/src/claude-plan-rotation.ts
+++ b/src/claude-plan-rotation.ts
@@ -144,3 +144,29 @@ export function decideRotationAction(input: {
 
   return { action: 'rotate', targetPlanId: target, reason: `pressure:${usedPct}%->${target}` }
 }
+
+// Reactive path (design 6.3 addendum, Kobza Attila 2026-09-11): a live 429 /
+// "quota exceeded" response during a session should trigger rotation
+// immediately, without waiting for the next proactive heartbeat tick. The
+// design left the exact detection SITE open ("hol figyeljük a 429-et...
+// implementációs kérdés") -- this PR ships only the pure classifier; wiring
+// it into a live tmux-output watcher is a separate, riskier follow-up (it
+// means parsing a running session's output, not just reading a JSON
+// snapshot) and is intentionally NOT part of this PR. See the PR description.
+//
+// Deliberately conservative: false negatives (missing a real quota error) are
+// safe -- the proactive path still catches it within one heartbeat cycle.
+// False positives are not: this string match must not fire on a plain error
+// message that happens to mention "limit" for an unrelated reason, so it
+// requires one of a short list of high-specificity phrases rather than any
+// single common word.
+const QUOTA_EXCEEDED_PATTERNS = [
+  /\b429\b/,
+  /quota[\s_-]?exceeded/i,
+  /usage[\s_-]?limit[\s_-]?reached/i,
+  /rate[\s_-]?limit[\s_-]?exceeded/i,
+] as const
+
+export function isQuotaExceededError(text: string): boolean {
+  return QUOTA_EXCEEDED_PATTERNS.some((re) => re.test(text))
+}

--- a/src/config-registry.ts
+++ b/src/config-registry.ts
@@ -477,16 +477,18 @@ export const SETTINGS_REGISTRY: SettingDefinition[] = [
       'claude-haiku-4-5-20251001',
     ],
   },
-  // --- Claude plans module (PR2b) ---
-  // Inert until PR2c ships the rotation wiring that reads it -- see
-  // docs/superpowers/specs/2026-09-11-claude-key-rotation-design.md section 7.
-  // Shipping the toggle now lets the dashboard UI (plan list + this switch)
-  // land as one reviewable unit; flipping it to '1' today has no effect yet.
+  // --- Claude plans module (PR2b/PR2c) ---
+  // Gates BOTH POST /api/claude-plans/rotate (returns 409 while off) and the
+  // heartbeat script's decision to call it (scripts/claude-plan-rotate-check.ts)
+  // -- see docs/superpowers/specs/2026-09-11-claude-key-rotation-design.md
+  // sections 6-7. Default OFF: staging verification (live session-restart,
+  // the riskiest part of this feature) happens before an operator ever flips
+  // this to '1'.
   {
     key: 'CLAUDE_ROTATION_ENABLED',
     type: 'boolean',
     default: '0',
-    description: 'Automata Claude-kulcs rotáció: ha a fő agent aktív előfizetése kifogy, automatikusan váltson egy másik regisztrált planre. Előfeltétel: MAIN_AGENT_ISOLATED_CONFIG=1 és legalább 2 regisztrált plan a claude-plans.json-ban. A tényleges rotációs logika (PR2c) még nincs bekötve -- ez a kapcsoló egyelőre hatástalan.',
+    description: 'Automata Claude-kulcs rotáció: ha a fő agent aktív előfizetése kifogy, automatikusan váltson egy másik regisztrált planre. Előfeltétel: MAIN_AGENT_ISOLATED_CONFIG=1 és legalább 2 regisztrált plan a claude-plans.json-ban. A váltás a fő agent session-jének újraindításával jár.',
     module: 'claude-plans',
     secret: false,
     requiresRestart: false,

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -32,7 +32,8 @@ import { scheduleRecoveryBrief } from './restart-recovery-brief.js'
 import { beginRestart, endRestart } from './restart-lock.js'
 import { agentDir, listAgentNames, readAgentModel, readAgentClaudeConfigDir, readAgentClaudePlan, readAgentChannelProvider, readAgentAuthMode, readAgentDisplayName, readAgentRemoteConfig, readAgentRemoteHost, readAgentRunAsUser, readAgentMemoryIsolation, readAgentWorksourceChannel } from './agent-config.js'
 import { worksourceRootFor } from './worksource-queue.js'
-import { resolveAgentConfigDir } from './claude-plans.js'
+import { resolveAgentConfigDir, readClaudePlans, getClaudePlan } from './claude-plans.js'
+import { readClaudePlansState } from './claude-plans-state.js'
 import { provisionMemoryBoundaryDir } from './memory-boundary.js'
 import { renameSharedCredentialsIfSafe } from './claude-credentials-guard.js'
 import { atomicWriteFileSync } from './atomic-write.js'
@@ -512,6 +513,35 @@ export function resolveMainAgentConfigDir(): string | null {
     return null
   }
   return dir
+}
+
+// The main agent's CLAUDE_CONFIG_DIR when the rotation side-car
+// (store/claude-plans-state.json, PR2c) has recorded an active plan for it.
+//
+// Unlike the isolated credential-less dir above, a plan's configDir carries
+// its OWN real login -- the operator ran `claude setup-token` into it
+// directly (design 6.5/4, same as the per-agent resolveAgentConfigDir path).
+// So this behaves like an EXPLICIT dir, not an isolated one: the caller
+// (main-agent-isolated-config.mjs) must NOT inject the fleet token here,
+// exactly as it would not for resolveMainAgentConfigDir()'s result.
+//
+// Gated the same way rotation itself is gated (design 6.2): only applies
+// when MAIN_AGENT_ISOLATED_CONFIG=1 AND 2+ plans are registered. Below
+// either threshold this returns null even if a stale activePlanByAgent entry
+// exists on disk, so turning rotation off (or dropping back to one plan)
+// cannot strand the main agent on a dir nobody is maintaining anymore.
+export function resolveMainAgentRotatedConfigDir(): string | null {
+  let isolationEnabled = false
+  try { isolationEnabled = String(getEffectiveSettingValue('MAIN_AGENT_ISOLATED_CONFIG')) === '1' } catch { return null }
+  if (!isolationEnabled) return null
+
+  if (readClaudePlans().length < 2) return null
+
+  const activeId = readClaudePlansState().activePlanByAgent[MAIN_AGENT_ID]
+  if (!activeId) return null
+
+  const plan = getClaudePlan(activeId)
+  return plan ? plan.configDir : null
 }
 
 // Shared provisioning core for BOTH the sub-agents (ensureIsolatedChannelConfigDir)

--- a/src/web/claude-plans-state.ts
+++ b/src/web/claude-plans-state.ts
@@ -1,18 +1,25 @@
-// Read-only view onto store/claude-plans-state.json, the machine-managed
-// rotation side-car described in
+// store/claude-plans-state.json, the machine-managed rotation side-car
+// described in
 // docs/superpowers/specs/2026-09-11-claude-key-rotation-design.md section 5.2.
 //
-// PR2b ships ONLY this reader (behind GET /api/claude-plans/state, for the
-// dashboard's plan cards). Nothing writes the file yet -- that lands with the
-// rotation wiring (PR2c). The design doc's open question #1 (decided
-// 2026-09-12: sub-agents rotate too, so `activePlanId` likely becomes
-// per-agent, not one global value) is not yet reflected in a finalized
-// schema, so this stays deliberately lenient: it reads back whatever object
-// PR2c ends up writing rather than asserting a shape nobody has built yet,
-// and reports a safe empty state when the file is absent or malformed.
-import { existsSync, readFileSync } from 'node:fs'
-import { join } from 'node:path'
+// PR2b shipped ONLY the reader (behind GET /api/claude-plans/state, for the
+// dashboard's plan cards), with a deliberately lenient schema because open
+// question #1 (decided 2026-09-12: sub-agents rotate too) had not yet been
+// reflected. PR2c finalizes the schema per that decision: `activePlanId` is
+// now `activePlanByAgent`, keyed by agent id (MAIN_AGENT_ID for the main
+// channels agent, or a sub-agent's name), because rotation runs per agent,
+// not once for the fleet. `plans` stays a flat map keyed by plan id -- a
+// plan's own usage does not depend on which agent currently points at it.
+//
+// PR2c also ships the writer: recordObservation() and applyRotation() are
+// pure state-transition functions (no fs), unit-tested in isolation, and
+// writeClaudePlansState() is the one atomic-write call site. The heartbeat
+// entry point (scripts/claude-plan-rotate-check.ts) is the only production
+// caller of the writer.
+import { existsSync, mkdirSync, readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
 import { PROJECT_ROOT } from '../config.js'
+import { atomicWriteFileSync } from './atomic-write.js'
 
 export const CLAUDE_PLANS_STATE_PATH = join(PROJECT_ROOT, 'store', 'claude-plans-state.json')
 
@@ -30,17 +37,22 @@ export interface ObservedPlanState {
 }
 
 export interface ClaudePlansState {
-  /** The plan currently active for the main agent, or null when rotation has
-   *  never run / the main agent is not on the isolated-config rotation path.
-   *  May become per-agent in PR2c -- see the module comment. */
-  activePlanId: string | null
+  /** Which plan id each agent is currently on. A missing key means that agent
+   *  has never been rotated (not on the isolated-config path yet, or
+   *  rotation has not run for it). */
+  activePlanByAgent: Record<string, string>
   plans: Record<string, ObservedPlanState>
 }
 
-const EMPTY_STATE: ClaudePlansState = { activePlanId: null, plans: {} }
+const EMPTY_STATE: ClaudePlansState = { activePlanByAgent: {}, plans: {} }
 
 function isPlainObject(v: unknown): v is Record<string, unknown> {
   return v !== null && typeof v === 'object' && !Array.isArray(v)
+}
+
+function isStringRecord(v: unknown): v is Record<string, string> {
+  if (!isPlainObject(v)) return false
+  return Object.values(v).every((x) => typeof x === 'string')
 }
 
 export function readClaudePlansState(): ClaudePlansState {
@@ -48,10 +60,48 @@ export function readClaudePlansState(): ClaudePlansState {
   try {
     const raw: unknown = JSON.parse(readFileSync(CLAUDE_PLANS_STATE_PATH, 'utf8'))
     if (!isPlainObject(raw)) return EMPTY_STATE
-    const activePlanId = typeof raw.activePlanId === 'string' ? raw.activePlanId : null
+    const activePlanByAgent = isStringRecord(raw.activePlanByAgent) ? raw.activePlanByAgent : {}
     const plans = isPlainObject(raw.plans) ? (raw.plans as unknown as ClaudePlansState['plans']) : {}
-    return { activePlanId, plans }
+    return { activePlanByAgent, plans }
   } catch {
     return EMPTY_STATE
   }
+}
+
+// Atomic overwrite of the whole side-car. Callers read-modify-write via
+// recordObservation()/applyRotation() below, then call this once -- mirrors
+// writeClaudePlans()'s single-writer-per-call shape in claude-plans.ts.
+export function writeClaudePlansState(state: ClaudePlansState): void {
+  mkdirSync(dirname(CLAUDE_PLANS_STATE_PATH), { recursive: true })
+  atomicWriteFileSync(CLAUDE_PLANS_STATE_PATH, JSON.stringify(state, null, 2) + '\n')
+}
+
+// Pure state transition: record a freshly observed quota snapshot for
+// `planId` (the plan `agentId` is CURRENTLY on) and make sure `agentId` is
+// marked as being on that plan. Called every heartbeat tick regardless of
+// whether a rotation decision follows, so the dashboard's "last known %"
+// badge stays current even when nothing rotates.
+export function recordObservation(
+  state: ClaudePlansState,
+  agentId: string,
+  planId: string,
+  observed: ObservedPlanState,
+): ClaudePlansState {
+  return {
+    activePlanByAgent: { ...state.activePlanByAgent, [agentId]: planId },
+    plans: { ...state.plans, [planId]: observed },
+  }
+}
+
+// Pure state transition: point `agentId` at `targetPlanId`. Used both by an
+// actual rotation and by the one-time bootstrap assignment (design 6.5/4's
+// open bootstrap question, resolved in the PR2c description: the very first
+// assignment for an agent is just a rotation with no prior active plan --
+// there is no separate bootstrap code path).
+export function applyRotation(
+  state: ClaudePlansState,
+  agentId: string,
+  targetPlanId: string,
+): ClaudePlansState {
+  return { ...state, activePlanByAgent: { ...state.activePlanByAgent, [agentId]: targetPlanId } }
 }

--- a/src/web/routes/claude-plans.ts
+++ b/src/web/routes/claude-plans.ts
@@ -1,19 +1,38 @@
-// Named Claude subscription registry -- dashboard-facing CRUD (PR2b).
+// Named Claude subscription registry -- dashboard-facing CRUD (PR2b), plus
+// the rotation trigger (PR2c). See
+// docs/superpowers/specs/2026-09-11-claude-key-rotation-design.md sections 6
+// and 7.
 //
 // GET was the whole surface in PR1 (moved here unchanged from agents.ts).
-// PR2b adds POST/PUT/DELETE on store/claude-plans.json, plus a read-only
-// GET .../state for the (not-yet-written, PR2c) rotation side-car. See
-// docs/superpowers/specs/2026-09-11-claude-key-rotation-design.md section 7.
+// PR2b added POST/PUT/DELETE on store/claude-plans.json plus a read-only
+// GET .../state. PR2c adds the write side of the state side-car
+// (POST .../rotate) -- the one code path both the (not-yet-built) manual
+// dashboard button and the automatic heartbeat decision (design 6.3, wired in
+// scripts/claude-plan-rotate-check.ts) call.
 //
-// Every write runs the body through validatePlan() -- the exact function
+// Every plan write runs the body through validatePlan() -- the exact function
 // resolveClaudePlans() uses to parse the file back -- so nothing invalid can
 // reach disk through this route that the read side would then silently drop.
 import { homedir } from 'node:os'
+import { existsSync } from 'node:fs'
 import { readBody, json } from '../http-helpers.js'
 import { logger } from '../../logger.js'
+import { MAIN_AGENT_ID } from '../../config.js'
+import { getEffectiveSettingValue } from '../../settings-store.js'
 import { readClaudePlans, writeClaudePlans, validatePlan } from '../claude-plans.js'
-import { readClaudePlansState } from '../claude-plans-state.js'
+import { readClaudePlansState, writeClaudePlansState, applyRotation } from '../claude-plans-state.js'
+import { agentDir, writeAgentClaudePlan } from '../agent-config.js'
+import { restartAgentProcess } from '../agent-process.js'
+import { hardRestartMarveenChannels } from '../channel-monitor.js'
 import type { RouteContext } from './types.js'
+
+function isRotationEnabled(): boolean {
+  try { return String(getEffectiveSettingValue('CLAUDE_ROTATION_ENABLED')) === '1' } catch { return false }
+}
+
+function isMainAgentIsolated(): boolean {
+  try { return String(getEffectiveSettingValue('MAIN_AGENT_ISOLATED_CONFIG')) === '1' } catch { return false }
+}
 
 export async function tryHandleClaudePlans(ctx: RouteContext): Promise<boolean> {
   const { req, res, path, method } = ctx
@@ -55,14 +74,108 @@ export async function tryHandleClaudePlans(ctx: RouteContext): Promise<boolean> 
     return true
   }
 
-  // Rotation telemetry side-car (store/claude-plans-state.json). Nothing
-  // writes it until PR2c ships the rotation wiring -- until then this reports
-  // an honest empty state instead of 404ing, so the dashboard cards can
-  // render "no rotation data yet" rather than treating the endpoint itself as
-  // missing. Checked before the :id matcher below so a plan literally named
-  // "state" can never shadow this route.
+  // Rotation telemetry side-car (store/claude-plans-state.json). An honest
+  // empty state ({activePlanByAgent:{}, plans:{}}) when nothing has rotated
+  // yet, rather than 404ing, so the dashboard cards can render "no rotation
+  // data yet" instead of treating the endpoint itself as missing. Checked
+  // before the :id matcher below so a plan literally named "state" can never
+  // shadow this route.
   if (path === '/api/claude-plans/state' && method === 'GET') {
     json(res, readClaudePlansState())
+    return true
+  }
+
+  // Trigger a rotation for one agent (PR2c, design 6.5/5). Body:
+  // { agentId?: string, targetPlanId: string }. agentId defaults to the main
+  // channels agent -- the only caller today is the heartbeat script, and a
+  // manual dashboard button (not yet built) would default the same way.
+  //
+  // This is ALSO how an agent's very first plan assignment happens: there is
+  // no separate "bootstrap" endpoint. applyRotation() just adds an entry when
+  // none existed (design 6.5/4's open bootstrap question -- resolved this
+  // way because a first assignment and a later rotation are the same
+  // operation: "agentId is now on targetPlanId").
+  if (path === '/api/claude-plans/rotate' && method === 'POST') {
+    let body: unknown
+    try {
+      body = JSON.parse((await readBody(req)).toString())
+    } catch {
+      json(res, { error: 'Invalid JSON' }, 400)
+      return true
+    }
+    const b = (body && typeof body === 'object' ? body : {}) as Record<string, unknown>
+    const agentId = typeof b.agentId === 'string' && b.agentId.trim() ? b.agentId.trim() : MAIN_AGENT_ID
+    const targetPlanId = typeof b.targetPlanId === 'string' ? b.targetPlanId.trim() : ''
+    if (!targetPlanId) {
+      json(res, { error: 'targetPlanId is required' }, 400)
+      return true
+    }
+
+    if (!isRotationEnabled()) {
+      json(res, { error: 'Rotation is disabled (CLAUDE_ROTATION_ENABLED=0)' }, 409)
+      return true
+    }
+
+    const plans = readClaudePlans()
+    const target = plans.find((p) => p.id === targetPlanId)
+    if (!target) {
+      json(res, { error: `Unknown target plan id: ${targetPlanId}` }, 400)
+      return true
+    }
+    // Guardrail from design decision #5: a plan not marked channelsAllowed is
+    // not a rotation candidate, whatever the caller asks for.
+    if (!target.channelsAllowed) {
+      json(res, { error: `Plan ${targetPlanId} does not allow channels use (channelsAllowed=false)` }, 400)
+      return true
+    }
+
+    if (agentId === MAIN_AGENT_ID) {
+      // Design 6.2: rotation is only meaningful on the isolated-config path,
+      // and only once 2+ plans exist -- otherwise there is nothing to
+      // resolve a "rotated" configDir against (agent-process.js:
+      // resolveMainAgentRotatedConfigDir has the same gate, so a stale state
+      // entry can never silently take effect if the operator turns isolation
+      // back off or drops to one plan).
+      if (!isMainAgentIsolated() || plans.length < 2) {
+        json(res, {
+          error: 'Rotation not applicable: main agent needs MAIN_AGENT_ISOLATED_CONFIG=1 and at least 2 registered plans',
+        }, 409)
+        return true
+      }
+
+      // Record the decision BEFORE restarting: the next launch resolves its
+      // CLAUDE_CONFIG_DIR by reading this file back
+      // (main-agent-isolated-config.mjs -> resolveMainAgentRotatedConfigDir),
+      // so the state has to be on disk before the process that will read it
+      // comes up.
+      writeClaudePlansState(applyRotation(readClaudePlansState(), MAIN_AGENT_ID, targetPlanId))
+
+      const result = hardRestartMarveenChannels()
+      if (!result.ok) {
+        json(res, { error: result.error || 'Main agent restart failed' }, 500)
+        return true
+      }
+      logger.info({ agentId, targetPlanId }, 'Claude plan rotation: main agent restarted')
+      json(res, { ok: true, agentId, activePlanId: targetPlanId })
+      return true
+    }
+
+    // Sub-agent path: point its claudePlan field at the target and restart it
+    // through the same primitive the dashboard's own restart button uses --
+    // no separate sub-agent rotation mechanism to keep in sync.
+    if (!existsSync(agentDir(agentId))) {
+      json(res, { error: `Agent not found: ${agentId}` }, 404)
+      return true
+    }
+    writeClaudePlansState(applyRotation(readClaudePlansState(), agentId, targetPlanId))
+    writeAgentClaudePlan(agentId, targetPlanId)
+    const result = await restartAgentProcess(agentId)
+    if (!result.ok) {
+      json(res, { error: result.error || `Restart failed for agent ${agentId}` }, 500)
+      return true
+    }
+    logger.info({ agentId, targetPlanId }, 'Claude plan rotation: agent restarted')
+    json(res, { ok: true, agentId, activePlanId: targetPlanId })
     return true
   }
 

--- a/web/app.js
+++ b/web/app.js
@@ -14236,11 +14236,13 @@ function activateSettingsTab(mod) {
 
 // Claude Plans tab (PR2b): plan-list + add-form widget over
 // store/claude-plans.json, plus GET /api/claude-plans/state for the
-// active-plan / last-known-usage badges (state stays empty -- {activePlanId:
-// null, plans:{}} -- until PR2c's rotation wiring actually writes it).
-// Rotation itself is NOT wired here: this tab only lets the operator view and
-// hand-edit the registry, same as the dashboard already lets them do for
-// store/claude-plans.json by hand.
+// active-plan / last-known-usage badges. The "active" dot reflects the MAIN
+// agent's entry in activePlanByAgent (PR2c, design decision #1: the state is
+// per-agent, but this tab only shows the one that also drives the dashboard
+// header). There is still no manual rotate button here: this tab lets the
+// operator view and hand-edit the registry, the same way it already lets
+// them for store/claude-plans.json by hand; actual rotation is triggered by
+// the heartbeat script or POST /api/claude-plans/rotate directly.
 async function renderClaudePlansPanel(body) {
   body.innerHTML = `
     <p style="color:var(--text-muted);font-size:13px;margin:0 0 16px">${t('settings.claude_plans.intro')}</p>
@@ -14340,7 +14342,7 @@ async function loadClaudePlansList() {
       fetch('/api/claude-plans/state'),
     ])
     const plans = plansRes.ok ? await plansRes.json() : []
-    const state = stateRes.ok ? await stateRes.json() : { activePlanId: null, plans: {} }
+    const state = stateRes.ok ? await stateRes.json() : { activePlanByAgent: {}, plans: {} }
 
     if (!plans.length) {
       list.innerHTML = `<p style="color:var(--text-muted);font-size:13px">${t('settings.claude_plans.empty')}</p>`
@@ -14351,7 +14353,7 @@ async function loadClaudePlansList() {
     for (const plan of plans) {
       const observed = state.plans?.[plan.id]
       const fiveHour = observed?.windows?.five_hour
-      const isActive = state.activePlanId === plan.id
+      const isActive = state.activePlanByAgent?.[mainAgentId()] === plan.id
 
       const row = document.createElement('div')
       row.className = 'claude-plan-row'

--- a/web/lang/en.js
+++ b/web/lang/en.js
@@ -778,7 +778,7 @@ window._i18n.en = {
   'settings.claude_plans.form.add_btn':     '+ New plan',
   'settings.claude_plans.form.error_required': 'Id, label and CLAUDE_CONFIG_DIR are required.',
   'settings.claude_plans.form.error_generic':  'Could not save the plan.',
-  'settings.desc.CLAUDE_ROTATION_ENABLED': 'Automatic Claude key rotation: if the main agent\'s active subscription runs out, automatically switch to another registered plan. Requires MAIN_AGENT_ISOLATED_CONFIG=1 and at least 2 registered plans. The actual rotation logic is not wired up yet -- this toggle currently has no effect.',
+  'settings.desc.CLAUDE_ROTATION_ENABLED': 'Automatic Claude key rotation: if the main agent\'s active subscription runs out, automatically switch to another registered plan. Requires MAIN_AGENT_ISOLATED_CONFIG=1 and at least 2 registered plans. Switching restarts the main agent\'s session.',
   'settings.col.key':            'Key',
   'settings.col.value':          'Value',
   'settings.col.description':    'Description',

--- a/web/lang/hu.js
+++ b/web/lang/hu.js
@@ -1091,7 +1091,7 @@ window._i18n.hu = {
   'settings.claude_plans.form.add_btn':     '+ Új plan',
   'settings.claude_plans.form.error_required': 'Azonosító, címke és CLAUDE_CONFIG_DIR kötelező.',
   'settings.claude_plans.form.error_generic':  'Nem sikerült menteni a plant.',
-  'settings.desc.CLAUDE_ROTATION_ENABLED': 'Automata Claude-kulcs rotáció: ha a fő agent aktív előfizetése kifogy, automatikusan váltson egy másik regisztrált planre. Előfeltétel: MAIN_AGENT_ISOLATED_CONFIG=1 és legalább 2 regisztrált plan. A tényleges rotációs logika még nincs bekötve -- ez a kapcsoló egyelőre hatástalan.',
+  'settings.desc.CLAUDE_ROTATION_ENABLED': 'Automata Claude-kulcs rotáció: ha a fő agent aktív előfizetése kifogy, automatikusan váltson egy másik regisztrált planre. Előfeltétel: MAIN_AGENT_ISOLATED_CONFIG=1 és legalább 2 regisztrált plan. A váltás a fő agent session-jének újraindításával jár.',
   'settings.col.key':            'Kulcs',
   'settings.col.value':          'Érték',
   'settings.col.description':    'Leírás',


### PR DESCRIPTION
## Summary

Finishes the plan-rotation feature after PR2a (#1293) and PR2b (#1294). See docs/superpowers/specs/2026-09-11-claude-key-rotation-design.md section 9 for the original PR split and the new section 11 for implementation-time decisions.

- `store/claude-plans-state.json` is now agentenkénti (`activePlanByAgent`, design decision #1), with a writer (`writeClaudePlansState`) and pure transitions (`recordObservation`/`applyRotation`).
- `POST /api/claude-plans/rotate`: validates the target plan (exists, `channelsAllowed`), gates on `CLAUDE_ROTATION_ENABLED`, and branches on `agentId` -- the main channels agent restarts via the existing `hardRestartMarveenChannels()` (gated additionally on `MAIN_AGENT_ISOLATED_CONFIG` + 2 registered plans), any other agent via `writeAgentClaudePlan` + `restartAgentProcess` (no new sub-agent restart mechanism).
- `channels.sh`'s main-agent-isolated-config contract gains a third mode (`rotated`, alongside `explicit`/`isolated`): `resolveMainAgentRotatedConfigDir` in `agent-process.ts` resolves the active plan's OWN configDir (no fleet token injection, same handling as `explicit`). `channel-watchdog.sh` and `stuck-modal-guard.sh` -- the other two respawn paths that read this same contract (see `main-config-dir-parity.test.ts`) -- are updated too, or a watchdog respawn would have silently dropped a rotated identity back onto the shared `~/.claude`.
- `scripts/claude-plan-rotate-check.ts`: the heartbeat entry point (design 6.6). Its pure core (`src/claude-plan-rotate-heartbeat.ts`) decides and records telemetry; it prints a `ROTATE`/`NO_ALTERNATIVE` line rather than acting itself, because design 6.4's Telegram signal must go through the c3po `reply` tool, which only an agent turn can call -- mirrors the existing OPEN_QUESTION heartbeat pattern (`ledger-live-drain.py`).
- `isQuotaExceededError`: pure classifier for the reactive path (design 6.3 addendum). Wiring it into a live session-output watcher is a separate follow-up, not part of this PR.

### Known gaps, flagged rather than silently left

- This PR wires the **main channels agent only**. The state schema is already per-agent (decision #1), and the rotate route is agent-agnostic, but looping the heartbeat script over every sub-agent is deferred as a fast follow-up.
- The reactive (429-triggered, mid-session) rotation path exists only as a pure string classifier -- no live tmux/session-output wiring yet.
- The very first plan assignment for an agent (`activePlanByAgent` bootstrap) has to be one manual `POST /api/claude-plans/rotate` call; after that the heartbeat maintains it. There's no way for the script to guess which registered plan an agent is currently running from.
- Found, not fixed (pre-existing, unrelated to this PR): `stuck-modal-guard.sh` reads the main-agent-isolated-config contract straight off combined stdout/stderr rather than fd 3 like `channels.sh`/`channel-watchdog.sh` do post-CFGCONTRACT912 (#1289) -- a stray log line could still break it there. Worth a dedicated follow-up.

`CLAUDE_ROTATION_ENABLED` stays default `0`; nothing in this PR flips it live, and staging verification of the actual session-restart mechanics (the riskiest part) is still pending before that happens.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] Full suite green: 428 files / 5446 tests (1 pre-existing skip)
- [x] `node --check web/app.js web/sw.js` clean
- [x] Every test touching a restart primitive (`hardRestartMarveenChannels`, `restartAgentProcess`) mocks it -- no test spawns or kills a real tmux session
- [ ] Manual staging verification of the actual live session-restart (explicitly out of scope for this PR/session; flagged in the design doc as the prerequisite before `CLAUDE_ROTATION_ENABLED=1` anywhere)

🤖 Generated with [Claude Code](https://claude.com/claude-code)