### PR TITLE
fix(watchdog): portable mtime, so the macOS install stops measuring fresh files as ancient (PORTSTAT912)

### DIFF
--- a/scripts/__tests__/channel-watchdog-mtime.test.sh
+++ b/scripts/__tests__/channel-watchdog-mtime.test.sh
@@ -102,7 +102,31 @@ else
   fail "missing file: falls back to 0" "0" "[$got]"
 fi
 
-# --- case 4: the red-capable control -----------------------------------------
+# --- case 4: the SECOND copy of the helper ------------------------------------
+# channel-outage-alarm.sh carries its own mtime_of(). The duplication is
+# deliberate -- that unit exists precisely to share nothing with what it
+# watches -- but a second copy is a second thing that can be wrong, and this
+# one reads the keepalive file the whole alarm hangs on. Pull the function out
+# of the shipped file and hold it to the same contract.
+ALARM_SRC="$INSTALL_DIR/scripts/channel-outage-alarm.sh"
+if [ ! -f "$ALARM_SRC" ]; then
+  fail "alarm copy: channel-outage-alarm.sh is present" "the shipped file" "absent"
+else
+  awk '/^mtime_of\(\)/,/^}/' "$ALARM_SRC" > "$BOX/alarm-mtime.sh"
+  if ! grep -q 'stat ' "$BOX/alarm-mtime.sh"; then
+    fail "alarm copy: mtime_of extracted" "a function body calling stat" "[$(head -1 "$BOX/alarm-mtime.sh")]"
+  else
+    got="$(bash -c "source '$BOX/alarm-mtime.sh'; mtime_of '$fresh'" 2>/dev/null)"
+    want="$(mtime_oracle "$fresh")"
+    if [ "$got" = "$want" ] && [ "$got" != "0" ]; then
+      pass "alarm copy: mtime_of agrees with the oracle"
+    else
+      fail "alarm copy: mtime_of agrees with the oracle" "$want" "[$got]"
+    fi
+  fi
+fi
+
+# --- case 5: the red-capable control -----------------------------------------
 # Exactly one of the two single-form implementations is wrong on any given
 # host. Naming which one, on every run, is what keeps the cases above from
 # being green for free -- and it is the pre-fix expression verbatim, including

