### PR TITLE
fix(channels): stop the legacy migration parking its own live .env (ENVPARK912)

### DIFF
--- a/scripts/__tests__/channels-legacy-env-park.test.sh
+++ b/scripts/__tests__/channels-legacy-env-park.test.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+# ENVPARK912: the legacy-channel-dir migration block in scripts/channels.sh must
+# never park the .env it is standing on.
+#
+# Regression origin (2026-09-12): ~/.claude/channels/telegram is a SYMLINK into
+# the install-scoped $MAIN_CHAN_DIR on a migrated install. The gate was a STRING
+# comparison, so the two paths "differed" while naming the same directory; the
+# else-branch then moved that directory's own live .env to .env.legacy-<epoch>
+# on every channels.sh start. The plugin came up with "TELEGRAM_BOT_TOKEN
+# required" and the main agent went mute on Telegram with no error anywhere:
+# three parked byte-identical copies in one day (05:00, 13:03, 13:10) and an
+# 05:03-13:26 outage behind 139 consecutive keepalive WARNs.
+#
+# Two gates are under test and they cover different shapes:
+#   1. resolved-path comparison  -> symlinked legacy DIRECTORY;
+#   2. `-ef` before the mv       -> symlinked/hardlinked .env FILE, where the
+#      directories genuinely differ but the file does not.
+# Both assert the .env STAYS PUT, not merely that nothing errored -- the buggy
+# version exits 0 while destroying the token.
+#
+# The block is extracted from the real script and run in a sandboxed $HOME, so
+# the test reads the shipped source rather than a copy of it that can drift.
+# CHANNELS_BIN points the suite at a deliberately-old channels.sh to confirm it
+# actually goes red on the bug (measured: see the PR).
+# Run: bash scripts/__tests__/channels-legacy-env-park.test.sh
+
+set -u
+
+PASS=0; FAIL=0
+pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1 -- expected: $2, got: $3"; }
+
+INSTALL_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+CHANNELS="${CHANNELS_BIN:-$INSTALL_DIR/scripts/channels.sh}"
+
+echo "channels.sh legacy .env parking (ENVPARK912)"
+echo "  source under test: $CHANNELS"
+
+# --- extract the migration block ---------------------------------------------
+# From the LEGACY_CHAN_DIR assignment to the first column-0 `fi`. A silently
+# empty or wrong extraction would make every case below pass for free, so the
+# snippet is itself asserted before anything runs.
+SNIPPET="$(mktemp -t envpark912-snippet)"
+trap 'rm -f "$SNIPPET"' EXIT
+awk '/^LEGACY_CHAN_DIR=/{inblock=1} inblock{print} inblock && /^fi$/{exit}' "$CHANNELS" > "$SNIPPET"
+
+if [ ! -s "$SNIPPET" ]; then
+  fail "extraction: migration block found" "non-empty snippet" "empty (anchors moved?)"
+elif ! grep -q 'MAIN_CHAN_DIR' "$SNIPPET" || ! grep -q '\.env\.legacy-' "$SNIPPET"; then
+  fail "extraction: migration block found" "snippet with the parking mv" "$(head -1 "$SNIPPET")"
+else
+  pass "extraction: migration block found ($(wc -l < "$SNIPPET" | tr -d ' ') lines)"
+fi
+
+TOKEN='TELEGRAM_BOT_TOKEN=123456:live-token'
+
+# Runs the extracted block against a sandbox $HOME. Never touches the real one.
+# $1 = sandbox root, $2 = MAIN_CHAN_DIR
+run_block() {
+  ( HOME="$1/home" CHANNEL_PROVIDER=telegram MAIN_CHAN_DIR="$2" \
+    bash "$SNIPPET" >/dev/null 2>&1 )
+}
+
+new_box() { mktemp -d -t envpark912-box; }
+# Deletes only what new_box created: the mktemp template has to be in the name.
+drop_box() { case "$1" in *envpark912-box*) rm -rf "$1" ;; esac; }
+
+# --- case 1: symlinked legacy DIRECTORY (the measured outage) -----------------
+box="$(new_box)"
+main="$box/install/.claude/channels/telegram"
+mkdir -p "$main" "$box/home/.claude/channels"
+printf '%s\n' "$TOKEN" > "$main/.env"
+ln -s "$main" "$box/home/.claude/channels/telegram"
+run_block "$box" "$main"
+if [ -f "$main/.env" ] && grep -q 'live-token' "$main/.env"; then
+  pass "symlinked legacy dir: the live .env stays in place"
+else
+  fail "symlinked legacy dir: the live .env stays in place" "readable .env with the token" \
+       "$(ls -A "$main" | tr '\n' ' ')"
+fi
+if [ -z "$(find "$main" -maxdepth 1 -name '.env.legacy-*' -print -quit)" ]; then
+  pass "symlinked legacy dir: no .env.legacy-* copy is born"
+else
+  fail "symlinked legacy dir: no .env.legacy-* copy is born" "none" \
+       "$(find "$main" -maxdepth 1 -name '.env.legacy-*' -exec basename {} \; | tr '\n' ' ')"
+fi
+drop_box "$box"
+
+# --- case 2a: distinct dirs, main/.env is a SYMLINK to the legacy file --------
+# The resolved-dir gate does NOT save this one: the directories really differ.
+# Only the `-ef` gate does. Pre-fix the mv moves the real file out from under
+# the symlink and main/.env is left dangling.
+box="$(new_box)"
+main="$box/install/.claude/channels/telegram"
+legacy="$box/home/.claude/channels/telegram"
+mkdir -p "$main" "$legacy"
+printf '%s\n' "$TOKEN" > "$legacy/.env"
+ln -s "$legacy/.env" "$main/.env"
+run_block "$box" "$main"
+if [ -f "$main/.env" ] && grep -q 'live-token' "$main/.env" 2>/dev/null; then
+  pass "symlinked .env file: the token stays readable through main/.env"
+else
+  fail "symlinked .env file: the token stays readable through main/.env" \
+       "readable token" "dangling or missing"
+fi
+drop_box "$box"
+
+# --- case 2b: distinct dirs, the two .env files are HARDLINKED ----------------
+box="$(new_box)"
+main="$box/install/.claude/channels/telegram"
+legacy="$box/home/.claude/channels/telegram"
+mkdir -p "$main" "$legacy"
+printf '%s\n' "$TOKEN" > "$main/.env"
+ln "$main/.env" "$legacy/.env"
+run_block "$box" "$main"
+if [ -f "$main/.env" ] && [ -f "$legacy/.env" ] \
+   && [ -z "$(find "$main" -maxdepth 1 -name '.env.legacy-*' -print -quit)" ]; then
+  pass "hardlinked .env file: nothing is parked, both names survive"
+else
+  fail "hardlinked .env file: nothing is parked, both names survive" "no park, both names" \
+       "main=[$(ls -A "$main" | tr '\n' ' ')] legacy=[$(ls -A "$legacy" | tr '\n' ' ')]"
+fi
+drop_box "$box"
+
+# --- case 3: NEGATIVE CONTROL -- two genuinely separate .env files ------------
+# The #915 behaviour this fix must NOT weaken: a real shared-path token still
+# has to be parked, or the hijack window #915 closed reopens.
+box="$(new_box)"
+main="$box/install/.claude/channels/telegram"
+legacy="$box/home/.claude/channels/telegram"
+mkdir -p "$main" "$legacy"
+printf '%s\n' "$TOKEN" > "$main/.env"
+printf '%s\n' 'TELEGRAM_BOT_TOKEN=999:stale-shared-token' > "$legacy/.env"
+run_block "$box" "$main"
+parked="$(find "$main" -maxdepth 1 -name '.env.legacy-*' -print -quit)"
+if [ -n "$parked" ] && grep -q 'stale-shared-token' "$parked" \
+   && [ ! -f "$legacy/.env" ] && grep -q 'live-token' "$main/.env"; then
+  pass "separate .env files: the stale shared token is still parked (#915 kept)"
+else
+  fail "separate .env files: the stale shared token is still parked (#915 kept)" \
+       "legacy parked, main untouched" \
+       "parked=[$parked] legacy=[$(ls -A "$legacy" | tr '\n' ' ')]"
+fi
+drop_box "$box"
+
+# --- case 4: unmigrated install still migrates -------------------------------
+# The resolve helper must not break the one path that is supposed to move data.
+box="$(new_box)"
+main="$box/install/.claude/channels/telegram"
+legacy="$box/home/.claude/channels/telegram"
+mkdir -p "$legacy" "$box/install/.claude/channels"
+printf '%s\n' "$TOKEN" > "$legacy/.env"
+printf '%s\n' '{"allowFrom":["<owner-chat-id>"]}' > "$legacy/access.json"
+run_block "$box" "$main"
+if [ -f "$main/.env" ] && grep -q 'live-token' "$main/.env" && [ -f "$main/access.json" ]; then
+  pass "unmigrated install: the whole legacy dir still migrates"
+else
+  fail "unmigrated install: the whole legacy dir still migrates" \
+       "token + access.json install-scoped" "$(ls -A "$main" 2>/dev/null | tr '\n' ' ')"
+fi
+drop_box "$box"
+
+echo
+echo "  $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/scripts/channels.sh
+++ b/scripts/channels.sh
@@ -821,7 +821,23 @@ fi
 # of the legacy dir while it moves. Idempotent: a migrated install skips both
 # branches.
 LEGACY_CHAN_DIR="$HOME/.claude/channels/$CHANNEL_PROVIDER"
