### PR TITLE
fix(claude-plans): make watchdog/keep-alive respawn rotation-aware

### DIFF
--- a/src/__tests__/channel-deafness-recovery.test.ts
+++ b/src/__tests__/channel-deafness-recovery.test.ts
@@ -78,6 +78,21 @@ describe('buildMainSessionRespawnCmd', () => {
     expect(cmd).not.toContain('CLAUDE_CODE_OAUTH_TOKEN')
     expect(cmd).not.toContain('CLAUDE_CONFIG_DIR')
   })
+
+  // CLAUDEPLANWATCHDOG912: an own-credential dir (explicit MAIN_AGENT_CONFIG_DIR,
+  // or a rotated claude-plans entry) carries its OWN .credentials.json. Injecting
+  // the fleet token on top of it authenticates as the flotta instead of that
+  // login -- exactly the bug that silently undid a live plan rotation on the
+  // next watchdog respawn (observed 2026-09-12, solarforce-ai host).
+  it('exports ONLY the config dir, no fleet token, when the dir carries its own credentials (rotated/explicit)', () => {
+    const cmd = buildMainSessionRespawnCmd({
+      ...base,
+      continueSession: false,
+      config: mainConfigDecisionForTest({ isolatedConfigDir: '/home/solarforce/.claude-second', ownCredentials: true, fleetToken: true }),
+    })
+    expect(cmd).toContain("export CLAUDE_CONFIG_DIR='/home/solarforce/.claude-second'")
+    expect(cmd).not.toContain('CLAUDE_CODE_OAUTH_TOKEN')
+  })
 })
 
 // CONTRACT: the post-resume guard (CC 2.1.193) escalates to a fresh respawn iff