--- a/scripts/__tests__/channel-watchdog-mtime.test.sh
+++ b/scripts/__tests__/channel-watchdog-mtime.test.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+# PORTSTAT912: channel-watchdog.sh must read a file's mtime on BSD (macOS) and
+# GNU (Linux) alike.
+#
+# Regression origin (2026-09-12): both call sites used `stat -c %Y`, which is
+# GNU-only. On macOS it exits 1 with "illegal option -- c" and the old
+# `|| echo 0` fallback turned that into mtime=0, so a BRAND NEW keepalive file
+# measured as infinitely old:
+#
+#   ka_mtime=0 -> age=1789213088s vs STALE_SECONDS=900 -> STALE=true, every tick
+#
+# Installing the watchdog on a Mac would therefore not have protected the main
+# agent; it would have respawned its channels pane every 5 minutes up to
+# MAX_CONSECUTIVE. The same zero also defeats the respawn-grace gate (the brake
+# meant to stop exactly that storm), so the two failures compound.
+#
+# The assertions run against the SHIPPED script through its `--file-mtime`
+# debug entry point, so this measures the code the timer runs, not a copy.
+#
+# Red-capability is not assumed, it is measured on every run: the last case
+# proves that a single-form implementation is genuinely wrong on THIS host, so
+# the passing cases above it cannot be passing for free. On macOS the broken
+# form is the GNU one (the actual regression); on Linux it is the BSD one.
+# Run: bash scripts/__tests__/channel-watchdog-mtime.test.sh
+
+set -u
+
+PASS=0; FAIL=0
+pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1 -- expected: $2, got: $3"; }
+
+INSTALL_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+WATCHDOG="${WATCHDOG_BIN:-$INSTALL_DIR/scripts/channel-watchdog.sh}"
+
+echo "channel-watchdog.sh portable mtime (PORTSTAT912)"
+echo "  source under test: $WATCHDOG"
+echo "  platform: $(uname -s)"
+
+# An mtime oracle that shares no code with the thing under test.
+mtime_oracle() { python3 -c 'import os,sys; print(int(os.stat(sys.argv[1]).st_mtime))' "$1" 2>/dev/null; }
+helper_mtime() { bash "$WATCHDOG" --file-mtime "$1" 2>/dev/null; }
+
+if ! command -v python3 >/dev/null 2>&1; then
+  fail "prerequisite: an independent mtime oracle" "python3 on PATH" "absent"
+  echo; echo "  $PASS passed, $FAIL failed"; exit 1
+fi
+
+BOX="$(mktemp -d -t portstat912)"
+trap 'case "$BOX" in *portstat912*) rm -rf "$BOX" ;; esac' EXIT
+
+# --- positive control: the debug entry point exists at all -------------------
+# Without it every case below would read an empty string and could never fail
+# in a way that means anything.
+probe="$(helper_mtime "$INSTALL_DIR/scripts/channel-watchdog.sh")"
+case "$probe" in
+  ''|*[!0-9]*) fail "the --file-mtime entry point answers with a number" "digits" "[$probe]" ;;
+  *)           pass "the --file-mtime entry point answers with a number" ;;
+esac
+
+# --- case 1: a fresh, existing file ------------------------------------------
+# The regression in one assertion: a file created a moment ago must NOT read 0.
+fresh="$BOX/.channel-keepalive"
+: > "$fresh"
+got="$(helper_mtime "$fresh")"
+want="$(mtime_oracle "$fresh")"
+if [ "$got" = "0" ] || [ -z "$got" ]; then
+  fail "fresh file: mtime is not 0" "a real epoch second" "[$got]"
+else
+  pass "fresh file: mtime is not 0"
+fi
+if [ -n "$got" ] && [ -n "$want" ] && [ "$got" -ge 0 ] 2>/dev/null; then
+  drift=$(( got - want )); [ "$drift" -lt 0 ] && drift=$(( -drift ))
+  if [ "$drift" -lt 2 ]; then
+    pass "fresh file: within 2s of the real mtime (drift ${drift}s)"
+  else
+    fail "fresh file: within 2s of the real mtime" "drift < 2s" "${drift}s (got=$got want=$want)"
+  fi
+else
+  fail "fresh file: within 2s of the real mtime" "comparable numbers" "got=[$got] want=[$want]"
+fi
+
+# --- case 2: an OLD file still reads old -------------------------------------
+# Guards the other direction: a helper that always answered `now` would pass
+# case 1 and silently disable staleness detection altogether.
+old="$BOX/.channel-keepalive-old"
+: > "$old"
+touch -t 202601011200 "$old" 2>/dev/null || touch -d '2026-01-01 12:00' "$old" 2>/dev/null
+got="$(helper_mtime "$old")"
+want="$(mtime_oracle "$old")"
+if [ "$got" = "$want" ] && [ "$got" != "0" ]; then
+  pass "backdated file: the old mtime is reported, not now"
+else
+  fail "backdated file: the old mtime is reported, not now" "$want" "[$got]"
+fi
+
+# --- case 3: a missing file still falls back to 0 ----------------------------
+# The historical contract: unknown means "act", not "crash".
+got="$(helper_mtime "$BOX/does-not-exist")"
+if [ "$got" = "0" ]; then
+  pass "missing file: falls back to 0"
+else
+  fail "missing file: falls back to 0" "0" "[$got]"
+fi
+
+# --- case 4: the red-capable control -----------------------------------------
+# Exactly one of the two single-form implementations is wrong on any given
+# host. Naming which one, on every run, is what keeps the cases above from
+# being green for free -- and it is the pre-fix expression verbatim, including
+# its `|| echo 0` fallback.
+gnu_form="$(stat -c %Y "$fresh" 2>/dev/null || echo 0)"
+bsd_form="$(stat -f %m "$fresh" 2>/dev/null || echo 0)"
+truth="$(mtime_oracle "$fresh")"
+broken=""
+[ "$gnu_form" != "$truth" ] && broken="$broken stat-c(GNU)=[$gnu_form]"
+[ "$bsd_form" != "$truth" ] && broken="$broken stat-f(BSD)=[$bsd_form]"
+if [ -n "$broken" ]; then
+  pass "single-form control: wrong here ->$broken (truth=$truth), so the cases above can go red"
+else
+  fail "single-form control: at least one form must be wrong here" \
+       "a broken single form to prove red-capability" "both forms agreed ($truth)"
+fi
+
+echo
+echo "  $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/scripts/channel-keepalive-probe.sh
+++ b/scripts/channel-keepalive-probe.sh
@@ -34,17 +34,26 @@ LOG_TAG="channel-keepalive-probe"
 
 log() { echo "$(date '+%Y-%m-%d %H:%M:%S') [$LOG_TAG] $*"; }
 