-if [ "$LEGACY_CHAN_DIR" != "$MAIN_CHAN_DIR" ] && [ -f "$LEGACY_CHAN_DIR/.env" ]; then
+# ENVPARK912: compare RESOLVED paths, not strings. On a migrated install
+# ~/.claude/channels/<provider> is typically a SYMLINK into $MAIN_CHAN_DIR, so
+# the two strings differ while both name the same directory. The else-branch
+# below then parked the dir's OWN live .env as .env.legacy-<epoch> on every
+# single channels.sh start: the plugin came up with "TELEGRAM_BOT_TOKEN
+# required" and the main agent went mute on Telegram with no error anywhere.
+# Measured 2026-09-12: three parked copies in one day (05:00, 13:03, 13:10),
+# byte-identical, and an 05:03-13:26 outage behind 139 consecutive keepalive
+# WARNs.
+_chan_resolve_dir() {
+  if [ -d "$1" ]; then
+    ( cd "$1" 2>/dev/null && pwd -P ) || printf '%s\n' "$1"
+  else
+    printf '%s\n' "$1"
+  fi
+}
+if [ "$(_chan_resolve_dir "$LEGACY_CHAN_DIR")" != "$(_chan_resolve_dir "$MAIN_CHAN_DIR")" ] && [ -f "$LEGACY_CHAN_DIR/.env" ]; then
   if [ ! -f "$MAIN_CHAN_DIR/.env" ]; then
     mkdir -p "$(dirname "$MAIN_CHAN_DIR")"
     if [ ! -e "$MAIN_CHAN_DIR" ] && mv "$LEGACY_CHAN_DIR" "$MAIN_CHAN_DIR" 2>/dev/null; then
