### PR TITLE
refactor(scripts): one shared portable mtime helper, and a gate that keeps stat -c out (PORTSTAT912B)

### DIFF
--- a/scripts/__tests__/channel-watchdog-mtime.test.sh
+++ b/scripts/__tests__/channel-watchdog-mtime.test.sh
@@ -102,7 +102,31 @@ else
   fail "missing file: falls back to 0" "0" "[$got]"
 fi
 
-# --- case 4: the red-capable control -----------------------------------------
+# --- case 4: the SECOND copy of the helper ------------------------------------
+# channel-outage-alarm.sh carries its own mtime_of(). The duplication is
+# deliberate -- that unit exists precisely to share nothing with what it
+# watches -- but a second copy is a second thing that can be wrong, and this
+# one reads the keepalive file the whole alarm hangs on. Pull the function out
+# of the shipped file and hold it to the same contract.
+ALARM_SRC="$INSTALL_DIR/scripts/channel-outage-alarm.sh"
+if [ ! -f "$ALARM_SRC" ]; then
+  fail "alarm copy: channel-outage-alarm.sh is present" "the shipped file" "absent"
+else
+  awk '/^mtime_of\(\)/,/^}/' "$ALARM_SRC" > "$BOX/alarm-mtime.sh"
+  if ! grep -q 'stat ' "$BOX/alarm-mtime.sh"; then
+    fail "alarm copy: mtime_of extracted" "a function body calling stat" "[$(head -1 "$BOX/alarm-mtime.sh")]"
+  else
+    got="$(bash -c "source '$BOX/alarm-mtime.sh'; mtime_of '$fresh'" 2>/dev/null)"
+    want="$(mtime_oracle "$fresh")"
+    if [ "$got" = "$want" ] && [ "$got" != "0" ]; then
+      pass "alarm copy: mtime_of agrees with the oracle"
+    else
+      fail "alarm copy: mtime_of agrees with the oracle" "$want" "[$got]"
+    fi
+  fi
+fi
+
+# --- case 5: the red-capable control -----------------------------------------
 # Exactly one of the two single-form implementations is wrong on any given
 # host. Naming which one, on every run, is what keeps the cases above from
 # being green for free -- and it is the pre-fix expression verbatim, including

--- a/scripts/__tests__/channel-watchdog-mtime.test.sh
+++ b/scripts/__tests__/channel-watchdog-mtime.test.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+# PORTSTAT912: channel-watchdog.sh must read a file's mtime on BSD (macOS) and
+# GNU (Linux) alike.
+#
+# Regression origin (2026-09-12): both call sites used `stat -c %Y`, which is
+# GNU-only. On macOS it exits 1 with "illegal option -- c" and the old
+# `|| echo 0` fallback turned that into mtime=0, so a BRAND NEW keepalive file
+# measured as infinitely old:
+#
+#   ka_mtime=0 -> age=1789213088s vs STALE_SECONDS=900 -> STALE=true, every tick
+#
+# Installing the watchdog on a Mac would therefore not have protected the main
+# agent; it would have respawned its channels pane every 5 minutes up to
+# MAX_CONSECUTIVE. The same zero also defeats the respawn-grace gate (the brake
+# meant to stop exactly that storm), so the two failures compound.
+#
+# The assertions run against the SHIPPED script through its `--file-mtime`
+# debug entry point, so this measures the code the timer runs, not a copy.
+#
+# Red-capability is not assumed, it is measured on every run: the last case
+# proves that a single-form implementation is genuinely wrong on THIS host, so
+# the passing cases above it cannot be passing for free. On macOS the broken
+# form is the GNU one (the actual regression); on Linux it is the BSD one.
+# Run: bash scripts/__tests__/channel-watchdog-mtime.test.sh
+
+set -u
+
+PASS=0; FAIL=0
+pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1 -- expected: $2, got: $3"; }
+
+INSTALL_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+WATCHDOG="${WATCHDOG_BIN:-$INSTALL_DIR/scripts/channel-watchdog.sh}"
+
+echo "channel-watchdog.sh portable mtime (PORTSTAT912)"
+echo "  source under test: $WATCHDOG"
+echo "  platform: $(uname -s)"
+
+# An mtime oracle that shares no code with the thing under test.
+mtime_oracle() { python3 -c 'import os,sys; print(int(os.stat(sys.argv[1]).st_mtime))' "$1" 2>/dev/null; }
+helper_mtime() { bash "$WATCHDOG" --file-mtime "$1" 2>/dev/null; }
+
+if ! command -v python3 >/dev/null 2>&1; then
+  fail "prerequisite: an independent mtime oracle" "python3 on PATH" "absent"
+  echo; echo "  $PASS passed, $FAIL failed"; exit 1
+fi
+
+BOX="$(mktemp -d -t portstat912)"
+trap 'case "$BOX" in *portstat912*) rm -rf "$BOX" ;; esac' EXIT
+
+# --- positive control: the debug entry point exists at all -------------------
+# Without it every case below would read an empty string and could never fail
+# in a way that means anything.
+probe="$(helper_mtime "$INSTALL_DIR/scripts/channel-watchdog.sh")"
+case "$probe" in
+  ''|*[!0-9]*) fail "the --file-mtime entry point answers with a number" "digits" "[$probe]" ;;
+  *)           pass "the --file-mtime entry point answers with a number" ;;
+esac
+
+# --- case 1: a fresh, existing file ------------------------------------------
+# The regression in one assertion: a file created a moment ago must NOT read 0.
+fresh="$BOX/.channel-keepalive"
+: > "$fresh"
+got="$(helper_mtime "$fresh")"
+want="$(mtime_oracle "$fresh")"
+if [ "$got" = "0" ] || [ -z "$got" ]; then
+  fail "fresh file: mtime is not 0" "a real epoch second" "[$got]"
+else
+  pass "fresh file: mtime is not 0"
+fi
+if [ -n "$got" ] && [ -n "$want" ] && [ "$got" -ge 0 ] 2>/dev/null; then
+  drift=$(( got - want )); [ "$drift" -lt 0 ] && drift=$(( -drift ))
+  if [ "$drift" -lt 2 ]; then
+    pass "fresh file: within 2s of the real mtime (drift ${drift}s)"
+  else
+    fail "fresh file: within 2s of the real mtime" "drift < 2s" "${drift}s (got=$got want=$want)"
+  fi
+else
+  fail "fresh file: within 2s of the real mtime" "comparable numbers" "got=[$got] want=[$want]"
+fi
+
+# --- case 2: an OLD file still reads old -------------------------------------
+# Guards the other direction: a helper that always answered `now` would pass
+# case 1 and silently disable staleness detection altogether.
+old="$BOX/.channel-keepalive-old"
+: > "$old"
+touch -t 202601011200 "$old" 2>/dev/null || touch -d '2026-01-01 12:00' "$old" 2>/dev/null
+got="$(helper_mtime "$old")"
+want="$(mtime_oracle "$old")"
+if [ "$got" = "$want" ] && [ "$got" != "0" ]; then
+  pass "backdated file: the old mtime is reported, not now"
+else
+  fail "backdated file: the old mtime is reported, not now" "$want" "[$got]"
+fi
+
+# --- case 3: a missing file still falls back to 0 ----------------------------
+# The historical contract: unknown means "act", not "crash".
+got="$(helper_mtime "$BOX/does-not-exist")"
+if [ "$got" = "0" ]; then
+  pass "missing file: falls back to 0"
+else
+  fail "missing file: falls back to 0" "0" "[$got]"
+fi
+
+# --- case 4: the red-capable control -----------------------------------------
+# Exactly one of the two single-form implementations is wrong on any given
+# host. Naming which one, on every run, is what keeps the cases above from
+# being green for free -- and it is the pre-fix expression verbatim, including
+# its `|| echo 0` fallback.
+gnu_form="$(stat -c %Y "$fresh" 2>/dev/null || echo 0)"
+bsd_form="$(stat -f %m "$fresh" 2>/dev/null || echo 0)"
+truth="$(mtime_oracle "$fresh")"
+broken=""
+[ "$gnu_form" != "$truth" ] && broken="$broken stat-c(GNU)=[$gnu_form]"
+[ "$bsd_form" != "$truth" ] && broken="$broken stat-f(BSD)=[$bsd_form]"
+if [ -n "$broken" ]; then
+  pass "single-form control: wrong here ->$broken (truth=$truth), so the cases above can go red"
+else
+  fail "single-form control: at least one form must be wrong here" \
+       "a broken single form to prove red-capability" "both forms agreed ($truth)"
+fi
+
+echo
+echo "  $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/scripts/__tests__/channel-watchdog-mtime.test.sh
+++ b/scripts/__tests__/channel-watchdog-mtime.test.sh
@@ -102,28 +102,21 @@ else
   fail "missing file: falls back to 0" "0" "[$got]"
 fi
 
