### PR TITLE
feat(installer): macOS offers Discord with Linux parity, docs stop hiding it (DISCORDLATHATO913)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@
 
 > AI csapatod, ami fut amíg te alszol.
 
-Marveen egy AI asszisztens keretrendszer, ami Claude Code-ra épül. Saját AI csapatot építhetsz, akik Telegramon vagy Slacken kommunikálnak veled, önállóan dolgoznak, és egymással is együttműködnek.
+Marveen egy AI asszisztens keretrendszer, ami Claude Code-ra épül. Saját AI csapatot építhetsz, akik Telegramon, Slacken vagy Discordon kommunikálnak veled, önállóan dolgoznak, és egymással is együttműködnek.
 
-Marveen is a self-hostable **agent harness** for Claude Code: it runs a team of AI agents, each with its own chat channel (Telegram or Slack), persistent memory, scheduled tasks, and MCP tools, lets them delegate work to one another, and gives you a web dashboard to watch and steer them.
+Marveen is a self-hostable **agent harness** for Claude Code: it runs a team of AI agents, each with its own chat channel (Telegram, Slack or Discord), persistent memory, scheduled tasks, and MCP tools, lets them delegate work to one another, and gives you a web dashboard to watch and steer them.
 
 ## Funkciók
 
-- **AI Csapat**: Több ágens, mindegyik saját csatornával (Telegram vagy Slack), személyiséggel és memóriával
+- **AI Csapat**: Több ágens, mindegyik saját csatornával (Telegram, Slack vagy Discord), személyiséggel és memóriával
 - **Mission Control**: Web dashboard (http://localhost:3420) a csapat kezeléséhez
 - **Inter-agent kommunikáció**: Az ágensek delegálhatnak egymásnak feladatokat
 - **Ütemezések**: Cron-alapú feladatok automatikus futtatása
@@ -42,7 +42,7 @@ Részletes, funkciónkénti leírások a [`docs/`](docs/README.md) mappában —
 | Ügynök-flotta + inter-agent | [docs/agent-fleet.md](docs/agent-fleet.md) |
 | Föderáció (több példány összekötése, dashboard-menüvel) | [docs/federation.md](docs/federation.md) |
 | Skill-factory (öntanulás) | [docs/skill-factory.md](docs/skill-factory.md) |
-| Channels (Telegram / Slack) | [docs/channels.md](docs/channels.md) |
+| Channels (Telegram / Slack / Discord) | [docs/channels.md](docs/channels.md) |
 | Printing-press CLI-k | [docs/printing-press-cli.md](docs/printing-press-cli.md) |
 | Skool CLI | [docs/skool-cli.md](docs/skool-cli.md) |
 | connectors.hu | [docs/connectors-hu.md](docs/connectors-hu.md) |
@@ -146,9 +146,9 @@ A `MAIN_AGENT_ID` és `SERVICE_ID` értékeket a telepítő automatikusan szárm
 ### Dashboard
 Nyisd meg: http://localhost:3420
 
-### Csatorna (Telegram vagy Slack)
+### Csatorna (Telegram, Slack vagy Discord)
 
-A telepítés során választhatsz csatorna providert. Az alapértelmezett a Telegram.
+A telepítés során választhatsz csatorna providert (Linuxon és macOS-en is). Az alapértelmezett a Telegram.
 
 #### Telegram (alapértelmezett)
 Írj a botodnak Telegramon -- Marveen válaszol.
@@ -171,6 +171,27 @@ Slack használatához a telepítő automatikusan végigvezet, de manuálisan is 
    SLACK_CHANNEL_ID=C01234ABCDE
    ```
 8. A Slack channel plugin automatikusan települ: `slack@jeremylongshore/claude-code-slack-channel`
+
+
+#### Discord (alternatív)
+
+A telepítő végigvezet (Linuxon és macOS-en is a 3. opció), de manuálisan is beállíthatod:
+
+1. Hozz létre egy alkalmazást a [Discord Developer Portalon](https://discord.com/developers/applications)
+2. A Bot fülön add hozzá a botot és másold ki a tokent
+3. Privileged Gateway Intents: kapcsold be a MESSAGE CONTENT INTENT-et
+4. OAuth2 > URL Generator: bot scope, majd hívd meg a botot a szerveredre
+5. Developer Mode-dal másold ki a csatorna ID-t és a saját (operátor) user ID-det
+6. A `.env` fájlban állítsd be:
+   ```
+   CHANNEL_PROVIDER=discord
+   DISCORD_BOT_TOKEN=...
+   DISCORD_CHANNEL_ID=...
+   OPERATOR_DISCORD_USER_ID=...
+   ```
+7. A Discord channel plugin automatikusan települ: `discord@claude-plugins-official`
+
+Részletek (managed-settings allowlist, párosítás): [docs/channels.md](docs/channels.md).
 
 A csatorna váltáshoz futtasd újra a `./install.sh`-t vagy szerkeszd a `.env` fájlt manuálisan.
 

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -1,12 +1,12 @@
-# Channels (Telegram / Slack / WhatsApp / Teams)
+# Channels (Telegram / Slack / Discord / WhatsApp / Teams)
 
-> Ott éred el ahol amúgy is írsz. Telegram vagy Slack — proaktív értesítésekkel, nem csak válaszokkal.
+> Ott éred el ahol amúgy is írsz. Telegram, Slack vagy Discord — proaktív értesítésekkel, nem csak válaszokkal.
 
 ---
 
 ## 🎯 Mit tud / miért érdekes
 
-Marveennel ott beszélgetsz, ahol kényelmes: **Telegramon** vagy **Slacken**. Nem webfelület, nem külön app — a meglévő üzenetküldődben él. De nem csak válaszol: magától ír, ha valami fontos. Reggeli összefoglaló (email, naptár, AI-hírek), beakadt feladatnál értesítés, hosszú munka végén "kész" — érzed, hogy van valaki a másik oldalon, nem csak egy chatbox.
+Marveennel ott beszélgetsz, ahol kényelmes: **Telegramon**, **Slacken** vagy **Discordon**. Nem webfelület, nem külön app — a meglévő üzenetküldődben él. De nem csak válaszol: magától ír, ha valami fontos. Reggeli összefoglaló (email, naptár, AI-hírek), beakadt feladatnál értesítés, hosszú munka végén "kész" — érzed, hogy van valaki a másik oldalon, nem csak egy chatbox.
 
 Hangüzenetet is megért (átírja szöveggé), képet és fájlt küld-fogad — pl. egy kész videót attachmentként, vagy egy táblázatot, ami épp elkészült.
 
@@ -18,7 +18,7 @@ Hangüzenetet is megért (átírja szöveggé), képet és fájlt küld-fogad �
 
 ### Architektúra
 
-A csatorna-integráció Claude Code **plugin**-ként fut (Telegram, Slack, WhatsApp és Teams plugin). Az inbound üzenetek `<channel source="..." chat_id="..." user="..." ts="...">` formátumban érkeznek; a válasz a `reply` tool-on megy vissza (a `chat_id`-vel). Kép: `image_path` attribútum → beolvasás; egyéb attachment: `download_attachment`.
+A csatorna-integráció Claude Code **plugin**-ként fut (Telegram, Slack, Discord, WhatsApp és Teams plugin). Az inbound üzenetek `<channel source="..." chat_id="..." user="..." ts="...">` formátumban érkeznek; a válasz a `reply` tool-on megy vissza (a `chat_id`-vel). Kép: `image_path` attribútum → beolvasás; egyéb attachment: `download_attachment`.
 
 ### Időkezelés
 
@@ -84,6 +84,21 @@ Beüzemelés:
    { "plugin": "teams", "marketplace": "marveen-marketplace" }
    ```
 3. **Párosítás + zárolás.** A párosítás és az allowlist-policy a `/teams:access` paranccsal állítható, a tulajdonos termináljából (csatornán érkező engedély-kérést a rendszer sosem hajt végre magától).
+
+### Discord-specifikum
+
+A Discord csatorna a hivatalos `discord@claude-plugins-official` plugin. `CHANNEL_PROVIDER=discord` -> a `channels.sh` a discord plugint indítja, az állapot a `~/.claude/channels/discord/` mappában (a `DISCORD_STATE_DIR` env-en keresztül). A provider-elágazások (PLUGIN_ID, state-dir, plugin-watchdog) ugyanúgy viselkednek mint a többi providernél, külön kezelés nélkül. A telepítő a Linux ÉS a macOS úton is felkínálja (3. opció).
+
+Beüzemelés:
+
+1. **Discord alkalmazás.** Hozz létre egy alkalmazást a [discord.com/developers/applications](https://discord.com/developers/applications) oldalon, a Bot fülön add hozzá a botot és másold ki a tokent. Kapcsold be a Privileged Gateway Intents alatt a MESSAGE CONTENT INTENT-et, majd az OAuth2 > URL Generatorral (bot scope) hívd meg a szerveredre.
+2. **Csatorna és operátor azonosítók.** Developer Mode-dal másold ki a csatorna ID-jét (jobb klikk a csatornán > Copy Channel ID) és a saját user ID-det (jobb klikk a nevedre > Copy User ID). A telepítő ezeket bekéri; a `.env` kulcsok: `DISCORD_BOT_TOKEN`, `DISCORD_CHANNEL_ID`, `OPERATOR_DISCORD_USER_ID`.
+3. **`allowedChannelPlugins` engedélyezés (csak ha van managed-settings).** Friss telepítésnél a hivatalos marketplace-es plugin allowlist-fájl nélkül is fut. Ha viszont a gépen MÁR van `managed-settings.json` (pl. egy korábbi Slack/Teams telepítés írta), az allowlist a benne nem szereplő plugint csendben eldobja (a bot online-nak látszik, de sosem válaszol). A macOS telepítő discord-ágon ezt install-time érzékeli és felveszi a `discord` bejegyzést. Kézi pótlásnál ugyanaz a menet, mint a Teamsnél, a bejegyzés:
+
+   ```json
+   { "plugin": "discord", "marketplace": "claude-plugins-official" }
+   ```
+4. **Párosítás + zárolás.** A DM-policy alapból `pairing`; az engedélyezés a `/discord:access` paranccsal, a tulajdonos termináljából történik (csatornán érkező engedély-kérést a rendszer sosem hajt végre magától).
 
 ### Biztonság
 

--- a/install-lang.sh
+++ b/install-lang.sh
@@ -40,8 +40,8 @@ _t() {
     hu:prompt_login) echo "  Szeretnéd most bejelentkezni? (i/n) " ;;
     en:prompt_your_name) echo "  Your name? " ;;
     hu:prompt_your_name) echo "  Mi a neved? " ;;