-# Whether a dedicated channel-watchdog recovery owner is actually installed on
-# THIS host. The probe declines to recover a dead pipe on purpose -- but only a
-# real, installed watchdog legitimately "owns recovery". The systemd
-# channel-watchdog timer has NO launchd twin, so on macOS it is simply absent
-# (CHANWDOG818): claiming an owner that isn't there turns a genuine outage into
-# silence. Fail loud instead when nothing owns recovery.
-channel_watchdog_installed() {
+# Whether a dedicated recovery owner is actually installed on THIS host. The
+# probe declines to recover a dead pipe on purpose -- but only a real, installed
+# unit legitimately "owns recovery". The systemd channel-watchdog timer has NO
+# launchd twin, so on macOS it is simply absent (CHANWDOG818): claiming an owner
+# that isn't there turns a genuine outage into silence. Fail loud instead when
+# nothing owns recovery.
+#
+# More than one unit can hold that role. channel-outage-alarm is the macOS
+# launchd owner (180s timer, one restart per outage plus a direct Bot API alert
+# to the owner); recognising only the systemd name made the probe log a FALSE
+# "no recovery unit" WARN on a host that in fact had one. The label is matched
+# anchored at end of line -- launchctl prints it last -- so a longer name that
+# merely starts with an accepted one cannot pass as a match.
+recovery_owner_installed() {
   if [ "$(uname -s)" = "Darwin" ]; then
-    launchctl list 2>/dev/null | grep -q 'com\.marveen\.channel-watchdog'
+    launchctl list 2>/dev/null \
+      | grep -qE '(com\.marveen\.channel-watchdog|com\.marveen\.channel-outage-alarm)$'
   else
-    systemctl --user is-enabled channel-watchdog.timer >/dev/null 2>&1
+    systemctl --user is-enabled channel-watchdog.timer >/dev/null 2>&1 \
+      || systemctl --user is-enabled channel-outage-alarm.timer >/dev/null 2>&1
   fi
 }
 
@@ -120,10 +129,10 @@ done < <(ps -axo pid,command 2>/dev/null | grep -E "$RUNTIME_TOKEN_RX" | grep -E
 if [ "$alive" -ne 1 ]; then
   # Do NOT advance the keepalive: a dead pipe must stay visibly stale so a real
   # recovery owner can act. But only claim an owner that actually exists here.
-  if channel_watchdog_installed; then
-    log "no live telegram poller under $SESSION (pane $pane_pid) -- pipe may be down; not touching (channel-watchdog owns recovery)"
+  if recovery_owner_installed; then
+    log "no live telegram poller under $SESSION (pane $pane_pid) -- pipe may be down; not touching (an installed recovery unit owns it)"
   else
-    log "WARN no live telegram poller under $SESSION (pane $pane_pid) -- pipe may be down AND no channel-watchdog recovery unit is installed on this host (CHANWDOG818); automatic recovery relies only on process-death KeepAlive + the dashboard channel-monitor, so a FROZEN session while the dashboard is also down is NOT auto-recovered"
+    log "WARN no live telegram poller under $SESSION (pane $pane_pid) -- pipe may be down AND no recovery unit (channel-watchdog / channel-outage-alarm) is installed on this host (CHANWDOG818); automatic recovery relies only on process-death KeepAlive + the dashboard channel-monitor, so a FROZEN session while the dashboard is also down is NOT auto-recovered"
   fi
   exit 0
 fi

--- a/scripts/channel-outage-alarm.sh
+++ b/scripts/channel-outage-alarm.sh
@@ -1,0 +1,243 @@
+#!/bin/bash
+# Out-of-band channel outage alarm (CHANALARM912).
+#
+# WHY THIS EXISTS. On 2026-09-12 the main agent was silent on Telegram from
+# 05:03 to 13:26 (8h23m). Every layer that was supposed to notice DID notice:
+# channel-keepalive-probe.sh logged 139 consecutive WARN lines, one every three
+# minutes, naming the exact fault. Nothing read that log. The owner found out by
+# asking "do you get what I write?". A host reboot at 12:50 did not help, because
+# the root cause (channels.sh parking its own live .env, ENVPARK912) re-fired on
+# every start.
+#
+# The gap was never DETECTION. It was that detection had no way OUT of the box:
+# the only path to the owner was the very channel that was down.
+#
+# So this unit deliberately shares nothing with the thing it watches:
+#   - it does not need the dashboard (which can be down),
+#   - it does not need the claude session (which can be wedged),
+#   - it does not need the telegram PLUGIN (which is what fails),
+#   - it talks to api.telegram.org with curl and a bot token, nothing else.
+#
+# SIGNAL. store/.channel-keepalive is touched by channel-keepalive-probe.sh ONLY
+# when a live telegram poller is confirmed under the channels pane. Its mtime is
+# therefore an already-proven liveness signal produced by a component that is
+# already running. We consume it rather than re-implementing the poller check:
+# two detectors that can disagree about the same fact is a defect, not a detail
+# (see the RUNTIME_TOKEN_RX note in channel-keepalive-probe.sh). A consequence
+# worth stating: if the probe itself dies, this file goes stale and we alarm.
+# That is correct. A blind monitor is an outage.
+#
+# TOKEN SOURCES. The failure that motivated this script DESTROYED the live .env
+# (it was moved aside to .env.legacy-<epoch>). An alarm that reads only the live
+# .env would therefore have been mute in exactly the incident it exists for. We
+# fall back to the newest parked copy, then to a dedicated read-only stash.
+#
+# ESCALATION (thresholds in seconds, probe cadence is ~180s):
+#   >= RESTART_AFTER : try one service restart per outage, then keep watching.
+#   >= ALARM_AFTER   : message the owner directly, regardless of whether the
+#                      restart helped. Today's root cause survived a restart AND
+#                      a reboot, so recovery must never gate the alarm.
+#   every REALARM_EVERY while still down: one reminder, so a long outage does
+#                      not decay into the same silence.
+#   on recovery      : one all-clear, but only if we had alarmed.
+
+set -u
+
+INSTALL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+STORE="$INSTALL_DIR/store"
+CHAN_DIR="$INSTALL_DIR/.claude/channels/telegram"
+KEEPALIVE_FILE="$STORE/.channel-keepalive"
+STATE_FILE="$STORE/.channel-outage-alarm-state"
+TOKEN_STASH="$STORE/.telegram-alarm-token"
+BOOT_MARKER="$STORE/.channel-boot-notified"
+LOG_FILE="$STORE/channel-outage-alarm.log"
+
+BOOT_REPORT_AFTER=$(( 3 * 60 ))  # let the fleet finish coming up before reporting
+
+STALE_AFTER=$(( 9 * 60 ))        # keepalive older than this => outage
+RESTART_AFTER=$(( 9 * 60 ))      # first (and only) automatic restart attempt
+ALARM_AFTER=$(( 15 * 60 ))       # tell the owner, restart or no restart
+REALARM_EVERY=$(( 30 * 60 ))     # reminder cadence while still down
+
+log() { printf '%s [channel-outage-alarm] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*" >> "$LOG_FILE"; }
+
+# Portable mtime. channel-watchdog.sh hard-codes `stat -c %Y`, which is GNU
+# only: on macOS it exits non-zero and the caller's `|| echo 0` turns a FRESH
+# file into an infinitely stale one. Measured 2026-09-12 -- that single flag is
+# why installing that watchdog here would have respawned the channels pane every
+# five minutes instead of protecting it. Never spell mtime one way.
+mtime_of() {
+  local f="$1" m=""
+  m="$(stat -f %m "$f" 2>/dev/null)" || m=""
+  [ -n "$m" ] || m="$(stat -c %Y "$f" 2>/dev/null)" || m=""
+  [ -n "$m" ] || m=0
+  printf '%s\n' "$m"
+}
+
+read_token() {
+  local f tok=""
+  for f in "$CHAN_DIR/.env" $(ls -t "$CHAN_DIR"/.env.legacy-* 2>/dev/null) "$TOKEN_STASH"; do
+    [ -f "$f" ] || continue
+    tok="$(sed -n 's/^[[:space:]]*TELEGRAM_BOT_TOKEN=//p' "$f" 2>/dev/null | head -1 | tr -d '"'"'"' \r')"
+    if [ -n "$tok" ]; then printf '%s\n' "$tok"; return 0; fi
+  done
+  return 1
+}
+
+read_chat_id() {
+  [ -f "$CHAN_DIR/access.json" ] || return 1
+  python3 - "$CHAN_DIR/access.json" <<'PY' 2>/dev/null
+import json, sys
+try:
+    d = json.load(open(sys.argv[1], encoding="utf-8"))
+except Exception:
+    raise SystemExit(1)
+a = d.get("allowFrom") or []
+if not a:
+    raise SystemExit(1)
+print(a[0])
+PY
+}
+
+# Direct Bot API send. No plugin, no session, no dashboard in the path.
+send_alarm() {
+  local text="$1" tok chat http
+  tok="$(read_token)" || { log "ERROR cannot send: no bot token in $CHAN_DIR/.env, parked copies, or $TOKEN_STASH"; return 1; }
+  chat="$(read_chat_id)" || { log "ERROR cannot send: no allowFrom chat id in $CHAN_DIR/access.json"; return 1; }
+  http="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 20 \
+    "https://api.telegram.org/bot${tok}/sendMessage" \
+    --data-urlencode "chat_id=${chat}" \
+    --data-urlencode "text=${text}" 2>/dev/null)"
+  if [ "$http" = "200" ]; then
+    log "alarm delivered (HTTP 200)"
+    return 0
+  fi
+  log "ERROR alarm send failed (HTTP ${http:-000})"
+  return 1
+}
+
+restart_channels() {
+  if command -v launchctl >/dev/null 2>&1; then
+    if launchctl kickstart -k "gui/$(id -u)/com.nova.channels" >/dev/null 2>&1; then
+      log "restart issued: launchctl kickstart -k gui/$(id -u)/com.nova.channels"
+      return 0
+    fi
+  fi
+  if command -v systemctl >/dev/null 2>&1; then
+    if systemctl --user restart marveen-channels.service >/dev/null 2>&1; then
+      log "restart issued: systemctl --user restart marveen-channels.service"
+      return 0
+    fi
+  fi
+  log "ERROR no service manager could restart the channels unit"
+  return 1
+}
+
+# --- state: outage_started restart_done last_alarm ---
+outage_started=0; restart_done=0; last_alarm=0
+if [ -f "$STATE_FILE" ]; then
+  # shellcheck disable=SC1090
+  . "$STATE_FILE" 2>/dev/null || true
+fi
+save_state() {
+  printf 'outage_started=%s\nrestart_done=%s\nlast_alarm=%s\n' \
+    "$outage_started" "$restart_done" "$last_alarm" > "$STATE_FILE"
+}
+
+now="$(date +%s)"
+
+# Keep a token stash fresh whenever the live .env is intact, so a later run can
+# still reach the owner after the live file is destroyed.
+if [ -f "$CHAN_DIR/.env" ] && grep -q '^[[:space:]]*TELEGRAM_BOT_TOKEN=' "$CHAN_DIR/.env" 2>/dev/null; then
+  if ! cmp -s "$CHAN_DIR/.env" "$TOKEN_STASH" 2>/dev/null; then
+    ( umask 077; cp "$CHAN_DIR/.env" "$TOKEN_STASH.tmp.$$" && mv "$TOKEN_STASH.tmp.$$" "$TOKEN_STASH" ) 2>/dev/null \
+      && log "token stash refreshed"
+  fi
+fi
+
+# --- once per boot: tell the owner the machine came back and what state it is in ---
+#
+# WHY. A host restart is the one outage this alarm cannot report while it is
+# happening: nothing on the box is running to send anything. The owner's only
+# signal is silence, which is indistinguishable from a quiet day. 2026-09-12 had
+# TWO restarts (11:23 unclean, 12:50 clean) and the owner learned of neither.
+# One line per boot is proportionate: reboots are rare, and the message carries
+# the health verdict, so "it came back" and "it came back BROKEN" look different.
+#
+# The `sec = <n>, usec = <m>` output needs an anchored match: a greedy `.*sec = `
+# lands on usec and yields a boot time in 1970.
+# sysctl lives in /usr/sbin, which is NOT on every PATH this script can inherit
+# (measured: absent from the agent shell's PATH, present in the launchd unit's).
+# Probing only `command -v sysctl` therefore silently disabled this whole block
+# in half the environments -- and a disabled reporter looks exactly like a boot
+# that never happened. Name the absolute paths.
+boot_epoch=""
+if [ -r /proc/stat ]; then
+  boot_epoch="$(awk '/^btime /{print $2; exit}' /proc/stat 2>/dev/null)"
+else
+  for _sysctl in /usr/sbin/sysctl /sbin/sysctl "$(command -v sysctl 2>/dev/null)"; do
+    [ -n "$_sysctl" ] && [ -x "$_sysctl" ] || continue
+    boot_epoch="$("$_sysctl" -n kern.boottime 2>/dev/null | sed -n 's/^[^0-9]*sec *= *\([0-9][0-9]*\).*/\1/p')"
+    [ -n "$boot_epoch" ] && break
+  done
+  unset _sysctl
+fi
+if [ -n "$boot_epoch" ] && [ "$boot_epoch" -gt 0 ] 2>/dev/null; then
+  uptime_s=$(( now - boot_epoch ))
+  seen_boot="$(cat "$BOOT_MARKER" 2>/dev/null || echo '')"
+  if [ "$seen_boot" != "$boot_epoch" ] && [ "$uptime_s" -ge "$BOOT_REPORT_AFTER" ]; then
+    ka_now=0; [ -f "$KEEPALIVE_FILE" ] && ka_now="$(mtime_of "$KEEPALIVE_FILE")"
+    if [ "$ka_now" -gt 0 ] && [ $(( now - ka_now )) -lt "$STALE_AFTER" ]; then
+      verdict="a Telegram-csatorna el"
+    else
+      verdict="a Telegram-csatorna NEM el -- nezd meg a gepet"
+    fi
+    if send_alarm "A gep ujraindult ($(date -r "$boot_epoch" '+%H:%M' 2>/dev/null || echo '?')), ujra futok. Allapot: ${verdict}."; then
+      printf '%s\n' "$boot_epoch" > "$BOOT_MARKER"
+      log "boot report sent (boot_epoch=$boot_epoch, $verdict)"
+    else
+      log "boot report NOT sent (send failed) -- will retry next tick"
+    fi
+  elif [ "$seen_boot" != "$boot_epoch" ]; then
+    log "boot ${boot_epoch} not reported yet (uptime ${uptime_s}s < ${BOOT_REPORT_AFTER}s)"
+  fi
+fi
+
+if [ ! -f "$KEEPALIVE_FILE" ]; then
+  log "no keepalive file yet ($KEEPALIVE_FILE) -- probe not established, staying silent"
+  exit 0
+fi
+
+ka="$(mtime_of "$KEEPALIVE_FILE")"
+age=$(( now - ka ))
+
+if [ "$age" -lt "$STALE_AFTER" ]; then
+  if [ "$outage_started" != "0" ]; then
+    down_for=$(( now - outage_started ))
+    if [ "$last_alarm" != "0" ]; then
+      send_alarm "A Telegram-csatorna ujra el. Kimaradas: $(( down_for / 60 )) perc." || true
+    fi
+    log "recovered after ${down_for}s (alarmed=$([ "$last_alarm" != 0 ] && echo yes || echo no))"
+    outage_started=0; restart_done=0; last_alarm=0; save_state
+  fi
+  exit 0
+fi
+
+# --- we are in an outage ---
+[ "$outage_started" = "0" ] && { outage_started="$now"; log "outage opened (keepalive ${age}s stale)"; }
+down_for=$(( now - outage_started ))
+
+if [ "$restart_done" = "0" ] && [ "$age" -ge "$RESTART_AFTER" ]; then
+  restart_channels && restart_done="$now" || restart_done="failed-$now"
+fi
+
+if [ "$age" -ge "$ALARM_AFTER" ]; then
+  if [ "$last_alarm" = "0" ] || [ $(( now - last_alarm )) -ge "$REALARM_EVERY" ]; then
+    if send_alarm "A Telegram-csatorna $(( age / 60 )) perce nem el. Automatikus ujrainditas: $([ "$restart_done" = "0" ] && echo "nem tortent" || echo "megtortent, nem segitett"). A gepen a naplo: store/channel-outage-alarm.log"; then
+      last_alarm="$now"
+    fi
+  fi
+fi
+
+save_state
+exit 0

--- a/scripts/channel-watchdog.sh
+++ b/scripts/channel-watchdog.sh
@@ -61,6 +61,40 @@ AUTH_DEAD_THRESHOLD_TICKS=3     # consecutive dead-token ticks (~15min @ 5min/ti
 
 log() { echo "$(date '+%Y-%m-%d %H:%M:%S') [$LOG_TAG] $*"; }
 
+# PORTSTAT912: mtime in epoch seconds, portable across BSD (macOS) and GNU
+# (Linux) stat. `stat -c %Y` is GNU-only: on macOS it exits 1 with "illegal
+# option -- c", the old `|| echo 0` fallback turned that into mtime=0, and a
+# BRAND NEW keepalive file then measured as infinitely old. STALE was therefore
+# true on every single tick, so installing this watchdog on a Mac would not have
+# protected the main agent -- it would have respawned its channels pane every
+# 5 minutes up to MAX_CONSECUTIVE. The same zero also defeats the respawn-grace
+# gate below, which is the brake meant to stop exactly that storm, so the two
+# failures compound instead of cancelling.
+#
+# Both guards are needed, not just the exit code: under GNU stat `-f` is a
+# valid but DIFFERENT option (file-system status), so a wrong-platform call can
+# print something that is not an mtime. A value is only accepted if the command
+# succeeded AND the output is all digits; 0 is returned only when neither form
+# yielded one, which keeps the historical "unknown means act" behaviour.
+file_mtime() {
+  local _f="$1" _m=""
+  _m=$(stat -f %m "$_f" 2>/dev/null) || _m=""
+  case "$_m" in (''|*[!0-9]*) _m="";; esac
+  if [ -z "$_m" ]; then
+    _m=$(stat -c %Y "$_f" 2>/dev/null) || _m=""
+    case "$_m" in (''|*[!0-9]*) _m="";; esac
+  fi
+  printf '%s\n' "${_m:-0}"
+}
+
+# Debug entry point for the regression test: print one file's resolved mtime and
+# exit before any session lookup, .env read or tmux call, so the helper can be
+# measured on a host where the watchdog itself cannot run.
+if [ "${1:-}" = "--file-mtime" ]; then
+  file_mtime "${2:-}"
+  exit 0
+fi
+
 # --- resolve the channels session + provider (launch-order / rename independent) ---
 MAIN_AGENT_ID="$(grep -E '^MAIN_AGENT_ID=' "$INSTALL_DIR/.env" 2>/dev/null | head -1 | cut -d= -f2-)"
 MAIN_AGENT_ID="${MAIN_AGENT_ID:-marveen}"
@@ -113,7 +147,7 @@ if [ ! -f "$KEEPALIVE_FILE" ]; then
   # keepalive probe itself was never configured.
   log "no keepalive file yet ($KEEPALIVE_FILE) -- keep-alive task not established, STALE=false"
 else
-  ka_mtime=$(stat -c %Y "$KEEPALIVE_FILE" 2>/dev/null || echo 0)
+  ka_mtime=$(file_mtime "$KEEPALIVE_FILE")
   age=$(( now - ka_mtime ))
   [ "$age" -ge "$STALE_SECONDS" ] && STALE=true
 fi
@@ -150,7 +184,7 @@ fi
 
 # --- gate 4: respawn grace (shared with the dashboard watchdog) ---
 if [ -f "$RESPAWN_STAMP" ]; then
-  last=$(stat -c %Y "$RESPAWN_STAMP" 2>/dev/null || echo 0)
+  last=$(file_mtime "$RESPAWN_STAMP")
   if [ $(( now - last )) -lt "$GRACE_SECONDS" ]; then
     log "problem detected (STALE=$STALE AUTHDEAD=$AUTHDEAD) but within respawn grace -- deferring"
     exit 0

--- a/scripts/install-channel-outage-alarm.sh
+++ b/scripts/install-channel-outage-alarm.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# install-channel-outage-alarm.sh
+#
+# Installs the launchd unit for scripts/channel-outage-alarm.sh (CHANALARM912),
+# the out-of-band alarm that tells the owner when the Telegram channel is down.
+#
+# WHY IT IS SEPARATE FROM EVERY OTHER WATCHER. On 2026-09-12 the main agent was
+# silent on Telegram for 8h23m (05:03-13:26). Detection was never the gap:
+# channel-keepalive-probe.sh logged 139 consecutive WARN lines naming the exact
+# fault. Nothing read that log, and the only path to the owner was the very
+# channel that was down. This unit therefore shares nothing with what it
+# watches -- no dashboard, no claude session, no telegram plugin, just curl
+# against api.telegram.org.
+#
+# Cadence and thresholds live in the script itself; the unit only has to run it
+# often enough to resolve them:
+#   StartInterval 180   -- the same ~3 min cadence as the keepalive probe, so
+#                          the 9/15/30-minute thresholds land where intended
+#   RunAtLoad true      -- an immediate first run is safe: the script is
+#                          idempotent and stays silent while healthy
+#
+# PATH MATTERS HERE, unlike in the keepalive-probe unit. The once-per-boot
+# report reads the boot time from `sysctl -n kern.boottime`, and sysctl lives in
+# /usr/sbin -- absent from many inherited PATHs. The script names absolute paths
+# for exactly that reason, but the unit's PATH carries /usr/sbin:/sbin too, so
+# neither layer alone has to be right. A silently disabled boot reporter looks
+# exactly like a boot that never happened.
+#
+# Usage:
+#   scripts/install-channel-outage-alarm.sh            # install, do not start
+#   scripts/install-channel-outage-alarm.sh --load     # install and start
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+LABEL="com.marveen.channel-outage-alarm"
+PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
+ALARM="$PROJECT_DIR/scripts/channel-outage-alarm.sh"
+
+LOAD=0
+[ "${1:-}" = "--load" ] && LOAD=1
+
+if [ ! -f "$ALARM" ]; then
+  echo "ERROR: $ALARM not found." >&2
+  exit 1
+fi
+
+mkdir -p "$HOME/Library/LaunchAgents"
+cat > "$PLIST" <<PLIST_EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>$LABEL</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>$ALARM</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>$PROJECT_DIR</string>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>StartInterval</key>
+  <integer>180</integer>
+  <key>StandardOutPath</key>
+  <string>$PROJECT_DIR/store/channel-outage-alarm.stdout.log</string>
+  <key>StandardErrorPath</key>
+  <string>$PROJECT_DIR/store/channel-outage-alarm.stdout.log</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    <key>HOME</key>
+    <string>$HOME</string>
+    <key>USER</key>
+    <string>$(id -un)</string>
+    <key>TZ</key>
+    <string>Europe/Budapest</string>
+  </dict>
+</dict>
+</plist>
+PLIST_EOF
+echo "Wrote launchd unit: $PLIST"
+
+if [ "$LOAD" = "1" ]; then
+  launchctl unload "$PLIST" 2>/dev/null || true
+  launchctl load "$PLIST"
+  echo "Loaded $LABEL (every 180s + at load). It stays silent while the channel is healthy; it messages the owner directly over the Bot API once the keepalive has been stale for 15 minutes, whether or not its one restart attempt helped."
+else
+  echo "Installed but NOT loaded. To start: launchctl load $PLIST"
+fi


### PR DESCRIPTION
# fix(watchdog): portable mtime, so the macOS install stops measuring fresh files as ancient (PORTSTAT912)

Branch: `fix/portstat912-watchdog-mtime` (local worktree: `~/marveen-wt-portstat912`, tip `57f4f36`, based on `origin/develop` `3d02f37`)
Target: `develop`
Commits: `5ecde2b` (portable mtime + probe), `57f4f36` (ship the alarm)
Files: `scripts/channel-watchdog.sh`, `scripts/channel-keepalive-probe.sh`, `scripts/channel-outage-alarm.sh` (new), `scripts/install-channel-outage-alarm.sh` (new), `scripts/__tests__/channel-watchdog-mtime.test.sh` (new)

## 1. The mtime bug

Both mtime reads in `channel-watchdog.sh` (lines 116 and 153) used `stat -c %Y`, which is GNU-only.
Measured on this host:

```
$ stat -c %Y /etc/hosts
stat: illegal option -- c
exit 1
$ stat -f %m /etc/hosts
1782354543
```

The `|| echo 0` fallback turned that exit 1 into `mtime=0`, so a **brand new** keepalive file
measured as infinitely old: `age = now - 0 = 1789213088s` against `STALE_SECONDS=900`, hence
`STALE=true` on every tick. Installing this watchdog on a Mac would not have protected the main
agent; it would have respawned its channels pane every 5 minutes up to `MAX_CONSECUTIVE=3`.

Worth noting because it makes the failure worse rather than self-limiting: the **second** call site
(line 153) is the respawn-grace stamp, the brake meant to stop exactly that storm. With `mtime=0`,
`now - last` is always larger than `GRACE_SECONDS`, so the brake never engages either. The two
failures compound instead of cancelling.

### The fix

`file_mtime()` tries `stat -f %m` (BSD) first, then `stat -c %Y` (GNU), and returns `0` only when
neither yielded a value — preserving the historical "unknown means act" behaviour. Both call sites
use it.

A value is accepted only if the command **succeeded AND the output is all digits**. The exit code
alone is not enough: under GNU stat `-f` is a valid but *different* option (file-system status), so
a wrong-platform call can print something that is not an mtime.

## 2. The regression test and its red/green measurement

`scripts/__tests__/channel-watchdog-mtime.test.sh` drives the **shipped** script through a new
`--file-mtime <path>` debug entry point, which returns before any `.env` read, session lookup or
tmux call — so the helper is measurable on a host where the watchdog itself cannot run. An
independent oracle (`python3 os.stat`) supplies the expected value; it shares no code with the
thing under test.

**Green — the fixed script (macOS):**

```
  PASS: the --file-mtime entry point answers with a number
  PASS: fresh file: mtime is not 0
  PASS: fresh file: within 2s of the real mtime (drift 0s)
  PASS: backdated file: the old mtime is reported, not now
  PASS: missing file: falls back to 0
  PASS: alarm copy: mtime_of agrees with the oracle
  PASS: single-form control: wrong here -> stat-c(GNU)=[0] (truth=1789214213), so the cases above can go red

  7 passed, 0 failed          (exit 0)
```

**Red — the pre-fix code (macOS):**

```
  PASS: the --file-mtime entry point answers with a number
  FAIL: fresh file: mtime is not 0 -- expected: a real epoch second, got: [0]
  FAIL: fresh file: within 2s of the real mtime -- expected: drift < 2s, got: 1789213807s (got=0 want=1789213807)
  FAIL: backdated file: the old mtime is reported, not now -- expected: 1767265200, got: [0]
  PASS: missing file: falls back to 0
  PASS: alarm copy: mtime_of agrees with the oracle
  PASS: single-form control: wrong here -> stat-c(GNU)=[0] (truth=1789214213), so the cases above can go red

  4 passed, 3 failed          (exit 1)
```

That `1789213807s` drift is the production symptom itself, reproduced in the test.

**How the red run was built** (reproducible, and it does not retype the old code): the pre-fix
`scripts/channel-watchdog.sh` is taken from `origin/develop` `3d02f37`; its mtime expression is
lifted **verbatim** out of the file with a regex on the `ka_mtime=$(...)` line — yielding
`stat -c %Y "$KEEPALIVE_FILE" 2>/dev/null || echo 0` — and exposed under the same `--file-mtime`
interface, with only `"$KEEPALIVE_FILE"` swapped for `"$1"`. The same test file then runs against it
via `WATCHDOG_BIN=`.

Two properties the test is built to keep:

- **Case 2 (backdated file)** guards the opposite direction. A helper that always answered "now"
  would pass the freshness case while silently disabling staleness detection altogether.
- **Case 5 (single-form control)** re-measures red-capability on *every* run rather than assuming
  it: it asserts that one of the two single-form implementations is genuinely wrong on this host,
  and names it. On macOS that is the GNU form (the actual regression). On a Linux runner it flips
  and names the BSD form — which is also how the GNU branch of the helper gets measured on a
  platform I cannot reach from here (see Limits).

## 3. Also in this PR: the false "no recovery unit" WARN

`channel_watchdog_installed()` in `scripts/channel-keepalive-probe.sh` recognised only
`com.marveen.channel-watchdog`. This host runs a different owner for the same role,
`com.marveen.channel-outage-alarm` (180s launchd timer, one restart per outage plus a direct Bot API
alert), so the probe logged a false `WARN ... no recovery unit is installed` while a recovery unit
was in fact installed. Measured live on this host:

```
old pattern 'com\.marveen\.channel-watchdog'        -> false   (the false WARN)
new pattern, anchored, either label                 -> true
'com.marveen.channel-watchdog-DISABLED'             -> rejected (anchoring control)
```

The function now accepts either unit and is renamed `recovery_owner_installed`, because that is what
it asserts — a function named after one specific unit returning true for a different one is a name
that will mislead the next reader. The launchd label is matched anchored at end of line (launchctl
prints it last), so a longer name that merely starts with an accepted one cannot pass as a match.
The `CHANWDOG818` tag is kept in the WARN, since that is the searchable anchor.

## 3b. Also in this PR: the alarm script itself now ships

The unit name accepted above pointed at a script that existed on one host only. `scripts/channel-outage-alarm.sh` and `scripts/install-channel-outage-alarm.sh` are therefore included, so the repo no longer names a unit whose implementation ships nowhere.

What the alarm is, in one paragraph: the 2026-09-12 outage (8h23m silent) was never a detection failure. The keepalive probe logged 139 consecutive WARNs naming the exact fault; nothing read that log, and the only path to the owner was the channel that was down. So this unit shares nothing with what it watches -- no dashboard, no claude session, no telegram plugin, just curl against api.telegram.org.

- **Signal**: the `store/.channel-keepalive` mtime, consumed rather than re-derived. Two detectors that can disagree about the same fact is a defect, so there is deliberately no second one. Consequence worth stating: if the probe dies, this file goes stale and we alarm. That is correct -- a blind monitor is an outage.
- **Escalation**: one restart attempt at 9 min; a direct Bot API message to the owner at 15 min **regardless of whether that restart helped** (today's root cause survived a service restart *and* a host reboot, so recovery must never gate the alarm); a reminder every 30 min while down; one all-clear on recovery; and one per-boot report carrying the channel's health verdict, so "it came back" and "it came back broken" look different.
- **Token chain**: live `.env` -> newest parked `.env.legacy-*` -> a 0600 stash. Not belt-and-braces: the failure this exists for is the one that destroyed the live `.env`.
- **The sysctl trap**, already caught in the script and now also in the installer: `sysctl` lives in `/usr/sbin`, which is not on every inherited PATH. A first version probing only `command -v sysctl` silently disabled the entire boot report in the agent shell -- and a disabled reporter looks exactly like a boot that never happened. The script names absolute paths and the unit's PATH carries `/usr/sbin:/sbin`, so neither layer alone has to be right.

Six probes were run against it before it was installed (healthy = silent; 20-min staleness = HTTP 200; HTTP 200 even with the live `.env` deleted; recovery = one all-clear plus state reset, second run silent; no token = ERROR logged and `last_alarm` stays 0 so it retries; boot report once, silent the second time).

Checks I added on top before committing it:

- **No literal secret in the file** -- it reads the token from disk at runtime; `store/` is gitignored, so the stash, state and log can never be committed.
- **The restart label is real**: `com.nova.channels` is loaded on this host (pid 35547). Worth flagging only because every other unit here is `com.marveen.*`; the mixed naming is the installed reality, not a typo I should silently "fix".
- **The installer reproduces the live unit**: generated into a sandbox `HOME` and diffed against the installed plist -- label, `StartInterval`, `RunAtLoad`, PATH, USER and TZ are byte-identical; only the substituted paths differ.
- **The alarm's own `mtime_of()` is now under test** (case 4 above). It is a deliberate second copy of the helper -- the isolation is the whole point of this unit -- but a second copy is a second thing that can be wrong, and this one reads the file the entire alarm hangs on.

## 4. Other `stat -c` occurrences (listed here, fixed in a separate PR)

**Same bug class** — GNU-only, no BSD fallback, no `uname` guard anywhere in the file; each one is a
staleness or grace gate, so on macOS the value is `0` and the gate mis-fires in the permissive
direction:

| Site | What it gates | Consequence on macOS |
|---|---|---|
| `scripts/watchdog.sh:169` | main respawn-grace stamp (900s) | grace never applies; the last-resort backstop stops deferring |
| `scripts/stuck-modal-guard.sh:238` | respawn grace | same: "a respawn happened Ns ago" never defers |
| `scripts/stuck-modal-guard.sh:248` | backoff stamp (3600s) | the hourly alert backoff never holds |
| `scripts/host-restart-watchdog.sh:88` | last-alive from `*.log` mtimes | every log reads 0, so `last_alive` stays 0 and the downtime gap is wrong |

**Already portable — no change needed** (checked, not merely grepped):

- `scripts/doctor.sh:118` — inside an explicit `uname -s = Darwin` branch that uses `stat -f "%m"`. A
  grep hit, not a defect.
- `scripts/hooks/channel-image-resize.sh:45,62` and `scripts/hooks/telegram-image-resize.sh:51,68` —
  BSD form first, GNU fallback.
- `scripts/install-voice.sh:113,127` — GNU form first, BSD fallback (the opposite order to this fix;
  both are correct).
- `seed-skills/skill-management/SKILL.md:137` — documentation, already dual-form.

## 5. Limits — what is measured and what is not

- The **BSD/macOS path is measured** (green and red runs above, on Darwin).
- The **GNU/Linux path is NOT measured here**: no Docker daemon running (Colima down) and no
  `gstat`/coreutils on this host, so I could not execute GNU `stat`. The guard against GNU's
  different `-f` meaning is reasoned, not observed. The test is written so a Linux CI run measures
  it automatically — case 4 will there name the BSD form as the broken one, and cases 1-3 would fail
  if the digit guard were wrong under GNU.
- `scripts/channel-outage-alarm.sh`, the script behind the newly accepted unit name, is **not in the
  repo** (untracked, local to this host, created today). Accepting the name is still safe — the
  check only matches units actually loaded, so other installs keep warning correctly — but after
  this merges the repo references a unit whose implementation ships nowhere. Worth a follow-up
  decision on whether that script should be committed.
- `bash -n` clean on both changed scripts. No `shellcheck` on this host.
