### PR TITLE
fix(installer): slack-agi managed-settings iras atomikus, es soha nem epiti ujra az org-policyt (SLACKMGDATOM913)

### DIFF
--- a/install-macos.sh
+++ b/install-macos.sh
@@ -595,28 +595,73 @@ except: sys.exit(1)
 " 2>/dev/null && echo "yes" || echo "no")
     if [ "$HAS_ALL" = "no" ]; then
       echo -e "  ${ORANGE}⚠${NC} $(_t macos.managed_update)"
-      echo "$REQUIRED_JSON" | sudo python3 -c "
-import json, sys
-new = json.loads(sys.stdin.read())
+      # Safe JSON merge (same shape as the Discord branch / #1306): tmp file +
+      # copymode + os.replace, so no interruption can leave a truncated
+      # managed-settings behind. And an org-policy file is NEVER rebuilt from
+      # scratch: on a parse failure we say so and leave it untouched -- the old
+      # empty-object fallback silently dropped every OTHER managed key
+      # (channelsEnabled, other allowlists) host-wide. The old shape also
+      # piped through `sudo tee`, which TRUNCATES the file even when the merge
+      # process fails -- a failed merge left an EMPTY org-policy file behind.
+      if sudo python3 - "$MANAGED_FILE" <<'SLACKMERGEPY'
+import json, os, shutil, sys
+p = sys.argv[1]
+required = [
+    {'plugin': 'slack-channel', 'marketplace': 'marveen-marketplace'},
+    {'plugin': 'telegram', 'marketplace': 'claude-plugins-official'},
+    {'plugin': 'teams', 'marketplace': 'marveen-marketplace'},
+    {'plugin': 'discord', 'marketplace': 'claude-plugins-official'},
+]
 try:
-  with open('$MANAGED_FILE') as f: existing = json.load(f)
-except: existing = {}
-plugins = existing.get('allowedChannelPlugins', [])
-for entry in new['allowedChannelPlugins']:
-  if not any(p.get('plugin')==entry['plugin'] and p.get('marketplace')==entry['marketplace'] for p in plugins):
-    plugins.append(entry)
-existing['allowedChannelPlugins'] = plugins
-print(json.dumps(existing, indent=2))
-" | sudo tee "$MANAGED_FILE" > /dev/null
-      echo -e "  ${GREEN}✓${NC} $(_t macos.managed_updated)"
+    d = json.load(open(p))
+except Exception as e:
+    print(f"managed-settings parse failed, NOT writing: {e}", file=sys.stderr)
+    sys.exit(1)
+if not isinstance(d, dict):
+    print("managed-settings root is not an object, NOT writing", file=sys.stderr)
+    sys.exit(1)
+plugins = d.get('allowedChannelPlugins', [])
+for entry in required:
+    if not any(p2.get('plugin') == entry['plugin'] and p2.get('marketplace') == entry['marketplace'] for p2 in plugins):
+        plugins.append(entry)
+d['allowedChannelPlugins'] = plugins
+tmp = p + '.tmp'
+with open(tmp, 'w') as f:
+    f.write(json.dumps(d, indent=2) + "\n")
+shutil.copymode(p, tmp)
+os.replace(tmp, p)
+SLACKMERGEPY
+      then
+        echo -e "  ${GREEN}✓${NC} $(_t macos.managed_updated)"
+      else
+        echo -e "  ${RED}✗${NC} A managed-settings.json nem volt biztonsagosan frissitheto -- a fajl ERINTETLEN maradt."
+        echo -e "  ${DIM}Kezi potlas (root): add az allowedChannelPlugins tombhoz a hianyzo bejegyzeseket:${NC}"
+        echo -e "  ${DIM}  $REQUIRED_JSON${NC}"
+      fi
     else
       echo -e "  ${GREEN}✓${NC} $(_t macos.managed_has_slack)"
     fi
   else
     echo -e "  ${ORANGE}⚠${NC} $(_t macos.managed_create)"
     sudo mkdir -p "$MANAGED_DIR"