@@ -839,8 +855,18 @@ if [ "$LEGACY_CHAN_DIR" != "$MAIN_CHAN_DIR" ] && [ -f "$LEGACY_CHAN_DIR/.env" ];
     # Both hold a .env (e.g. a fresh onboarding already wrote install-scoped):
     # the shared-path token must not stay live -- park it next to the new one,
     # keeping the file instead of deleting history.
-    mv "$LEGACY_CHAN_DIR/.env" "$MAIN_CHAN_DIR/.env.legacy-$(date +%s)" 2>/dev/null || true
-    echo "[channels] #915: parked stale legacy .env from $LEGACY_CHAN_DIR"
+    #
+    # ENVPARK912 second gate: never park a file that IS the live one. The
+    # resolved-path guard above covers a symlinked DIRECTORY; this covers a
+    # symlinked or hardlinked .env FILE, where the directories genuinely
+    # differ but the file does not. Without it the mv destroys the very token
+    # it means to protect.
+    if [ "$LEGACY_CHAN_DIR/.env" -ef "$MAIN_CHAN_DIR/.env" ]; then
+      echo "[channels] ENVPARK912: legacy and main .env are the same file -- not parking"
+    else
+      mv "$LEGACY_CHAN_DIR/.env" "$MAIN_CHAN_DIR/.env.legacy-$(date +%s)" 2>/dev/null || true
+      echo "[channels] #915: parked stale legacy .env from $LEGACY_CHAN_DIR"
+    fi
   fi
 fi
 # Export for this script AND build the launch-command prefix for the spawned


### PR DESCRIPTION
# fix(channels): stop the legacy migration parking its own live .env (ENVPARK912)

Branch: `fix/envpark912-channels-env-park` (local worktree: `~/marveen-wt-envpark912`, commit `fdee637`, based on `origin/develop` `3d02f37`)
Target: `develop`
Files: `scripts/channels.sh` (+29/-3), `scripts/__tests__/channels-legacy-env-park.test.sh` (new)

## What broke

On a migrated install `~/.claude/channels/<provider>` is a **symlink** into the install-scoped
`$MAIN_CHAN_DIR` (on this host since 2026-09-11 06:47). The migration gate at
`scripts/channels.sh:824` compared the two paths as **strings**:

```sh
if [ "$LEGACY_CHAN_DIR" != "$MAIN_CHAN_DIR" ] && [ -f "$LEGACY_CHAN_DIR/.env" ]; then
```

The strings differ while both name the same directory, so the else-branch at line 842 moved that
directory's **own live `.env`** to `.env.legacy-<epoch>` on every single `channels.sh` start. The
plugin then came up with `TELEGRAM_BOT_TOKEN required` and the main agent went mute on Telegram,
with no error logged anywhere.

Measured on this install (2026-09-12): three parked, byte-identical (66 B) copies in one day —
`.env.legacy-1789182042` (05:00), `-1789211039` (13:03), `-1789211459` (13:10) — and an
05:03–13:26 outage behind 139 consecutive keepalive WARNs.

## The two gates

1. **Resolved-path comparison.** `_chan_resolve_dir()` canonicalises an existing directory with
   `cd` + `pwd -P` (and returns the path untouched when it does not exist, so the migration path
   still works). The condition compares the two *resolved* paths. Covers the symlinked legacy
   **directory** — the shape that actually fired here.
2. **`-ef` before the `mv`.** Covers a symlinked or hardlinked `.env` **file**, where the
   directories genuinely differ but the file does not. Gate 1 does not save that case; without
   gate 2 the `mv` destroys the very token it means to protect.

#915's own behaviour is unchanged: two genuinely separate `.env` files still get the shared-path
token parked, and an unmigrated install still migrates whole.

## The regression test, and its red/green measurement

`scripts/__tests__/channels-legacy-env-park.test.sh` extracts the migration block from the real
`channels.sh` (from the `LEGACY_CHAN_DIR=` assignment to the first column-0 `fi`) and runs it
against a sandboxed `$HOME`. It asserts the `.env` **stays put**, not merely that nothing errored —
the buggy version exits 0 while destroying the token. Following the `channels-mcp-unlock` idiom,
`CHANNELS_BIN` points the suite at another copy of the script so the red run is measurable.

An empty or mis-anchored extraction would let every case pass for free, so the snippet itself is
asserted first (non-empty + contains the parking `mv`). It is the line that reports 23 vs 49 lines
below, which is also the proof that each run really read the source it claims to.

**Green — the fixed script:**

```
  PASS: extraction: migration block found (49 lines)
  PASS: symlinked legacy dir: the live .env stays in place
  PASS: symlinked legacy dir: no .env.legacy-* copy is born
  PASS: symlinked .env file: the token stays readable through main/.env
  PASS: hardlinked .env file: nothing is parked, both names survive
  PASS: separate .env files: the stale shared token is still parked (#915 kept)
  PASS: unmigrated install: the whole legacy dir still migrates

  7 passed, 0 failed          (exit 0)
```

**Red — `CHANNELS_BIN` = the pre-fix `scripts/channels.sh` from `origin/develop` `3d02f37`:**

```
  PASS: extraction: migration block found (23 lines)
  FAIL: symlinked legacy dir: the live .env stays in place -- expected: readable .env with the token, got: .env.legacy-1789213288
  FAIL: symlinked legacy dir: no .env.legacy-* copy is born -- expected: none, got: .env.legacy-1789213288
  FAIL: symlinked .env file: the token stays readable through main/.env -- expected: readable token, got: dangling or missing
  FAIL: hardlinked .env file: nothing is parked, both names survive -- expected: no park, both names, got: main=[.env .env.legacy-1789213288 ] legacy=[]
  PASS: separate .env files: the stale shared token is still parked (#915 kept)
  PASS: unmigrated install: the whole legacy dir still migrates

  3 passed, 4 failed          (exit 1)
```

The four gate assertions go red on the old code and green on the new. The two behaviour-preserving
cases (the #915 negative control and the migration path) are green on **both** — so the suite is
not simply "everything fails on the old file", and the fix is shown not to weaken #915.

## Other checks

- `bash -n scripts/channels.sh` clean. No `shellcheck` on this host.
- Existing shell suites on the fixed tree: `channel-inbox-drain` OK, `channels-main-model` 15/15,
  `channels-mcp-unlock` 18/18. `channels-auth-probe` **SKIPPED** — it needs `dist/web/reauth-detect.js`,
  absent in a fresh worktree (`npm run build` not run); that is pre-existing and unrelated to this
  change, but it means that file's contract is unmeasured here.
- Premise re-verified read-only on this host: `~/.claude/channels/telegram` is a symlink to
  `/Users/macmini/marveen/.claude/channels/telegram`, and the three `.env.legacy-*` copies are present.
