### PR TITLE
fix(heartbeat): a nyeses-lemaradas a jel, nem a DB abszolut merete (HBDBKUSZOB823)

### DIFF
--- a/scripts/heartbeat-metrics.sh
+++ b/scripts/heartbeat-metrics.sh
@@ -21,6 +21,7 @@
 #   WAITING <id> <title>           (0..n lines)
 #   CALENDAR_EVENTS n=N window=2h  (measured; n=0 is a MEASURED empty calendar)
 #   CAL_EVENT <HH:MM|all-day> <summary> [attendees=N]   (0..n lines)
+#   TOKEN_PRUNE state=ok|stale|empty retention_days=N lag_hours=N tolerance_hours=N
 #   SCHEDULES enabled=N
 #   TASK_RUNS_1H total=N [<status>=N ...]
 #   ERROR <section>: <reason>      (any failed measurement)
@@ -113,6 +114,19 @@ if tok is not None:
                 print('URGENT', x.get('id'), x.get('title'))
             for x in d.get('waiting') or []:
                 print('WAITING', x.get('id'), x.get('title'))
+        # HBDBKUSZOB823: the prune-lag state is computed server-side too
+        # (db.ts getTokenPruneLag) -- the retention resolution is
+        # override > .env > registry default, and re-implementing that chain
+        # here would be a second source of truth. Fail-closed like the rest:
+        # a missing block is an ERROR line, never a cheerful default.
+        tp = d.get('token_prune')
+        if not isinstance(tp, dict) or tp.get('state') is None:
+            err('token_prune', 'token_prune missing from response')
+        else:
+            print('TOKEN_PRUNE state=%s retention_days=%s lag_hours=%s '
+                  'tolerance_hours=%s'
+                  % (tp['state'], tp.get('retention_days'),
+                     tp.get('lag_hours'), tp.get('tolerance_hours')))
     except Exception as e:
         err('summary', repr(e))
 

--- a/src/__tests__/heartbeat-db-size.test.ts
+++ b/src/__tests__/heartbeat-db-size.test.ts
@@ -41,12 +41,12 @@ describe('the endpoint serves the number under counts.* (truncation-safe surface
   const empty = { urgent: [], in_progress: [], waiting: [] }
 
   it('db_size_mb rides in counts, inside the first 200 bytes', () => {
-    const json = JSON.stringify(buildHeartbeatSummaryResponse(empty, 0, 0, 159.7))
+    const json = JSON.stringify(buildHeartbeatSummaryResponse(empty, 0, 0, 159.7, { state: 'ok', retention_days: 90, tolerance_hours: 48, lag_hours: 0.27, oldest_age_days: 90.01 }))
     expect(json.slice(0, 200)).toContain('"db_size_mb":159.7')
   })
 
   it('null passes through as null -- the builder must not coerce "unknown" into a calm-looking 0', () => {
-    const r = buildHeartbeatSummaryResponse(empty, 0, 0, null)
+    const r = buildHeartbeatSummaryResponse(empty, 0, 0, null, { state: 'ok', retention_days: 90, tolerance_hours: 48, lag_hours: 0.27, oldest_age_days: 90.01 })
     expect(r.counts.db_size_mb).toBeNull()
     expect(JSON.stringify(r)).toContain('"db_size_mb":null')
   })

--- a/src/__tests__/heartbeat-metrics-inject.test.ts
+++ b/src/__tests__/heartbeat-metrics-inject.test.ts
@@ -17,6 +17,7 @@ const HAPPY = [
   'CALENDAR_EVENTS n=2 window=2h',
   'CAL_EVENT all-day Stay somewhere nice attendees=1',
   'CAL_EVENT 08:00 Új esemény',
+  'TOKEN_PRUNE state=ok retention_days=90 lag_hours=0.27 tolerance_hours=48',
   'SCHEDULES enabled=34',
   'TASK_RUNS_1H total=41 fired=12 skipped=29',
 ].join('\n')
@@ -113,9 +114,66 @@ describe('fail-closed rendering -- a value the instrument did not print never be
     ].join('\n')
     const out = renderHeartbeatMetricsBlock(raw)
     const hits = out.match(/muszer-hiba: ERROR token/g) ?? []
-    // calendar + kanban + schedules + memory = 4 sections; task_runs measured.
-    expect(hits.length).toBe(4)
+    // calendar + kanban + schedules + memory + token_prune = 5 sections;
+    // task_runs measured. HBDBKUSZOB823 added the fifth: the prune verdict is
+    // API-backed too, so an API-wide failure must take it down VISIBLY instead
+    // of leaving a reassuring silence where the health line belongs.
+    expect(hits.length).toBe(5)
     expect(out).toContain('- last hour: TASK_RUNS_1H total=3 fired=3')
+  })
+})
+
+describe('TOKEN_PRUNE -- the health line that replaced the DB-size threshold (HBDBKUSZOB823)', () => {
+  const withPrune = (line: string) => renderHeartbeatMetricsBlock([
+    'HB_METRICS_V1 ts=2026-09-13 10:00',
+    'COUNTS urgent=0 in_progress=0 waiting=0 planned=0 new_hot_memories_1h=0 db_size_mb=481.7 waiting_shown=0',
+    line,
+    'SCHEDULES enabled=34',
+    'TASK_RUNS_1H total=3 fired=3',
+  ].join('\n'))
+
+  it('ok renders quietly, WITH the numbers that make it checkable', () => {
+    const out = withPrune('TOKEN_PRUNE state=ok retention_days=90 lag_hours=0.27 tolerance_hours=48')
+    expect(out).toContain('- token_usage prune: rendben (0.27 ora lemaradas, tures 48 ora)')
+    expect(out).not.toContain('FIGYELEM')
+  })
+
+  it('stale is loud, and says the sweep is not running -- not merely that a number is high', () => {
+    const out = withPrune('TOKEN_PRUNE state=stale retention_days=90 lag_hours=61.2 tolerance_hours=48')
+    expect(out).toContain('FIGYELEM, token_usage NYESES ELMARADT')
+    expect(out).toContain('61.2 ora lemaradas')
+    expect(out).toContain('A napi decay-sweep nem fut')
+  })
+
+  it('empty is its own line -- a fresh install is not a healthy verdict', () => {
+    const out = withPrune('TOKEN_PRUNE state=empty retention_days=90 lag_hours=none tolerance_hours=48')
+    expect(out).toContain('nincs meg sor (uj telepites)')
+    expect(out).not.toContain('rendben')
+  })
+
+  it('FAIL-CLOSED: an output with NO TOKEN_PRUNE line renders muszer-hiba, never silence', () => {
+    // The shape that matters in practice: an older instrument paired with a
+    // newer injector. A health signal that simply vanishes when the contract
+    // drifts is worse than the threshold this replaced -- that one at least
+    // printed something.
+    const out = renderHeartbeatMetricsBlock([
+      'HB_METRICS_V1 ts=2026-09-13 10:00',
+      'COUNTS urgent=0 in_progress=0 waiting=0 planned=0 new_hot_memories_1h=0 db_size_mb=481.7 waiting_shown=0',
+      'SCHEDULES enabled=34',
+      'TASK_RUNS_1H total=3 fired=3',
+    ].join('\n'))
+    expect(out).toContain('muszer-hiba')
+    expect(out).not.toContain('token_usage prune: rendben')
+  })
+
+  it('MUTATION CONTROL: the rendered verdict follows the state, not the DB size', () => {
+    // Same 481.7 MB in both renders -- if the two outputs did not diverge, the
+    // line would be decoration re-deriving the old always-true size alarm.
+    const ok = withPrune('TOKEN_PRUNE state=ok retention_days=90 lag_hours=0.27 tolerance_hours=48')
+    const stale = withPrune('TOKEN_PRUNE state=stale retention_days=90 lag_hours=61.2 tolerance_hours=48')
+    expect(ok).toContain('481.7 MB')
+    expect(stale).toContain('481.7 MB')
+    expect(ok).not.toBe(stale)
   })
 })
 

