### PR TITLE
fix(hooks): fleet hooks leave the user-global settings.json -- repo-shipped project scope + write-refusal (#1305, ISSUE1305HOOKSCOPE resz 2)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,11 +8,18 @@
       { "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/ledger-capture.py\"", "timeout": 15 } ] },
       { "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/inbox-drain.py\"", "timeout": 15 } ] },
       { "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/telegram-reply-directive.py\"", "timeout": 10 } ] },
-      { "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/provenance-gate.py\"", "timeout": 10 } ] }
+      { "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/provenance-gate.py\"", "timeout": 10 } ] },
+      { "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/staleness-guard.py\"", "timeout": 10 } ] },
+      { "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/channel-inbox-drain.py\"", "timeout": 5 } ] },
+      { "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/voice-reply-directive.py\"", "timeout": 60 } ] },
+      { "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/telegram_progress.py\"", "timeout": 15 } ] },
+      { "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/claude-usage.py\"", "timeout": 45 } ] }
     ],
     "PostToolUse": [
       { "matcher": "mcp__plugin_telegram_telegram__reply", "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/ledger-outbound.py\"", "timeout": 15 } ] },
-      { "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/tool-log-capture.py\"", "timeout": 5 } ] }
+      { "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/tool-log-capture.py\"", "timeout": 5 } ] },
+      { "matcher": "telegram.*reply", "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/telegram_progress_reply_clear.py\"", "timeout": 15 } ] },
+      { "matcher": "Skill|Read", "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/skill-usage-capture.py\"", "timeout": 10 } ] }
     ],
     "PreToolUse": [
       { "matcher": "Bash", "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/outgoing-copy-gate.py\"", "timeout": 15 } ] },
@@ -21,13 +28,21 @@
       { "matcher": "mcp__plugin_telegram_telegram__reply|mcp__plugin_telegram_telegram__edit_message", "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/outgoing-copy-gate.py\"", "timeout": 15 } ] },
       { "matcher": "Bash", "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/email-approval-gate.py\"", "timeout": 10 } ] },
       { "matcher": ".*send_email.*", "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/email-approval-gate.py\"", "timeout": 10 } ] },
-      { "matcher": ".*manage_email.*", "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/email-approval-gate.py\"", "timeout": 10 } ] }
+      { "matcher": ".*manage_email.*", "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/email-approval-gate.py\"", "timeout": 10 } ] },
+      { "matcher": "Read", "hooks": [ { "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR/scripts/hooks/channel-image-resize.sh\"", "timeout": 15 } ] },
+      { "matcher": "WebFetch", "hooks": [ { "type": "command", "command": "command -v node >/dev/null 2>&1 || { echo \"governance-kapu: node interpreter hianyzik, a kapu BLOKKOL\" >&2; exit 2; }; node \"$CLAUDE_PROJECT_DIR/scripts/hooks/egress-gate.mjs\"", "timeout": 10 } ] }
     ],
     "Stop": [
-      { "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/telegram-reply-guard.py\"", "timeout": 10 } ] }
+      { "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/telegram-reply-guard.py\"", "timeout": 10 } ] },
+      { "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/telegram_progress_clear.py\"", "timeout": 15 } ] }
     ],
     "SessionStart": [
-      { "matcher": "startup|resume|clear", "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/ledger-replay.py\"", "timeout": 15 } ] }
+      { "matcher": "startup|resume|clear", "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/ledger-replay.py\"", "timeout": 15 } ] },
+      { "matcher": "compact|resume|clear", "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/taskstate-replay.py\"", "timeout": 15 } ] },
+      { "matcher": "clear", "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/clear-replay.py\"", "timeout": 15 } ] }
+    ],
+    "SessionEnd": [
+      { "hooks": [ { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/scripts/hooks/clear-capture.py\"", "timeout": 15 } ] }
     ]
   }
 }