-    en:prompt_channel_select_macos) echo "  Choose (1/2) [1]: " ;;
-    hu:prompt_channel_select_macos) echo "  Válassz (1/2) [1]: " ;;
+    en:prompt_channel_select_macos) echo "  Choose (1/2/3) [1]: " ;;
+    hu:prompt_channel_select_macos) echo "  Válassz (1/2/3) [1]: " ;;
     en:prompt_channel_select_linux) echo "  Choose (1/2/3) [1]: " ;;
     hu:prompt_channel_select_linux) echo "  Válassz (1/2/3) [1]: " ;;
     en:prompt_telegram_token) echo "  Telegram bot token (or leave empty, set later): " ;;
@@ -162,6 +162,8 @@ _t() {
     hu:macos.tg_channel_configured) echo "  Telegram csatorna konfigurálva" ;;
     en:macos.slack_channel_configured) echo "  Slack channel configured" ;;
     hu:macos.slack_channel_configured) echo "  Slack csatorna konfigurálva" ;;
+    en:macos.discord_channel_configured) echo "  Discord channel configured" ;;
+    hu:macos.discord_channel_configured) echo "  Discord csatorna konfigurálva" ;;
     # ── Plugin ────────────────────────────────────────────────────────
     en:macos.plugin_retry) echo "  First attempt failed, retrying..." ;;
     hu:macos.plugin_retry) echo "  Elso probalkozas sikertelen, ujraprobalok..." ;;