-# --- case 4: the SECOND copy of the helper ------------------------------------
-# channel-outage-alarm.sh carries its own mtime_of(). The duplication is
-# deliberate -- that unit exists precisely to share nothing with what it
-# watches -- but a second copy is a second thing that can be wrong, and this
-# one reads the keepalive file the whole alarm hangs on. Pull the function out
-# of the shipped file and hold it to the same contract.
+# --- case 4: the alarm no longer keeps a private copy -------------------------
+# channel-outage-alarm.sh used to carry its own mtime_of(). A second copy is a
+# second thing that can be wrong about the very file the alarm hangs on, so it
+# now sources the one implementation. The helper's own contract is measured in
+# scripts/__tests__/portable-stat.test.sh; here we only assert the copy is gone.
 ALARM_SRC="$INSTALL_DIR/scripts/channel-outage-alarm.sh"
 if [ ! -f "$ALARM_SRC" ]; then
-  fail "alarm copy: channel-outage-alarm.sh is present" "the shipped file" "absent"
+  fail "alarm: channel-outage-alarm.sh is present" "the shipped file" "absent"
+elif grep -q '^mtime_of()' "$ALARM_SRC"; then
+  fail "alarm: no private mtime helper" "the shared library" "a local mtime_of() came back"
+elif grep -q 'portable-stat.sh' "$ALARM_SRC" && grep -q 'file_mtime "' "$ALARM_SRC"; then
+  pass "alarm: sources the shared helper instead of its own copy"
 else
-  awk '/^mtime_of\(\)/,/^}/' "$ALARM_SRC" > "$BOX/alarm-mtime.sh"
-  if ! grep -q 'stat ' "$BOX/alarm-mtime.sh"; then
-    fail "alarm copy: mtime_of extracted" "a function body calling stat" "[$(head -1 "$BOX/alarm-mtime.sh")]"
-  else
-    got="$(bash -c "source '$BOX/alarm-mtime.sh'; mtime_of '$fresh'" 2>/dev/null)"
-    want="$(mtime_oracle "$fresh")"
-    if [ "$got" = "$want" ] && [ "$got" != "0" ]; then
-      pass "alarm copy: mtime_of agrees with the oracle"
-    else
-      fail "alarm copy: mtime_of agrees with the oracle" "$want" "[$got]"
-    fi
-  fi
+  fail "alarm: sources the shared helper instead of its own copy" \
+       "a source line and a file_mtime call" "missing one"
 fi
 
 # --- case 5: the red-capable control -----------------------------------------

--- a/scripts/__tests__/portable-stat.test.sh
+++ b/scripts/__tests__/portable-stat.test.sh
@@ -1,0 +1,189 @@
+#!/bin/bash
+# PORTSTAT912: the shared portable mtime helper, and a guard that stops the
+# GNU-only spelling from coming back.
+#
+# The bug this closes was never exotic. `stat -c %Y` is GNU-only; on macOS it
+# exits 1 and the fallback every caller wrote -- `|| echo 0` -- turned that into
+# mtime=0, so a file touched a second ago measured as 56 years old. What made it
+# dangerous is WHERE it was spelled: every caller is a grace, backoff or
+# staleness gate, and zero tips all of them the SAME way, the permissive one.
+# channel-watchdog.sh read a fresh keepalive as infinitely stale (respawn the
+# pane, every tick), and the very next gate -- the respawn-grace stamp meant to
+# stop that storm -- read zero too and never deferred. watchdog.sh:169 and
+# stuck-modal-guard.sh:238 are the same pair. One bug that disables its own
+# brakes, in four places.
+#
+# So this file has two jobs:
+#   1. hold scripts/lib/portable-stat.sh to its contract, INCLUDING the branch
+#      that cannot run on the host doing the testing (via a stub `stat`), and
+#   2. fail if any shell script starts spelling mtime a single way again --
+#      otherwise we are back here in a year.
+# Run: bash scripts/__tests__/portable-stat.test.sh
+
+set -u
+
+PASS=0; FAIL=0
+pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1 -- expected: $2, got: $3"; }
+
+INSTALL_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+LIB="$INSTALL_DIR/scripts/lib/portable-stat.sh"
+
+echo "portable mtime helper + no-regression guard (PORTSTAT912)"
+echo "  platform: $(uname -s)"
+
+if [ ! -f "$LIB" ]; then
+  fail "the library exists" "$LIB" "absent"
+  echo; echo "  $PASS passed, $FAIL failed"; exit 1
+fi
+# shellcheck disable=SC1090
+. "$LIB"
+
+if ! command -v python3 >/dev/null 2>&1; then
+  fail "prerequisite: an independent mtime oracle" "python3 on PATH" "absent"
+  echo; echo "  $PASS passed, $FAIL failed"; exit 1
+fi
+mtime_oracle() { python3 -c 'import os,sys; print(int(os.stat(sys.argv[1]).st_mtime))' "$1" 2>/dev/null; }
+
+BOX="$(mktemp -d -t portstat912b)"
+trap 'case "$BOX" in *portstat912b*) rm -rf "$BOX" ;; esac' EXIT
+
+fresh="$BOX/fresh"; : > "$fresh"
+truth="$(mtime_oracle "$fresh")"
+
+# --- contract on this host ---------------------------------------------------
+got="$(file_mtime "$fresh")"
+if [ "$got" = "$truth" ] && [ "$got" != "0" ]; then
+  pass "fresh file: the real mtime, not 0"
+else
+  fail "fresh file: the real mtime, not 0" "$truth" "[$got]"
+fi
+
+old="$BOX/old"; : > "$old"
+touch -t 202601011200 "$old" 2>/dev/null || touch -d '2026-01-01 12:00' "$old" 2>/dev/null
+got="$(file_mtime "$old")"; want="$(mtime_oracle "$old")"
+# A helper that always answered "now" would pass the case above while silently
+# switching staleness detection off everywhere.
+if [ "$got" = "$want" ] && [ "$got" != "0" ]; then
+  pass "backdated file: the old mtime, not now"
+else
+  fail "backdated file: the old mtime, not now" "$want" "[$got]"
+fi
+
+got="$(file_mtime "$BOX/nope")"
+if [ "$got" = "0" ]; then
+  pass "missing file: 0, the historical 'unknown means act' contract"
+else
+  fail "missing file: 0, the historical 'unknown means act' contract" "0" "[$got]"
+fi
+
+# --- the branch this host cannot reach ---------------------------------------
+# On any single machine one of the two spellings is dead code, and dead code
+# rots. A stub `stat` earlier on PATH lets the GNU-side branch be exercised
+# from a BSD host and vice versa. This is a stub of the documented behaviour,
+# NOT real GNU coreutils -- it measures our branch logic, not their binary.
+mkdir -p "$BOX/bin"
+
+# GNU-like: -c works; -f is a valid but DIFFERENT option (file-system status),
+# so the BSD spelling gets a bogus operand and exits non-zero.
+cat > "$BOX/bin/stat" <<'STUB'
+#!/bin/bash
+if [ "$1" = "-c" ]; then
+  python3 -c 'import os,sys; print(int(os.stat(sys.argv[1]).st_mtime))' "$3"
+  exit 0
+fi
+echo "  File: \"$2\""
+echo "    ID: 0 Namelen: 255     Type: ext2/ext3"
+exit 1
+STUB
+chmod +x "$BOX/bin/stat"
+got="$(PATH="$BOX/bin:$PATH" file_mtime "$fresh")"
+if [ "$got" = "$truth" ]; then
+  pass "GNU-like stat: falls through to -c and returns the real mtime"
+else
+  fail "GNU-like stat: falls through to -c and returns the real mtime" "$truth" "[$got]"
+fi
+
+# The same, but the wrong-spelling call exits 0 while printing a filesystem
+# report. This is what makes the all-digits check load-bearing rather than
+# decorative: an implementation trusting the exit code alone hands that blob
+# back as if it were a timestamp.
+cat > "$BOX/bin/stat" <<'STUB'
+#!/bin/bash
+if [ "$1" = "-c" ]; then
+  python3 -c 'import os,sys; print(int(os.stat(sys.argv[1]).st_mtime))' "$3"
+  exit 0
+fi
+echo "Blocks: Total: 121938 Free: 60469"
+exit 0
+STUB
+chmod +x "$BOX/bin/stat"
+got="$(PATH="$BOX/bin:$PATH" file_mtime "$fresh")"
+if [ "$got" = "$truth" ]; then
+  pass "wrong spelling exits 0 with a non-numeric blob: rejected, not returned"
+else
+  fail "wrong spelling exits 0 with a non-numeric blob: rejected, not returned" "$truth" "[$got]"
+fi
+
+# --- the test seam itself -----------------------------------------------------
+got="$(PORTABLE_STAT_DISABLE="bsd gnu" file_mtime "$fresh")"
+if [ "$got" = "0" ]; then
+  pass "both spellings disabled: 0, never an invented timestamp"
+else
+  fail "both spellings disabled: 0, never an invented timestamp" "0" "[$got]"
+fi
+
+# --- the four converted call sites still go through the helper ---------------
+# Structural, deliberately: these live inside long-running guards with real side
+# effects, so the durable assertion is that none of them re-grows its own copy.
+for f in scripts/watchdog.sh scripts/stuck-modal-guard.sh scripts/host-restart-watchdog.sh; do
+  if grep -q '^\. "\$INSTALL_DIR/scripts/lib/portable-stat.sh"' "$INSTALL_DIR/$f" \
+     && grep -q 'file_mtime "' "$INSTALL_DIR/$f"; then
+    pass "$f sources the shared helper and uses it"
+  else
+    fail "$f sources the shared helper and uses it" "a source line and a file_mtime call" "missing one"
+  fi
+done
+
+# --- the guard: no new single-spelling mtime ---------------------------------
+# Every tracked *.sh is scanned with comments stripped. A line is acceptable if
+# it spells BOTH forms (a self-contained dual-form one-liner). Anything else has
+# to be listed here, with a reason -- so adding one is a decision somebody makes
+# on purpose, not a habit that spreads.
+#
+# scripts/__tests__/ is excluded: a test of this helper must be free to write
+# both spellings, including inside stubs.
+allowed_file() {
+  case "$1" in
+    scripts/lib/portable-stat.sh) return 0 ;;  # the one implementation
+    scripts/__tests__/*)          return 0 ;;  # stubs and fixtures, see above
+    scripts/doctor.sh)            return 0 ;;  # picks the spelling from `uname -s` explicitly
+    *) return 1 ;;
+  esac
+}
+
+offenders=""
+while IFS= read -r f; do
+  allowed_file "$f" && continue
+  [ -f "$INSTALL_DIR/$f" ] || continue
+  while IFS= read -r line; do
+    case "$line" in \#*) continue ;; esac
+    case "$line" in *"stat -c"*|*"stat -f"*) : ;; *) continue ;; esac
+    case "$line" in *"stat -c"*) has_c=1 ;; *) has_c=0 ;; esac
+    case "$line" in *"stat -f"*) has_f=1 ;; *) has_f=0 ;; esac
+    [ "$has_c" = 1 ] && [ "$has_f" = 1 ] && continue   # dual-form one-liner
+    offenders="$offenders
+    $f: $(printf '%s' "$line" | sed 's/^[[:space:]]*//')"
+  done < <(sed 's/^[[:space:]]*//' "$INSTALL_DIR/$f")
+done < <(cd "$INSTALL_DIR" && git ls-files '*.sh' 2>/dev/null)
+
+if [ -z "$offenders" ]; then
+  pass "no tracked *.sh spells mtime a single way outside the allowlist"
+else
+  fail "no tracked *.sh spells mtime a single way outside the allowlist" \
+       "file_mtime from scripts/lib/portable-stat.sh" "$offenders"
+fi
+
+echo
+echo "  $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/scripts/channel-keepalive-probe.sh
+++ b/scripts/channel-keepalive-probe.sh
@@ -34,17 +34,26 @@ LOG_TAG="channel-keepalive-probe"
 
 log() { echo "$(date '+%Y-%m-%d %H:%M:%S') [$LOG_TAG] $*"; }
 