--- a/src/__tests__/main-config-decision-rotation-precedence.test.ts
+++ b/src/__tests__/main-config-decision-rotation-precedence.test.ts
@@ -1,0 +1,92 @@
+// CLAUDEPLANWATCHDOG912: resolveMainConfigDecision() used to know only about
+// the generic, credential-less flotta-isolated dir (ensureMainAgentIsolatedConfigDir).
+// The JS in-process respawn paths (channel-monitor.ts's resumeMarveenSession /
+// respawnMainSessionFresh) build their launch command from THIS decision, not
+// from scripts/main-agent-isolated-config.mjs -- so a main agent that had just
+// been rotated onto a claude-plans entry (POST /api/claude-plans/rotate) got
+// silently reverted to the shared flotta identity on the very next watchdog or
+// keep-alive respawn, because neither an explicit MAIN_AGENT_CONFIG_DIR nor a
+// rotated claude-plans entry was ever consulted here -- only the shell
+// respawners (scripts/main-agent-isolated-config.mjs, locked by
+// main-config-dir-parity.test.ts) already had the full explicit > rotated >
+// isolated precedence. Observed live on 2026-09-12 (solarforce-ai host): a
+// successful rotate to a registered plan was undone by the next background
+// respawn, landing the main session on an unauthenticated isolated dir.
+//
+// This file locks the SAME precedence into resolveMainConfigDecision(), so the
+// two decision-makers (the mjs script and this module) cannot drift again.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, mkdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+let ROOT = ''
+
+vi.mock('../config.js', async (orig) => ({
+  ...(await orig<Record<string, unknown>>()),
+  MAIN_AGENT_ID: 'boss',
+  get PROJECT_ROOT() { return ROOT },
+}))
+vi.mock('../db.js', async (orig) => ({
+  ...(await orig<Record<string, unknown>>()),
+  createAgentMessage: () => 1,
+}))
+
+let fakeExplicit: string | null = null
+let fakeRotated: string | null = null
+let fakeIsolated: string | null = null
+let isolatedCalls = 0
+
+vi.mock('../web/agent-process.js', async (orig) => ({
+  ...(await orig<Record<string, unknown>>()),
+  resolveMainAgentConfigDir: () => fakeExplicit,
+  resolveMainAgentRotatedConfigDir: () => fakeRotated,
+  ensureMainAgentIsolatedConfigDir: () => { isolatedCalls++; return fakeIsolated },
+  readMainSharedConfigState: (dir: string | null) => ({
+    isolatedConfigDir: dir,
+    fleetToken: true,
+    isolatedDirExists: true,
+  }),
+}))
+
+const { resolveMainConfigDecision } = await import('../web/main-config-decision.js')
+
+beforeEach(() => {
+  ROOT = mkdtempSync(join(tmpdir(), 'mcguard-rotation-'))
+  mkdirSync(join(ROOT, 'store'), { recursive: true })
+  fakeExplicit = null
+  fakeRotated = null
+  fakeIsolated = '/srv/m/.channels-config'
+  isolatedCalls = 0
+})
+afterEach(() => { rmSync(ROOT, { recursive: true, force: true }) })
+
+describe('resolveMainConfigDecision precedence (CLAUDEPLANWATCHDOG912)', () => {
+  it('uses the rotated plan dir over the plain isolated dir, and flags it as own-credential', () => {
+    fakeRotated = '/home/solarforce/.claude-second'
+    const d = resolveMainConfigDecision()
+    expect(d.isolatedConfigDir).toBe('/home/solarforce/.claude-second')
+    expect(d.ownCredentials).toBe(true)
+    expect(d.trigger).toBeNull()
+    // The generic isolated-dir provisioner must not even be consulted once a
+    // rotated dir already answers the question -- it PROVISIONS on disk, and
+    // a rotated/explicit dir needs none of that.
+    expect(isolatedCalls).toBe(0)
+  })
+
+  it('an explicit MAIN_AGENT_CONFIG_DIR wins over a rotated plan', () => {
+    fakeExplicit = '/home/solarforce/.claude-bot'
+    fakeRotated = '/home/solarforce/.claude-second'
+    const d = resolveMainConfigDecision()
+    expect(d.isolatedConfigDir).toBe('/home/solarforce/.claude-bot')
+    expect(d.ownCredentials).toBe(true)
+  })
+
+  it('falls back to the plain isolated dir when nothing is rotated, and flags it as NOT own-credential', () => {
+    fakeRotated = null
+    const d = resolveMainConfigDecision()
+    expect(d.isolatedConfigDir).toBe('/srv/m/.channels-config')
+    expect(d.ownCredentials).toBe(false)
+    expect(isolatedCalls).toBe(1)
+  })
+})