--- a/install-macos.sh
+++ b/install-macos.sh
@@ -412,11 +412,14 @@ echo -e "${BOLD}$(_t section_4_macos)${NC}"
 echo -e "${DIM}$(_t macos.channel_select_hint)${NC}"
 echo -e "  ${BOLD}1.${NC} $(_t macos.channel_option_1)"
 echo -e "  ${BOLD}2.${NC} Slack"
+echo -e "  ${BOLD}3.${NC} Discord"
 echo ""
 read -rp "$(_t prompt_channel_select_macos)" PROVIDER_CHOICE
 PROVIDER_CHOICE=${PROVIDER_CHOICE:-1}
 if [ "$PROVIDER_CHOICE" = "2" ]; then
   CHANNEL_PROVIDER="slack"
+elif [ "$PROVIDER_CHOICE" = "3" ]; then
+  CHANNEL_PROVIDER="discord"
 else
   CHANNEL_PROVIDER="telegram"
 fi
@@ -462,6 +465,9 @@ probe_telegram_token() {
 BOT_TOKEN=""
 SLACK_BOT_TOKEN=""
 SLACK_APP_TOKEN=""
+DISCORD_BOT_TOKEN=""
+DISCORD_CHANNEL_ID=""
+OPERATOR_DISCORD_USER_ID=""
 
 if [ "$CHANNEL_PROVIDER" = "telegram" ]; then
   echo ""
@@ -473,6 +479,58 @@ if [ "$CHANNEL_PROVIDER" = "telegram" ]; then
   echo ""
   read -rp "$(_t prompt_telegram_token)" BOT_TOKEN
   probe_telegram_token "$BOT_TOKEN"
+elif [ "$CHANNEL_PROVIDER" = "discord" ]; then
+  echo ""
+  echo -e "${DIM}  Az AI asszisztensed Discordon kommunikal veled.${NC}"
+  echo -e "${DIM}  1. Hozz letre egy alkalmazast: discord.com/developers/applications${NC}"
+  echo -e "${DIM}  2. Bot fulon: Add Bot, majd masold ki a Tokent${NC}"
+  echo -e "${DIM}  3. Privileged Gateway Intents: kapcsold be a MESSAGE CONTENT INTENT-et${NC}"
+  echo -e "${DIM}  4. OAuth2 > URL Generator: bot scope, majd hivd meg a szerveredre${NC}"
+  echo -e "${DIM}  5. Masold ki a csatorna ID-jet (Developer Mode > jobb klikk > Copy Channel ID)${NC}"
+  echo -e "${DIM}  6. Sajat (operator) user ID: jobb klikk a nevedre > Copy User ID${NC}"
+  echo ""
+  read -rp "$(_t prompt_discord_bot_token)" DISCORD_BOT_TOKEN
+  read -rp "$(_t prompt_discord_channel_id)" DISCORD_CHANNEL_ID
+  echo ""
+  echo -e "${DIM}  Az operator user ID-re a parositashoz kell: amikor egy uj felhasznalo${NC}"
+  echo -e "${DIM}  DM-et ir a botnak, a bot ezen az ID-n ertesit teged jovahagyasert.${NC}"
+  read -rp "$(_t prompt_discord_user_id)" OPERATOR_DISCORD_USER_ID
+
+  # A previously written managed allowlist (a slack/teams install writes one)
+  # BLOCKS every channel plugin missing from it -- measured on the fleet host:
+  # /Library/Application Support/ClaudeCode/managed-settings.json lists
+  # slack-channel + telegram + teams, no discord, so a discord plugin on such a
+  # machine goes silently mute. A fresh telegram-only install never creates the
+  # file and the official-marketplace plugin runs fine without it, so we only
+  # MERGE when the file already exists -- never create it here.
+  MANAGED_FILE="/Library/Application Support/ClaudeCode/managed-settings.json"
+  if [ -f "$MANAGED_FILE" ]; then
+    HAS_DISCORD=$(sudo python3 -c "
+import json, sys
+try:
+  d = json.load(open('$MANAGED_FILE'))
+  have = {(p.get('plugin'),p.get('marketplace')) for p in d.get('allowedChannelPlugins', [])}
+  sys.exit(0 if ('discord','claude-plugins-official') in have else 1)
+except: sys.exit(1)
+" 2>/dev/null && echo "yes" || echo "no")
+    if [ "$HAS_DISCORD" = "no" ]; then
+      echo -e "  ${ORANGE}⚠${NC} $(_t macos.managed_update)"
+      sudo python3 -c "
+import json
+path = '$MANAGED_FILE'
+try:
+  d = json.load(open(path))
+except Exception:
+  d = {}
+plugins = d.get('allowedChannelPlugins', [])
+entry = {'plugin': 'discord', 'marketplace': 'claude-plugins-official'}
+if entry not in plugins:
+  plugins.append(entry)
+d['allowedChannelPlugins'] = plugins
+json.dump(d, open(path, 'w'), indent=2)
+" && echo -e "  ${GREEN}✓${NC} Discord engedelyezve a managed-settings allowlistben"
+    fi
+  fi
 else
   echo ""
   echo -e "${DIM}  Az AI asszisztensed Slack-en kommunikal veled.${NC}"
@@ -495,7 +553,8 @@ else
   SLACK_ENTRY='{"plugin":"slack-channel","marketplace":"marveen-marketplace"}'
   TELEGRAM_ENTRY='{"plugin":"telegram","marketplace":"claude-plugins-official"}'
   TEAMS_ENTRY='{"plugin":"teams","marketplace":"marveen-marketplace"}'
-  REQUIRED_JSON="{\"allowedChannelPlugins\":[$SLACK_ENTRY,$TELEGRAM_ENTRY,$TEAMS_ENTRY]}"
+  DISCORD_ENTRY='{"plugin":"discord","marketplace":"claude-plugins-official"}'
+  REQUIRED_JSON="{\"allowedChannelPlugins\":[$SLACK_ENTRY,$TELEGRAM_ENTRY,$TEAMS_ENTRY,$DISCORD_ENTRY]}"
 
   if [ -f "$MANAGED_FILE" ]; then
     # Gate on ALL required plugins being present (not just slack) -- otherwise an
@@ -505,7 +564,7 @@ else
     # at install time, so no manual managed-settings edit is needed later.
     HAS_ALL=$(sudo python3 -c "
 import json, sys
-required = [('slack-channel','marveen-marketplace'),('telegram','claude-plugins-official'),('teams','marveen-marketplace')]
+required = [('slack-channel','marveen-marketplace'),('telegram','claude-plugins-official'),('teams','marveen-marketplace'),('discord','claude-plugins-official')]
 try:
   d = json.load(open('$MANAGED_FILE'))
   plugins = d.get('allowedChannelPlugins', [])
@@ -723,6 +782,10 @@ if [ "$CHANNEL_PROVIDER" = "telegram" ]; then
   if [ "${CHAT_ID}" != "0" ] || [ -z "$_existing_chat" ]; then
     env_merge_key ALLOWED_CHAT_ID "${CHAT_ID}"
   fi
+elif [ "$CHANNEL_PROVIDER" = "discord" ]; then
+  env_keep_or_set DISCORD_BOT_TOKEN "${DISCORD_BOT_TOKEN}"
+  env_keep_or_set DISCORD_CHANNEL_ID "${DISCORD_CHANNEL_ID}"
+  env_keep_or_set OPERATOR_DISCORD_USER_ID "${OPERATOR_DISCORD_USER_ID}"
 else
   env_keep_or_set SLACK_BOT_TOKEN "${SLACK_BOT_TOKEN}"
   env_keep_or_set SLACK_APP_TOKEN "${SLACK_APP_TOKEN}"
@@ -911,6 +974,22 @@ SLACKENVEOF
 }
 ACCESSEOF
   echo -e "  ${GREEN}✓${NC} $(_t macos.slack_channel_configured)"
+elif [ "$CHANNEL_PROVIDER" = "discord" ] && [ -n "$DISCORD_BOT_TOKEN" ]; then
+  (umask 077 && cat > "$CHANNEL_DIR/.env" << DISCORDENVEOF
+DISCORD_BOT_TOKEN=$DISCORD_BOT_TOKEN
+DISCORD_CHANNEL_ID=$DISCORD_CHANNEL_ID
+DISCORDENVEOF
+  )
+  chmod 600 "$CHANNEL_DIR/.env"
+  cat > "$CHANNEL_DIR/access.json" << ACCESSEOF
+{
+  "dmPolicy": "pairing",
+  "allowFrom": [],
+  "channels": {},
+  "pending": {}
+}
+ACCESSEOF
+  echo -e "  ${GREEN}✓${NC} $(_t macos.discord_channel_configured)"
 fi
 
 # Install channel plugin
@@ -918,6 +997,10 @@ if [ "$CHANNEL_PROVIDER" = "telegram" ]; then
   PLUGIN_MARKETPLACE="anthropics/claude-plugins-official"
   PLUGIN_ID="telegram@claude-plugins-official"
   PLUGIN_SHORT="telegram"
+elif [ "$CHANNEL_PROVIDER" = "discord" ]; then
+  PLUGIN_MARKETPLACE="anthropics/claude-plugins-official"
+  PLUGIN_ID="discord@claude-plugins-official"
+  PLUGIN_SHORT="discord"
 else
   PLUGIN_MARKETPLACE="Szotasz/marveen-marketplace"
   PLUGIN_ID="slack-channel@marveen-marketplace"
@@ -1362,8 +1445,8 @@ fi
 sleep 3
 echo ""
 echo -e "${BOLD}$(_t section_checks)${NC}"
-if [ "$CHANNEL_PROVIDER" = "telegram" ] && ! command -v bun &>/dev/null; then
-  echo -e "  ${RED}✗${NC} Bun nem talalhato. A Telegram plugin nem fog mukodni."
+if { [ "$CHANNEL_PROVIDER" = "telegram" ] || [ "$CHANNEL_PROVIDER" = "discord" ]; } && ! command -v bun &>/dev/null; then
+  echo -e "  ${RED}✗${NC} Bun nem talalhato. A ${CHANNEL_PROVIDER} plugin nem fog mukodni."
   echo -e "  ${BOLD}Javitas:${NC} curl -fsSL https://bun.sh/install | bash"
   echo -e "  ${DIM}Utana: source ~/.zshrc && ./scripts/start.sh${NC}"
 fi

--- a/install-macos.sh
+++ b/install-macos.sh
@@ -515,20 +515,41 @@ except: sys.exit(1)
 " 2>/dev/null && echo "yes" || echo "no")
     if [ "$HAS_DISCORD" = "no" ]; then
       echo -e "  ${ORANGE}⚠${NC} $(_t macos.managed_update)"
-      sudo python3 -c "
-import json
-path = '$MANAGED_FILE'
+      # Safe JSON merge (same shape as ensure-managed-channels-enabled.sh):
+      # tmp file + copymode + os.replace, so no interruption can leave a
+      # truncated managed-settings behind. And an org-policy file is NEVER
+      # rebuilt from scratch: on a parse failure we say so and leave it
+      # untouched -- a {} fallback would silently drop the OTHER channels'
+      # allowlist entries, muting them host-wide.
+      if sudo python3 - "$MANAGED_FILE" <<'DISCORDMERGEPY'
+import json, os, shutil, sys
+p = sys.argv[1]
 try:
-  d = json.load(open(path))
-except Exception:
-  d = {}
+    d = json.load(open(p))
+except Exception as e:
+    print(f"managed-settings parse failed, NOT writing: {e}", file=sys.stderr)
+    sys.exit(1)
+if not isinstance(d, dict):
+    print("managed-settings root is not an object, NOT writing", file=sys.stderr)
+    sys.exit(1)
 plugins = d.get('allowedChannelPlugins', [])
 entry = {'plugin': 'discord', 'marketplace': 'claude-plugins-official'}
 if entry not in plugins:
-  plugins.append(entry)
+    plugins.append(entry)
 d['allowedChannelPlugins'] = plugins
-json.dump(d, open(path, 'w'), indent=2)
-" && echo -e "  ${GREEN}✓${NC} Discord engedelyezve a managed-settings allowlistben"
+tmp = p + '.tmp'
+with open(tmp, 'w') as f:
+    f.write(json.dumps(d, indent=2) + "\n")
+shutil.copymode(p, tmp)
+os.replace(tmp, p)
+DISCORDMERGEPY
+      then
+        echo -e "  ${GREEN}✓${NC} Discord engedelyezve a managed-settings allowlistben"
+      else
+        echo -e "  ${RED}✗${NC} A managed-settings.json nem volt biztonsagosan frissitheto -- a fajl ERINTETLEN maradt."
+        echo -e "  ${DIM}Kezi potlas (root): add az allowedChannelPlugins tombhoz:${NC}"
+        echo -e "  ${DIM}  {\"plugin\":\"discord\",\"marketplace\":\"claude-plugins-official\"}${NC}"
+      fi
     fi
   fi
 else

--- a/src/__tests__/installer-discord-macos-parity.test.ts
+++ b/src/__tests__/installer-discord-macos-parity.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+// DISCORDLATHATO913: a paying customer wrote their own Discord plugin because
+// ours was invisible -- first-class in the runtime and offered by the Linux
+// installer, absent from the macOS menu and from every doc. These are
+// structural anchors on the shipped files (the installer runs on a customer
+// Mac where no harness can execute it end to end); each asserts one half of
+// the parity, so a silent removal of any one fails the suite.
+
+const ROOT = join(__dirname, '..', '..')
+const MAC = readFileSync(join(ROOT, 'install-macos.sh'), 'utf-8')
+const LANG = readFileSync(join(ROOT, 'install-lang.sh'), 'utf-8')
+
+describe('macOS installer offers Discord with Linux parity', () => {
+  it('the menu has a third option and a discord branch', () => {
+    expect(MAC).toContain('3.${NC} Discord')
+    expect(MAC).toContain('CHANNEL_PROVIDER="discord"')
+  })
+
+  it('collects the same three credentials as the Linux path', () => {
+    expect(MAC).toContain('prompt_discord_bot_token')
+    expect(MAC).toContain('prompt_discord_channel_id')
+    expect(MAC).toContain('prompt_discord_user_id')
+  })
+
+  it('persists them into the install .env', () => {
+    expect(MAC).toContain('env_keep_or_set DISCORD_BOT_TOKEN')
+    expect(MAC).toContain('env_keep_or_set DISCORD_CHANNEL_ID')
+    expect(MAC).toContain('env_keep_or_set OPERATOR_DISCORD_USER_ID')
+  })
+
+  it('writes the channel dir env and a pairing access.json', () => {
+    // The channel .env carries token + channel id only; the operator id lives
+    // in the install .env -- the exact split the Linux path ships.
+    expect(MAC).toMatch(/DISCORDENVEOF[\s\S]*DISCORD_CHANNEL_ID=\$DISCORD_CHANNEL_ID[\s\S]*DISCORDENVEOF/)
+  })
+
+  it('installs the official plugin', () => {
+    expect(MAC).toContain('PLUGIN_ID="discord@claude-plugins-official"')
+  })
+
+  it('repairs a pre-existing managed allowlist that would silently mute discord', () => {
+    // Measured on the fleet host: a managed-settings.json written by a
+    // slack/teams install lists slack-channel+telegram+teams and BLOCKS every
+    // plugin missing from it. A fresh telegram-only install never creates the
+    // file, so the discord branch merges ONLY when the file already exists.
+    const discordEntry = "'plugin': 'discord', 'marketplace': 'claude-plugins-official'"
+    expect(MAC).toContain(discordEntry)
+    // And the slack-branch REQUIRED_JSON now allowlists discord too, so a
+    // later provider switch is not silently blocked.
+    expect(MAC).toContain('"plugin":"discord","marketplace":"claude-plugins-official"')
+  })
+
+  it('the bun advisory covers discord, not only telegram', () => {
+    expect(MAC).toMatch(/"\$CHANNEL_PROVIDER" = "telegram" \] \|\| \[ "\$CHANNEL_PROVIDER" = "discord"/)
+  })
+
+  it('the shared lang file carries the macOS discord keys and a 3-way chooser', () => {
+    expect(LANG).toContain('macos.discord_channel_configured')
+    expect(LANG).toContain('(1/2/3)')
+  })
+})
+
+describe('the docs stop hiding the Discord provider', () => {
+  it('docs/channels.md names it in the title and has a specifics section', () => {
+    const doc = readFileSync(join(ROOT, 'docs', 'channels.md'), 'utf-8')
+    expect(doc).toMatch(/^# Channels \(.*Discord.*\)/)
+    expect(doc).toContain('### Discord-specifikum')
+  })
+
+  it('README offers Discord next to Telegram and Slack', () => {
+    const readme = readFileSync(join(ROOT, 'README.md'), 'utf-8')
+    expect(readme).toContain('#### Discord (alternatív)')
+    expect(readme).toContain('CHANNEL_PROVIDER=discord')
+  })
+})

--- a/src/__tests__/installer-discord-macos-parity.test.ts
+++ b/src/__tests__/installer-discord-macos-parity.test.ts
@@ -53,6 +53,19 @@ describe('macOS installer offers Discord with Linux parity', () => {
     expect(MAC).toContain('"plugin":"discord","marketplace":"claude-plugins-official"')
   })
 
+  it('the managed merge is atomic and never rebuilds the policy from scratch', () => {
+    // Review condition (#1306): an in-place json.dump truncates the file
+    // before writing, and a {} parse-failure fallback would re-create the org
+    // policy with ONLY discord in it -- muting every other channel host-wide.
+    // The shipped shape is the repo's safe merge: tmp + copymode + os.replace,
+    // and on a parse failure it exits without writing.
+    const block = MAC.slice(MAC.indexOf('DISCORDMERGEPY'), MAC.lastIndexOf('DISCORDMERGEPY'))
+    expect(block).toContain('os.replace(tmp, p)')
+    expect(block).toContain('shutil.copymode(p, tmp)')
+    expect(block).toContain('NOT writing')
+    expect(block).not.toContain("d = {}")
+  })
+
   it('the bun advisory covers discord, not only telegram', () => {
     expect(MAC).toMatch(/"\$CHANNEL_PROVIDER" = "telegram" \] \|\| \[ "\$CHANNEL_PROVIDER" = "discord"/)
   })


### PR DESCRIPTION
A customer-side finding (source on the card, deliberately not quoted here): the Discord provider is first-class in the runtime and installable on Linux, but invisible on macOS and in every doc.

## Measured before writing (the card's substantive question)

- **No OS-dependent part**: `scripts/channels.sh` handles discord generically (`PLUGIN_ID` map, `DISCORD_STATE_DIR`, token scrubbing), and the shared `install-lang.sh` already carries the discord prompt keys the Linux path uses. Nothing blocks the macOS branch.
- **The one real macOS-specific hazard**: the managed-settings allowlist. Measured on the fleet host: `/Library/Application Support/ClaudeCode/managed-settings.json` (written by a slack/teams install) lists slack-channel + telegram + teams and **silently blocks** any plugin missing from it (bot online, never replies). A fresh telegram-only macOS install never creates the file and the official-marketplace plugin runs without it.

## What changed

- **install-macos.sh**: third menu option; the same three credential prompts as Linux (bot token, channel id, operator user id, with the same on-screen setup steps); install `.env` keys via `env_keep_or_set`; channel-dir `.env` + pairing `access.json` with the exact Linux split (operator id lives in the install `.env` only); official `discord@claude-plugins-official` plugin; the bun advisory covers discord too.
- **Managed allowlist**: the discord branch merges the discord entry **only when the file already exists** (repairs the silent-mute case without introducing the file where it is not needed); the slack branch's `REQUIRED_JSON` and required-tuple gate now include discord, so a later provider switch on a slack-initialized Mac is not silently muted.
- **install-lang.sh**: 3-way chooser copy (1/2/3) + `macos.discord_channel_configured` (en+hu).
- **docs/channels.md**: Discord in the title and intro, plus a `Discord-specifikum` section (setup steps, env keys, allowlist repair with the exact JSON entry, pairing via `/discord:access`).
- **README**: provider lists updated (hu+en), a `#### Discord (alternatív)` manual-setup section, docs table row.

## Verify

- `bash -n` green on both shell files; new structural parity test `installer-discord-macos-parity.test.ts` 10/10, with a mutation control (removing the menu line turns it red; reverted, green).
- Homoglyph scan clean on all four touched files; no em-dash in the added Hungarian copy.
- Acceptance mapping: (1) macOS installer == Linux on Discord: yes, no carve-out needed; (2) docs/channels.md title+content: done; (3) README: done. Release is not this PR's step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)