--- a/docs/telegram-progress-indicator.md
+++ b/docs/telegram-progress-indicator.md
@@ -81,12 +81,15 @@ Loop-safe: a per-session `enforce-<sid>.marker` guarantees at most one block, an
 bash ~/ClaudeClaw/scripts/install-telegram-progress-hook.sh
 ```
 
-It is idempotent and is auto-run by `scripts/sync-hooks.sh` on every update. It:
+It is idempotent and is auto-run by `scripts/sync-hooks.sh` on every update.
 
-1. Copies the four hook scripts to `~/.claude/hooks/`.
-2. Patches `~/.claude/settings.json` (UserPromptSubmit / PostToolUse / Stop).
-3. Installs the watchdog as a **launchd** agent (macOS) or **systemd** user
-   service+timer (Linux), running every ~60s.
+Since #1305 the three settings hooks (UserPromptSubmit / PostToolUse / Stop)
+are **repo-shipped** in the tracked `.claude/settings.json` (project scope,
+`$CLAUDE_PROJECT_DIR` form) -- the installer never touches
+`~/.claude/settings.json` and copies nothing into `~/.claude/hooks/`. The only
+thing it installs is the watchdog, as a **launchd** agent (macOS) or
+**systemd** user service+timer (Linux), running every ~60s straight from the
+repo checkout.
 
 ## Tuning
 
@@ -97,8 +100,8 @@ It is idempotent and is auto-run by `scripts/sync-hooks.sh` on every update. It:
 
 ## Remove
 
-Delete the four `~/.claude/hooks/telegram_progress*.py` files and their entries
-in `~/.claude/settings.json`, then unload the watchdog
+Remove the three `telegram_progress*` entries from the tracked
+`.claude/settings.json`, then unload the watchdog
 (`launchctl unload ~/Library/LaunchAgents/com.marveen.telegram-progress-watchdog.plist`
 on macOS, or `systemctl --user disable --now marveen-telegram-progress-watchdog.timer`
 on Linux).

--- a/scripts/__tests__/install-telegram-progress-hook.test.sh
+++ b/scripts/__tests__/install-telegram-progress-hook.test.sh
@@ -155,57 +155,59 @@ assert_eq   "MAIN_AGENT_ID fallback: SERVICE_ID resolves to myagent" \
             "SERVICE_ID=myagent" "$(echo "$OUT" | grep '^SERVICE_ID=')"
 
 # ---------------------------------------------------------------------------
-# (g) Hook files are copied when the full script runs (behaviour preserved)
-# We drive the full script with a fake INSTALL_DIR + HOME + stub hook sources.
-# Daemon install is left to run; on macOS launchctl is a no-op here, on Linux
-# systemd --user is unavailable so it prints a warning and exits 0.
+# (g) Full script (#1305 contract): NO ~/.claude write, watchdog from the repo
+# The installer must not copy anything into ~/.claude/hooks and must not touch
+# ~/.claude/settings.json -- the settings hooks are repo-shipped in the tracked
+# project .claude/settings.json. The only thing it installs is the watchdog
+# daemon, whose unit must run the REPO copy of telegram_progress_watchdog.py.
+# launchctl/systemctl/pidof are stubbed via PATH so no real daemon is (un)loaded.
 # ---------------------------------------------------------------------------
 echo ""
-echo "(g) Full script: hook files are copied to DEST_DIR"
+echo "(g) Full script: no ~/.claude write, watchdog unit targets the repo"
 CASE="$TMP/case-g"
-INSTALL_G="$CASE/marveen"
 HOME_G="$CASE/home"
-HOOKS_SRC_G="$INSTALL_G/scripts/hooks"
-mkdir -p "$HOOKS_SRC_G" "$HOME_G/.claude/hooks"
-for f in telegram_progress.py telegram_progress_clear.py \
-          telegram_progress_reply_clear.py telegram_progress_watchdog.py \
-          telegram_fallback_send.py; do
-  printf '#!/usr/bin/env python3\n# stub\n' > "$HOOKS_SRC_G/$f"
+BIN_G="$CASE/bin"
+mkdir -p "$HOME_G/.claude/hooks" "$BIN_G"
+for stub in launchctl systemctl pidof; do
+  printf '#!/bin/bash\nexit 1\n' > "$BIN_G/$stub"
+  chmod +x "$BIN_G/$stub"
 done
-echo '{"hooks":{}}' > "$HOME_G/.claude/settings.json"
-cat > "$INSTALL_G/.env" <<'EOF'
-SERVICE_ID=testbot
-OWNER_NAME=Foo Bar
-BOT_NAME=TestBot
-EOF
+SETTINGS_BEFORE='{"hooks":{"marker":"untouched"}}'
+printf '%s' "$SETTINGS_BEFORE" > "$HOME_G/.claude/settings.json"
 
-# Run the real script with overridden HOME and a symlinked scripts/hooks.
-REAL_HOOKS="$REPO_ROOT/scripts/hooks"
-rm -rf "$INSTALL_G/scripts/hooks"
-mkdir -p "$INSTALL_G/scripts"
-# Use the stub hooks we created (not real ones), already in $HOOKS_SRC_G.
-OUT="$(HOME="$HOME_G" bash "$SCRIPT" 2>&1)" || true
-# The script resolves INSTALL_DIR from its own __dirname. We can't override that
-# via env, so we inject a .env next to the script's actual install dir for this
-# specific case we test via the run_env_parse helper above -- the full-run (g)
-# test focuses only on whether the copy + settings patch succeeds when a
-# spaced OWNER_NAME is present. Since the script resolves its own install dir,
-# we verify via run_env_parse that SERVICE_ID is read correctly (covered by b/f).
-# Here we just confirm the real script exits 0 with a clean .env (no spaces).
-cat > "/tmp/marveen-hook-fix/.env" <<'EOF'
-SERVICE_ID=testbot
-BOT_NAME=TestBot
-EOF
-OUT2="$(HOME="$HOME_G" bash "$SCRIPT" 2>&1)"
+OUT="$(HOME="$HOME_G" PATH="$BIN_G:$PATH" bash "$SCRIPT" 2>&1)"
 EXIT=$?
-assert_zero "full script: exits 0 with clean .env" $EXIT
+assert_zero "full script: exits 0" $EXIT
+
 for f in telegram_progress.py telegram_progress_clear.py \
           telegram_progress_reply_clear.py telegram_progress_watchdog.py \
           telegram_fallback_send.py; do
-  if [ -f "$HOME_G/.claude/hooks/$f" ]; then pass "full script: $f copied"
-  else fail "full script: $f NOT copied"; fi
+  assert_absent "$HOME_G/.claude/hooks/$f" "full script: $f NOT copied to ~/.claude/hooks"
 done
-rm -f "/tmp/marveen-hook-fix/.env"
+
+SETTINGS_AFTER="$(cat "$HOME_G/.claude/settings.json")"
+assert_eq "full script: user-global settings.json untouched" \
+          "$SETTINGS_BEFORE" "$SETTINGS_AFTER"
+
+# The daemon unit (plist on Darwin, systemd service on Linux) must reference
+# the repo watchdog, never a ~/.claude/hooks copy.
+UNIT_FILE="$(find "$HOME_G/Library/LaunchAgents" "$HOME_G/.config/systemd/user" \
+             -type f \( -name '*.plist' -o -name '*.service' \) 2>/dev/null | head -1)"
+if [ -n "$UNIT_FILE" ]; then
+  pass "full script: daemon unit written ($(basename "$UNIT_FILE"))"
+  if grep -q "$REPO_ROOT/scripts/hooks/telegram_progress_watchdog.py" "$UNIT_FILE"; then
+    pass "full script: unit runs the REPO watchdog"
+  else
+    fail "full script: unit does not reference the repo watchdog path"
+  fi
+  if grep -q "$HOME_G/.claude/hooks" "$UNIT_FILE"; then
+    fail "full script: unit still references a ~/.claude/hooks copy"
+  else
+    pass "full script: unit has no ~/.claude/hooks reference"
+  fi
+else
+  fail "full script: no daemon unit file written"
+fi
 
 # ---------------------------------------------------------------------------
 echo ""

--- a/scripts/install-channel-image-hook.sh
+++ b/scripts/install-channel-image-hook.sh
@@ -1,110 +1,19 @@
 #!/bin/bash
-# Install the channel-image-resize PreToolUse hook into ~/.claude/.
-# Protects against large channel-received images filling the context window.
-# Works for any channel provider (Telegram, Slack, etc.).
+# DEPRECATED no-op (#1305, ISSUE1305HOOKSCOPE).
 #
-# What it does:
-#   1. Copies the hook to ~/.claude/hooks/channel-image-resize.sh
-#   2. Patches ~/.claude/settings.json hooks.PreToolUse idempotently
+# This installer used to copy channel-image-resize.sh into ~/.claude/hooks and
+# patch the USER-GLOBAL ~/.claude/settings.json. Writing fleet hooks into the
+# user-global file made them fire in the owner's own, unrelated Claude Code
+# sessions (#1305), so no fleet installer may touch that file anymore.
 #
-# Also migrates the old telegram-image-resize.sh hook if present.
+# The hook is now repo-shipped: the tracked <repo>/.claude/settings.json
+# registers PreToolUse(Read) -> "$CLAUDE_PROJECT_DIR/scripts/hooks/channel-image-resize.sh"
+# in project scope, which Claude Code loads by cwd. There is nothing to install.
 #
-# Usage:
-#   bash ~/ClaudeClaw/scripts/install-channel-image-hook.sh
+# The file stays because scripts/sync-hooks.sh runs every install-*-hook.sh on
+# update; deleting it on old installs would only happen after their next pull,
+# so a loud no-op is the safe shape. Cleanup of the old ~/.claude/hooks copies
+# and stale user-global entries belongs to the global-prune round, not here.
 
-set -euo pipefail
-
-REPO_HOOK="$(cd "$(dirname "$0")" && pwd)/hooks/channel-image-resize.sh"
-DEST_HOOK="$HOME/.claude/hooks/channel-image-resize.sh"
-OLD_HOOK="$HOME/.claude/hooks/telegram-image-resize.sh"
-SETTINGS="$HOME/.claude/settings.json"
-
-if [ ! -f "$REPO_HOOK" ]; then
-  echo "❌ Source hook not found at $REPO_HOOK" >&2
-  exit 1
-fi
-
-mkdir -p "$HOME/.claude/hooks"
-cp "$REPO_HOOK" "$DEST_HOOK"
-chmod +x "$DEST_HOOK"
-echo "✓ Hook installed: $DEST_HOOK"
-
-if [ ! -f "$SETTINGS" ]; then
-  # Bootstrap minimal settings.json
-  echo '{"hooks":{"PreCompact":[],"PreToolUse":[],"PostToolUse":[]}}' > "$SETTINGS"
-fi
-
-# Patch settings.json idempotently via Python (handles JSON parse + dedup)
-python3 - "$SETTINGS" "$DEST_HOOK" <<'PYEOF'
-import json, sys
-
-settings_path, hook_path = sys.argv[1], sys.argv[2]
-with open(settings_path) as f:
-    cfg = json.load(f)
-
-hooks = cfg.setdefault('hooks', {})
-pre = hooks.setdefault('PreToolUse', [])
-
-# Already installed?
-for matcher in pre:
-    if matcher.get('matcher') != 'Read':
-        continue
-    for h in matcher.get('hooks', []):
-        if h.get('command') == hook_path:
-            print(f"⊙ Already in settings.json — skipping")
-            sys.exit(0)
-
-# Insert
-read_matcher = None
-for matcher in pre:
-    if matcher.get('matcher') == 'Read':
-        read_matcher = matcher
-        break
-
-if read_matcher is None:
-    read_matcher = {'matcher': 'Read', 'hooks': []}
-    pre.append(read_matcher)
-
-read_matcher['hooks'].append({
-    'type': 'command',
-    'command': hook_path,
-    'timeout': 15,
-})
-
-with open(settings_path, 'w') as f:
-    json.dump(cfg, f, indent=2, ensure_ascii=False)
-print(f"✓ Added PreToolUse hook for Read tool in {settings_path}")
-PYEOF
-
-# Migrate old hook: remove telegram-image-resize.sh from settings and disk
-if [ -f "$OLD_HOOK" ]; then
-  rm -f "$OLD_HOOK"
-  python3 - "$SETTINGS" "$OLD_HOOK" <<'MIGRATEOF'
-import json, sys
-
-settings_path, old_path = sys.argv[1], sys.argv[2]
-try:
-    with open(settings_path) as f:
-        cfg = json.load(f)
-except Exception:
-    sys.exit(0)
-
-pre = cfg.get('hooks', {}).get('PreToolUse', [])
-changed = False
-for matcher in pre:
-    hooks = matcher.get('hooks', [])
-    new_hooks = [h for h in hooks if h.get('command') != old_path]
-    if len(new_hooks) != len(hooks):
-        matcher['hooks'] = new_hooks
-        changed = True
-
-if changed:
-    with open(settings_path, 'w') as f:
-        json.dump(cfg, f, indent=2, ensure_ascii=False)
-    print(f"  Migrated: removed old telegram-image-resize.sh from settings")
-MIGRATEOF
-fi
-
-echo ""
-echo "Done. Channel-received images >500KB will be auto-resized."
-echo "   Originals preserved at ~/.claude/channels/<provider>/inbox/original/<filename>"
+echo "⊙ install-channel-image-hook.sh: deprecated no-op (#1305) -- the hook is repo-shipped in .claude/settings.json (project scope)"
+exit 0

--- a/scripts/install-telegram-progress-hook.sh
+++ b/scripts/install-telegram-progress-hook.sh
@@ -1,26 +1,26 @@
 #!/bin/bash
-# Install the Telegram "working…" progress indicator: hooks + a standalone
-# watchdog (sentry). Plugin-independent — needs no changes to the official
-# telegram plugin, so it survives plugin updates.
+# Install the Telegram progress-indicator WATCHDOG (sentry) daemon.
 #
-# What you get:
-#   - inbound Telegram message  -> a "✍️ Dolgozom rajta…" placeholder appears
-#   - the agent sends a reply   -> the placeholder is deleted the instant the
-#                                  answer goes out (PostToolUse), Stop as fallback
-#   - the turn never finishes    -> a watchdog rewrites the placeholder into a
-#     (crash/wedged/agent down)    clear error, so the user always gets either an
-#                                  answer or an explicit failure
+# Since #1305 (ISSUE1305HOOKSCOPE) this installer no longer touches
+# ~/.claude/settings.json and no longer copies hook files into ~/.claude/hooks:
+# writing fleet hooks into the user-global settings made them fire in the
+# owner's own, unrelated Claude Code sessions. The three settings hooks
+# (UserPromptSubmit -> telegram_progress.py, PostToolUse(telegram.*reply) ->
+# telegram_progress_reply_clear.py, Stop -> telegram_progress_clear.py) are
+# repo-shipped in the tracked <repo>/.claude/settings.json (project scope,
+# $CLAUDE_PROJECT_DIR form) -- nothing to install for them.
 #
-# What it does:
-#   1. Copies the 4 hook scripts to ~/.claude/hooks/
-#   2. Patches ~/.claude/settings.json idempotently:
-#        UserPromptSubmit -> telegram_progress.py
-#        PostToolUse(telegram.*reply) -> telegram_progress_reply_clear.py
-#        Stop -> telegram_progress_clear.py
-#   3. Installs the watchdog as a launchd agent (macOS) or systemd
-#      service+timer (Linux), running ~every 60s.
+# What REMAINS here is the piece that is not a Claude Code hook at all:
+#   telegram_progress_watchdog.py as a launchd agent (macOS) or systemd user
+#   service+timer (Linux), running ~every 60s straight from the repo checkout
+#   (no ~/.claude/hooks copy, so the daemon can never drift from the repo).
+#   The watchdog is the only layer that can speak when the agent itself is
+#   down: it rewrites an orphaned "Dolgozom rajta…" placeholder into a clear
+#   error.
 #
 # Idempotent: safe to re-run (e.g. from sync-hooks.sh on every update).
+# Cleanup of the old ~/.claude/hooks copies and stale user-global settings
+# entries belongs to the global-prune round, not here.
 #
 # Usage:
 #   bash ~/ClaudeClaw/scripts/install-telegram-progress-hook.sh
@@ -28,8 +28,6 @@
 set -euo pipefail
 
 SRC_DIR="$(cd "$(dirname "$0")" && pwd)/hooks"
-DEST_DIR="$HOME/.claude/hooks"
-SETTINGS="$HOME/.claude/settings.json"
 
 # The watchdog unit/label name keys off SERVICE_ID, matching install-linux.sh's
 # ${SERVICE_ID}-dashboard/-channels units and the macOS com.${SERVICE_ID}.*
@@ -57,112 +55,20 @@ BOT_NAME="$(read_env BOT_NAME)"
 SERVICE_ID="${SERVICE_ID:-${MAIN_AGENT_ID_ENV:-marveen}}"
 BOT_NAME="${BOT_NAME:-Marveen}"
 
-SUBMIT_HOOK="$DEST_DIR/telegram_progress.py"
-STOP_HOOK="$DEST_DIR/telegram_progress_clear.py"
-REPLY_HOOK="$DEST_DIR/telegram_progress_reply_clear.py"
-WATCHDOG="$DEST_DIR/telegram_progress_watchdog.py"
-# Agent-invoked CLI (not a settings.json hook): the Bot API fallback sender that
-# clears the placeholder on manual delivery so the Stop hook never re-sends.
-FALLBACK_SEND="$DEST_DIR/telegram_fallback_send.py"
+# The daemon runs the repo copy directly -- no drift-prone ~/.claude/hooks copy.
+WATCHDOG="$SRC_DIR/telegram_progress_watchdog.py"
 
-for f in telegram_progress.py telegram_progress_clear.py \
-         telegram_progress_reply_clear.py telegram_progress_watchdog.py \
-         telegram_fallback_send.py; do
-  if [ ! -f "$SRC_DIR/$f" ]; then
-    echo "❌ Source hook not found: $SRC_DIR/$f" >&2
-    exit 1
-  fi
-done
-
-mkdir -p "$DEST_DIR"
-cp "$SRC_DIR/telegram_progress.py"             "$SUBMIT_HOOK"
-cp "$SRC_DIR/telegram_progress_clear.py"       "$STOP_HOOK"
-cp "$SRC_DIR/telegram_progress_reply_clear.py" "$REPLY_HOOK"
-cp "$SRC_DIR/telegram_progress_watchdog.py"    "$WATCHDOG"
-cp "$SRC_DIR/telegram_fallback_send.py"        "$FALLBACK_SEND"
-chmod +x "$SUBMIT_HOOK" "$STOP_HOOK" "$REPLY_HOOK" "$WATCHDOG" "$FALLBACK_SEND"
-echo "✓ Hooks installed in $DEST_DIR"
-
-if [ ! -f "$SETTINGS" ]; then
-  echo '{"hooks":{}}' > "$SETTINGS"
+if [ ! -f "$WATCHDOG" ]; then
+  echo "❌ Watchdog source not found: $WATCHDOG" >&2
+  exit 1
 fi
 
-# Resolve an absolute python3 for both the hooks and the daemon unit.
+# Resolve an absolute python3 for the daemon unit.
 PY="$(command -v python3 || true)"
 if [ -z "$PY" ]; then
   echo "❌ python3 not found in PATH" >&2
   exit 1
 fi
-
-# --- Patch settings.json idempotently --------------------------------------
-"$PY" - "$SETTINGS" "$PY" "$SUBMIT_HOOK" "$STOP_HOOK" "$REPLY_HOOK" <<'PYEOF'
-import json, sys
-
-settings_path, py, submit_hook, stop_hook, reply_hook = sys.argv[1:6]
-with open(settings_path) as f:
-    cfg = json.load(f)
-hooks = cfg.setdefault('hooks', {})
-
-def cmd(path):
-    return f"{py} {path}"
-
-def has_command(group_list, command, matcher=None):
-    for g in group_list:
-        if matcher is not None and g.get('matcher') != matcher:
-            continue
-        for h in g.get('hooks', []):
-            if h.get('command') == command:
-                return True
-    return False
-
-def find_group(group_list, matcher):
-    for g in group_list:
-        if g.get('matcher') == matcher:
-            return g
-    return None
-
-changed = False
-
-# UserPromptSubmit (no matcher) -> placeholder
-ups = hooks.setdefault('UserPromptSubmit', [])
-if not has_command(ups, cmd(submit_hook)):
-    grp = next((g for g in ups if 'matcher' not in g), None)
-    if grp is None:
-        grp = {'hooks': []}
-        ups.append(grp)
-    grp.setdefault('hooks', []).append(
-        {'type': 'command', 'command': cmd(submit_hook), 'timeout': 15})
-    changed = True
-
-# Stop (no matcher) -> clear fallback
-stop = hooks.setdefault('Stop', [])
-if not has_command(stop, cmd(stop_hook)):
-    grp = next((g for g in stop if 'matcher' not in g), None)
-    if grp is None:
-        grp = {'hooks': []}
-        stop.append(grp)
-    grp.setdefault('hooks', []).append(
-        {'type': 'command', 'command': cmd(stop_hook), 'timeout': 15})
-    changed = True
-
-# PostToolUse(matcher="telegram.*reply") -> clear on reply
-post = hooks.setdefault('PostToolUse', [])
-if not has_command(post, cmd(reply_hook), matcher='telegram.*reply'):
-    grp = find_group(post, 'telegram.*reply')
-    if grp is None:
-        grp = {'matcher': 'telegram.*reply', 'hooks': []}
-        post.append(grp)
-    grp.setdefault('hooks', []).append(
-        {'type': 'command', 'command': cmd(reply_hook), 'timeout': 15})
-    changed = True
-
-if changed:
-    with open(settings_path, 'w') as f:
-        json.dump(cfg, f, indent=2, ensure_ascii=False)
-    print("✓ settings.json hooks patched (UserPromptSubmit / PostToolUse / Stop)")
-else:
-    print("⊙ settings.json already has the progress hooks — skipping")
-PYEOF
 
 # --- Install the watchdog daemon -------------------------------------------
 OS="$(uname -s)"
@@ -203,7 +109,7 @@ if [ "$OS" = "Darwin" ]; then
 PLISTEOF
   launchctl unload "$PLIST" 2>/dev/null || true
   launchctl load "$PLIST" 2>/dev/null || true
-  echo "✓ Watchdog installed (launchd: $LABEL, every 60s)"
+  echo "✓ Watchdog installed (launchd: $LABEL, every 60s, running $WATCHDOG)"
 else
   # Linux: systemd user service + timer
   UNIT_DIR="$HOME/.config/systemd/user"
@@ -233,7 +139,7 @@ TIMEREOF
   if pidof systemd >/dev/null 2>&1 && systemctl --user status >/dev/null 2>&1; then
     systemctl --user daemon-reload
     systemctl --user enable --now "$SVC.timer" 2>/dev/null || true
-    echo "✓ Watchdog installed (systemd timer: $SVC.timer, every 60s)"
+    echo "✓ Watchdog installed (systemd timer: $SVC.timer, every 60s, running $WATCHDOG)"
   else
     echo "⚠ systemd --user not available — units written to $UNIT_DIR"
     echo "  Enable later: systemctl --user enable --now $SVC.timer"
@@ -241,5 +147,5 @@ TIMEREOF
 fi
 
 echo ""
-echo "Done. Telegram turns now show a 'Dolgozom rajta…' placeholder that clears"
-echo "on reply, and a watchdog turns any stuck turn into a clear error."
+echo "Done. The settings hooks are repo-shipped (.claude/settings.json, project"
+echo "scope); the watchdog daemon turns any stuck Telegram turn into a clear error."

--- a/src/__tests__/hook-registration-completeness.test.ts
+++ b/src/__tests__/hook-registration-completeness.test.ts
@@ -49,6 +49,10 @@ const EXEMPT: Record<string, string> = {
     'legacy: referenced only by a historical rebuild prompt, wired nowhere; kept pending a maintainer decision to remove it',
   'telegram-ack.py':
     'unreferenced anywhere in the repo; dead code kept pending a maintainer decision to remove it',
+  'telegram_fallback_send.py':
+    'agent-invoked CLI (manual Bot API fallback sender, see scripts/lib/send-telegram.sh), not a settings hook; since #1305 the progress installer no longer copies or names it',
+  'telegram-image-resize.sh':
+    'legacy predecessor of channel-image-resize.sh; only its old installer migration path named it, and since #1305 that installer is a no-op stub -- kept pending a maintainer decision to remove it',
 }
 
 function registrationCorpus(): string {

--- a/src/__tests__/hook-scope-main-refusal.test.ts
+++ b/src/__tests__/hook-scope-main-refusal.test.ts
@@ -1,0 +1,120 @@
+// #1305 (ISSUE1305HOOKSCOPE): no scaffold write may target the user-global
+// ~/.claude/settings.json. The main agent's hooks are repo-shipped in the
+// tracked <root>/.claude/settings.json (project scope); writing them into the
+// user scope is what made fleet gates fire in the owner's own, unrelated
+// Claude Code sessions (blocked WebFetch, injected provenance banners).
+//
+// Every writer that resolves its target through agentSettingsPath() is gated:
+// ensureAgentHooks, ensureAgentStalenessHook, ensureAgentProvenanceHook,
+// ensureEgressGate. Each test asserts the REFUSAL (return false + the
+// user-global file untouched) and each has a mutation control (the same call
+// for a sub-agent still writes), so a broken gate cannot pass as "nothing
+// happened for anyone".
+//
+// HOME is redirected to a temp dir for every test: agentSettingsPath(main)
+// resolves through os.homedir() at call time, so even a broken gate can only
+// write into the sandbox, never into the operator's real home.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  ensureAgentHooks,
+  ensureAgentStalenessHook,
+  ensureAgentProvenanceHook,
+  ensureEgressGate,
+  agentSettingsPath,
+} from '../web/agent-scaffold.js'
+import { MAIN_AGENT_ID, PROJECT_ROOT } from '../config.js'
+
+const PROBE = 'mainrefusal-probe'
+const probeDir = join(PROJECT_ROOT, 'agents', PROBE)
+
+let fakeHome: string
+let realHome: string | undefined
+let mainSettings: string
+
+const MARKER = '{"hooks":{"marker":"untouched-by-1305-gate"}}'
+
+beforeEach(() => {
+  realHome = process.env.HOME
+  fakeHome = mkdtempSync(join(tmpdir(), 'refuse1305-'))
+  process.env.HOME = fakeHome
+  mkdirSync(join(fakeHome, '.claude'), { recursive: true })
+  mainSettings = agentSettingsPath(MAIN_AGENT_ID)
+  // Sanity: the redirect took, we are sandboxed.
+  expect(mainSettings).toBe(join(fakeHome, '.claude', 'settings.json'))
+  writeFileSync(mainSettings, MARKER)
+
+  if (existsSync(join(probeDir, 'HANDOFF.md'))) {
+    throw new Error(`refusing: agents/${PROBE} looks like a live agent`)
+  }
+  rmSync(probeDir, { recursive: true, force: true })
+  mkdirSync(join(probeDir, '.claude'), { recursive: true })
+})
+
+afterEach(() => {
+  process.env.HOME = realHome
+  rmSync(fakeHome, { recursive: true, force: true })
+  rmSync(probeDir, { recursive: true, force: true })
+})
+
+function mainFileUntouched(): void {
+  expect(readFileSync(mainSettings, 'utf-8')).toBe(MARKER)
+}
+
+function probeHookCommands(): string[] {
+  const p = agentSettingsPath(PROBE)
+  if (!existsSync(p)) return []
+  const parsed = JSON.parse(readFileSync(p, 'utf-8')) as {
+    hooks?: Record<string, Array<{ hooks?: Array<{ command?: string }> }>>
+  }
+  return Object.values(parsed.hooks ?? {})
+    .flat()
+    .flatMap((e) => e.hooks ?? [])
+    .map((h) => h.command ?? '')
+}
+
+describe('#1305: scaffold hook writers refuse the main agent', () => {
+  it('ensureAgentHooks: main is a no-op, a sub-agent still gets the template', () => {
+    expect(ensureAgentHooks(MAIN_AGENT_ID)).toBe(false)
+    mainFileUntouched()
+    // Mutation control: the identical call for a sub-agent writes.
+    expect(ensureAgentHooks(PROBE)).toBe(true)
+    expect(probeHookCommands().length).toBeGreaterThan(0)
+    mainFileUntouched()
+  })
+
+  it('ensureAgentStalenessHook: main is a no-op, a sub-agent still gets the hook', () => {
+    expect(ensureAgentStalenessHook(MAIN_AGENT_ID)).toBe(false)
+    mainFileUntouched()
+    expect(ensureAgentStalenessHook(PROBE)).toBe(true)
+    expect(probeHookCommands().some((c) => c.includes('staleness-guard.py'))).toBe(true)
+    mainFileUntouched()
+  })
+
+  it('ensureAgentProvenanceHook: main is a no-op, a sub-agent still gets the gate', () => {
+    expect(ensureAgentProvenanceHook(MAIN_AGENT_ID)).toBe(false)
+    mainFileUntouched()
+    expect(ensureAgentProvenanceHook(PROBE)).toBe(true)
+    expect(probeHookCommands().some((c) => c.includes('provenance-gate.py'))).toBe(true)
+    mainFileUntouched()
+  })
+
+  it('ensureEgressGate: main is a no-op, a sub-agent still gets the gate', () => {
+    expect(ensureEgressGate(MAIN_AGENT_ID)).toBe(false)
+    mainFileUntouched()
+    expect(ensureEgressGate(PROBE)).toBe(true)
+    expect(probeHookCommands().some((c) => c.includes('egress-gate.mjs'))).toBe(true)
+    mainFileUntouched()
+  })
+
+  it('a main-agent settings file is not even created when absent', () => {
+    rmSync(mainSettings, { force: true })
+    ensureAgentHooks(MAIN_AGENT_ID)
+    ensureAgentStalenessHook(MAIN_AGENT_ID)
+    ensureAgentProvenanceHook(MAIN_AGENT_ID)
+    ensureEgressGate(MAIN_AGENT_ID)
+    expect(existsSync(mainSettings)).toBe(false)
+  })
+})

--- a/src/__tests__/isolated-channel-config.test.ts
+++ b/src/__tests__/isolated-channel-config.test.ts
@@ -105,7 +105,7 @@ describe('ensureIsolatedChannelConfigDir', () => {
     expect(s.enabledPlugins[TG]).toBe(true)
     expect(s.enabledPlugins[SL]).toBe(false)
     expect(s.enabledPlugins[DI]).toBe(false)
-    expect(s.hooks).toEqual({ Stop: [] }) // shared non-plugin settings preserved
+    expect(s.hooks).toBeUndefined() // #1305: hooks never ride the clone (see isolated-config-hook-strip)
   })
 
   it('a slack agent enables ONLY slack in its isolated settings', () => {
@@ -134,7 +134,7 @@ describe('ensureIsolatedChannelConfigDir', () => {
     expect(s.enabledPlugins[TG]).toBe(false)
     expect(s.enabledPlugins[SL]).toBe(false)
     expect(s.enabledPlugins[DI]).toBe(false)
-    expect(s.hooks).toEqual({ Stop: [] }) // shared non-plugin settings preserved
+    expect(s.hooks).toBeUndefined() // #1305: hooks never ride the clone (see isolated-config-hook-strip)
   })
 
   it('channel-less provisioning still carries NO .credentials.json', () => {

--- a/src/__tests__/isolated-config-hook-strip.test.ts
+++ b/src/__tests__/isolated-config-hook-strip.test.ts
@@ -1,0 +1,95 @@
+// #1305 (ISSUE1305HOOKSCOPE): hooks never ride the isolated-config clone.
+//
+// provisionIsolatedConfigDir copies ~/.claude/settings.json into every agent's
+// .claude-config. Before this fix the copy carried the user-global `hooks`
+// block, so every isolated dir held a second, derived copy of the fleet hooks:
+// each gate fired twice per prompt (measured 2026-09-04), and the user-global
+// file looked load-bearing when it was not -- hooks load from the PROJECT
+// scope (tracked .claude/settings.json) by cwd, regardless of
+// CLAUDE_CONFIG_DIR.
+//
+// Two directions are pinned:
+//   - the shared file's hooks are stripped from the clone;
+//   - an isolated dir that ALREADY carries old derived hooks does not get
+//     them back through the target-only-key inheritance on re-provision
+//     (the inheritance block runs after the strip, so without its own
+//     'hooks' exclusion it would resurrect them every start).
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { ensureIsolatedChannelConfigDir } from '../web/agent-process.js'
+import { PROJECT_ROOT } from '../config.js'
+
+const PROBE = 'hookstrip-probe'
+const probeDir = join(PROJECT_ROOT, 'agents', PROBE)
+const isolatedSettings = join(probeDir, '.claude-config', 'settings.json')
+
+let fakeHome: string
+let realHome: string | undefined
+
+const SHARED = {
+  enabledPlugins: { 'telegram@claude-plugins-official': true },
+  statusLine: { type: 'command', command: 'echo shared' },
+  hooks: {
+    UserPromptSubmit: [
+      { hooks: [{ type: 'command', command: 'python3 /abs/scripts/hooks/provenance-gate.py' }] },
+    ],
+  },
+}
+
+function readIsolated(): Record<string, unknown> {
+  return JSON.parse(readFileSync(isolatedSettings, 'utf-8')) as Record<string, unknown>
+}
+
+beforeEach(() => {
+  realHome = process.env.HOME
+  fakeHome = mkdtempSync(join(tmpdir(), 'hookstrip-'))
+  process.env.HOME = fakeHome
+  mkdirSync(join(fakeHome, '.claude'), { recursive: true })
+  writeFileSync(join(fakeHome, '.claude', 'settings.json'), JSON.stringify(SHARED))
+
+  if (existsSync(join(probeDir, 'HANDOFF.md'))) {
+    throw new Error(`refusing: agents/${PROBE} looks like a live agent`)
+  }
+  rmSync(probeDir, { recursive: true, force: true })
+  mkdirSync(probeDir, { recursive: true })
+})
+
+afterEach(() => {
+  process.env.HOME = realHome
+  rmSync(fakeHome, { recursive: true, force: true })
+  rmSync(probeDir, { recursive: true, force: true })
+})
+
+describe('#1305: isolated-config clone strips hooks', () => {
+  it('the shared hooks block does not reach the clone (other keys do)', () => {
+    const cfg = ensureIsolatedChannelConfigDir(PROBE, null)
+    expect(cfg).not.toBeNull()
+    const settings = readIsolated()
+    expect(settings.hooks).toBeUndefined()
+    // Control: the copy itself still works -- shared keys arrive.
+    expect(settings.statusLine).toEqual(SHARED.statusLine)
+    expect(settings.enabledPlugins).toBeDefined()
+  })
+
+  it('old derived hooks in an existing isolated dir are not inherited back', () => {
+    mkdirSync(join(probeDir, '.claude-config'), { recursive: true })
+    writeFileSync(isolatedSettings, JSON.stringify({
+      hooks: SHARED.hooks, // the pre-#1305 derived copy
+      agentOnlyKey: 'must-survive',
+    }))
+    ensureIsolatedChannelConfigDir(PROBE, null)
+    const settings = readIsolated()
+    expect(settings.hooks).toBeUndefined()
+    // Control: target-only inheritance itself still works for other keys --
+    // the strip is surgical, not a veto on the merge.
+    expect(settings.agentOnlyKey).toBe('must-survive')
+  })
+
+  it('stays hook-free on a second provision (idempotent)', () => {
+    ensureIsolatedChannelConfigDir(PROBE, null)
+    ensureIsolatedChannelConfigDir(PROBE, null)
+    expect(readIsolated().hooks).toBeUndefined()
+  })
+})

--- a/src/__tests__/project-settings-hook-anchor.test.ts
+++ b/src/__tests__/project-settings-hook-anchor.test.ts
@@ -1,0 +1,94 @@
+// #1305 (ISSUE1305HOOKSCOPE): the tracked .claude/settings.json is the
+// AUTHORITATIVE registration surface for the main agent's fleet hooks. The
+// scaffold refuses to write them anywhere else (hook-scope-main-refusal
+// pins that), so if an entry silently falls out of this file, nothing
+// re-adds it -- the hook just stops firing. This anchor makes such a drop
+// loud: the full expected set is spelled out, per event.
+//
+// Portability is part of the contract: every command must resolve through
+// $CLAUDE_PROJECT_DIR (the file ships to every install), and the WebFetch
+// egress gate must keep its fail-CLOSED preamble -- the user-global variant
+// pinned a machine-local node path, which is exactly what broke in the
+// owner's own sessions (#1305) and what a "simplifying" edit would
+// reintroduce.
+import { describe, it, expect } from 'vitest'
+import { readFileSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+
+const ROOT = join(__dirname, '..', '..')
+const SETTINGS_PATH = join(ROOT, '.claude', 'settings.json')
+
+interface HookEntry { matcher?: string; hooks?: Array<{ type?: string; command?: string; timeout?: number }> }
+type Hooks = Record<string, HookEntry[]>
+
+const settings = JSON.parse(readFileSync(SETTINGS_PATH, 'utf-8')) as { hooks?: Hooks }
+const hooks: Hooks = settings.hooks ?? {}
+
+// The full expected registration: event -> script basenames (order-free).
+// A change here is a REVIEWED decision about what runs in the main session,
+// never a side effect.
+const EXPECTED: Record<string, string[]> = {
+  UserPromptSubmit: [
+    'ledger-capture.py', 'inbox-drain.py', 'telegram-reply-directive.py',
+    'provenance-gate.py', 'staleness-guard.py', 'channel-inbox-drain.py',
+    'voice-reply-directive.py', 'telegram_progress.py', 'claude-usage.py',
+  ],
+  PostToolUse: [
+    'ledger-outbound.py', 'tool-log-capture.py',
+    'telegram_progress_reply_clear.py', 'skill-usage-capture.py',
+  ],
+  PreToolUse: [
+    'outgoing-copy-gate.py', 'email-approval-gate.py',
+    'channel-image-resize.sh', 'egress-gate.mjs',
+  ],
+  Stop: ['telegram-reply-guard.py', 'telegram_progress_clear.py'],
+  SessionStart: ['ledger-replay.py', 'taskstate-replay.py', 'clear-replay.py'],
+  SessionEnd: ['clear-capture.py'],
+}
+
+function commands(event: string): string[] {
+  return (hooks[event] ?? []).flatMap((e) => e.hooks ?? []).map((h) => h.command ?? '')
+}
+
+function scriptNames(event: string): Set<string> {
+  return new Set(
+    commands(event)
+      .map((c) => c.match(/scripts\/hooks\/([^/\s'"]+?\.(?:py|sh|mjs))/)?.[1] ?? '')
+      .filter(Boolean),
+  )
+}
+
+describe('tracked .claude/settings.json hook anchor (#1305)', () => {
+  it('registers exactly the expected script set per event', () => {
+    expect(Object.keys(hooks).sort()).toEqual(Object.keys(EXPECTED).sort())
+    for (const [event, expected] of Object.entries(EXPECTED)) {
+      expect([...scriptNames(event)].sort(), `event ${event}`).toEqual([...new Set(expected)].sort())
+    }
+  })
+
+  it('every referenced script exists in scripts/hooks/', () => {
+    for (const event of Object.keys(EXPECTED)) {
+      for (const name of scriptNames(event)) {
+        expect(existsSync(join(ROOT, 'scripts', 'hooks', name)), `missing scripts/hooks/${name}`).toBe(true)
+      }
+    }
+  })
+
+  it('every command is portable: $CLAUDE_PROJECT_DIR, no machine-local paths', () => {
+    for (const event of Object.keys(hooks)) {
+      for (const cmd of commands(event)) {
+        expect(cmd, `event ${event}`).toContain('$CLAUDE_PROJECT_DIR')
+        expect(cmd).not.toMatch(/\/(Users|home|opt|var)\//)
+      }
+    }
+  })
+
+  it('the WebFetch egress gate keeps its fail-closed preamble', () => {
+    const webfetch = (hooks.PreToolUse ?? []).filter((e) => e.matcher === 'WebFetch')
+    expect(webfetch).toHaveLength(1)
+    const cmd = webfetch[0].hooks?.[0]?.command ?? ''
+    // No node -> BLOCK (exit 2), never fail-open silence.
+    expect(cmd).toMatch(/command -v node[^;]*\|\|\s*\{[^}]*exit 2/)
+    expect(cmd).toContain('egress-gate.mjs')
+  })
+})

--- a/src/web/agent-process.ts
+++ b/src/web/agent-process.ts
@@ -746,6 +746,15 @@ function provisionIsolatedConfigDir(
       try { settings = JSON.parse(readFileSync(sharedSettings, 'utf-8')) as Record<string, unknown> }
       catch { settings = {} }
     }
+    // #1305: hooks never ride the clone. Fleet hooks live in the PROJECT scope
+    // (tracked <root>/.claude/settings.json for the main agent, agents/<n>/
+    // .claude/ for sub-agents), which Claude Code loads by cwd regardless of
+    // CLAUDE_CONFIG_DIR. Copying the shared file's hooks here is what made the
+    // isolated dirs carry a second, derived copy of the user-global entries --
+    // it double-fired every gate (measured 2026-09-04: two identical
+    // PROVENANCE-KAPU blocks per prompt) and made the global file look load-
+    // bearing when it was not.
+    delete settings.hooks
     const scopedPlugins = scopeChannelPlugins(
       providerType,
       settings.enabledPlugins as Record<string, boolean> | undefined,
@@ -787,7 +796,11 @@ function provisionIsolatedConfigDir(
         if (isPlainObject(own)) {
           const inherited: string[] = []
           for (const [key, value] of Object.entries(own)) {
-            if (key !== 'enabledPlugins' && !(key in settings)) {
+            // 'hooks' is excluded here too: the shared copy just dropped it
+            // (#1305), so without this exclusion an isolated dir that already
+            // carries the old derived hooks would inherit them right back as a
+            // "target-only" key on every re-provision.
+            if (key !== 'enabledPlugins' && key !== 'hooks' && !(key in settings)) {
               settings[key] = value
               inherited.push(key)
             }

--- a/src/web/agent-scaffold.ts
+++ b/src/web/agent-scaffold.ts
@@ -146,12 +146,27 @@ export function resolveTemplatePlaceholders(content: string): string {
 }
 
 // Return the settings.json path for an agent.
-// The main agent's settings live at ~/.claude/settings.json (not inside agents/).
-// Exported so the startup self-heal (hook-registration-guard) can prune stale
-// entries from the same files this module writes.
+// The main agent's path still names ~/.claude/settings.json, but since
+// ISSUE1305HOOKSCOPE that file is READ-ONLY territory for this module: the
+// startup self-heal (hook-registration-guard) may still prune stale entries
+// out of it, while every WRITE path below refuses the main agent -- its hooks
+// are repo-shipped in the tracked <PROJECT_ROOT>/.claude/settings.json
+// (project scope, portable $CLAUDE_PROJECT_DIR form). Writing fleet hooks
+// into the user-global file is what made them fire in the owner's own,
+// unrelated Claude Code sessions (#1305: blocked WebFetch there, plus a
+// prompt-injection surface and foreign content reaching fleet memory).
 export function agentSettingsPath(name: string): string {
   if (name === MAIN_AGENT_ID) return join(homedir(), '.claude', 'settings.json')
   return join(agentDir(name), '.claude', 'settings.json')
+}
+
+// The single gate for the #1305 class: no scaffold write may target the
+// user-global settings. Main-agent hooks ship in the repo's project settings;
+// sub-agents keep their per-agent project files (agents/<n>/.claude/).
+function refuseMainAgentHookWrite(name: string, fn: string): boolean {
+  if (name !== MAIN_AGENT_ID) return false
+  logger.debug({ fn }, 'hook write skipped for main agent: hooks are repo-shipped project settings (#1305)')
+  return true
 }
 
 // Volatile tmpfs prefixes: a hook command referencing these directories is
@@ -344,6 +359,7 @@ export function ensureAgentHooks(
   // writing into the operator's real home.
   scopes?: { user: string; project: string },
 ): boolean {
+  if (refuseMainAgentHookWrite(name, 'ensureAgentHooks')) return false
   const settingsPath = agentSettingsPath(name)
   const tplPath = join(PROJECT_ROOT, 'templates', 'settings.json.template')
   if (!existsSync(tplPath)) return false
@@ -479,6 +495,7 @@ const _stalenessScript = join(PROJECT_ROOT, 'scripts', 'hooks', 'staleness-guard
 const STALENESS_HOOK_CMD = `bash -c '[ -f ${_stalenessScript} ] && exec python3 ${_stalenessScript}; exit 0'`
 
 export function ensureAgentStalenessHook(name: string): boolean {
+  if (refuseMainAgentHookWrite(name, 'ensureAgentStalenessHook')) return false
   // agentSettingsPath() maps MAIN_AGENT_ID to ~/.claude/settings.json; using
   // agentDir() directly here would create a spurious agents/<main> dir and make
   // the main agent show up as a phantom "down" agent on the dashboard.
@@ -521,6 +538,7 @@ const _provenanceScript = join(PROJECT_ROOT, 'scripts', 'hooks', 'provenance-gat
 const PROVENANCE_HOOK_CMD = `bash -c '[ -f ${_provenanceScript} ] && exec python3 ${_provenanceScript}; exit 0'`
 
 export function ensureAgentProvenanceHook(name: string): boolean {
+  if (refuseMainAgentHookWrite(name, 'ensureAgentProvenanceHook')) return false
   const settingsPath = agentSettingsPath(name)
   let settings: Record<string, unknown> = {}
   if (existsSync(settingsPath)) {
@@ -1030,6 +1048,11 @@ export function ensureTelegramCopyGate(name: string): boolean {
 // the hook is applied to both existing and newly-created agents without a full
 // respawn. Returns true if the file was updated, false if already wired.
 export function ensureEgressGate(name: string): boolean {
+  // #1305: the main agent's egress gate is repo-shipped in the tracked project
+  // settings (portable, fail-CLOSED `command -v node` form). Writing the
+  // machine-pinned node path into ~/.claude/settings.json is exactly what
+  // blocked WebFetch in the owner's own unrelated sessions.
+  if (refuseMainAgentHookWrite(name, 'ensureEgressGate')) return false
   const settingsPath = agentSettingsPath(name)
   let settings: Record<string, unknown> = {}
   if (existsSync(settingsPath)) {


### PR DESCRIPTION
## Mit old meg

#1305 (külső vevő-panasz): a flotta hookjai a user-globális `~/.claude/settings.json`-ba íródtak, ezért a gazda SAJÁT, tőlünk független Claude Code sessionjeiben is futottak — WebFetch-blokk, prompt-injekció-felület, idegen tartalom a flotta-memóriában. A határ: a user-globális fájl nem a miénk.

Ez a Marveen-GO (msg 24524) szerinti bontás **(2) része**: a fő-agens hookjai repo-szállított, portable projekt-scope-ba kerülnek, és minden kód-út, ami eddig a globálba írt, refuse-kaput kap. A **(3) vevő-gépi rész NEM indul** (Marveen-tiltás); az **(1) globál-prune ezután a merge + host-update UTÁN ismételhető meg, és akkor már TARTÓS** (lásd lent, miért fordult a sorrend).

## DESIGN-DELTA — review-döntés Marveené

A GO-szöveg (24526-os terv) az `agentSettingsPath(main)` átcélzását mondta a `.channels-config/settings.json`-ra izolált módban. **Az implementált terv ettől eltér, mérésre alapozva:** a provisioner (`agent-process.ts` `provisionIsolatedConfigDir`) a `.channels-config/settings.json`-t MINDEN startnál újraírja a globál-klónból — az oda írt hook minden restartnál törlődne, a config-dir nem tartós írás-cél. Ehelyett a hookok a KÖVETETT `.claude/settings.json`-ban élnek (projekt-scope), amit a Claude Code cwd szerint tölt be `CLAUDE_CONFIG_DIR`-től függetlenül — a kód saját kommentje szerint is ez az autoritatív réteg, és a 2026-09-04-i dupla-tüzelés mérés bizonyítja, hogy a fő-session betölti. `agentSettingsPath` változatlan (a hook-registration-guard prune-olvasója továbbra is a globált olvassa).

## Miért fordult a sorrend ((2) előbb, (1) utána)

Az (1) globál-törlés első kísérlete kódból dőlt meg (jelentve 24526):
1. `ensureAgentHooks` minden dashboard-startnál visszamergeli a template-et a globálba;
2. `agent-process.ts` a globált klónozza per-spawn az izolált config-dirökbe — a config-dir "duplikátumok" a globálból származnak, törlés után a respawn hook-nélküli klónt kapott volna.

E PR mindkét mechanizmust elzárja, ezért merge + host-update után az (1) prune megismételhető és tartós.

## Változások

1. **`.claude/settings.json`** (tömör alak megtartva — a diff csak a tartalmi deltát mutatja, +20/−5): 13 hiányzó bejegyzés portolva portable `$CLAUDE_PROJECT_DIR` alakban. A WebFetch egress-kapu **fail-closed** portolással: `command -v node || exit 2` a gép-pinnelt `/opt/homebrew/...` út helyett — ha nincs node, a kapu BLOKKOL, nem nyílik ki csendben. Provenance-gate nem duplikálva, üres PreCompact kihagyva.
2. **`agent-scaffold.ts`**: `refuseMainAgentHookWrite()` — mind a NÉGY globálba író fn kapuzva (ensureAgentHooks, ensureAgentStalenessHook, ensureAgentProvenanceHook, ensureEgressGate).
3. **`agent-process.ts`**: a klón `delete settings.hooks` — hookok soha nem utaznak az izolált config-dirökbe. **Plusz egy munka közben talált rés lezárva:** a target-only kulcs-öröklés a strip UTÁN fut, tehát a meglévő izolált dirök RÉGI derived hookjai visszaöröklődtek volna minden re-provisionnél — a `hooks` kulcs az öröklésből is kizárva, teszt pineli.
4. **Installerek**: `install-channel-image-hook.sh` → hangos no-op stub; `install-telegram-progress-hook.sh` → csak a watchdog-démon marad (az nem Claude Code hook), és a REPO-beli watchdogot futtatja `~/.claude/hooks` másolat helyett. Egyik sem ír többé `~/.claude/settings.json`-t.
5. **Tesztek**: 3 új fájl (main-refusal mutációs kontrollal sandbox-HOME alatt; clone-strip a visszaöröklés-esettel; tracked-fájl anchor a teljes elvárt bejegyzés-halmazra + portabilitásra + fail-closed WebFetch alakra), installer-kontrakt teszt (g) újraírva, isolated-channel-config igazítva, 2 indokolt EXEMPT a completeness-lintben.

## Bizonyíték: a fő-session a PROJEKT-scope-ról tüzel (hatás, nem fájl-visszaolvasás)

Mérve 2026-09-13 08:44-kor az élő fő-gépen, a `tool-log-capture.py` műszerrel (PostToolUse → `tool_call_log` tábla), amely CSAK a tracked projekt-fájlban van regisztrálva:
- user-globális `~/.claude/settings.json`: **0 találat** a tool-log-capture-re;
- a fő-agens izolált klónja (`.channels-config/settings.json`): **0 találat**;
- tracked `.claude/settings.json` a prod fán: **1 találat**;
- és közben a `tool_call_log`-ban **165 friss `marveen` sor** az elmúlt 4 órából (utolsó: 2026-09-13 08:44:06).

Az egyetlen regisztráció, ami ezeket a sorokat táplálhatja, a projekt-scope — tehát a fő-session bizonyítottan betölti és futtatja a repo-szállított hookokat, pontosan az új úton.

## Verifikáció

- `tsc --noEmit`: zöld
- teljes vitest suite a worktree-ben (friss `npm ci` után): **434 fájl / 5506 teszt zöld, 0 hiba**
- `scripts/__tests__/install-telegram-progress-hook.test.sh`: 27/27 PASS
- `.claude/settings.json` szemantikus egyenlőség-ellenőrzéssel regenerálva (json.load-egyezés a kézzel szerkesztett változattal), majd anchor-teszttel pinelve

## Párhuzamos külső PR-ok ugyanebben a fájlban (Marveen 24533/24537)

Három nyitott külső PR dolgozik a `src/web/agent-process.ts`-ben: **#978** (mogganhun, isolated-hook merge), **#972** (Vlbbtabs, email-gate ledger), **#804** (nortops, custom model-provider). Az itteni `agent-process.ts` érintés ezért szándékosan minimális: 10 sor (a `delete settings.hooks` + komment, és a target-only öröklés `hooks`-kizárása). A külső PR-ok sorsa Marveen asztala.

**#978 viszonya ehhez a PR-hez (mérve):** a kettő ugyanazon a kód-helyen POLICY-ellentét. A #978 az izolált fájl SAJÁT hookjait per-entry merge-dzsel megőrizné; ez a PR azt mondja ki, hogy az izolált fájl egyáltalán nem hook-regisztrációs felület (a hookok projekt-scope-ban élnek). A #978 által mért vesztés-mechanizmus ezt a PR-t NEM éri el: a hookok a tracked `.claude/settings.json`-ban vannak, amit a provisioner soha nem ír újra — pont ezért nem a config-dir lett a cél (lásd DESIGN-DELTA fent). Textuális ütközés mérve: 3 conflict-marker a két fej merge-tree-jében. A #978-ról szóló döntés nem ennek a PR-nek a része.

**Bizonyíték-frissítés — restart UTÁNI mérés (Marveen kérése):** a fő-session (`marveen-channels` tmux) 2026-09-13 02:23:03-kor indult újra (ekkor fut le a teljes izolált-config provisioning is). Az első tool-log-capture sor a `tool_call_log`-ban **02:23:21** — 18 másodperccel a start után —, azóta **339 marveen-sor** (utolsó 08:52:37). A hook tehát friss induláskor is az egyetlen regisztrációs helyéről, a projekt-scope-ból tüzel; a #978-féle induláskori vesztés ezt az utat nem érinti.

## Ami szándékosan NEM része

- A meglévő `~/.claude/hooks` másolatok és az élő globál bejegyzéseinek takarítása → (1) prune-kör, merge + host-update után (backup+hatás-verify+rollback keret, meglévő backup: `store/hookscope-backup/settings.json.pre-prune-20260913-081040`).
- A (3) vevő-gépi rész (Marveen 24524 szerint nem indul).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