--- a/src/__tests__/heartbeat-metrics-script.test.ts
+++ b/src/__tests__/heartbeat-metrics-script.test.ts
@@ -43,6 +43,11 @@ const FULL_SUMMARY = () => ({
     new_hot_memories_1h: 0,
     db_size_mb: 166.6,
   },
+  // HBDBKUSZOB823: the prune verdict rides in the same payload, computed
+  // server-side like every other number here (the retention resolution is
+  // override > .env > registry default -- re-deriving it in the script would
+  // be a second source of truth).
+  token_prune: { state: 'ok', retention_days: 90, lag_hours: 0.27, tolerance_hours: 48 },
   waiting_shown: 8,
   urgent: [{ id: 'CARD1', title: 'first urgent' }],
   waiting: [{ id: 'CARD2', title: 'a waiting card' }],
@@ -160,7 +165,38 @@ describe('positive control: full fixture', () => {
     expect(r.stdout).toContain('WAITING CARD2 a waiting card')
     expect(r.stdout).toContain('CALENDAR_EVENTS n=0 window=2h')
     expect(r.stdout).toContain('SCHEDULES enabled=2')
+    expect(r.stdout).toContain('TOKEN_PRUNE state=ok retention_days=90 lag_hours=0.27 tolerance_hours=48')
     expect(r.stdout).not.toContain('ERROR')
+  })
+
+  it('carries a stale prune verdict through verbatim (HBDBKUSZOB823)', async () => {
+    const body = FULL_SUMMARY() as Record<string, unknown>
+    body.token_prune = { state: 'stale', retention_days: 90, lag_hours: 61.2, tolerance_hours: 48 }
+    summaryBody = body
+    schedulesBody = []
+    const r = await runScript()
+    expect(r.stdout).toContain('TOKEN_PRUNE state=stale retention_days=90 lag_hours=61.2 tolerance_hours=48')
+    // The instrument REPORTS the state; it is not the alarm's judge. A stale
+    // prune is a finding for the reader, not a broken measurement, so the
+    // exit code stays 0 -- conflating the two would make every stale round
+    // look like an instrument failure.
+    expect(r.status).toBe(0)
+  })
+
+  it('FAIL-CLOSED: a payload without token_prune is an ERROR and a non-zero exit', async () => {
+    // The realistic shape: an older dashboard paired with this script. The
+    // health line must never quietly disappear -- that is precisely how the
+    // threshold it replaces stayed invisible for weeks.
+    const body = FULL_SUMMARY() as Record<string, unknown>
+    delete body.token_prune
+    summaryBody = body
+    schedulesBody = []
+    const r = await runScript()
+    expect(r.stdout).toContain('ERROR token_prune: token_prune missing from response')
+    expect(r.stdout).not.toContain('TOKEN_PRUNE state=')
+    expect(r.status).not.toBe(0)
+    // NEGATIVE CONTROL on the blast radius: the other sections still measure.
+    expect(r.stdout).toContain('COUNTS urgent=2')
   })
 
   it('counts only the millisecond rows inside the hour (the *1000 cutoff, behaviourally)', async () => {

--- a/src/__tests__/heartbeat-native-scheduler-dormant.test.ts
+++ b/src/__tests__/heartbeat-native-scheduler-dormant.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+
+// HBDBKUSZOB823 -- A WAKE-UP GATE, not documentation.
+//
+// src/heartbeat.ts still exports a full notification filter (shouldNotify),
+// and it is still unit-tested (heartbeat-calendar-fail-open.test.ts pins its
+// 22:00 curfew), so it LOOKS like a working filter. It is not running: the
+// 2026-06-02 architecture switch moved the hourly summary to the `heartbeat`
+// sub-agent via the scheduled-task runner, and index.ts deliberately never
+// calls initHeartbeat() (see its comment there). Measured 2026-09-13 on the
+// live host: zero "Heartbeat ellenorzes indul" lines in store/dashboard.log
+// against 580 other heartbeat lines in the same file.
+//
+// Why a test and not a comment: the module carries a defect that only bites
+// on revival, and a comment does not fire at the moment someone reintroduces
+// it. Whoever starts the native scheduler again lands here first.
+//
+// WHAT THIS DOES NOT CATCH, said plainly: it matches call sites textually, so
+// an aliased or dynamically-dispatched call (`const f = initHeartbeat; f()`)
+// walks past it. It is aimed at the realistic revival -- a literal
+// initHeartbeat() call added back to the boot path -- not at an adversary.
+
+const SRC = join(__dirname, '..')
+
+function tsFiles(dir: string): string[] {
+  const out: string[] = []
+  for (const entry of readdirSync(dir)) {
+    if (entry === '__tests__' || entry === 'node_modules') continue
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) out.push(...tsFiles(full))
+    else if (entry.endsWith('.ts')) out.push(full)
+  }
+  return out
+}
+
+describe('the native heartbeat scheduler stays dormant', () => {
+  it('nobody calls initHeartbeat() -- and if you are here to change that, read the message', () => {
+    const callSites: string[] = []
+    for (const file of tsFiles(SRC)) {
+      const body = readFileSync(file, 'utf8')
+      body.split('\n').forEach((line, i) => {
+        if (!line.includes('initHeartbeat(')) return
+        // The definition itself and the (kept) import are not call sites.
+        if (/export\s+function\s+initHeartbeat\(/.test(line)) return
+        if (/^\s*import\s|from '\.\/heartbeat\.js'/.test(line)) return
+        callSites.push(`${file.slice(SRC.length + 1)}:${i + 1}: ${line.trim()}`)
+      })
+    }
+    expect(callSites, [
+      'A NATIV HEARTBEAT-UTEMEZOT VALAKI UJRA ELINDITJA. Elotte KET dolgot kell rendezni,',
+      'kulonben a fo-agens ertesites-szuroje gyakorlatilag kikapcsolva indul ujra:',
+      '',
+      '  1. src/heartbeat.ts shouldNotify(): a `if (data.system.dbWarning) return true` a',
+      '     FUGGVENY ELSO sora, tehat megkeruli a 22:00-as csendes ablakot, az esti',
+      '     urgent-only es a hetvegi szurot is. Vidd a csendes ablak ALA.',
+      '  2. src/heartbeat.ts collectSystem(): a kuszob hardkodolt `dbSize > 100`. Az',
+      '     abszolut meret itt ROSSZ MUSZER: a DB merete tervezesbol korlatos (2026-09-13:',
+      '     481,7 MB, ~65 % a naponta nyesett token-naplo), tehat a feltetel SOHA nem lehet',
+      '     hamis -- a szuro allando megkerulese nem hiba-allapot, hanem az uzemszeru allapot.',
+      '     Ha kell kuszob, config-kulcs legyen; a valodi jel viszont a nyeses-lemaradas,',
+      '     ami mar meg van irva: db.ts getTokenPruneLag().',
+      '',
+      'Talalt hivas(ok):',
+      ...callSites,
+    ].join('\n')).toEqual([])
+  })
+
+  it('POSITIVE CONTROL: the detector really finds a call site when one exists', () => {
+    // Without this, "zero call sites" could equally mean "the matcher is
+    // broken" -- the same green-looking nothing the dead filter itself is.
+    const sample = [
+      "import { initHeartbeat } from './heartbeat.js'",
+      '  initHeartbeat()',
+    ]
+    const hits = sample.filter((line) =>
+      line.includes('initHeartbeat(')
+      && !/export\s+function\s+initHeartbeat\(/.test(line)
+      && !/^\s*import\s|from '\.\/heartbeat\.js'/.test(line))
+    expect(hits).toEqual(['  initHeartbeat()'])
+  })
+})

--- a/src/__tests__/heartbeat-summary-truncation-safe.test.ts
+++ b/src/__tests__/heartbeat-summary-truncation-safe.test.ts
@@ -29,7 +29,7 @@ function bigSummary() {
 
 describe('buildHeartbeatSummaryResponse (pure)', () => {
   it('counts is the FIRST serialized key, so truncated reads lose lists, never numbers', () => {
-    const json = JSON.stringify(buildHeartbeatSummaryResponse(bigSummary(), 2, 305, 159.7))
+    const json = JSON.stringify(buildHeartbeatSummaryResponse(bigSummary(), 2, 305, 159.7, { state: 'ok', retention_days: 90, tolerance_hours: 48, lag_hours: 0.27, oldest_age_days: 90.01 }))
     expect(json.startsWith('{"counts":')).toBe(true)
     // The whole counts object must fit well inside any sane read window: the
     // first 200 bytes carry every number even if 99% of the payload is lost.
@@ -42,31 +42,31 @@ describe('buildHeartbeatSummaryResponse (pure)', () => {
   })
 
   it('counts.waiting is the FULL total, never the capped list length (the 2026-08-04 lesson in endpoint form)', () => {
-    const r = buildHeartbeatSummaryResponse(bigSummary(), 0, 305, 159.7)
+    const r = buildHeartbeatSummaryResponse(bigSummary(), 0, 305, 159.7, { state: 'ok', retention_days: 90, tolerance_hours: 48, lag_hours: 0.27, oldest_age_days: 90.01 })
     expect(r.counts.waiting).toBe(280)
     expect(r.waiting.length).toBe(HEARTBEAT_SUMMARY_WAITING_CAP)
     expect(r.waiting_shown).toBe(HEARTBEAT_SUMMARY_WAITING_CAP)
   })
 
   it('the waiting list carries the most recently UPDATED cards', () => {
-    const r = buildHeartbeatSummaryResponse(bigSummary(), 0, 305, 159.7)
+    const r = buildHeartbeatSummaryResponse(bigSummary(), 0, 305, 159.7, { state: 'ok', retention_days: 90, tolerance_hours: 48, lag_hours: 0.27, oldest_age_days: 90.01 })
     // Fixture updated_at grows with the index, so the newest ids are the highest.
     expect(r.waiting[0].id).toBe('W279')
     expect(r.waiting[HEARTBEAT_SUMMARY_WAITING_CAP - 1].id).toBe(`W${280 - HEARTBEAT_SUMMARY_WAITING_CAP}`)
   })
 
   it('every title is truncated server-side; short titles pass through untouched', () => {
-    const r = buildHeartbeatSummaryResponse(bigSummary(), 0, 305, 159.7)
+    const r = buildHeartbeatSummaryResponse(bigSummary(), 0, 305, 159.7, { state: 'ok', retention_days: 90, tolerance_hours: 48, lag_hours: 0.27, oldest_age_days: 90.01 })
     for (const c of [...r.urgent, ...r.waiting]) {
       expect(c.title.length).toBeLessThanOrEqual(HEARTBEAT_SUMMARY_TITLE_MAX + 1) // +1 for the ellipsis
     }
     const small = buildHeartbeatSummaryResponse(
-      { urgent: [card('A', 'rövid cím', 'waiting', 1)], in_progress: [], waiting: [] }, 0, 0, null)
+      { urgent: [card('A', 'rövid cím', 'waiting', 1)], in_progress: [], waiting: [] }, 0, 0, null, { state: 'ok', retention_days: 90, tolerance_hours: 48, lag_hours: 0.27, oldest_age_days: 90.01 })
     expect(small.urgent[0].title).toBe('rövid cím')
   })
 
   it('the payload with 280 huge-titled cards stays small enough to never truncate in practice', () => {
-    const json = JSON.stringify(buildHeartbeatSummaryResponse(bigSummary(), 0, 305, 159.7))
+    const json = JSON.stringify(buildHeartbeatSummaryResponse(bigSummary(), 0, 305, 159.7, { state: 'ok', retention_days: 90, tolerance_hours: 48, lag_hours: 0.27, oldest_age_days: 90.01 }))
     // Pre-fix this was ~4.2MB with these fixtures (280 x 15KB); the cap+trunc
     // must keep it in the low KB range.
     expect(json.length).toBeLessThan(10_000)

--- a/src/__tests__/heartbeat-urgent-open-only.test.ts
+++ b/src/__tests__/heartbeat-urgent-open-only.test.ts
@@ -162,6 +162,7 @@ describe('the heartbeat AGENT is handed the rendered block, not a filter to re-a
       'HB_METRICS_V1 ts=2026-09-11 12:00',
       'COUNTS urgent=0 in_progress=0 waiting=0 planned=3 new_hot_memories_1h=0 db_size_mb=100 waiting_shown=0',
       'CALENDAR_EVENTS n=0 window=2h',
+      'TOKEN_PRUNE state=ok retention_days=90 lag_hours=0.27 tolerance_hours=48',
       'SCHEDULES enabled=1',
       'TASK_RUNS_1H total=0',
     ].join('\n'))

--- a/src/__tests__/token-prune-lag.test.ts
+++ b/src/__tests__/token-prune-lag.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest'
+import Database from 'better-sqlite3'
+import { mkdtempSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import {
+  TOKEN_PRUNE_OLDEST_SQL,
+  TOKEN_PRUNE_TOLERANCE_CYCLES,
+  DECAY_SWEEP_INTERVAL_MS,
+  classifyTokenPruneLag,
+} from '../db.js'
+
+// HBDBKUSZOB823. The heartbeat carried a `dbSize > 100 MB` warning; measured
+// 2026-09-13 the DB is 481.7 MB and ~65 % of it is the token ledger, which the
+// daily sweep holds at exactly the retention. The size is bounded BY DESIGN,
+// so that alarm can never go quiet -- and the failure it claimed to watch (the
+// prune silently stopping) is invisible to it, because "the DB is big" is
+// already permanently true. This replaces it with a signal that CAN be quiet.
+//
+// The number that shaped these fixtures, measured on the live DB the same day:
+// 50 rows sat past the 90-day cutoff, the oldest overshooting by 16.4 MINUTES.
+// That is not a prune failure, it is rows aging since the last sweep -- so the
+// naive "oldest row older than retention" test would be true almost always.
+
+const RETENTION = 90
+const TOLERANCE_H = (TOKEN_PRUNE_TOLERANCE_CYCLES * DECAY_SWEEP_INTERVAL_MS) / 3_600_000
+const NOW = 1_789_000_000 // fixed clock: the classifier takes `now`, so no skew
+const cutoff = (overshootHours: number) => NOW - RETENTION * 86400 - Math.round(overshootHours * 3600)
+
+describe('TOKEN_PRUNE_OLDEST_SQL (the shipped statement, on a fixture DB)', () => {
+  function fixtureDb() {
+    const dir = mkdtempSync(join(tmpdir(), 'token-prune-'))
+    const db = new Database(join(dir, 'test.db'))
+    db.exec('CREATE TABLE token_usage (id INTEGER PRIMARY KEY, timestamp INTEGER)')
+    return db
+  }
+
+  it('returns the oldest timestamp, not the newest', () => {
+    const db = fixtureDb()
+    const ins = db.prepare('INSERT INTO token_usage (timestamp) VALUES (?)')
+    ins.run(NOW - 500); ins.run(NOW - 90_000); ins.run(NOW - 42)
+    expect((db.prepare(TOKEN_PRUNE_OLDEST_SQL).get() as { oldest: number }).oldest).toBe(NOW - 90_000)
+  })
+
+  it('returns null on an empty table -- never 0, which would read as 1970', () => {
+    const db = fixtureDb()
+    expect((db.prepare(TOKEN_PRUNE_OLDEST_SQL).get() as { oldest: number | null }).oldest).toBeNull()
+  })
+})
+
+describe('classifyTokenPruneLag: the verdict', () => {
+  it('NEGATIVE CONTROL -- the real live shape (16.4 min past the cutoff) is quiet', () => {
+    const r = classifyTokenPruneLag(cutoff(16.4 / 60), RETENTION, NOW, TOLERANCE_H)
+    expect(r.state).toBe('ok')
+  })
+
+  it('MUTATION CONTROL -- with a zero tolerance that SAME input fires', () => {
+    // If this did not diverge, the fixture above would be pinning a constant
+    // rather than measuring the tolerance, and the naive rule would look
+    // indistinguishable from the shipped one.
+    const naive = classifyTokenPruneLag(cutoff(16.4 / 60), RETENTION, NOW, 0)
+    const shipped = classifyTokenPruneLag(cutoff(16.4 / 60), RETENTION, NOW, TOLERANCE_H)
+    expect(naive.state).toBe('stale')
+    expect(naive.state).not.toBe(shipped.state)
+  })
+
+  it('POSITIVE CONTROL -- a row past the tolerance fires', () => {
+    const r = classifyTokenPruneLag(cutoff(TOLERANCE_H + 1), RETENTION, NOW, TOLERANCE_H)
+    expect(r.state).toBe('stale')
+    expect(r.lag_hours).toBeGreaterThan(TOLERANCE_H)
+  })
+
+  it('the boundary is strict: exactly at the tolerance is still ok, just past is stale', () => {
+    expect(classifyTokenPruneLag(cutoff(TOLERANCE_H), RETENTION, NOW, TOLERANCE_H).state).toBe('ok')
+    expect(classifyTokenPruneLag(cutoff(TOLERANCE_H + 0.02), RETENTION, NOW, TOLERANCE_H).state).toBe('stale')
+  })
+
+  it('a fresh sweep (nothing aged past the cutoff yet) is ok, not a finding', () => {
+    const r = classifyTokenPruneLag(cutoff(-5), RETENTION, NOW, TOLERANCE_H)
+    expect(r.state).toBe('ok')
+    expect(r.lag_hours).toBeLessThan(0)
+  })
+
+  it('an empty table is its OWN state -- neither healthy nor broken', () => {
+    const r = classifyTokenPruneLag(null, RETENTION, NOW, TOLERANCE_H)
+    expect(r.state).toBe('empty')
+    expect(r.lag_hours).toBeNull()
+    expect(r.oldest_age_days).toBeNull()
+  })
+
+  it('the lag IS the time since the last sweep (that is what makes it readable)', () => {
+    const r = classifyTokenPruneLag(cutoff(30), RETENTION, NOW, TOLERANCE_H)
+    expect(r.lag_hours).toBeCloseTo(30, 1)
+  })
+
+  it('the tolerance is two REAL sweep cycles, derived from the interval', () => {
+    // Pins the relation, not the number: if the sweep cadence changes, the
+    // tolerance follows instead of silently becoming wrong.
+    expect(TOLERANCE_H).toBe((2 * DECAY_SWEEP_INTERVAL_MS) / 3_600_000)
+    expect(TOLERANCE_H).toBe(48)
+  })
+
+  it('a longer retention moves the cutoff, not the verdict logic', () => {
+    const oldest = NOW - 200 * 86400
+    expect(classifyTokenPruneLag(oldest, 90, NOW, TOLERANCE_H).state).toBe('stale')
+    expect(classifyTokenPruneLag(oldest, 365, NOW, TOLERANCE_H).state).toBe('ok')
+  })
+})

--- a/src/db.ts
+++ b/src/db.ts
@@ -4173,6 +4173,99 @@ export function pruneTokenUsage(): number {
   return info.changes
 }
 
+// The decay-sweep cadence. Lives HERE, beside the prune it drives, because
+// db.ts is what needs it for the lag tolerance below and memory.ts already
+// imports from db.ts -- putting it there would close an import cycle.
+// index.ts sweeps once at boot AND on this interval, so a restart only ever
+// SHORTENS the gap between two sweeps.
+export const DECAY_SWEEP_INTERVAL_MS = 24 * 60 * 60 * 1000
+
+/**
+ * HBDBKUSZOB823: whether the daily token_usage prune is still running.
+ *
+ * WHY THIS AND NOT A DB-SIZE THRESHOLD. The heartbeat carried a
+ * `dbSize > 100 MB` warning. Measured 2026-09-13: the DB is 481.7 MB and about
+ * 65 % of it IS the token ledger, which this sweep holds at exactly
+ * TOKEN_USAGE_RETENTION_DAYS (oldest row: 90.01 days against a 90-day
+ * retention). The size is bounded BY DESIGN and can never fall under such a
+ * threshold, so the warning can never go quiet -- and the one failure it
+ * claims to watch, the prune silently stopping, is invisible to it, because
+ * "the DB is big" is already permanently true.
+ *
+ * WHAT THE LAG MEASURES. Rows below `now - retention` are deleted, so the
+ * oldest surviving row's overshoot past that cutoff IS the time since the last
+ * successful sweep. No separate last-run bookkeeping, and a sweep that ran but
+ * deleted nothing cannot fake it.
+ *
+ * WHY TWO SWEEP CYCLES AND NOT A ROUND NUMBER. Measured on the live DB the
+ * same day: 50 rows sat past the cutoff, the oldest overshooting by 16.4
+ * MINUTES -- rows that merely aged past it since the last sweep. So a naive
+ * "oldest row older than retention" test is true almost always and would die
+ * of false positives exactly the way the size threshold died of always-true.
+ * The tolerance is derived from DECAY_SWEEP_INTERVAL_MS so it cannot drift
+ * from the real cadence; two cycles means two consecutive missed sweeps with
+ * no restart in between, which is not jitter.
+ *
+ * A STATE, never a bare number: 'empty' (no rows yet) is a fresh install with
+ * nothing to judge, and must read as neither healthy nor broken.
+ */
+export const TOKEN_PRUNE_OLDEST_SQL = 'SELECT MIN(timestamp) AS oldest FROM token_usage'
+
+export const TOKEN_PRUNE_TOLERANCE_CYCLES = 2
+
+export interface TokenPruneLag {
+  state: 'ok' | 'stale' | 'empty'
+  retention_days: number
+  tolerance_hours: number
+  /** Hours the oldest row overshoots the cutoff = time since the last sweep. */
+  lag_hours: number | null
+  oldest_age_days: number | null
+}
+
+/**
+ * The verdict itself, as a PURE function: three lines of decision inside a
+ * DB-reading wrapper is exactly the place a later refactor drops in silence,
+ * with only an end-to-end run left to notice. Exported so the controls run
+ * against the SHIPPED decision and not a re-typed equivalent.
+ */
+export function classifyTokenPruneLag(
+  oldestTimestamp: number | null,
+  retentionDays: number,
+  nowSeconds: number,
+  toleranceHours: number,
+): TokenPruneLag {
+  if (oldestTimestamp == null) {
+    return {
+      state: 'empty',
+      retention_days: retentionDays,
+      tolerance_hours: toleranceHours,
+      lag_hours: null,
+      oldest_age_days: null,
+    }
+  }
+  const ageSeconds = nowSeconds - oldestTimestamp
+  const lagHours = (ageSeconds - retentionDays * 86400) / 3600
+  return {
+    // A negative lag (nothing has aged past the cutoff yet) is healthy, not a
+    // finding -- it only means the sweep ran recently.
+    state: lagHours > toleranceHours ? 'stale' : 'ok',
+    retention_days: retentionDays,
+    tolerance_hours: toleranceHours,
+    lag_hours: Math.round(lagHours * 100) / 100,
+    oldest_age_days: Math.round((ageSeconds / 86400) * 100) / 100,
+  }
+}
+
+export function getTokenPruneLag(): TokenPruneLag {
+  const row = db.prepare(TOKEN_PRUNE_OLDEST_SQL).get() as { oldest: number | null } | undefined
+  return classifyTokenPruneLag(
+    row?.oldest ?? null,
+    Number(getEffectiveSettingValue('TOKEN_USAGE_RETENTION_DAYS')),
+    Math.floor(Date.now() / 1000),
+    (TOKEN_PRUNE_TOLERANCE_CYCLES * DECAY_SWEEP_INTERVAL_MS) / 3_600_000,
+  )
+}
+
 // --- Vault SSH Keys (shared key pool) ---
 // Each key is independent of any server -- one key may be assigned to many
 // servers. The private key blob lives in the AES-256-GCM vault (vault.ts);

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { PROJECT_ROOT, STORE_DIR, PID_FILENAME, WEB_PORT, MAIN_AGENT_ID, RESPAWN
 import { resolveOwnerChatId } from './owner-chat.js'
 import { initDatabase, backfillEmbeddings } from './db.js'
 import { runDecaySweep, runDailyDigest } from './memory.js'
+import { DECAY_SWEEP_INTERVAL_MS } from './db.js'
 import { initHeartbeat, stopHeartbeat, ensureHeartbeatWorkerHidden } from './heartbeat.js'
 import { ensureHeartbeatAgent, shouldBootHeartbeatAgent, HEARTBEAT_AGENT_NAME } from './web/heartbeat-agent-scaffold.js'
 import { startAgentProcess } from './web/agent-process.js'
@@ -482,7 +483,7 @@ async function main(): Promise<void> {
 
   // Memory decay (24h cycle)
   runDecaySweep()
-  decayInterval = setInterval(runDecaySweep, 24 * 60 * 60 * 1000)
+  decayInterval = setInterval(runDecaySweep, DECAY_SWEEP_INTERVAL_MS)
   logger.info('Memoria leepulesi ciklus beallitva (24 oras)')
 
   // Log rotation (LOGROTATE910): copytruncate on the launcher-redirected

--- a/src/web/heartbeat-metrics-inject.ts
+++ b/src/web/heartbeat-metrics-inject.ts
@@ -59,6 +59,7 @@ interface ParsedMetrics {
   calEvents: string[] // rendered "- <time> -- <summary>" lines
   schedulesEnabled: string | null
   taskRuns: string | null // the TASK_RUNS_1H line, verbatim
+  tokenPrune: Record<string, string> | null
   errors: Map<string, string> // section -> full ERROR line
 }
 
@@ -73,6 +74,7 @@ function parseInstrumentOutput(lines: string[]): ParsedMetrics {
     calEvents: [],
     schedulesEnabled: null,
     taskRuns: null,
+    tokenPrune: null,
     errors: new Map(),
   }
   const tsMatch = lines[0]?.match(/^HB_METRICS_V1 ts=(.+)$/)
@@ -106,6 +108,12 @@ function parseInstrumentOutput(lines: string[]): ParsedMetrics {
     } else if (line.startsWith('SCHEDULES ')) {
       const m = line.match(/enabled=(\d+)/)
       p.schedulesEnabled = m ? m[1] : null
+    } else if (line.startsWith('TOKEN_PRUNE ')) {
+      const kv: Record<string, string> = {}
+      for (const m of line.slice('TOKEN_PRUNE '.length).matchAll(/(\w+)=(\S+)/g)) {
+        kv[m[1]] = m[2]
+      }
+      p.tokenPrune = kv
     } else if (line.startsWith('TASK_RUNS_1H ')) {
       p.taskRuns = line
     } else if (line.startsWith('ERROR ')) {
@@ -126,6 +134,20 @@ function hibaLine(p: ParsedMetrics, section: string, firstLine: string): string 
   const token = p.errors.get('token')
   if (token) return `- muszer-hiba: ${token}`
   return `- muszer-hiba: ${firstLine}`
+}
+
+// The prune verdict as ONE line. 'stale' is the only loud state, and it says
+// what to do rather than what is broken: the daily decay sweep has not run.
+function renderTokenPruneLine(p: ParsedMetrics, firstLine: string): string {
+  const tp = p.tokenPrune
+  if (!tp || !tp['state']) return hibaLine(p, 'token_prune', firstLine)
+  if (tp['state'] === 'empty') return '- token_usage prune: nincs meg sor (uj telepites)'
+  if (tp['state'] === 'stale') {
+    return `- FIGYELEM, token_usage NYESES ELMARADT: ${tp['lag_hours']} ora lemaradas `
+      + `(tures ${tp['tolerance_hours']} ora = ket sweep-ciklus). A napi decay-sweep nem fut -- `
+      + `a token-naplo ettol korlatlanul no.`
+  }
+  return `- token_usage prune: rendben (${tp['lag_hours']} ora lemaradas, tures ${tp['tolerance_hours']} ora)`
 }
 
 function renderSections(p: ParsedMetrics, firstLine: string): string {
@@ -179,6 +201,12 @@ function renderSections(p: ParsedMetrics, firstLine: string): string {
   } else {
     out.push(hibaLine(p, 'summary', firstLine))
   }
+  // HBDBKUSZOB823: the DB size above is a bounded number (the token ledger is
+  // pruned daily), so it cannot carry a health verdict on its own -- this line
+  // is the verdict. Absent TOKEN_PRUNE renders as muszer-hiba, never as
+  // silence: a health signal that disappears when the instrument changes shape
+  // is the failure mode this whole module exists to close.
+  out.push(renderTokenPruneLine(p, firstLine))
 
   return out.join('\n')
 }

--- a/src/web/routes/kanban.ts
+++ b/src/web/routes/kanban.ts
@@ -17,6 +17,8 @@ import {
   countNewHotMemories,
   countPlannedKanbanCards,
   getDbFileSizeMb,
+  getTokenPruneLag,
+  type TokenPruneLag,
 } from '../../db.js'
 import { normalizeKanbanRefs } from '../kanban-ref-normalize.js'
 import { OWNER_NAME, BOT_NAME, MAIN_AGENT_ID, STORE_DIR, WEB_HOST, WEB_PORT, KANBAN_LABEL_COLORS } from '../../config.js'
@@ -232,6 +234,7 @@ export function buildHeartbeatSummaryResponse(
   newHotMemories1h: number,
   plannedCount: number,
   dbSizeMb: number | null,
+  tokenPrune: TokenPruneLag,
 ) {
   const trunc = (t: string) =>
     t.length > HEARTBEAT_SUMMARY_TITLE_MAX ? t.slice(0, HEARTBEAT_SUMMARY_TITLE_MAX) + '…' : t
@@ -263,6 +266,12 @@ export function buildHeartbeatSummaryResponse(
       // for a growth signal a false zero looks like calm, not like failure.
       db_size_mb: dbSizeMb,
     },
+    // HBDBKUSZOB823: placed immediately after `counts` and BEFORE the lists,
+    // for the same reason counts comes first -- a truncated read must keep the
+    // health signal and lose only the annotating card lists. The retired
+    // `dbSize > 100 MB` warning could never go quiet (the DB is bounded by
+    // design at ~480 MB); this one is quiet whenever the daily sweep runs.
+    token_prune: tokenPrune,
     urgent: summary.urgent.map(slim),
     waiting: waitingRecent.map(slim),
     waiting_shown: Math.min(summary.waiting.length, HEARTBEAT_SUMMARY_WAITING_CAP),
@@ -308,7 +317,7 @@ export async function tryHandleKanban(ctx: RouteContext): Promise<boolean> {
   // few -- while counts.* always carries the FULL totals. The list is for
   // naming items; the numbers ONLY ever come from counts.
   if (path === '/api/kanban/heartbeat-summary' && method === 'GET') {
-    json(res, buildHeartbeatSummaryResponse(getHeartbeatKanbanSummary(), countNewHotMemories(MAIN_AGENT_ID), countPlannedKanbanCards(), getDbFileSizeMb()))
+    json(res, buildHeartbeatSummaryResponse(getHeartbeatKanbanSummary(), countNewHotMemories(MAIN_AGENT_ID), countPlannedKanbanCards(), getDbFileSizeMb(), getTokenPruneLag()))
     return true
   }
 


### PR DESCRIPTION
## Miert nem a kuszob ertekét javitottam

A kartya azt kerdezte, mennyi legyen a `dbSize > 100 MB` kuszob. A meres mast mondott:

1. **A kuszobot tarto modul nem fut.** Az `initHeartbeat(` hivasainak szama a `src/` alatt nulla
   (csak import), es az `src/index.ts` komment ki is mondja a 2026-06-02-i valtast: "we keep the
   native module imported ... but we do NOT start its scheduler". Elo log-kontroll a gazda gepen:
   a "Heartbeat ellenorzes indul" sorok szama 0 a `store/dashboard.log`-ban -- **pozitiv kontroll**:
   ugyanabban a fajlban 580 egyeb heartbeat-sor van, tehat nem ures korpuszra allitok nullat.
2. **Ami elesben fut**, az a `hourly-heartbeat` utemezett feladat (12/14/17/14 kor/nap, 09:00-22:00),
   es a definicioja szerint "inter-agent message Marveennek (NEM Telegram direkt)". Ebben nincs
   dbWarning-kapu. Tehat se gazda-ertesites-zaj, se dbWarning-eredetu koltseg: **nem surgos**.
3. **A kuszob viszont strukturalisan rossz muszer.** A DB 481,7 MB, ~65 %-a a token-naplo, amit a napi
   sweep pontosan a retention-on tart (legregebbi sor: 90,01 nap, 90 napos retention mellett). A meret
   TERVEZESBOL korlatos, tehat a feltetel uzemszeruen igaz -- es az egyetlen hiba, amit allitolag figyel
   (a nyeses csendben megall), lathatatlan neki, mert "a DB nagy" amugy is mindig igaz.

Ezert a jel oda kerult, ahol ma tenylegesen merunk (a worker metrika-blokkja), a holt ag pedig kapot
kapott torles helyett.

## 1. A nyeses-lemaradas jele

A sorok a `now - retention` alatt torlodnek, tehat **a legregebbi tulelo sor tullogasa a vagason
maga az eltelt ido az utolso sikeres sweep ota**. Nincs szukseg kulon last-run konyvelesre, es egy
sweep, ami lefutott de nem torolt, nem tudja meghamisitani.

**A tures ket sweep-ciklus, nem kerek szam.** Eles meresben 50 sor allt a vagason tul, a legregebbi
**16,4 perccel** -- ezek a legutobbi sweep ota atoregedett sorok. A naiv "legregebbi sor regebbi a
retention-nal" teszt tehat majdnem mindig igaz, es ugyanugy hamis riasztasba halna, ahogy a
meret-kuszob a mindig-igazba. A tures a `DECAY_SWEEP_INTERVAL_MS`-bol szarmazik, igy nem tud
elcsuszni a valos ritmustol; az `index.ts` boot-kor IS sweepel, tehat egy ujraindulas csak roviditi
a kozt -- ezert lehet a turest egesz ciklusokban kimondani.

A verdikt allapot, nem szam: `ok` / `stale` / `empty` (uj telepites nem olvashato sem egeszsegesnek,
sem romlottnak).

## 2. Ebreszto-kapu a holt agra (torles helyett)

A `shouldNotify` exportalt es unit-tesztelt, tehat ugy NEZ KI, mint egy mukodo szuro -- kozben a
`dbWarning` ag a fuggveny ELSO sora, vagyis a 22:00-as csendes ablakot, az esti urgent-only-t es a
hetvegi szurot is megkeruli, VEGLEG, mert a feltetel nem tud hamis lenni. Ez ma nem incidens (a modul
nem fut), hanem csapda a felelesztes pillanatara.

Uj teszt pinneli, hogy nulla hivoja van, es a **bukasi uzenete** megmondja az elesztonek a ket
rendezendo dolgot (dbWarning-ag a csendes ablak ALA; kuszob config-kulcsba, a valodi jel pedig a mar
megirt `getTokenPruneLag()`). Kimondott korlat a tesztben: szoveges illesztes, tehat egy aliasolt hivas
atmegy rajta -- a realis felelesztest fogja, nem tamadot.

## Kontrollok

| kontroll | mit bizonyit |
|---|---|
| negativ | a valos 16,4 perces alak **nema** |
| mutans | ugyanaz a bemenet **nulla turessel TUZEL** -- a fixture a turest meri, nem szamot rogzit |
| pozitiv | turesen tuli sor tuzel, a lag > tures |
| hatareset | pontosan a turesen `ok`, egy hajszallal tul `stale` |
| fail-closed (szkript) | hianyzo `token_prune` -> ERROR + nem-nulla kilepes, a tobbi szekcio meg mer |
| fail-closed (render) | hianyzo `TOKEN_PRUNE` sor -> muszer-hiba, **nem csend** |
| mutans (render) | azonos 481,7 MB mellett az `ok` es a `stale` kimenet ELTER |
| a kapura | probahivas beirva -> a teszt exit 1 a teljes uzenettel; visszaallitva -> exit 0 |

## Meres

- Suite: 435/437 fajl zold. A ket bukas (`secret-gate-runner`, `enroll-port-follows-web-port`)
  **meglevo**: ugyanabban a kornyezetben, az en diffem visszaveve is bukik. Nem tippeltem, megmertem.
- `npm run build` tiszta. A szignatura-valtas (`buildHeartbeatSummaryResponse` +1 parameter) 8 hivot
  utott ki teszt-fajlokban -- mind javitva, ez volt a "minden hivot merj" ellenorzes.
- Em dash 0, homoglifa 0 a hozzaadott sorokban (a `db.ts`-ben talalt `λ`/`τ` meglevo keplet-sor).

Kartya: HBDBKUSZOB823 (lelet: 15035-os komment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