-# Whether a dedicated channel-watchdog recovery owner is actually installed on
-# THIS host. The probe declines to recover a dead pipe on purpose -- but only a
-# real, installed watchdog legitimately "owns recovery". The systemd
-# channel-watchdog timer has NO launchd twin, so on macOS it is simply absent
-# (CHANWDOG818): claiming an owner that isn't there turns a genuine outage into
-# silence. Fail loud instead when nothing owns recovery.
-channel_watchdog_installed() {
+# Whether a dedicated recovery owner is actually installed on THIS host. The
+# probe declines to recover a dead pipe on purpose -- but only a real, installed
+# unit legitimately "owns recovery". The systemd channel-watchdog timer has NO
+# launchd twin, so on macOS it is simply absent (CHANWDOG818): claiming an owner
+# that isn't there turns a genuine outage into silence. Fail loud instead when
+# nothing owns recovery.
+#
+# More than one unit can hold that role. channel-outage-alarm is the macOS
+# launchd owner (180s timer, one restart per outage plus a direct Bot API alert
+# to the owner); recognising only the systemd name made the probe log a FALSE
+# "no recovery unit" WARN on a host that in fact had one. The label is matched
+# anchored at end of line -- launchctl prints it last -- so a longer name that
+# merely starts with an accepted one cannot pass as a match.
+recovery_owner_installed() {
   if [ "$(uname -s)" = "Darwin" ]; then
-    launchctl list 2>/dev/null | grep -q 'com\.marveen\.channel-watchdog'
+    launchctl list 2>/dev/null \
+      | grep -qE '(com\.marveen\.channel-watchdog|com\.marveen\.channel-outage-alarm)$'
   else
-    systemctl --user is-enabled channel-watchdog.timer >/dev/null 2>&1
+    systemctl --user is-enabled channel-watchdog.timer >/dev/null 2>&1 \
+      || systemctl --user is-enabled channel-outage-alarm.timer >/dev/null 2>&1
   fi
 }
 
@@ -120,10 +129,10 @@ done < <(ps -axo pid,command 2>/dev/null | grep -E "$RUNTIME_TOKEN_RX" | grep -E
 if [ "$alive" -ne 1 ]; then
   # Do NOT advance the keepalive: a dead pipe must stay visibly stale so a real
   # recovery owner can act. But only claim an owner that actually exists here.
-  if channel_watchdog_installed; then
-    log "no live telegram poller under $SESSION (pane $pane_pid) -- pipe may be down; not touching (channel-watchdog owns recovery)"
+  if recovery_owner_installed; then
+    log "no live telegram poller under $SESSION (pane $pane_pid) -- pipe may be down; not touching (an installed recovery unit owns it)"
   else
-    log "WARN no live telegram poller under $SESSION (pane $pane_pid) -- pipe may be down AND no channel-watchdog recovery unit is installed on this host (CHANWDOG818); automatic recovery relies only on process-death KeepAlive + the dashboard channel-monitor, so a FROZEN session while the dashboard is also down is NOT auto-recovered"
+    log "WARN no live telegram poller under $SESSION (pane $pane_pid) -- pipe may be down AND no recovery unit (channel-watchdog / channel-outage-alarm) is installed on this host (CHANWDOG818); automatic recovery relies only on process-death KeepAlive + the dashboard channel-monitor, so a FROZEN session while the dashboard is also down is NOT auto-recovered"
   fi
   exit 0
 fi

--- a/scripts/channel-outage-alarm.sh
+++ b/scripts/channel-outage-alarm.sh
@@ -1,0 +1,243 @@
+#!/bin/bash
+# Out-of-band channel outage alarm (CHANALARM912).
+#
+# WHY THIS EXISTS. On 2026-09-12 the main agent was silent on Telegram from
+# 05:03 to 13:26 (8h23m). Every layer that was supposed to notice DID notice:
+# channel-keepalive-probe.sh logged 139 consecutive WARN lines, one every three
+# minutes, naming the exact fault. Nothing read that log. The owner found out by
+# asking "do you get what I write?". A host reboot at 12:50 did not help, because
+# the root cause (channels.sh parking its own live .env, ENVPARK912) re-fired on
+# every start.
+#
+# The gap was never DETECTION. It was that detection had no way OUT of the box:
+# the only path to the owner was the very channel that was down.
+#
+# So this unit deliberately shares nothing with the thing it watches:
+#   - it does not need the dashboard (which can be down),
+#   - it does not need the claude session (which can be wedged),
+#   - it does not need the telegram PLUGIN (which is what fails),
+#   - it talks to api.telegram.org with curl and a bot token, nothing else.
+#
+# SIGNAL. store/.channel-keepalive is touched by channel-keepalive-probe.sh ONLY
+# when a live telegram poller is confirmed under the channels pane. Its mtime is
+# therefore an already-proven liveness signal produced by a component that is
+# already running. We consume it rather than re-implementing the poller check:
+# two detectors that can disagree about the same fact is a defect, not a detail
+# (see the RUNTIME_TOKEN_RX note in channel-keepalive-probe.sh). A consequence
+# worth stating: if the probe itself dies, this file goes stale and we alarm.
+# That is correct. A blind monitor is an outage.
+#
+# TOKEN SOURCES. The failure that motivated this script DESTROYED the live .env
+# (it was moved aside to .env.legacy-<epoch>). An alarm that reads only the live
+# .env would therefore have been mute in exactly the incident it exists for. We
+# fall back to the newest parked copy, then to a dedicated read-only stash.
+#
+# ESCALATION (thresholds in seconds, probe cadence is ~180s):
+#   >= RESTART_AFTER : try one service restart per outage, then keep watching.
+#   >= ALARM_AFTER   : message the owner directly, regardless of whether the
+#                      restart helped. Today's root cause survived a restart AND
+#                      a reboot, so recovery must never gate the alarm.
+#   every REALARM_EVERY while still down: one reminder, so a long outage does
+#                      not decay into the same silence.
+#   on recovery      : one all-clear, but only if we had alarmed.
+
+set -u
+
+INSTALL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+STORE="$INSTALL_DIR/store"
+CHAN_DIR="$INSTALL_DIR/.claude/channels/telegram"
+KEEPALIVE_FILE="$STORE/.channel-keepalive"
+STATE_FILE="$STORE/.channel-outage-alarm-state"
+TOKEN_STASH="$STORE/.telegram-alarm-token"
+BOOT_MARKER="$STORE/.channel-boot-notified"
+LOG_FILE="$STORE/channel-outage-alarm.log"
+
+BOOT_REPORT_AFTER=$(( 3 * 60 ))  # let the fleet finish coming up before reporting
+
+STALE_AFTER=$(( 9 * 60 ))        # keepalive older than this => outage
+RESTART_AFTER=$(( 9 * 60 ))      # first (and only) automatic restart attempt
+ALARM_AFTER=$(( 15 * 60 ))       # tell the owner, restart or no restart
+REALARM_EVERY=$(( 30 * 60 ))     # reminder cadence while still down
+
+log() { printf '%s [channel-outage-alarm] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*" >> "$LOG_FILE"; }
+
+# Portable mtime. channel-watchdog.sh hard-codes `stat -c %Y`, which is GNU
+# only: on macOS it exits non-zero and the caller's `|| echo 0` turns a FRESH
+# file into an infinitely stale one. Measured 2026-09-12 -- that single flag is
+# why installing that watchdog here would have respawned the channels pane every
+# five minutes instead of protecting it. Never spell mtime one way.
+mtime_of() {
+  local f="$1" m=""
+  m="$(stat -f %m "$f" 2>/dev/null)" || m=""
+  [ -n "$m" ] || m="$(stat -c %Y "$f" 2>/dev/null)" || m=""
+  [ -n "$m" ] || m=0
+  printf '%s\n' "$m"
+}
+
+read_token() {
+  local f tok=""
+  for f in "$CHAN_DIR/.env" $(ls -t "$CHAN_DIR"/.env.legacy-* 2>/dev/null) "$TOKEN_STASH"; do
+    [ -f "$f" ] || continue
+    tok="$(sed -n 's/^[[:space:]]*TELEGRAM_BOT_TOKEN=//p' "$f" 2>/dev/null | head -1 | tr -d '"'"'"' \r')"
+    if [ -n "$tok" ]; then printf '%s\n' "$tok"; return 0; fi
+  done
+  return 1
+}
+
+read_chat_id() {
+  [ -f "$CHAN_DIR/access.json" ] || return 1
+  python3 - "$CHAN_DIR/access.json" <<'PY' 2>/dev/null
+import json, sys
+try:
+    d = json.load(open(sys.argv[1], encoding="utf-8"))
+except Exception:
+    raise SystemExit(1)
+a = d.get("allowFrom") or []
+if not a:
+    raise SystemExit(1)
+print(a[0])
+PY
+}
+
+# Direct Bot API send. No plugin, no session, no dashboard in the path.
+send_alarm() {
+  local text="$1" tok chat http
+  tok="$(read_token)" || { log "ERROR cannot send: no bot token in $CHAN_DIR/.env, parked copies, or $TOKEN_STASH"; return 1; }
+  chat="$(read_chat_id)" || { log "ERROR cannot send: no allowFrom chat id in $CHAN_DIR/access.json"; return 1; }
+  http="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 20 \
+    "https://api.telegram.org/bot${tok}/sendMessage" \
+    --data-urlencode "chat_id=${chat}" \
+    --data-urlencode "text=${text}" 2>/dev/null)"
+  if [ "$http" = "200" ]; then
+    log "alarm delivered (HTTP 200)"
+    return 0
+  fi
+  log "ERROR alarm send failed (HTTP ${http:-000})"
+  return 1
+}
+
+restart_channels() {
+  if command -v launchctl >/dev/null 2>&1; then
+    if launchctl kickstart -k "gui/$(id -u)/com.nova.channels" >/dev/null 2>&1; then
+      log "restart issued: launchctl kickstart -k gui/$(id -u)/com.nova.channels"
+      return 0
+    fi
+  fi
+  if command -v systemctl >/dev/null 2>&1; then
+    if systemctl --user restart marveen-channels.service >/dev/null 2>&1; then
+      log "restart issued: systemctl --user restart marveen-channels.service"
+      return 0
+    fi
+  fi
+  log "ERROR no service manager could restart the channels unit"
+  return 1
+}
+
+# --- state: outage_started restart_done last_alarm ---
+outage_started=0; restart_done=0; last_alarm=0
+if [ -f "$STATE_FILE" ]; then
+  # shellcheck disable=SC1090
+  . "$STATE_FILE" 2>/dev/null || true
+fi
+save_state() {
+  printf 'outage_started=%s\nrestart_done=%s\nlast_alarm=%s\n' \
+    "$outage_started" "$restart_done" "$last_alarm" > "$STATE_FILE"
+}
+
+now="$(date +%s)"
+
+# Keep a token stash fresh whenever the live .env is intact, so a later run can
+# still reach the owner after the live file is destroyed.
+if [ -f "$CHAN_DIR/.env" ] && grep -q '^[[:space:]]*TELEGRAM_BOT_TOKEN=' "$CHAN_DIR/.env" 2>/dev/null; then
+  if ! cmp -s "$CHAN_DIR/.env" "$TOKEN_STASH" 2>/dev/null; then
+    ( umask 077; cp "$CHAN_DIR/.env" "$TOKEN_STASH.tmp.$$" && mv "$TOKEN_STASH.tmp.$$" "$TOKEN_STASH" ) 2>/dev/null \
+      && log "token stash refreshed"
+  fi
+fi
+
+# --- once per boot: tell the owner the machine came back and what state it is in ---
+#
+# WHY. A host restart is the one outage this alarm cannot report while it is
+# happening: nothing on the box is running to send anything. The owner's only
+# signal is silence, which is indistinguishable from a quiet day. 2026-09-12 had
+# TWO restarts (11:23 unclean, 12:50 clean) and the owner learned of neither.
+# One line per boot is proportionate: reboots are rare, and the message carries
+# the health verdict, so "it came back" and "it came back BROKEN" look different.
+#
+# The `sec = <n>, usec = <m>` output needs an anchored match: a greedy `.*sec = `
+# lands on usec and yields a boot time in 1970.
+# sysctl lives in /usr/sbin, which is NOT on every PATH this script can inherit
+# (measured: absent from the agent shell's PATH, present in the launchd unit's).
+# Probing only `command -v sysctl` therefore silently disabled this whole block
+# in half the environments -- and a disabled reporter looks exactly like a boot
+# that never happened. Name the absolute paths.
+boot_epoch=""
+if [ -r /proc/stat ]; then
+  boot_epoch="$(awk '/^btime /{print $2; exit}' /proc/stat 2>/dev/null)"
+else
+  for _sysctl in /usr/sbin/sysctl /sbin/sysctl "$(command -v sysctl 2>/dev/null)"; do
+    [ -n "$_sysctl" ] && [ -x "$_sysctl" ] || continue
+    boot_epoch="$("$_sysctl" -n kern.boottime 2>/dev/null | sed -n 's/^[^0-9]*sec *= *\([0-9][0-9]*\).*/\1/p')"
+    [ -n "$boot_epoch" ] && break
+  done
+  unset _sysctl
+fi
+if [ -n "$boot_epoch" ] && [ "$boot_epoch" -gt 0 ] 2>/dev/null; then
+  uptime_s=$(( now - boot_epoch ))
+  seen_boot="$(cat "$BOOT_MARKER" 2>/dev/null || echo '')"
+  if [ "$seen_boot" != "$boot_epoch" ] && [ "$uptime_s" -ge "$BOOT_REPORT_AFTER" ]; then
+    ka_now=0; [ -f "$KEEPALIVE_FILE" ] && ka_now="$(mtime_of "$KEEPALIVE_FILE")"
+    if [ "$ka_now" -gt 0 ] && [ $(( now - ka_now )) -lt "$STALE_AFTER" ]; then
+      verdict="a Telegram-csatorna el"
+    else
+      verdict="a Telegram-csatorna NEM el -- nezd meg a gepet"
+    fi
+    if send_alarm "A gep ujraindult ($(date -r "$boot_epoch" '+%H:%M' 2>/dev/null || echo '?')), ujra futok. Allapot: ${verdict}."; then
+      printf '%s\n' "$boot_epoch" > "$BOOT_MARKER"
+      log "boot report sent (boot_epoch=$boot_epoch, $verdict)"
+    else
+      log "boot report NOT sent (send failed) -- will retry next tick"
+    fi
+  elif [ "$seen_boot" != "$boot_epoch" ]; then
+    log "boot ${boot_epoch} not reported yet (uptime ${uptime_s}s < ${BOOT_REPORT_AFTER}s)"
+  fi
+fi
+
+if [ ! -f "$KEEPALIVE_FILE" ]; then
+  log "no keepalive file yet ($KEEPALIVE_FILE) -- probe not established, staying silent"
+  exit 0
+fi
+
+ka="$(mtime_of "$KEEPALIVE_FILE")"
+age=$(( now - ka ))
+
+if [ "$age" -lt "$STALE_AFTER" ]; then
+  if [ "$outage_started" != "0" ]; then
+    down_for=$(( now - outage_started ))
+    if [ "$last_alarm" != "0" ]; then
+      send_alarm "A Telegram-csatorna ujra el. Kimaradas: $(( down_for / 60 )) perc." || true
+    fi
+    log "recovered after ${down_for}s (alarmed=$([ "$last_alarm" != 0 ] && echo yes || echo no))"
+    outage_started=0; restart_done=0; last_alarm=0; save_state
+  fi
+  exit 0
+fi
+
+# --- we are in an outage ---
+[ "$outage_started" = "0" ] && { outage_started="$now"; log "outage opened (keepalive ${age}s stale)"; }
+down_for=$(( now - outage_started ))
+
+if [ "$restart_done" = "0" ] && [ "$age" -ge "$RESTART_AFTER" ]; then
+  restart_channels && restart_done="$now" || restart_done="failed-$now"
+fi
+
+if [ "$age" -ge "$ALARM_AFTER" ]; then
+  if [ "$last_alarm" = "0" ] || [ $(( now - last_alarm )) -ge "$REALARM_EVERY" ]; then
+    if send_alarm "A Telegram-csatorna $(( age / 60 )) perce nem el. Automatikus ujrainditas: $([ "$restart_done" = "0" ] && echo "nem tortent" || echo "megtortent, nem segitett"). A gepen a naplo: store/channel-outage-alarm.log"; then
+      last_alarm="$now"
+    fi
+  fi
+fi
+
+save_state
+exit 0

--- a/scripts/channel-outage-alarm.sh
+++ b/scripts/channel-outage-alarm.sh
@@ -61,18 +61,12 @@ REALARM_EVERY=$(( 30 * 60 ))     # reminder cadence while still down
 
 log() { printf '%s [channel-outage-alarm] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*" >> "$LOG_FILE"; }
 
-# Portable mtime. channel-watchdog.sh hard-codes `stat -c %Y`, which is GNU
-# only: on macOS it exits non-zero and the caller's `|| echo 0` turns a FRESH
-# file into an infinitely stale one. Measured 2026-09-12 -- that single flag is
-# why installing that watchdog here would have respawned the channels pane every
-# five minutes instead of protecting it. Never spell mtime one way.
-mtime_of() {
-  local f="$1" m=""
-  m="$(stat -f %m "$f" 2>/dev/null)" || m=""
-  [ -n "$m" ] || m="$(stat -c %Y "$f" 2>/dev/null)" || m=""
-  [ -n "$m" ] || m=0
-  printf '%s\n' "$m"
-}
+# Portable mtime, from the one implementation the repo has (PORTSTAT912). This
+# unit deliberately shares no RUNTIME dependency with what it watches -- no
+# dashboard, no session, no plugin -- but a source file is not a runtime
+# dependency, and a second private copy of this helper is a second thing that
+# can be wrong about the very file the whole alarm hangs on.
+. "$INSTALL_DIR/scripts/lib/portable-stat.sh"
 
 read_token() {
   local f tok=""
@@ -186,7 +180,7 @@ if [ -n "$boot_epoch" ] && [ "$boot_epoch" -gt 0 ] 2>/dev/null; then
   uptime_s=$(( now - boot_epoch ))
   seen_boot="$(cat "$BOOT_MARKER" 2>/dev/null || echo '')"
   if [ "$seen_boot" != "$boot_epoch" ] && [ "$uptime_s" -ge "$BOOT_REPORT_AFTER" ]; then
-    ka_now=0; [ -f "$KEEPALIVE_FILE" ] && ka_now="$(mtime_of "$KEEPALIVE_FILE")"
+    ka_now=0; [ -f "$KEEPALIVE_FILE" ] && ka_now="$(file_mtime "$KEEPALIVE_FILE")"
     if [ "$ka_now" -gt 0 ] && [ $(( now - ka_now )) -lt "$STALE_AFTER" ]; then
       verdict="a Telegram-csatorna el"
     else
@@ -208,7 +202,7 @@ if [ ! -f "$KEEPALIVE_FILE" ]; then
   exit 0
 fi
 
-ka="$(mtime_of "$KEEPALIVE_FILE")"
+ka="$(file_mtime "$KEEPALIVE_FILE")"
 age=$(( now - ka ))
 
 if [ "$age" -lt "$STALE_AFTER" ]; then

--- a/scripts/channel-watchdog.sh
+++ b/scripts/channel-watchdog.sh
@@ -61,31 +61,12 @@ AUTH_DEAD_THRESHOLD_TICKS=3     # consecutive dead-token ticks (~15min @ 5min/ti
 
 log() { echo "$(date '+%Y-%m-%d %H:%M:%S') [$LOG_TAG] $*"; }
 
-# PORTSTAT912: mtime in epoch seconds, portable across BSD (macOS) and GNU
-# (Linux) stat. `stat -c %Y` is GNU-only: on macOS it exits 1 with "illegal
-# option -- c", the old `|| echo 0` fallback turned that into mtime=0, and a
-# BRAND NEW keepalive file then measured as infinitely old. STALE was therefore
-# true on every single tick, so installing this watchdog on a Mac would not have
-# protected the main agent -- it would have respawned its channels pane every
-# 5 minutes up to MAX_CONSECUTIVE. The same zero also defeats the respawn-grace
-# gate below, which is the brake meant to stop exactly that storm, so the two
-# failures compound instead of cancelling.
-#
-# Both guards are needed, not just the exit code: under GNU stat `-f` is a
-# valid but DIFFERENT option (file-system status), so a wrong-platform call can
-# print something that is not an mtime. A value is only accepted if the command
-# succeeded AND the output is all digits; 0 is returned only when neither form
-# yielded one, which keeps the historical "unknown means act" behaviour.
-file_mtime() {
-  local _f="$1" _m=""
-  _m=$(stat -f %m "$_f" 2>/dev/null) || _m=""
-  case "$_m" in (''|*[!0-9]*) _m="";; esac
-  if [ -z "$_m" ]; then
-    _m=$(stat -c %Y "$_f" 2>/dev/null) || _m=""
-    case "$_m" in (''|*[!0-9]*) _m="";; esac
-  fi
-  printf '%s\n' "${_m:-0}"
-}
+# PORTSTAT912: mtime has exactly one spelling in this repo, and it is not
+# inline. `stat -c %Y` is GNU-only; on macOS it exits non-zero and the old
+# `|| echo 0` turned a fresh keepalive into an infinitely stale one -- STALE on
+# every tick, and the respawn-grace gate below (the brake for exactly that
+# storm) read zero too and never deferred. The library carries the full account.
+. "$INSTALL_DIR/scripts/lib/portable-stat.sh"
 
 # Debug entry point for the regression test: print one file's resolved mtime and
 # exit before any session lookup, .env read or tmux call, so the helper can be

--- a/scripts/channel-watchdog.sh
+++ b/scripts/channel-watchdog.sh
@@ -61,6 +61,40 @@ AUTH_DEAD_THRESHOLD_TICKS=3     # consecutive dead-token ticks (~15min @ 5min/ti
 
 log() { echo "$(date '+%Y-%m-%d %H:%M:%S') [$LOG_TAG] $*"; }
 
+# PORTSTAT912: mtime in epoch seconds, portable across BSD (macOS) and GNU
+# (Linux) stat. `stat -c %Y` is GNU-only: on macOS it exits 1 with "illegal
+# option -- c", the old `|| echo 0` fallback turned that into mtime=0, and a
+# BRAND NEW keepalive file then measured as infinitely old. STALE was therefore
+# true on every single tick, so installing this watchdog on a Mac would not have
+# protected the main agent -- it would have respawned its channels pane every
+# 5 minutes up to MAX_CONSECUTIVE. The same zero also defeats the respawn-grace
+# gate below, which is the brake meant to stop exactly that storm, so the two
+# failures compound instead of cancelling.
+#
+# Both guards are needed, not just the exit code: under GNU stat `-f` is a
+# valid but DIFFERENT option (file-system status), so a wrong-platform call can
+# print something that is not an mtime. A value is only accepted if the command
+# succeeded AND the output is all digits; 0 is returned only when neither form
+# yielded one, which keeps the historical "unknown means act" behaviour.
+file_mtime() {
+  local _f="$1" _m=""
+  _m=$(stat -f %m "$_f" 2>/dev/null) || _m=""
+  case "$_m" in (''|*[!0-9]*) _m="";; esac
+  if [ -z "$_m" ]; then
+    _m=$(stat -c %Y "$_f" 2>/dev/null) || _m=""
+    case "$_m" in (''|*[!0-9]*) _m="";; esac
+  fi
+  printf '%s\n' "${_m:-0}"
+}
+
+# Debug entry point for the regression test: print one file's resolved mtime and
+# exit before any session lookup, .env read or tmux call, so the helper can be
+# measured on a host where the watchdog itself cannot run.
+if [ "${1:-}" = "--file-mtime" ]; then
+  file_mtime "${2:-}"
+  exit 0
+fi
+
 # --- resolve the channels session + provider (launch-order / rename independent) ---
 MAIN_AGENT_ID="$(grep -E '^MAIN_AGENT_ID=' "$INSTALL_DIR/.env" 2>/dev/null | head -1 | cut -d= -f2-)"
 MAIN_AGENT_ID="${MAIN_AGENT_ID:-marveen}"
@@ -113,7 +147,7 @@ if [ ! -f "$KEEPALIVE_FILE" ]; then
   # keepalive probe itself was never configured.
   log "no keepalive file yet ($KEEPALIVE_FILE) -- keep-alive task not established, STALE=false"
 else
-  ka_mtime=$(stat -c %Y "$KEEPALIVE_FILE" 2>/dev/null || echo 0)
+  ka_mtime=$(file_mtime "$KEEPALIVE_FILE")
   age=$(( now - ka_mtime ))
   [ "$age" -ge "$STALE_SECONDS" ] && STALE=true
 fi
@@ -150,7 +184,7 @@ fi
 
 # --- gate 4: respawn grace (shared with the dashboard watchdog) ---
 if [ -f "$RESPAWN_STAMP" ]; then
-  last=$(stat -c %Y "$RESPAWN_STAMP" 2>/dev/null || echo 0)
+  last=$(file_mtime "$RESPAWN_STAMP")
   if [ $(( now - last )) -lt "$GRACE_SECONDS" ]; then
     log "problem detected (STALE=$STALE AUTHDEAD=$AUTHDEAD) but within respawn grace -- deferring"
     exit 0

--- a/scripts/host-restart-watchdog.sh
+++ b/scripts/host-restart-watchdog.sh
@@ -23,6 +23,11 @@ set -uo pipefail
 STATE_DIR="${MARVEEN_STORE:-$HOME/marveen/store}"
 STATE_FILE="$STATE_DIR/.last-btime"
 INSTALL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+# PORTSTAT912: mtime must not be spelled `stat -c %Y` (GNU-only). On macOS that
+# exits non-zero and the old `|| echo 0` turned a fresh file into an infinitely
+# old one -- which tips every grace/staleness gate below to the permissive side.
+. "$INSTALL_DIR/scripts/lib/portable-stat.sh"
 # #915: main channel state is install-scoped once migrated; the legacy shared
 # path only serves unmigrated installs.
 TG_CHAN_DIR="${TELEGRAM_STATE_DIR:-}"
@@ -85,7 +90,7 @@ boot_local="$(date -d "@$btime" '+%Y-%m-%d %H:%M:%S %Z' 2>/dev/null || echo "@$b
 last_alive=0
 if compgen -G "$STATE_DIR/*.log" >/dev/null 2>&1; then
   for f in "$STATE_DIR"/*.log; do
-    m="$(stat -c '%Y' "$f" 2>/dev/null || echo 0)"
+    m="$(file_mtime "$f")"
     if (( m < btime && m > last_alive )); then last_alive="$m"; fi
   done
 fi

--- a/scripts/install-channel-outage-alarm.sh
+++ b/scripts/install-channel-outage-alarm.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# install-channel-outage-alarm.sh
+#
+# Installs the launchd unit for scripts/channel-outage-alarm.sh (CHANALARM912),
+# the out-of-band alarm that tells the owner when the Telegram channel is down.
+#
+# WHY IT IS SEPARATE FROM EVERY OTHER WATCHER. On 2026-09-12 the main agent was
+# silent on Telegram for 8h23m (05:03-13:26). Detection was never the gap:
+# channel-keepalive-probe.sh logged 139 consecutive WARN lines naming the exact
+# fault. Nothing read that log, and the only path to the owner was the very
+# channel that was down. This unit therefore shares nothing with what it
+# watches -- no dashboard, no claude session, no telegram plugin, just curl
+# against api.telegram.org.
+#
+# Cadence and thresholds live in the script itself; the unit only has to run it
+# often enough to resolve them:
+#   StartInterval 180   -- the same ~3 min cadence as the keepalive probe, so
+#                          the 9/15/30-minute thresholds land where intended
+#   RunAtLoad true      -- an immediate first run is safe: the script is
+#                          idempotent and stays silent while healthy
+#
+# PATH MATTERS HERE, unlike in the keepalive-probe unit. The once-per-boot
+# report reads the boot time from `sysctl -n kern.boottime`, and sysctl lives in
+# /usr/sbin -- absent from many inherited PATHs. The script names absolute paths
+# for exactly that reason, but the unit's PATH carries /usr/sbin:/sbin too, so
+# neither layer alone has to be right. A silently disabled boot reporter looks
+# exactly like a boot that never happened.
+#
+# Usage:
+#   scripts/install-channel-outage-alarm.sh            # install, do not start
+#   scripts/install-channel-outage-alarm.sh --load     # install and start
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+LABEL="com.marveen.channel-outage-alarm"
+PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
+ALARM="$PROJECT_DIR/scripts/channel-outage-alarm.sh"
+
+LOAD=0
+[ "${1:-}" = "--load" ] && LOAD=1
+
+if [ ! -f "$ALARM" ]; then
+  echo "ERROR: $ALARM not found." >&2
+  exit 1
+fi
+
+mkdir -p "$HOME/Library/LaunchAgents"
+cat > "$PLIST" <<PLIST_EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>$LABEL</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>$ALARM</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>$PROJECT_DIR</string>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>StartInterval</key>
+  <integer>180</integer>
+  <key>StandardOutPath</key>
+  <string>$PROJECT_DIR/store/channel-outage-alarm.stdout.log</string>
+  <key>StandardErrorPath</key>
+  <string>$PROJECT_DIR/store/channel-outage-alarm.stdout.log</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    <key>HOME</key>
+    <string>$HOME</string>
+    <key>USER</key>
+    <string>$(id -un)</string>
+    <key>TZ</key>
+    <string>Europe/Budapest</string>
+  </dict>
+</dict>
+</plist>
+PLIST_EOF
+echo "Wrote launchd unit: $PLIST"
+
+if [ "$LOAD" = "1" ]; then
+  launchctl unload "$PLIST" 2>/dev/null || true
+  launchctl load "$PLIST"
+  echo "Loaded $LABEL (every 180s + at load). It stays silent while the channel is healthy; it messages the owner directly over the Bot API once the keepalive has been stale for 15 minutes, whether or not its one restart attempt helped."
+else
+  echo "Installed but NOT loaded. To start: launchctl load $PLIST"
+fi

--- a/scripts/lib/portable-stat.sh
+++ b/scripts/lib/portable-stat.sh
@@ -1,0 +1,66 @@
+# Shared, platform-independent file mtime for shell scripts (PORTSTAT912).
+#
+# Why this exists. `stat -c %Y` is GNU-only. On macOS it exits 1 with
+# "illegal option -- c", and the fallback every caller had written --
+# `|| echo 0` -- turned that into mtime=0. A file touched one second ago then
+# measured as 56 years old.
+#
+# What makes this worse than a wrong number: every caller was a GRACE, BACKOFF
+# or STALENESS gate, and zero tips all of them the SAME way -- the permissive
+# one. channel-watchdog.sh read a fresh keepalive as infinitely stale (respawn
+# the pane, every tick), and the very next gate, the respawn-grace stamp meant
+# to stop that storm, read zero too and never deferred. watchdog.sh:169 and
+# stuck-modal-guard.sh:238 are the same pair. So this is not four independent
+# bugs: it is one bug that also disables its own brakes.
+#
+# Callers read a moment in time, so the helper must never invent one. It
+# returns 0 only when neither spelling produced a usable answer, preserving the
+# historical "unknown means act" contract -- the callers already treat 0 that
+# way, and changing that silently would be a second bug wearing the first one's
+# clothes.
+#
+# Usage:
+#   . "$INSTALL_DIR/scripts/lib/portable-stat.sh"
+#   m="$(file_mtime "$some_file")"      # epoch seconds, or 0 if unknowable
+#
+# Test seam: PORTABLE_STAT_DISABLE is a space-separated list of spellings to
+# treat as absent ("bsd", "gnu"). It exists because on any single host one of
+# the two branches is unreachable -- and a branch that cannot be exercised is a
+# branch that rots. Same reasoning as CONTENT_HASH_DISABLE in content-hash.sh,
+# which guards the same class of bug (a GNU-only tool answering emptily on
+# macOS).
+_ps_enabled() {
+  case " ${PORTABLE_STAT_DISABLE:-} " in *" $1 "*) return 1 ;; esac
+  return 0
+}
+
+# Accept a candidate only if the command SUCCEEDED and the output is all
+# digits. The exit code alone is not enough, and not as a belt-and-braces
+# nicety: under GNU stat `-f` is a valid but entirely different option
+# (file-system status), so calling the BSD spelling on a GNU host can print a
+# multi-line filesystem report rather than failing outright. A pure
+# exit-code implementation would hand that back as if it were a timestamp.
+_ps_accept() {
+  case "$1" in
+    ''|*[!0-9]*) return 1 ;;
+    *)           return 0 ;;
+  esac
+}
+
+file_mtime() {
+  _ps_f="$1"
+  _ps_m=""
+
+  if _ps_enabled bsd; then
+    _ps_m="$(stat -f %m "$_ps_f" 2>/dev/null)" || _ps_m=""
+    _ps_accept "$_ps_m" || _ps_m=""
+  fi
+
+  if [ -z "$_ps_m" ] && _ps_enabled gnu; then
+    _ps_m="$(stat -c %Y "$_ps_f" 2>/dev/null)" || _ps_m=""
+    _ps_accept "$_ps_m" || _ps_m=""
+  fi
+
+  printf '%s\n' "${_ps_m:-0}"
+  unset _ps_f _ps_m
+}

--- a/scripts/stuck-modal-guard.sh
+++ b/scripts/stuck-modal-guard.sh
@@ -38,6 +38,11 @@
 set -u
 
 INSTALL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+# PORTSTAT912: mtime must not be spelled `stat -c %Y` (GNU-only). On macOS that
+# exits non-zero and the old `|| echo 0` turned a fresh file into an infinitely
+# old one -- which tips every grace/staleness gate below to the permissive side.
+. "$INSTALL_DIR/scripts/lib/portable-stat.sh"
 STORE="${STUCK_MODAL_STATE_DIR:-$INSTALL_DIR/store}"
 FIRSTSEEN_STAMP="$STORE/.stuck-modal-firstseen"
 RESPAWN_STAMP="$STORE/.channel-last-respawn"           # SHARED with channel-watchdog.sh
@@ -235,7 +240,7 @@ run_guard() {
   fi
 
   if [ -f "$RESPAWN_STAMP" ]; then
-    local last; last="$(stat -c %Y "$RESPAWN_STAMP" 2>/dev/null || echo 0)"
+    local last; last="$(file_mtime "$RESPAWN_STAMP")"
     if [ $(( now - last )) -lt "$GRACE_SECONDS" ]; then
       log "Escape failed but a respawn happened $(( now - last ))s ago (< grace) -- deferring"
       return 0
@@ -245,7 +250,7 @@ run_guard() {
   case "$count" in (*[!0-9]*|'') count=0;; esac
   if [ "$count" -ge "$MAX_CONSECUTIVE" ]; then
     log "ALERT: stuck modal after $count respawns -- backing off, manual check needed"
-    local bstamp=0; [ -f "$BACKOFF_STAMP" ] && bstamp="$(stat -c %Y "$BACKOFF_STAMP" 2>/dev/null || echo 0)"
+    local bstamp=0; [ -f "$BACKOFF_STAMP" ] && bstamp="$(file_mtime "$BACKOFF_STAMP")"
     if [ $(( now - bstamp )) -ge 3600 ]; then
       # Backoff stamp ONLY on confirmed delivery (NOTIFYVAKSWEEP826): this is
       # the "your messages may be lost, resend" alert -- burying its own

--- a/scripts/watchdog.sh
+++ b/scripts/watchdog.sh
@@ -3,6 +3,11 @@
 # Cron: */5 * * * * ~/marveen/scripts/watchdog.sh
 
 INSTALL_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+# PORTSTAT912: mtime must not be spelled `stat -c %Y` (GNU-only). On macOS that
+# exits non-zero and the old `|| echo 0` turned a fresh file into an infinitely
+# old one -- which tips every grace/staleness gate below to the permissive side.
+. "$INSTALL_DIR/scripts/lib/portable-stat.sh"
 LOG="$INSTALL_DIR/logs/watchdog.log"
 mkdir -p "$INSTALL_DIR/logs"
 
@@ -166,7 +171,7 @@ if ! tmux has-session -t "$MAIN_SESSION" 2>/dev/null; then
   # only act as the last-resort backstop once every other actor has stopped trying.
   MAIN_RESPAWN_STAMP="$INSTALL_DIR/store/.channel-last-respawn"
   _mlast=0
-  [ -f "$MAIN_RESPAWN_STAMP" ] && _mlast="$(stat -c %Y "$MAIN_RESPAWN_STAMP" 2>/dev/null || echo 0)"
+  [ -f "$MAIN_RESPAWN_STAMP" ] && _mlast="$(file_mtime "$MAIN_RESPAWN_STAMP")"
   if [ "$(( $(date +%s) - _mlast ))" -lt 900 ]; then
     echo "$(timestamp) [watchdog] $MAIN_SESSION missing but a respawn is within the 900s grace -- deferring (systemd/channels.sh/channel-watchdog cover it)" >> "$LOG"
   else


### PR DESCRIPTION
# fix(stat): one portable mtime for the whole repo, and a guard so it stays that way (PORTSTAT912B)

Branch: `fix/portstat912b-shared-portable-stat` (local worktree: `~/marveen-wt-portstat912b`, tip `1d2c862`)
Target: `develop`
**Stacked on `fix/portstat912-watchdog-mtime` (PORTSTAT912). Merge that one first** — this branch contains its two commits as its base, and the guard below cannot be honest without them.

Own commit: `1d2c862`. Files: `scripts/lib/portable-stat.sh` (new), `scripts/__tests__/portable-stat.test.sh` (new), `scripts/watchdog.sh`, `scripts/stuck-modal-guard.sh`, `scripts/host-restart-watchdog.sh`, plus the two earlier copies collapsed (`scripts/channel-watchdog.sh`, `scripts/channel-outage-alarm.sh`).

## It is one bug, not four

Every remaining `stat -c %Y` site is a grace, backoff or staleness gate. The GNU-only spelling returns 0 on macOS, and zero tips all of them the **same** way — the permissive one:

| Site | What it gates | Consequence on macOS |
|---|---|---|
| `scripts/watchdog.sh:169` | main respawn grace (900s) | the grace never applies; the last-resort backstop stops deferring |
| `scripts/stuck-modal-guard.sh:238` | respawn grace | "a respawn happened Ns ago" never defers |
| `scripts/stuck-modal-guard.sh:248` | backoff stamp (3600s) | the hourly alert backoff never holds |
| `scripts/host-restart-watchdog.sh:88` | last-alive from `*.log` mtimes | every log reads 0, `last_alive` stays 0, and the downtime gap is wrong |

`watchdog.sh:169` and `stuck-modal-guard.sh:238` are the same pair `channel-watchdog.sh` already showed in PORTSTAT912: **a bug that also disables its own brakes.** That is why they belong in one change rather than four.

`host-restart-watchdog.sh:88` deserves singling out: it computes the outage gap after a reboot — the number the owner is *told*. A wrong mtime there does not degrade a timer, it reports a false duration.

### Measured, per site

Each expression lifted **verbatim** from `origin/develop` (regex on the assignment, no retyping) and run against a real file whose true mtime is `1789214547`:

```
scripts/watchdog.sh               stat -c %Y "$MAIN_RESPAWN_STAMP" 2>/dev/null || echo 0  -> [0]
scripts/stuck-modal-guard.sh      stat -c %Y "$RESPAWN_STAMP"      2>/dev/null || echo 0  -> [0]
scripts/stuck-modal-guard.sh      stat -c %Y "$BACKOFF_STAMP"      2>/dev/null || echo 0  -> [0]
scripts/host-restart-watchdog.sh  stat -c '%Y' "$f"                2>/dev/null || echo 0  -> [0]
```

All four: `0` where the answer is `1789214547`.

## The library

`scripts/lib/portable-stat.sh` follows the `scripts/lib/` convention already used by `send-telegram.sh` and `content-hash.sh`. `content-hash.sh` is the closest precedent in every sense — it guards the same class of bug (a GNU-only tool answering *emptily* on macOS, so two empty hashes compared equal), and its `CONTENT_HASH_DISABLE` test seam is mirrored here as `PORTABLE_STAT_DISABLE`, for the same reason: on any single host one of the two branches is unreachable, and a branch that cannot be exercised is a branch that rots.

A value is accepted only if the command **succeeded AND the output is all digits**. That is load-bearing, not decorative — see the stub case below.

Return `0` only when neither spelling produced an answer. The callers already read 0 as "unknown, so act"; changing that quietly would be a second bug wearing the first one's clothes.

### Runtime verification, not just `bash -n`

For each converted script the real preamble (up to and including the source line) was executed and asked for a known file's mtime:

```
scripts/watchdog.sh                    runtime OK (1789214411)
scripts/stuck-modal-guard.sh           runtime OK (1789214411)
scripts/host-restart-watchdog.sh       runtime OK (1789214411)
```

The first attempt at this "failed" — from a scratchpad copy, `INSTALL_DIR` resolved elsewhere and the library was not found. That was the measuring rig being wrong, not the code; recorded here because the failure mode (a sourced library that resolves relative to `$0`) is exactly what would bite a caller that moves.

## Test: `scripts/__tests__/portable-stat.test.sh` — 10 passed, 0 failed

```
  PASS: fresh file: the real mtime, not 0
  PASS: backdated file: the old mtime, not now
  PASS: missing file: 0, the historical 'unknown means act' contract
  PASS: GNU-like stat: falls through to -c and returns the real mtime
  PASS: wrong spelling exits 0 with a non-numeric blob: rejected, not returned
  PASS: both spellings disabled: 0, never an invented timestamp
  PASS: scripts/watchdog.sh sources the shared helper and uses it
  PASS: scripts/stuck-modal-guard.sh sources the shared helper and uses it
  PASS: scripts/host-restart-watchdog.sh sources the shared helper and uses it
  PASS: no tracked *.sh spells mtime a single way outside the allowlist
```

**The branch this host cannot reach is now measured.** PORTSTAT912 had to admit the GNU path was reasoned rather than observed (no Docker daemon, no `gstat`). A stub `stat` earlier on `PATH` closes most of that gap: one stub behaves like GNU (`-c` works, the BSD `-f` spelling gets a bogus operand and exits non-zero), and a second prints a filesystem report while exiting **0**. The second is the one that justifies the all-digits check — an implementation trusting the exit code alone would return `Blocks: Total: 121938 Free: 60469` as a timestamp. This is a stub of the documented behaviour, **not** real GNU coreutils: it measures our branch logic, not their binary.

**The backdated-file case** guards the opposite direction: a helper that always answered "now" would pass the freshness case while switching staleness detection off everywhere.

## The guard, and the proof it has teeth

Every tracked `*.sh` is scanned with comments stripped. A line passes if it spells **both** forms (a self-contained dual-form one-liner); anything else must be listed in the test's allowlist with a reason. Today that list holds exactly one entry: `scripts/doctor.sh`, which picks the spelling from `uname -s` explicitly. (`scripts/__tests__/` is excluded, because a test of this helper must be free to write both spellings, including inside stubs.)

It is not decoration: **it failed on its first run**, before this branch was rebased onto PORTSTAT912, and named the exact lines:

```
  FAIL: no tracked *.sh spells mtime a single way outside the allowlist
    scripts/channel-watchdog.sh: ka_mtime=$(stat -c %Y "$KEEPALIVE_FILE" 2>/dev/null || echo 0)
    scripts/channel-watchdog.sh: last=$(stat -c %Y "$RESPAWN_STAMP" 2>/dev/null || echo 0)
```

That red is also why this branch is stacked rather than independent: allowlisting the two lines to make the guard pass would have whitewashed the very thing being guarded.

**Worth stating because I checked before building it:** `scripts/__tests__/ops-scripts-portable.test.sh` already exists and already says "portability". Its axis is different — install-specific literals (absolute home paths, chat ids, repo slugs) across four named scripts. OS-level tool spelling, across all scripts, was unguarded.

## Collapsing the two earlier copies

`channel-watchdog.sh` (from PORTSTAT912) and `channel-outage-alarm.sh` both carried their own helper; both now source the library.

The alarm keeps the isolation that is its entire reason for existing — no dashboard, no claude session, no telegram plugin — because a **sourced file is not a runtime dependency**. What it gives up is a private second opinion about the very file the whole alarm hangs on. It also gains the all-digits guard, which its own copy lacked.

`channel-watchdog.sh` keeps its `--file-mtime` debug entry point; it now delegates to the library. `scripts/__tests__/channel-watchdog-mtime.test.sh` is updated accordingly: its "second copy" case becomes an assertion that the copy is **gone** (7 passed, 0 failed).

## Full suite on this branch

All 22 shell suites in `scripts/__tests__/` run green, including the ones that own the files touched here (`stuck-modal-guard`, `watchdog-provider`, `watchdog-config-isolation`, `watchdog-scaffold-guard`).

Two are skips, and a skip is not a pass:

- `channels-auth-probe.test.sh` — needs `dist/web/reauth-detect.js`; pre-existing, tracked on the board as a separate item.
- `stop-start-system-unit.test.sh` — systemd branch, legitimately inapplicable on Darwin.