--- a/src/web/channel-monitor.ts
+++ b/src/web/channel-monitor.ts
@@ -762,12 +762,16 @@ export function buildMainSessionRespawnCmd(opts: {
    * shouting about. REQUIRED, and obtainable in production only from
    * resolveMainConfigDecision(), which reports as it resolves -- see
    * main-config-decision.ts for why the guard is wired as a value rather than a
-   * callback. `isolatedConfigDir` set => export the isolated dir plus the fleet
-   * setup-token (parity with channels.sh CFG_ENV); null with `fleetToken` =>
-   * export the token alone, which is what keeps a wizard-entered token reaching
-   * a respawned main session at all (2026-07-15 bootcamp, bug 2 latent path);
-   * null with no token => the shared root, unchanged for installs with
-   * isolation off.
+   * callback. `isolatedConfigDir` set with `ownCredentials` => export ONLY the
+   * dir (it carries its own .credentials.json -- explicit or a rotated
+   * claude-plans entry; injecting the fleet token on top would swap that
+   * login for the flotta's shared one, CLAUDEPLANWATCHDOG912); `isolatedConfigDir`
+   * set without `ownCredentials` => export the dir plus the fleet setup-token
+   * (parity with channels.sh CFG_ENV, the credential-less flotta dir); null
+   * with `fleetToken` => export the token alone, which is what keeps a
+   * wizard-entered token reaching a respawned main session at all (2026-07-15
+   * bootcamp, bug 2 latent path); null with no token => the shared root,
+   * unchanged for installs with isolation off.
    */
   config: MainConfigDecision
   /**
@@ -790,8 +794,13 @@ export function buildMainSessionRespawnCmd(opts: {
     '&& export MCP_SERVER_CONNECTION_BATCH_SIZE=10 MCP_CONNECTION_NONBLOCKING=1 MCP_TIMEOUT=60000',
     // macOS main-agent config isolation -- parity with channels.sh CFG_ENV. The
     // token is read at launch via $(cat) so the secret never lands in argv/`ps`.
+    // An own-credential dir (explicit or a rotated claude-plans entry) gets NO
+    // token: it already has its own .credentials.json, and injecting the fleet
+    // token on top would authenticate as the flotta instead of that login.
     ...(opts.config.isolatedConfigDir
-      ? [`&& export CLAUDE_CONFIG_DIR='${opts.config.isolatedConfigDir}' && export CLAUDE_CODE_OAUTH_TOKEN="$(cat '${FLEET_OAUTH_TOKEN_PATH}')"`]
+      ? (opts.config.ownCredentials
+          ? [`&& export CLAUDE_CONFIG_DIR='${opts.config.isolatedConfigDir}'`]
+          : [`&& export CLAUDE_CONFIG_DIR='${opts.config.isolatedConfigDir}' && export CLAUDE_CODE_OAUTH_TOKEN="$(cat '${FLEET_OAUTH_TOKEN_PATH}')"`])
       : opts.config.fleetToken
         ? [`&& export CLAUDE_CODE_OAUTH_TOKEN="$(cat '${FLEET_OAUTH_TOKEN_PATH}')"`]
         : []),

--- a/src/web/main-config-decision.ts
+++ b/src/web/main-config-decision.ts
@@ -33,6 +33,8 @@ import { logger } from '../logger.js'
 import { createAgentMessage } from '../db.js'
 import {
   ensureMainAgentIsolatedConfigDir,
+  resolveMainAgentConfigDir,
+  resolveMainAgentRotatedConfigDir,
   readMainSharedConfigState,
   mainSharedConfigTrigger,
   type MainSharedConfigTrigger,
@@ -48,6 +50,17 @@ declare const MAIN_CONFIG_DECISION: unique symbol
 export type MainConfigDecision = {
   readonly [MAIN_CONFIG_DECISION]: true
   readonly isolatedConfigDir: string | null
+  /** True when isolatedConfigDir came from resolveMainAgentConfigDir() (explicit)
+   *  or resolveMainAgentRotatedConfigDir() (rotated) -- both carry their OWN
+   *  .credentials.json, same as scripts/main-agent-isolated-config.mjs's
+   *  `explicit`/`rotated` modes. The fleet token must NOT be injected on top of
+   *  either: that would swap the dir's real login for the flotta's shared one,
+   *  which is exactly the CLAUDEPLANWATCHDOG912 bug this field closes (a
+   *  rotated plan silently reverting to the flotta identity on the next
+   *  watchdog/keep-alive respawn, because this decision used to know only
+   *  about the plain isolated dir). False for the generic credential-less
+   *  isolated dir, which DOES need the token. */
+  readonly ownCredentials: boolean
   readonly fleetToken: boolean
   readonly trigger: MainSharedConfigTrigger
 }
@@ -97,7 +110,7 @@ function noteState(d: Omit<MainConfigDecision, typeof MAIN_CONFIG_DECISION>): vo
   try {
     if (!d.trigger) {
       line(d.isolatedConfigDir
-        ? `main-agent respawn: isolated CLAUDE_CONFIG_DIR=${d.isolatedConfigDir}`
+        ? `main-agent respawn: ${d.ownCredentials ? 'own-credential' : 'isolated'} CLAUDE_CONFIG_DIR=${d.isolatedConfigDir}`
         : 'main-agent respawn: shared ~/.claude (no isolation configured, no fleet token) -- expected for a stock install')
       return
     }
@@ -119,12 +132,23 @@ function noteState(d: Omit<MainConfigDecision, typeof MAIN_CONFIG_DECISION>): vo
  * production source of a MainConfigDecision.
  */
 export function resolveMainConfigDecision(): MainConfigDecision {
-  const state = readMainSharedConfigState(ensureMainAgentIsolatedConfigDir())
+  // Same precedence as scripts/main-agent-isolated-config.mjs (the shell
+  // respawners' single source of truth): an explicit dir is a deliberate,
+  // permanent identity choice and wins outright; a rotated plan is the next
+  // strongest, more specific signal than the generic flotta fallback. Only
+  // ensureMainAgentIsolatedConfigDir() PROVISIONS anything on disk, so it is
+  // deliberately the last one tried -- neither explicit nor rotated needs
+  // (or should get) a freshly-provisioned credential-less dir.
+  const explicit = resolveMainAgentConfigDir()
+  const rotated = explicit ? null : resolveMainAgentRotatedConfigDir()
+  const ownDir = explicit ?? rotated
+  const state = readMainSharedConfigState(ownDir ?? ensureMainAgentIsolatedConfigDir())
   // isolatedDirExists is an INPUT to the verdict, not part of it: carrying it
   // along would invite a later reader to re-derive the trigger from the
   // decision and quietly disagree with mainSharedConfigTrigger.
   const d = {
     isolatedConfigDir: state.isolatedConfigDir,
+    ownCredentials: ownDir != null,
     fleetToken: state.fleetToken,
     trigger: mainSharedConfigTrigger(state),
   }
@@ -143,8 +167,10 @@ export function mainConfigDecisionForTest(
 ): MainConfigDecision {
   const isolatedConfigDir = partial.isolatedConfigDir ?? null
   const fleetToken = partial.fleetToken ?? false
+  const ownCredentials = partial.ownCredentials ?? false
   return {
     isolatedConfigDir,
+    ownCredentials,
     fleetToken,
     trigger: partial.trigger ?? mainSharedConfigTrigger({ isolatedConfigDir, fleetToken, isolatedDirExists: false }),
   } as MainConfigDecision


### PR DESCRIPTION
## Summary
- `resolveMainConfigDecision()` (used by the JS in-process respawn paths in `channel-monitor.ts`: `resumeMarveenSession`, `respawnMainSessionFresh`) only ever considered the generic, credential-less flotta-isolated dir (`ensureMainAgentIsolatedConfigDir`). It never consulted `resolveMainAgentConfigDir()` (explicit) or `resolveMainAgentRotatedConfigDir()` (PR2c rotation), unlike the shell respawners which already get the full `explicit > rotated > isolated` precedence via `scripts/main-agent-isolated-config.mjs`.
- Net effect, observed live today on a remote install: `POST /api/claude-plans/rotate` correctly switches the main agent onto a registered plan's own configDir, but the very next watchdog/keep-alive respawn (triggered by an unrelated channel-plugin hiccup) silently reverted it back to the shared flotta identity — undoing the rotation with no error anywhere.
- Fixed by giving `resolveMainConfigDecision()` the same three-tier precedence, and adding an `ownCredentials` flag to `MainConfigDecision` so `buildMainSessionRespawnCmd()` does not inject the fleet OAuth token on top of a dir that already carries its own `.credentials.json` (explicit or rotated) — mirroring exactly what `channel-watchdog.sh` / `stuck-modal-guard.sh` already do for the shell paths.
- Bonus: the `channels-failures.log` trace line for a healthy launch now distinguishes `own-credential` from `isolated`, so a launch's actual identity source is visible in the log instead of always reading "isolated".

## Test plan
- [x] New test file `main-config-decision-rotation-precedence.test.ts`: rotated wins over plain isolated, explicit wins over rotated, plain isolated is still the fallback and is the only case that calls the (provisioning) `ensureMainAgentIsolatedConfigDir`.
- [x] New case in `channel-deafness-recovery.test.ts`: `buildMainSessionRespawnCmd` exports only `CLAUDE_CONFIG_DIR` (no fleet token) when `ownCredentials` is true.
- [x] Full existing suite green: `npx vitest run` — 431 files / 5487 passed, 1 skipped.
- [x] `npx tsc --noEmit -p .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)