-    echo "$REQUIRED_JSON" | python3 -c "import json,sys; print(json.dumps(json.loads(sys.stdin.read()),indent=2))" | sudo tee "$MANAGED_FILE" > /dev/null
-    echo -e "  ${GREEN}✓${NC} $(_t macos.managed_created)"
+    # Fresh file: still tmp + os.replace, so an interrupted install can never
+    # leave a truncated/empty org-policy file that a later run would then
+    # refuse to touch (the merge above declines unparseable files by design).
+    if echo "$REQUIRED_JSON" | sudo python3 -c "
+import json, os, sys
+p = '$MANAGED_FILE'
+data = json.load(sys.stdin)
+tmp = p + '.tmp'
+with open(tmp, 'w') as f:
+    f.write(json.dumps(data, indent=2) + \"\n\")
+os.replace(tmp, p)
+"
+    then
+      echo -e "  ${GREEN}✓${NC} $(_t macos.managed_created)"
+    else
+      echo -e "  ${RED}✗${NC} A managed-settings.json letrehozasa nem sikerult -- kezi potlas (root):"
+      echo -e "  ${DIM}  echo '$REQUIRED_JSON' > \"$MANAGED_FILE\"${NC}"
+    fi
   fi
 fi
 

--- a/install-macos.sh
+++ b/install-macos.sh
@@ -647,15 +647,25 @@ SLACKMERGEPY
     # Fresh file: still tmp + os.replace, so an interrupted install can never
     # leave a truncated/empty org-policy file that a later run would then
     # refuse to touch (the merge above declines unparseable files by design).
-    if echo "$REQUIRED_JSON" | sudo python3 -c "
+    if sudo python3 - "$MANAGED_FILE" <<'SLACKCREATEPY'
 import json, os, sys
-p = '$MANAGED_FILE'
-data = json.load(sys.stdin)
+p = sys.argv[1]
+required = [
+    {'plugin': 'slack-channel', 'marketplace': 'marveen-marketplace'},
+    {'plugin': 'telegram', 'marketplace': 'claude-plugins-official'},
+    {'plugin': 'teams', 'marketplace': 'marveen-marketplace'},
+    {'plugin': 'discord', 'marketplace': 'claude-plugins-official'},
+]
 tmp = p + '.tmp'
 with open(tmp, 'w') as f:
-    f.write(json.dumps(data, indent=2) + \"\n\")
+    f.write(json.dumps({'allowedChannelPlugins': required}, indent=2) + "\n")
+# A fresh tmp inherits the caller's umask; under `umask 077` that leaves a
+# root-owned 0600 policy the unprivileged session cannot read, so the channel
+# policy silently never takes effect (the exact trap documented in
+# scripts/ensure-managed-channels-enabled.sh) -- pin the world-readable mode.
+os.chmod(tmp, 0o644)
 os.replace(tmp, p)
-"
+SLACKCREATEPY
     then
       echo -e "  ${GREEN}✓${NC} $(_t macos.managed_created)"
     else

--- a/src/__tests__/installer-slack-managed-atomic.test.ts
+++ b/src/__tests__/installer-slack-managed-atomic.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync, writeFileSync, mkdtempSync, rmSync, chmodSync, statSync, readdirSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+// SLACKMGDATOM913: the slack branch of the macOS installer wrote the system
+// org-policy file (/Library/Application Support/ClaudeCode/managed-settings.json)
+// through `... | sudo python3 | sudo tee` with an `except: existing = {}`
+// fallback. Two measured failure shapes:
+//   - tee TRUNCATES the target before its stdin arrives, so a failing merge
+//     process left an EMPTY org-policy file behind (host-wide channel mute);
+//   - the {} fallback silently rebuilt the policy from scratch on any parse
+//     hiccup, dropping every OTHER managed key (channelsEnabled, other
+//     allowlists).
+// The fix adopts the #1306 Discord-branch shape (tmp + copymode + os.replace,
+// refuse-to-write on parse failure). The installer runs on customer Macs where
+// no harness executes it end to end, so this suite anchors the shipped text
+// AND actually runs the extracted merge script against temp files.
+
+const ROOT = join(__dirname, '..', '..')
+const MAC = readFileSync(join(ROOT, 'install-macos.sh'), 'utf-8')
+
+function slackMergeSource(): string {
+  const open = MAC.indexOf("<<'SLACKMERGEPY'")
+  const start = MAC.indexOf('\n', open) + 1
+  const end = MAC.indexOf('\nSLACKMERGEPY', start)
+  expect(open, 'SLACKMERGEPY heredoc present').toBeGreaterThan(-1)
+  expect(end).toBeGreaterThan(start)
+  return MAC.slice(start, end)
+}
+
+describe('slack-branch managed-settings write is atomic and refuses to rebuild (SLACKMGDATOM913)', () => {
+  it('the old unsafe shapes are gone from the shipped installer', () => {
+    expect(MAC).not.toContain('except: existing = {}')
+    // tee must never target the org-policy file again -- it truncates first.
+    expect(MAC).not.toContain('tee "$MANAGED_FILE"')
+  })
+
+  it('the merge block carries the safe-merge markers', () => {
+    const block = slackMergeSource()
+    expect(block).toContain('os.replace(tmp, p)')
+    expect(block).toContain('shutil.copymode(p, tmp)')
+    expect(block).toContain('NOT writing')
+  })
+
+  it('the create branch also writes via tmp + os.replace', () => {
+    const createBlock = MAC.slice(MAC.indexOf('macos.managed_create'), MAC.indexOf('Channel inbound org-policy gate'))
+    expect(createBlock).toContain('os.replace(tmp, p)')
+  })
+
+  describe('the extracted merge script, executed for real', () => {
+    function run(dir: string, content: string, mode?: number): { status: number; after: string } {
+      const target = join(dir, 'managed-settings.json')
+      writeFileSync(target, content)
+      if (mode !== undefined) chmodSync(target, mode)
+      let status = 0
+      try {
+        execFileSync('python3', ['-', target], { input: slackMergeSource(), stdio: ['pipe', 'pipe', 'pipe'] })
+      } catch (err) {
+        status = (err as { status?: number }).status ?? -1
+      }
+      return { status, after: readFileSync(target, 'utf-8') }
+    }
+
+    it('merges the four entries into a live policy and KEEPS unrelated keys and the file mode', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'slackmgd-'))
+      try {
+        const before = JSON.stringify({
+          channelsEnabled: true,
+          allowedChannelPlugins: [{ plugin: 'slack-channel', marketplace: 'marveen-marketplace' }],
+        })
+        const { status, after } = run(dir, before, 0o600)
+        expect(status).toBe(0)
+        const parsed = JSON.parse(after) as { channelsEnabled?: boolean; allowedChannelPlugins: Array<{ plugin: string }> }
+        expect(parsed.channelsEnabled).toBe(true) // the {} fallback would have dropped this
+        expect(parsed.allowedChannelPlugins.map((p) => p.plugin).sort())
+          .toEqual(['discord', 'slack-channel', 'teams', 'telegram'])
+        // copymode: the 0600 org-policy stays 0600
+        expect(statSync(join(dir, 'managed-settings.json')).mode & 0o777).toBe(0o600)
+        // atomic: no leftover tmp file
+        expect(readdirSync(dir)).toEqual(['managed-settings.json'])
+      } finally {
+        rmSync(dir, { recursive: true, force: true })
+      }
+    })
+
+    it('a corrupt policy file is left BYTE-IDENTICAL, exit non-zero', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'slackmgd-'))
+      try {
+        const corrupt = '{ this is not json'
+        const { status, after } = run(dir, corrupt)
+        expect(status).not.toBe(0)
+        expect(after).toBe(corrupt)
+      } finally {
+        rmSync(dir, { recursive: true, force: true })
+      }
+    })
+
+    it('a non-object root is refused, file untouched', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'slackmgd-'))
+      try {
+        const { status, after } = run(dir, '[1,2,3]')
+        expect(status).not.toBe(0)
+        expect(after).toBe('[1,2,3]')
+      } finally {
+        rmSync(dir, { recursive: true, force: true })
+      }
+    })
+
+    it('is idempotent: a second run changes nothing', () => {
+      const dir = mkdtempSync(join(tmpdir(), 'slackmgd-'))
+      try {
+        const first = run(dir, JSON.stringify({ allowedChannelPlugins: [] }))
+        expect(first.status).toBe(0)
+        const target = join(dir, 'managed-settings.json')
+        const between = readFileSync(target, 'utf-8')
+        let status = 0
+        try {
+          execFileSync('python3', ['-', target], { input: slackMergeSource(), stdio: ['pipe', 'pipe', 'pipe'] })
+        } catch (err) {
+          status = (err as { status?: number }).status ?? -1
+        }
+        expect(status).toBe(0)
+        expect(readFileSync(target, 'utf-8')).toBe(between)
+      } finally {
+        rmSync(dir, { recursive: true, force: true })
+      }
+    })
+  })
+})

--- a/src/__tests__/installer-slack-managed-atomic.test.ts
+++ b/src/__tests__/installer-slack-managed-atomic.test.ts
@@ -21,14 +21,16 @@ import { join } from 'node:path'
 const ROOT = join(__dirname, '..', '..')
 const MAC = readFileSync(join(ROOT, 'install-macos.sh'), 'utf-8')
 
-function slackMergeSource(): string {
-  const open = MAC.indexOf("<<'SLACKMERGEPY'")
+function heredocSource(marker: string): string {
+  const open = MAC.indexOf(`<<'${marker}'`)
   const start = MAC.indexOf('\n', open) + 1
-  const end = MAC.indexOf('\nSLACKMERGEPY', start)
-  expect(open, 'SLACKMERGEPY heredoc present').toBeGreaterThan(-1)
+  const end = MAC.indexOf(`\n${marker}`, start)
+  expect(open, `${marker} heredoc present`).toBeGreaterThan(-1)
   expect(end).toBeGreaterThan(start)
   return MAC.slice(start, end)
 }
+const slackMergeSource = (): string => heredocSource('SLACKMERGEPY')
+const slackCreateSource = (): string => heredocSource('SLACKCREATEPY')
 
 describe('slack-branch managed-settings write is atomic and refuses to rebuild (SLACKMGDATOM913)', () => {
   it('the old unsafe shapes are gone from the shipped installer', () => {
@@ -44,9 +46,31 @@ describe('slack-branch managed-settings write is atomic and refuses to rebuild (
     expect(block).toContain('NOT writing')
   })
 
-  it('the create branch also writes via tmp + os.replace', () => {
-    const createBlock = MAC.slice(MAC.indexOf('macos.managed_create'), MAC.indexOf('Channel inbound org-policy gate'))
+  it('the create branch also writes via tmp + os.replace, with the mode pinned', () => {
+    const createBlock = slackCreateSource()
     expect(createBlock).toContain('os.replace(tmp, p)')
+    // Review condition (#1308): a fresh tmp inherits the caller's umask, and
+    // under umask 077 a root-owned 0600 policy is unreadable to the session --
+    // the channel policy silently never takes effect. Same pin as
+    // scripts/ensure-managed-channels-enabled.sh.
+    expect(createBlock).toContain('os.chmod(tmp, 0o644)')
+  })
+
+  it('the extracted create script writes a 0644 policy even under umask 077', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'slackmgd-'))
+    try {
+      const target = join(dir, 'managed-settings.json')
+      execFileSync('bash', ['-c', 'umask 077; exec python3 - "$0"', target], {
+        input: slackCreateSource(), stdio: ['pipe', 'pipe', 'pipe'],
+      })
+      const parsed = JSON.parse(readFileSync(target, 'utf-8')) as { allowedChannelPlugins: Array<{ plugin: string }> }
+      expect(parsed.allowedChannelPlugins.map((p) => p.plugin).sort())
+        .toEqual(['discord', 'slack-channel', 'teams', 'telegram'])
+      expect(statSync(target).mode & 0o777).toBe(0o644)
+      expect(readdirSync(dir)).toEqual(['managed-settings.json'])
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
   })
 
   describe('the extracted merge script, executed for real', () => {


### PR DESCRIPTION
## Mit old meg

A macOS telepítő slack-ága a rendszer-szintű org-policy fájlt (`/Library/Application Support/ClaudeCode/managed-settings.json`) `... | sudo python3 | sudo tee` láncon írta, üres-objektum parse-hiba fallbackkel. Két hibaalak, mindkettő host-szintű csatorna-némítás:
- a `tee` a cél-fájlt ELŐBB csonkolja, mint hogy az stdin megérkezne — egy elbukó merge-folyamat ÜRES managed-settings.json-t hagyott hátra;
- a fallback parse-hibánál nulláról építette újra a policyt, csendben eldobva minden MÁS managed kulcsot (channelsEnabled, más csatornák allowlist-bejegyzései).

## Hogyan

A #1306-os Discord-ág safe-merge alakja átvéve: a merge egyetlen sudo-python folyamatban fut (tmp + copymode + os.replace; parse-hiba = hangos elutasítás, a fájl ÉRINTETLEN, kézi pótlás kiírva), a fájl-létrehozó ág is tmp + os.replace. A `tee` többé sehol nem célozza a MANAGED_FILE-t.

`install-linux.sh`-ban nincs managed-settings írás (mérve: 0 MANAGED_FILE találat) — a scope mac-only.

## Verifikáció

- Új suite (`installer-slack-managed-atomic.test.ts`): a szállított szöveg horgonyai (unsafe alakok HIÁNYA, safe markerek megléte) + a kivágott SLACKMERGEPY szkript VALÓDI futtatása temp fájlokon: merge megtartja az idegen kulcsokat és a 0600 módot, korrupt bemenetnél a fájl bájt-azonos marad nem-nulla exittel, nem-objektum gyökér elutasítva, második futás no-op, nincs tmp-maradvány.
- `bash -n install-macos.sh` zöld; `tsc --noEmit` zöld; installer-suite-ok (discord-parity, start-and-fallback, token-probe, slack-managed-atomic) 53/53 zöld.

## Megjegyzés

A marveen-bridge-installer repo vendorált másolata (`installer/vendor/public-install-macos.sh` + golden) a következő re-vendor körben veszi át — az a marveen-installer-release-chain folyamat része, nem ezé a PR-é.

🤖 Generated with [Claude Code](https://claude.com/claude-code)